### PR TITLE
Introduce an OwnerRefable interface

### DIFF
--- a/apis/interfaces.go
+++ b/apis/interfaces.go
@@ -16,11 +16,6 @@ limitations under the License.
 
 package apis
 
-import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-)
-
 // Defaultable defines an interface for setting the defaults for the
 // uninitialized fields of this instance.
 type Defaultable interface {
@@ -39,15 +34,4 @@ type Immutable interface {
 	// CheckImmutableFields checks that the current instance's immutable
 	// fields haven't changed from the provided original.
 	CheckImmutableFields(original Immutable) *FieldError
-}
-
-// NewControllerRefable indicates that a particular type has sufficient
-// information to produce a metav1.OwnerReference to an object.
-type OwnerRefable interface {
-	metav1.ObjectMetaAccessor
-
-	// GetGroupVersionKind returns a GroupVersionKind. The name is chosen
-	// to avoid collision with TypeMeta's GroupVersionKind() method.
-	// See: https://issues.k8s.io/3030
-	GetGroupVersionKind() schema.GroupVersionKind
 }

--- a/apis/interfaces.go
+++ b/apis/interfaces.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package apis
 
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
 // Defaultable defines an interface for setting the defaults for the
 // uninitialized fields of this instance.
 type Defaultable interface {
@@ -34,4 +39,15 @@ type Immutable interface {
 	// CheckImmutableFields checks that the current instance's immutable
 	// fields haven't changed from the provided original.
 	CheckImmutableFields(original Immutable) *FieldError
+}
+
+// NewControllerRefable indicates that a particular type has sufficient
+// information to produce a metav1.OwnerReference to an object.
+type OwnerRefable interface {
+	metav1.ObjectMetaAccessor
+
+	// GetGroupVersionKind returns a GroupVersionKind. The name is chosen
+	// to avoid collision with TypeMeta's GroupVersionKind() method.
+	// See: https://issues.k8s.io/3030
+	GetGroupVersionKind() schema.GroupVersionKind
 }

--- a/kmeta/owner_references.go
+++ b/kmeta/owner_references.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kmeta
+
+import (
+	"github.com/knative/pkg/apis"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewOwnerReference creates an OwnerReference pointing to the given Resource.
+func NewOwnerReference(obj apis.OwnerRefable) *metav1.OwnerReference {
+	return metav1.NewControllerRef(obj.GetObjectMeta(), obj.GetGroupVersionKind())
+}

--- a/kmeta/owner_references.go
+++ b/kmeta/owner_references.go
@@ -17,11 +17,22 @@ limitations under the License.
 package kmeta
 
 import (
-	"github.com/knative/pkg/apis"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// OwnerRefable indicates that a particular type has sufficient
+// information to produce a metav1.OwnerReference to an object.
+type OwnerRefable interface {
+	metav1.ObjectMetaAccessor
+
+	// GetGroupVersionKind returns a GroupVersionKind. The name is chosen
+	// to avoid collision with TypeMeta's GroupVersionKind() method.
+	// See: https://issues.k8s.io/3030
+	GetGroupVersionKind() schema.GroupVersionKind
+}
+
 // NewOwnerReference creates an OwnerReference pointing to the given Resource.
-func NewOwnerReference(obj apis.OwnerRefable) *metav1.OwnerReference {
+func NewOwnerReference(obj OwnerRefable) *metav1.OwnerReference {
 	return metav1.NewControllerRef(obj.GetObjectMeta(), obj.GetGroupVersionKind())
 }


### PR DESCRIPTION
An OwnerRefable type provides sufficient information that we can
construct a metav1.OwnerReference from it, e.g. for
kmeta.NewOwnerReference, which does just that.

Addresses comment from: https://github.com/knative/serving/pull/2014