### PR TITLE
Move interfaces into single file.

### DIFF
--- a/apis/field_error.go
+++ b/apis/field_error.go
@@ -39,20 +39,6 @@ type FieldError struct {
 // FieldError implements error
 var _ error = (*FieldError)(nil)
 
-// Validatable indicates that a particular type may have its fields validated.
-type Validatable interface {
-	// Validate checks the validity of this types fields.
-	Validate() *FieldError
-}
-
-// Immutable indicates that a particular type has fields that should
-// not change after creation.
-type Immutable interface {
-	// CheckImmutableFields checks that the current instance's immutable
-	// fields haven't changed from the provided original.
-	CheckImmutableFields(original Immutable) *FieldError
-}
-
 // ViaField is used to propagate a validation error along a field access.
 // For example, if a type recursively validates its "spec" via:
 //   if err := foo.Spec.Validate(); err != nil {

--- a/apis/interfaces.go
+++ b/apis/interfaces.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Knative Authors
+Copyright 2018 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,4 +20,18 @@ package apis
 // uninitialized fields of this instance.
 type Defaultable interface {
 	SetDefaults()
+}
+
+// Validatable indicates that a particular type may have its fields validated.
+type Validatable interface {
+	// Validate checks the validity of this types fields.
+	Validate() *FieldError
+}
+
+// Immutable indicates that a particular type has fields that should
+// not change after creation.
+type Immutable interface {
+	// CheckImmutableFields checks that the current instance's immutable
+	// fields haven't changed from the provided original.
+	CheckImmutableFields(original Immutable) *FieldError
 }


### PR DESCRIPTION
I found it a bit odd that Defaultable interface was in a single file, yet the other interfaces immutable / validatable were in field_error.go. Obviously no functional changes, just thought this is cleaner. Thoughts?