### PR TITLE
Dont call flag.parse in pkg/test

### DIFF
--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -62,12 +62,5 @@ func initializeFlags() *EnvironmentFlags {
 	flag.BoolVar(&f.EmitMetrics, "emitmetrics", false,
 		"Set this flag to true if you would like tests to emit metrics, e.g. latency of resources being realized in the system.")
 
-	flag.Parse()
-	flag.Set("alsologtostderr", "true")
-	logging.InitializeLogger(f.LogVerbose)
-
-	if f.EmitMetrics {
-		logging.InitializeMetricExporter()
-	}
 	return &f
 }

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -24,8 +24,6 @@ import (
 	"os"
 	"os/user"
 	"path"
-
-	"github.com/knative/pkg/test/logging"
 )
 
 // Flags holds the command line flags or defaults for settings in the user's environment.


### PR DESCRIPTION
Part-1 of fixing https://github.com/knative/pkg/issues/60. Will update serving to call parse once this is merged.