### PR TITLE
Add a logkey for the reconcile key.

### DIFF
--- a/logging/logkey/constants.go
+++ b/logging/logkey/constants.go
@@ -20,6 +20,9 @@ const (
 	// ControllerType is the key used for controller type in structured logs
 	ControllerType = "knative.dev/controller"
 
+	// Key is the key (namespace/name) being reconciled.
+	Key = "knative.dev/key"
+
 	// Namespace is the key used for namespace in structured logs
 	Namespace = "knative.dev/namespace"
 


### PR DESCRIPTION
This adds a logkey.Key for attaching the key being reconciled to a logger we embed into the context passed to Reconcile.  The point of this is to enable us to eliminate [this](https://github.com/knative/serving/blob/928d580756855f24d400104ad4d4cc628a8a841f/pkg/reconciler/v1alpha1/service/service.go#L101-L104) boilerplate from each of the Reconcilers.

These aren't identical, this has the form:
```
   knative.dev/key: foo/bar
```

What it's replacing has the form:
```
   knative.dev/namespace: foo
   serving.knative.dev/service: bar
```

However, the type information present in the latter is redundant with the controller type that [should already be embedded](https://github.com/knative/serving/blob/928d580756855f24d400104ad4d4cc628a8a841f/pkg/reconciler/reconciler.go#L80) in the logger.

cc @mdemirhan 