### PR TITLE
Verbose error msg for config test

### DIFF
--- a/logging/config_test.go
+++ b/logging/config_test.go
@@ -193,7 +193,7 @@ func TestInvalidLevel(t *testing.T) {
 		},
 	}, "queueproxy")
 	if err == nil {
-		t.Errorf("Expected errors. got nothing")
+		t.Errorf("Expected errors when invalid level is present in logging config. got nothing")
 	}
 }
 


### PR DESCRIPTION
Use more verbose error msg in config test. 