### PR TITLE
Move VolatileTime into knative/pkg

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -270,6 +270,7 @@
   branch = "release-1.11"
   name = "k8s.io/apimachinery"
   packages = [
+    "pkg/api/equality",
     "pkg/api/errors",
     "pkg/api/meta",
     "pkg/api/resource",
@@ -522,6 +523,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3e50d0bf04aa4624f88f80e450fbba4f666e1e976d289019f077bfb58f8e3385"
+  inputs-digest = "9f97f0d738315cbe94dc6ecb326628562095087faa4c4d8b05c70134d9e7162b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/apis/volatile_time.go
+++ b/apis/volatile_time.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+import (
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// VolatileTime wraps metav1.Time
+type VolatileTime struct {
+	Inner metav1.Time
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (t VolatileTime) MarshalJSON() ([]byte, error) {
+	return t.Inner.MarshalJSON()
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface.
+func (t *VolatileTime) UnmarshalJSON(b []byte) error {
+	return t.Inner.UnmarshalJSON(b)
+}
+
+func init() {
+	equality.Semantic.AddFunc(
+		// Always treat VolatileTime fields as equivalent.
+		func(a, b VolatileTime) bool {
+			return true
+		},
+	)
+}

--- a/apis/volatile_time_test.go
+++ b/apis/volatile_time_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type testType struct {
+	LastTransitionTime VolatileTime `json:"lastTransitionTime"`
+}
+
+func TestVolatileSerializationEmpty(t *testing.T) {
+	tt := testType{}
+
+	b, err := json.Marshal(tt)
+	if err != nil {
+		t.Errorf("Marshal() = %v", err)
+	}
+
+	if got, want := string(b), `{"lastTransitionTime":null}`; got != want {
+		t.Errorf("Marshal() = %v, wanted %v", got, want)
+	}
+
+	got := testType{}
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Errorf("Unmarshal() = %v", err)
+	}
+	if got != tt {
+		t.Errorf("Unmarshal() = %v, wanted %v", got, tt)
+	}
+}
+
+func TestVolatileSerializationNow(t *testing.T) {
+	tt := testType{
+		LastTransitionTime: VolatileTime{metav1.NewTime(time.Unix(1024, 0))},
+	}
+
+	b, err := json.Marshal(tt)
+	if err != nil {
+		t.Errorf("Marshal() = %v", err)
+	}
+
+	if got, want := string(b), `{"lastTransitionTime":"1970-01-01T00:17:04Z"}`; got != want {
+		t.Errorf("Marshal() = %v, wanted %v", got, want)
+	}
+
+	got := testType{}
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Errorf("Unmarshal() = %v", err)
+	}
+	if got != tt {
+		t.Errorf("Unmarshal() = %v, wanted %v", got, tt)
+	}
+}
+
+func TestVolatileTimeEquality(t *testing.T) {
+	tt1 := testType{
+		LastTransitionTime: VolatileTime{metav1.NewTime(time.Unix(1024, 36))},
+	}
+	tt2 := testType{
+		LastTransitionTime: VolatileTime{metav1.NewTime(time.Unix(2048, 36))},
+	}
+
+	if !equality.Semantic.DeepEqual(tt1, tt2) {
+		t.Error("equality.Semantic.DeepEqual() = false, wanted true")
+	}
+}

--- a/vendor/k8s.io/apimachinery/pkg/api/equality/semantic.go
+++ b/vendor/k8s.io/apimachinery/pkg/api/equality/semantic.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package equality
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Semantic can do semantic deep equality checks for api objects.
+// Example: apiequality.Semantic.DeepEqual(aPod, aPodWithNonNilButEmptyMaps) == true
+var Semantic = conversion.EqualitiesOrDie(
+	func(a, b resource.Quantity) bool {
+		// Ignore formatting, only care that numeric value stayed the same.
+		// TODO: if we decide it's important, it should be safe to start comparing the format.
+		//
+		// Uninitialized quantities are equivalent to 0 quantities.
+		return a.Cmp(b) == 0
+	},
+	func(a, b metav1.MicroTime) bool {
+		return a.UTC() == b.UTC()
+	},
+	func(a, b metav1.Time) bool {
+		return a.UTC() == b.UTC()
+	},
+	func(a, b labels.Selector) bool {
+		return a.String() == b.String()
+	},
+	func(a, b fields.Selector) bool {
+		return a.String() == b.String()
+	},
+)


### PR DESCRIPTION
`VolatileTime` is a type that enables us to exclude certain volatile timestamp fields from causing semantic equality to report a difference when only that field changes.

We use this in `knative/serving` for `LastTransitionTime`, which can drift forward during reconciliation if different phases of the reconcile flip-flop a condition.