### PR TITLE
Adding ViaIndex, ViaKey, ViaFieldIndex, ViaFieldKey to FieldErrors

### DIFF
--- a/apis/field_error.go
+++ b/apis/field_error.go
@@ -104,7 +104,7 @@ func (fe *FieldError) ViaIndex(index ...int) *FieldError {
 // For example, if a type recursively validates a parameter that has a collection:
 //  for k, v := range spec.Bag. {
 //    if err := doValidation(v); err != nil {
-//      return err.ViaField("bag").ViaKey(k)
+//      return err.ViaKey(k).ViaField("bag")
 //    }
 //  }
 func (fe *FieldError) ViaKey(key ...string) *FieldError {

--- a/apis/field_error.go
+++ b/apis/field_error.go
@@ -74,7 +74,7 @@ func (fe *FieldError) ViaField(prefix ...string) *FieldError {
 		}
 	}
 
-	newPaths = flattenIndexes(newPaths)
+	newPaths = flattenIndices(newPaths)
 
 	fe.Paths = newPaths
 	return fe
@@ -87,17 +87,20 @@ func (fe *FieldError) ViaField(prefix ...string) *FieldError {
 //      return err.ViaIndex(i).ViaField("collection")
 //    }
 //  }
-func (fe *FieldError) ViaIndex(index ...int) *FieldError {
+func (fe *FieldError) ViaIndex(index int) *FieldError {
 	if fe == nil {
 		return nil
 	}
 
 	prefix := []string{}
-	for _, i := range index {
-		prefix = append(prefix, fmt.Sprintf("[%d]", i))
-	}
+	prefix = append(prefix, fmt.Sprintf("[%d]", index))
 
 	return fe.ViaField(prefix...)
+}
+
+// ViaFieldIndex is the short way to chain: err.ViaIndex(bar).ViaField(foo)
+func (fe *FieldError) ViaFieldIndex(field string, index int) *FieldError {
+	return fe.ViaIndex(index).ViaField(field)
 }
 
 // ViaKey is used to attach a key to the next via field provided.
@@ -107,26 +110,29 @@ func (fe *FieldError) ViaIndex(index ...int) *FieldError {
 //      return err.ViaKey(k).ViaField("bag")
 //    }
 //  }
-func (fe *FieldError) ViaKey(key ...string) *FieldError {
+func (fe *FieldError) ViaKey(key string) *FieldError {
 	if fe == nil {
 		return nil
 	}
 
 	prefix := []string{}
-	for _, k := range key {
-		prefix = append(prefix, fmt.Sprintf("[%s]", k))
-	}
+	prefix = append(prefix, fmt.Sprintf("[%s]", key))
 
 	return fe.ViaField(prefix...)
 }
 
-// flattenIndexes takes in a set of paths and looks for chances to flatten
+// ViaFieldKey is the short way to chain: err.ViaKey(bar).ViaField(foo)
+func (fe *FieldError) ViaFieldKey(field string, key string) *FieldError {
+	return fe.ViaKey(key).ViaField(field)
+}
+
+// flattenIndices takes in a set of paths and looks for chances to flatten
 // objects that have index prefixes, examples:
 //   err([0]).ViaField(bar).ViaField(foo) -> foo.bar.[0] converts to foo.bar[0]
 //   err(bar).ViaIndex(0).ViaField(foo) -> foo.[0].bar converts to foo[0].bar
 //   err(bar).ViaField(foo).ViaIndex(0) -> [0].foo.bar converts to [0].foo.bar
 //   err(bar).ViaIndex(0).ViaIndex[1].ViaField(foo) -> foo.[0].[1].bar converts to foo[1][0].bar
-func flattenIndexes(paths []string) []string {
+func flattenIndices(paths []string) []string {
 	var newPaths []string
 	for _, path := range paths {
 		if !strings.Contains(path, "[") && !strings.Contains(path, "]") {

--- a/apis/field_error.go
+++ b/apis/field_error.go
@@ -117,13 +117,13 @@ func (fe *FieldError) ViaFieldKey(field string, key string) *FieldError {
 //   err(bar).ViaField(foo).ViaIndex(0) -> [0].foo.bar converts to [0].foo.bar
 //   err(bar).ViaIndex(0).ViaIndex[1].ViaField(foo) -> foo.[1].[0].bar converts to foo[1][0].bar
 func flatten(path []string) string {
-	newPath := []string(nil)
+	var newPath []string
 	for _, part := range path {
 		for _, p := range strings.Split(part, ".") {
-			if len(newPath) != 0 && isIndex(p) {
-				newPath[len(newPath)-1] = fmt.Sprintf("%s%s", newPath[len(newPath)-1], p)
-			} else if p == CurrentField {
+			if p == CurrentField {
 				continue
+			} else if len(newPath) > 0 && isIndex(p) {
+				newPath[len(newPath)-1] = fmt.Sprintf("%s%s", newPath[len(newPath)-1], p)
 			} else {
 				newPath = append(newPath, p)
 			}

--- a/apis/field_error_test.go
+++ b/apis/field_error_test.go
@@ -335,7 +335,7 @@ can not use @, do not try`,
 	}
 }
 
-func TestFlattenIndices(t *testing.T) {
+func TestFlatten(t *testing.T) {
 	tests := []struct {
 		name    string
 		indices []string

--- a/apis/field_error_test.go
+++ b/apis/field_error_test.go
@@ -338,38 +338,42 @@ can not use @, do not try`,
 func TestFlattenIndices(t *testing.T) {
 	tests := []struct {
 		name    string
-		indices string
+		indices []string
 		want    string
 	}{{
 		name:    "simple",
-		indices: "foo.[1]",
+		indices: strings.Split("foo.[1]", "."),
 		want:    "foo[1]",
 	}, {
 		name:    "no brackets",
-		indices: "foo.bar",
+		indices: strings.Split("foo.bar", "."),
 		want:    "foo.bar",
 	}, {
 		name:    "err([0]).ViaField(bar).ViaField(foo)",
-		indices: "foo.bar.[0]",
+		indices: strings.Split("foo.bar.[0]", "."),
 		want:    "foo.bar[0]",
 	}, {
 		name:    "err(bar).ViaIndex(0).ViaField(foo)",
-		indices: "foo.[0].bar",
+		indices: strings.Split("foo.[0].bar", "."),
 		want:    "foo[0].bar",
 	}, {
 		name:    "err(bar).ViaField(foo).ViaIndex(0)",
-		indices: "[0].foo.bar",
+		indices: strings.Split("[0].foo.bar", "."),
 		want:    "[0].foo.bar",
 	}, {
 		name:    "err(bar).ViaIndex(0).ViaIndex[1].ViaField(foo)",
-		indices: "foo.[1].[0].bar",
+		indices: strings.Split("foo.[1].[0].bar", "."),
 		want:    "foo[1][0].bar",
+	}, {
+		name:    "err(bar).ViaIndex(0).ViaIndex[1].ViaField(foo)",
+		indices: []string{"foo", "bar.[0].baz"},
+		want:    "foo.bar[0].baz",
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			got := flattenIndices(test.indices)
+			got := flatten(test.indices)
 
 			if got != test.want {
 				t.Errorf("got: %q, want %q", got, test.want)

--- a/apis/field_error_test.go
+++ b/apis/field_error_test.go
@@ -267,7 +267,7 @@ can not use @, do not try`,
 	}, {
 		name:     "nil propagation",
 		err:      nil,
-		prefixes: [][]string{{"baz", "ugh", "INDEX:0"}},
+		prefixes: [][]string{{"baz", "ugh", "INDEX:0", "KEY:A"}},
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
I have found situations where I want to do the following:

```
  for i, c := range spec.Collection {
    if err := doValidation(c); err != nil {
      return err.ViaIndex(i).ViaField("collection")
    }
  }
```

OR

```
  for k, v := range spec.Bag. {
    if err := doValidation(v); err != nil {
      return err.ViaKey(k).ViaField("bag")
    }
  }
```

This adds helpers to do that.
