### PR TITLE
Support multiple group/kind contexts in shared webhook.

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -107,11 +107,10 @@ type ResourceDefaulter func(patches *[]jsonpatch.JsonPatchOperation, crd Generic
 // AdmissionController implements the external admission webhook for validation of
 // pilot configuration.
 type AdmissionController struct {
-	Client       kubernetes.Interface
-	Options      ControllerOptions
-	GroupVersion schema.GroupVersion
-	Handlers     map[string]runtime.Object
-	Logger       *zap.SugaredLogger
+	Client   kubernetes.Interface
+	Options  ControllerOptions
+	Handlers map[schema.GroupVersionKind]runtime.Object
+	Logger   *zap.SugaredLogger
 }
 
 // GenericCRD is the interface definition that allows us to perform the generic
@@ -329,30 +328,43 @@ func (ac *AdmissionController) register(
 	logger := logging.FromContext(ctx)
 	failurePolicy := admissionregistrationv1beta1.Fail
 
-	resources := sort.StringSlice{}
-	for k := range ac.Handlers {
+	var rules []admissionregistrationv1beta1.RuleWithOperations
+	for gvk := range ac.Handlers {
 		// Lousy pluralizer
-		resources = append(resources, strings.ToLower(k)+"s")
+		plural := strings.ToLower(gvk.Kind) + "s"
+
+		rules = append(rules, admissionregistrationv1beta1.RuleWithOperations{
+			Operations: []admissionregistrationv1beta1.OperationType{
+				admissionregistrationv1beta1.Create,
+				admissionregistrationv1beta1.Update,
+			},
+			Rule: admissionregistrationv1beta1.Rule{
+				APIGroups:   []string{gvk.Group},
+				APIVersions: []string{gvk.Version},
+				Resources:   []string{plural},
+			},
+		})
 	}
-	resources.Sort()
+
+	// Sort the rules by Group, Version, Kind so that things are deterministically ordered.
+	sort.Slice(rules, func(i, j int) bool {
+		lhs, rhs := rules[i], rules[j]
+		if lhs.APIGroups[0] != rhs.APIGroups[0] {
+			return lhs.APIGroups[0] < rhs.APIGroups[0]
+		}
+		if lhs.APIVersions[0] != rhs.APIVersions[0] {
+			return lhs.APIVersions[0] < rhs.APIVersions[0]
+		}
+		return lhs.Resources[0] < rhs.Resources[0]
+	})
 
 	webhook := &admissionregistrationv1beta1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ac.Options.WebhookName,
 		},
 		Webhooks: []admissionregistrationv1beta1.Webhook{{
-			Name: ac.Options.WebhookName,
-			Rules: []admissionregistrationv1beta1.RuleWithOperations{{
-				Operations: []admissionregistrationv1beta1.OperationType{
-					admissionregistrationv1beta1.Create,
-					admissionregistrationv1beta1.Update,
-				},
-				Rule: admissionregistrationv1beta1.Rule{
-					APIGroups:   []string{ac.GroupVersion.Group},
-					APIVersions: []string{ac.GroupVersion.Version},
-					Resources:   resources,
-				},
-			}},
+			Name:  ac.Options.WebhookName,
+			Rules: rules,
 			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
 				Service: &admissionregistrationv1beta1.ServiceReference{
 					Namespace: ac.Options.Namespace,
@@ -460,7 +472,7 @@ func (ac *AdmissionController) admit(ctx context.Context, request *admissionv1be
 		return &admissionv1beta1.AdmissionResponse{Allowed: true}
 	}
 
-	patchBytes, err := ac.mutate(ctx, request.Kind.Kind, request.OldObject.Raw, request.Object.Raw)
+	patchBytes, err := ac.mutate(ctx, request.Kind, request.OldObject.Raw, request.Object.Raw)
 	if err != nil {
 		return makeErrorStatus("mutation failed: %v", err)
 	}
@@ -476,12 +488,19 @@ func (ac *AdmissionController) admit(ctx context.Context, request *admissionv1be
 	}
 }
 
-func (ac *AdmissionController) mutate(ctx context.Context, kind string, oldBytes []byte, newBytes []byte) ([]byte, error) {
+func (ac *AdmissionController) mutate(ctx context.Context, kind metav1.GroupVersionKind, oldBytes []byte, newBytes []byte) ([]byte, error) {
+	// Why, oh why are these different types...
+	gvk := schema.GroupVersionKind{
+		Group:   kind.Group,
+		Version: kind.Version,
+		Kind:    kind.Kind,
+	}
+
 	logger := logging.FromContext(ctx)
-	handler, ok := ac.Handlers[kind]
+	handler, ok := ac.Handlers[gvk]
 	if !ok {
-		logger.Errorf("Unhandled kind %q", kind)
-		return nil, fmt.Errorf("unhandled kind: %q", kind)
+		logger.Errorf("Unhandled kind %v", gvk)
+		return nil, fmt.Errorf("unhandled kind: %v", gvk)
 	}
 
 	oldObj := handler.DeepCopyObject().(GenericCRD)

--- a/webhook/webhook_integration_test.go
+++ b/webhook/webhook_integration_test.go
@@ -164,7 +164,11 @@ func TestValidResponseForResource(t *testing.T) {
 
 	admissionreq := &admissionv1beta1.AdmissionRequest{
 		Operation: admissionv1beta1.Create,
-		Kind:      metav1.GroupVersionKind{Kind: "Resource"},
+		Kind: metav1.GroupVersionKind{
+			Group:   "pkg.knative.dev",
+			Version: "v1alpha1",
+			Kind:    "Resource",
+		},
 	}
 	testRev := createResource(1234, "testrev")
 	marshaled, err := json.Marshal(testRev)
@@ -263,7 +267,11 @@ func TestInvalidResponseForResource(t *testing.T) {
 
 	admissionreq := &admissionv1beta1.AdmissionRequest{
 		Operation: admissionv1beta1.Create,
-		Kind:      metav1.GroupVersionKind{Kind: "Resource"},
+		Kind: metav1.GroupVersionKind{
+			Group:   "pkg.knative.dev",
+			Version: "v1alpha1",
+			Kind:    "Resource",
+		},
 	}
 
 	admissionreq.Object.Raw = marshaled

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -125,7 +125,11 @@ func TestUnknownKindFails(t *testing.T) {
 
 	req := admissionv1beta1.AdmissionRequest{
 		Operation: admissionv1beta1.Create,
-		Kind:      metav1.GroupVersionKind{Kind: "Garbage"},
+		Kind: metav1.GroupVersionKind{
+			Group:   "pkg.knative.dev",
+			Version: "v1alpha1",
+			Kind:    "Garbage",
+		},
 	}
 
 	expectFailsWith(t, ac.admit(TestContextWithLogger(t), &req), "unhandled kind")
@@ -135,7 +139,11 @@ func TestInvalidNameFails(t *testing.T) {
 	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
 	req := &admissionv1beta1.AdmissionRequest{
 		Operation: admissionv1beta1.Create,
-		Kind:      metav1.GroupVersionKind{Kind: "Resource"},
+		Kind: metav1.GroupVersionKind{
+			Group:   "pkg.knative.dev",
+			Version: "v1alpha1",
+			Kind:    "Resource",
+		},
 	}
 	invalidName := "an.example"
 	config := createResource(0, invalidName)
@@ -416,7 +424,11 @@ func createResource(generation int64, name string) Resource {
 func createBaseUpdateResource() *admissionv1beta1.AdmissionRequest {
 	return &admissionv1beta1.AdmissionRequest{
 		Operation: admissionv1beta1.Update,
-		Kind:      metav1.GroupVersionKind{Kind: "Resource"},
+		Kind: metav1.GroupVersionKind{
+			Group:   "pkg.knative.dev",
+			Version: "v1alpha1",
+			Kind:    "Resource",
+		},
 	}
 }
 
@@ -438,7 +450,11 @@ func createUpdateResource(old, new *Resource) *admissionv1beta1.AdmissionRequest
 func createCreateResource(r *Resource) *admissionv1beta1.AdmissionRequest {
 	req := &admissionv1beta1.AdmissionRequest{
 		Operation: admissionv1beta1.Create,
-		Kind:      metav1.GroupVersionKind{Kind: "Resource"},
+		Kind: metav1.GroupVersionKind{
+			Group:   "pkg.knative.dev",
+			Version: "v1alpha1",
+			Kind:    "Resource",
+		},
 	}
 	marshaled, err := json.Marshal(r)
 	if err != nil {
@@ -502,12 +518,12 @@ func NewAdmissionController(client kubernetes.Interface, options ControllerOptio
 	return &AdmissionController{
 		Client:  client,
 		Options: options,
-		GroupVersion: schema.GroupVersion{
-			Group:   "pkg.knative.dev",
-			Version: "v1alpha1",
-		},
-		Handlers: map[string]runtime.Object{
-			"Resource": &Resource{},
+		Handlers: map[schema.GroupVersionKind]runtime.Object{
+			{
+				Group:   "pkg.knative.dev",
+				Version: "v1alpha1",
+				Kind:    "Resource",
+			}: &Resource{},
 		},
 		Logger: logger,
 	}, nil


### PR DESCRIPTION
In order to have a single webhook support multiple domain contexts, this reworks the `Handlers` argument to embed the `schema.GroupVersion` by wrapping the existing keys with it as a `schema.GroupVersionKind`.

This is mostly straightforward, but one oddity is that I discovered that `AdmissionRequest` gets this same tuple as the less capable `metav1.GroupVersionKind`, so there's a silly conversion we have to do.

I tried this manually vendored in serving with KPA and things worked great.
