### PR TITLE
Remove strict name metadata check to be shareable in eventing

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -558,24 +558,7 @@ func (ac *AdmissionController) mutate(ctx context.Context, kind metav1.GroupVers
 		}
 	}
 
-	if err := validateMetadata(newObj); err != nil {
-		logger.Error("Failed to validate", zap.Error(err))
-		return nil, fmt.Errorf("Failed to validate: %s", err)
-	}
 	return json.Marshal(patches)
-}
-
-func validateMetadata(new GenericCRD) error {
-	name := new.GetObjectMeta().GetName()
-
-	if strings.Contains(name, ".") {
-		return errors.New("Invalid resource name: special character . must not be present")
-	}
-
-	if len(name) > 63 {
-		return errors.New("Invalid resource name: length must be no more than 63 characters")
-	}
-	return nil
 }
 
 // updateGeneration sets the generation by following this logic:

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -135,35 +135,6 @@ func TestUnknownKindFails(t *testing.T) {
 	expectFailsWith(t, ac.admit(TestContextWithLogger(t), &req), "unhandled kind")
 }
 
-func TestInvalidNameFails(t *testing.T) {
-	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
-	req := &admissionv1beta1.AdmissionRequest{
-		Operation: admissionv1beta1.Create,
-		Kind: metav1.GroupVersionKind{
-			Group:   "pkg.knative.dev",
-			Version: "v1alpha1",
-			Kind:    "Resource",
-		},
-	}
-	invalidName := "an.example"
-	config := createResource(0, invalidName)
-	marshaled, err := json.Marshal(config)
-	if err != nil {
-		t.Fatalf("Failed to marshal resource: %s", err)
-	}
-	req.Object.Raw = marshaled
-	expectFailsWith(t, ac.admit(TestContextWithLogger(t), req), "Invalid resource name")
-
-	invalidName = strings.Repeat("a", 64)
-	config = createResource(0, invalidName)
-	marshaled, err = json.Marshal(config)
-	if err != nil {
-		t.Fatalf("Failed to marshal resource: %s", err)
-	}
-	req.Object.Raw = marshaled
-	expectFailsWith(t, ac.admit(TestContextWithLogger(t), req), "Invalid resource name")
-}
-
 func TestValidCreateResourceSucceeds(t *testing.T) {
 	r := createResource(1234, "a name")
 	r.SetDefaults() // Fill in defaults to check that there are no patches.


### PR DESCRIPTION
Eventing uses names like "dev.knatave.github.pullrequest" as a event type name. This fails the generic validation added for serving. Moving this logic to serving and removing from pkg.