### PR TITLE
Adding also always to return nil for nil errors

### DIFF
--- a/apis/field_error.go
+++ b/apis/field_error.go
@@ -111,6 +111,9 @@ func (fe *FieldError) Also(errs ...*FieldError) *FieldError {
 	for _, e := range errs {
 		newErr.errors = append(newErr.errors, e.getNormalizedErrors()...)
 	}
+	if len(newErr.errors) == 0 {
+		return nil
+	}
 	return newErr
 }
 

--- a/apis/field_error_test.go
+++ b/apis/field_error_test.go
@@ -370,6 +370,11 @@ func TestAlso(t *testing.T) {
 		prefixes: [][]string{{"foo"}},
 		want:     "also this: foo.woo",
 	}, {
+		name: "nil all the way",
+		err:  nil,
+		also: []FieldError{{}},
+		want: "",
+	}, {
 		name: "simple",
 		err: &FieldError{
 			Message: "hear me roar",
@@ -427,6 +432,28 @@ not without this: bar.C`,
 				t.Errorf("ViaField() = %v, wanted nil", fe)
 			}
 		})
+	}
+}
+
+func TestAlsoStaysNil(t *testing.T) {
+	var err *FieldError
+	if err != nil {
+		t.Errorf("expected nil, got %v, wanted nil", err)
+	}
+
+	err = err.Also(nil)
+	if err != nil {
+		t.Errorf("expected nil, got %v, wanted nil", err)
+	}
+
+	err = err.ViaField("nil").Also(nil)
+	if err != nil {
+		t.Errorf("expected nil, got %v, wanted nil", err)
+	}
+
+	err = err.Also(&FieldError{})
+	if err != nil {
+		t.Errorf("expected nil, got %v, wanted nil", err)
 	}
 }
 


### PR DESCRIPTION
Found an issue integrating with serving that `nil.also(nil)` should be `nil`, but it was returning an empty object. Fixed that.