### PR TITLE
Use fallback named logger

### DIFF
--- a/logging/config.go
+++ b/logging/config.go
@@ -51,10 +51,7 @@ func NewLogger(configJSON string, levelOverride string) (*zap.SugaredLogger, zap
 	if err2 != nil {
 		panic(err2)
 	}
-
-	logger.Error("Failed to parse the logging config. Falling back to default logger.",
-		zap.Error(err), zap.String(logkey.JSONConfig, configJSON))
-	return logger.Sugar(), loggingCfg.Level
+	return logger.Named("fallback-logger").Sugar(), loggingCfg.Level
 }
 
 // NewLoggerFromConfig creates a logger using the provided Config


### PR DESCRIPTION
Use fallback-named logger and remove any log statements from this function.

This will be followed up with another PR to allow a boolean flag to allow users to control whether or not it outputs logs, or not log at all. 

For context [serving PR](https://github.com/knative/serving/pull/1685) and corresponding [issue](https://github.com/knative/serving/issues/1630)