### PR TITLE
Remove docker repo from e2e flags

### DIFF
--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -35,7 +35,6 @@ var Flags = initializeFlags()
 // EnvironmentFlags define the flags that are needed to run the e2e tests.
 type EnvironmentFlags struct {
 	Cluster     string // K8s cluster (defaults to $K8S_CLUSTER_OVERRIDE)
-	DockerRepo  string // Docker repo (defaults to $DOCKER_REPO_OVERRIDE)
 	Kubeconfig  string // Path to kubeconfig (defaults to ./kube/config)
 	Namespace   string // K8s namespace (blank by default, to be overwritten by test suite)
 	LogVerbose  bool   // Enable verbose logging
@@ -47,10 +46,6 @@ func initializeFlags() *EnvironmentFlags {
 	defaultCluster := os.Getenv("K8S_CLUSTER_OVERRIDE")
 	flag.StringVar(&f.Cluster, "cluster", defaultCluster,
 		"Provide the cluster to test against. Defaults to $K8S_CLUSTER_OVERRIDE, then current cluster in kubeconfig if $K8S_CLUSTER_OVERRIDE is unset.")
-
-	defaultRepo := os.Getenv("DOCKER_REPO_OVERRIDE")
-	flag.StringVar(&f.DockerRepo, "dockerrepo", defaultRepo,
-		"Provide the uri of the docker repo you have uploaded the test image to using `uploadtestimage.sh`. Defaults to $DOCKER_REPO_OVERRIDE")
 
 	usr, _ := user.Current()
 	defaultKubeconfig := path.Join(usr.HomeDir, ".kube/config")


### PR DESCRIPTION
The flag docer repo gets different values based on the repo and should be in that repo. For eg. serving images are placed under knative-serving/.*