### PR TITLE
Informers / Listers for Duck Types.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -415,11 +415,13 @@
   version = "kubernetes-1.11.0"
 
 [[projects]]
-  digest = "1:7fa94edf47d2e91cffec1efe594a114f104199992f015086d673db5c776392cf"
+  digest = "1:292821230607e7e954ed569d52ede3006c2ecc5f44bb6af0e9eec79777316fee"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
     "discovery/fake",
+    "dynamic",
+    "dynamic/fake",
     "informers",
     "informers/admissionregistration",
     "informers/admissionregistration/v1alpha1",
@@ -666,6 +668,8 @@
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",
+    "k8s.io/client-go/dynamic",
+    "k8s.io/client-go/dynamic/fake",
     "k8s.io/client-go/informers",
     "k8s.io/client-go/informers/core/v1",
     "k8s.io/client-go/kubernetes",

--- a/apis/duck/cached.go
+++ b/apis/duck/cached.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package duck
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+// CachedInformerFactory implements InformerFactory by delegating to another
+// InformerFactory, but memoizing the results.
+type CachedInformerFactory struct {
+	Delegate InformerFactory
+
+	m     sync.Mutex
+	cache map[schema.GroupVersionResource]*result
+}
+
+// Check that CachedInformerFactory implements InformerFactory.
+var _ InformerFactory = (*CachedInformerFactory)(nil)
+
+// Get implements InformerFactory.
+func (cif *CachedInformerFactory) Get(gvr schema.GroupVersionResource) (cache.SharedIndexInformer, cache.GenericLister, error) {
+	cif.m.Lock()
+	if cif.cache == nil {
+		cif.cache = make(map[schema.GroupVersionResource]*result)
+	}
+	elt, ok := cif.cache[gvr]
+	if !ok {
+		elt = &result{}
+		elt.init = func() {
+			elt.inf, elt.lister, elt.err = cif.Delegate.Get(gvr)
+		}
+		cif.cache[gvr] = elt
+	}
+	// If this were done via "defer", then TestDifferentGVRs will fail.
+	cif.m.Unlock()
+
+	// The call to the delegate could be slow because it syncs informers, so do
+	// this outside of the main lock.
+	return elt.Get()
+}
+
+type result struct {
+	sync.Once
+	init func()
+
+	inf    cache.SharedIndexInformer
+	lister cache.GenericLister
+	err    error
+}
+
+func (t *result) Get() (cache.SharedIndexInformer, cache.GenericLister, error) {
+	t.Do(t.init)
+	return t.inf, t.lister, t.err
+}

--- a/apis/duck/cached_test.go
+++ b/apis/duck/cached_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package duck
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+type BlockingInformerFactory struct {
+	lock    sync.Mutex
+	getting int32
+}
+
+var _ InformerFactory = (*BlockingInformerFactory)(nil)
+
+func (bif *BlockingInformerFactory) Get(gvr schema.GroupVersionResource) (cache.SharedIndexInformer, cache.GenericLister, error) {
+	atomic.AddInt32(&bif.getting, 1)
+	// Wait here until we can acquire the lock!
+	bif.lock.Lock()
+	bif.lock.Unlock()
+	return nil, nil, nil
+}
+
+func TestSameGVR(t *testing.T) {
+	bif := &BlockingInformerFactory{}
+
+	// Suspend progress.
+	bif.lock.Lock()
+
+	cif := &CachedInformerFactory{
+		Delegate: bif,
+	}
+
+	grp, _ := errgroup.WithContext(context.TODO())
+	returned := int32(0)
+
+	// Use the same GVR each iteration to ensure we hit the cache
+	// and don't initialize too many InformerFactory's thru our
+	// Delegate.
+	gvr := schema.GroupVersionResource{
+		Group:    "testing.knative.dev",
+		Version:  "v3",
+		Resource: "caches",
+	}
+	for i := 0; i < 10; i++ {
+		grp.Go(func() error {
+			_, _, err := cif.Get(gvr)
+			atomic.AddInt32(&returned, 1)
+			return err
+		})
+	}
+
+	// Give the goroutines time to make progress.
+	time.Sleep(100 * time.Millisecond)
+
+	// Check that none have returned and we have one Get in progress.
+	if got, want := atomic.LoadInt32(&returned), int32(0); got != want {
+		t.Errorf("Got %v returned, wanted %v", got, want)
+	}
+	if got, want := atomic.LoadInt32(&bif.getting), int32(1); got != want {
+		t.Errorf("Got %v calls to bif.Get, wanted %v", got, want)
+	}
+
+	// Allow the Get calls to proceed.
+	bif.lock.Unlock()
+
+	if err := grp.Wait(); err != nil {
+		t.Errorf("Wait() = %v", err)
+	}
+}
+
+func TestDifferentGVRs(t *testing.T) {
+	bif := &BlockingInformerFactory{}
+
+	// Suspend progress.
+	bif.lock.Lock()
+
+	cif := &CachedInformerFactory{
+		Delegate: bif,
+	}
+
+	grp, _ := errgroup.WithContext(context.TODO())
+	returned := int32(0)
+	for i := 0; i < 10; i++ {
+		// Use a different GVR each iteration to check that calls
+		// to bif.Get can proceed even if a call is in progress
+		// for another GVR.
+		gvr := schema.GroupVersionResource{
+			Group:    "testing.knative.dev",
+			Version:  fmt.Sprintf("v%d", i),
+			Resource: "caches",
+		}
+		grp.Go(func() error {
+			_, _, err := cif.Get(gvr)
+			atomic.AddInt32(&returned, 1)
+			return err
+		})
+	}
+
+	// Give the goroutines time to make progress.
+	time.Sleep(100 * time.Millisecond)
+
+	// Check that none have returned and we have 10 Gets in progress.
+	if got, want := atomic.LoadInt32(&returned), int32(0); got != want {
+		t.Errorf("Got %v returned, wanted %v", got, want)
+	}
+	if got, want := atomic.LoadInt32(&bif.getting), int32(10); got != want {
+		t.Errorf("Got %v calls to bif.Get, wanted %v", got, want)
+	}
+
+	// Allow the Get calls to proceed.
+	bif.lock.Unlock()
+
+	if err := grp.Wait(); err != nil {
+		t.Errorf("Wait() = %v", err)
+	}
+}

--- a/apis/duck/enqueue.go
+++ b/apis/duck/enqueue.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package duck
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+// EnqueueInformerFactory implements InformerFactory by delegating to another
+// InformerFactory, but attaching a ResourceEventHandler to the informer.
+type EnqueueInformerFactory struct {
+	Delegate InformerFactory
+
+	EventHandler cache.ResourceEventHandler
+}
+
+// Check that EnqueueInformerFactory implements InformerFactory.
+var _ InformerFactory = (*EnqueueInformerFactory)(nil)
+
+// Get implements InformerFactory.
+func (cif *EnqueueInformerFactory) Get(gvr schema.GroupVersionResource) (cache.SharedIndexInformer, cache.GenericLister, error) {
+	inf, lister, err := cif.Delegate.Get(gvr)
+	if err != nil {
+		return nil, nil, err
+	}
+	// If there is an informer, attach our event handler.
+	inf.AddEventHandler(cif.EventHandler)
+	return inf, lister, nil
+}

--- a/apis/duck/enqueue_test.go
+++ b/apis/duck/enqueue_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package duck
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestEnqueueInformerFactory(t *testing.T) {
+	called := false
+	want := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			called = true
+		},
+	}
+	fsii := &fakeSharedIndexInformer{t: t}
+	fif := &FixedInformerFactory{inf: fsii}
+	eif := &EnqueueInformerFactory{
+		Delegate:     fif,
+		EventHandler: want,
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "testing.knative.dev",
+		Version:  "v3",
+		Resource: "caches",
+	}
+	inf, _, err := eif.Get(gvr)
+	if err != nil {
+		t.Fatalf("Get() = %v", err)
+	}
+	if inf != fsii {
+		t.Fatalf("Get() = %v, wanted %v", inf, fsii)
+	}
+
+	got, ok := fsii.eventHandler.(cache.ResourceEventHandlerFuncs)
+	if !ok {
+		t.Errorf("eventHandler = %T, wanted %T", fsii.eventHandler, want)
+	}
+	if called {
+		t.Error("Want not called, got called")
+	}
+
+	got.AddFunc(nil)
+
+	if !called {
+		t.Error("Want called, got not called")
+	}
+
+	if got.UpdateFunc != nil {
+		t.Error("UpdateFunc = non-nil, wanted nil")
+	}
+
+	if got.DeleteFunc != nil {
+		t.Error("DeleteFunc = non-nil, wanted nil")
+	}
+}
+
+func TestEnqueueInformerFactoryWithFailure(t *testing.T) {
+	want := errors.New("expected error")
+	fif := &FixedInformerFactory{err: want}
+	eif := &EnqueueInformerFactory{
+		Delegate: fif,
+		EventHandler: cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				t.Error("Unexpected call to AddFunc.")
+			},
+			UpdateFunc: func(old, new interface{}) {
+				t.Error("Unexpected call to UpdateFunc.")
+			},
+		},
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "testing.knative.dev",
+		Version:  "v3",
+		Resource: "caches",
+	}
+	inf, _, got := eif.Get(gvr)
+	if got != want {
+		t.Fatalf("Get() = %v, wanted %v", got, want)
+	}
+
+	if inf != nil {
+		t.Fatal("Get() = non nil, wanted nil")
+	}
+}
+
+type FixedInformerFactory struct {
+	inf    cache.SharedIndexInformer
+	lister cache.GenericLister
+	err    error
+}
+
+var _ InformerFactory = (*FixedInformerFactory)(nil)
+
+func (fif *FixedInformerFactory) Get(gvr schema.GroupVersionResource) (cache.SharedIndexInformer, cache.GenericLister, error) {
+	return fif.inf, fif.lister, fif.err
+}
+
+type fakeSharedIndexInformer struct {
+	t            *testing.T
+	eventHandler cache.ResourceEventHandler
+}
+
+var _ cache.SharedIndexInformer = (*fakeSharedIndexInformer)(nil)
+
+func (fsii *fakeSharedIndexInformer) AddEventHandler(handler cache.ResourceEventHandler) {
+	fsii.eventHandler = handler
+}
+
+func (fsii *fakeSharedIndexInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) {
+	fsii.t.Fatalf("NYI: AddEventHandlerWithResyncPeriod")
+}
+
+func (fsii *fakeSharedIndexInformer) GetStore() cache.Store {
+	fsii.t.Fatalf("NYI: GetStore")
+	return nil
+}
+
+func (fsii *fakeSharedIndexInformer) GetController() cache.Controller {
+	fsii.t.Fatalf("NYI: GetController")
+	return nil
+}
+
+func (fsii *fakeSharedIndexInformer) Run(stopCh <-chan struct{}) {
+	fsii.t.Fatalf("NYI: Run")
+}
+
+func (fsii *fakeSharedIndexInformer) HasSynced() bool {
+	fsii.t.Fatalf("NYI: HadSynced")
+	return false
+}
+
+func (fsii *fakeSharedIndexInformer) LastSyncResourceVersion() string {
+	fsii.t.Fatalf("NYI: LastSyncResourceVersion")
+	return ""
+}
+
+func (fsii *fakeSharedIndexInformer) AddIndexers(indexers cache.Indexers) error {
+	fsii.t.Fatalf("NYI: AddIndexers")
+	return nil
+}
+
+func (fsii *fakeSharedIndexInformer) GetIndexer() cache.Indexer {
+	fsii.t.Fatalf("NYI: GetIndexer")
+	return nil
+}

--- a/apis/duck/interface.go
+++ b/apis/duck/interface.go
@@ -17,21 +17,12 @@ limitations under the License.
 package duck
 
 import (
-	"encoding/json"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
 )
 
-// Marshallable is implementated by the Unstructured K8s types.
-type Marshalable interface {
-	MarshalJSON() ([]byte, error)
-}
-
-// FromUnstructured takes unstructured object from (say from client-go/dynamic) and
-// converts it into our duck types.
-func FromUnstructured(obj Marshalable, target interface{}) error {
-	// Use the unstructured marshaller to ensure it's proper JSON
-	raw, err := obj.MarshalJSON()
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(raw, &target)
+// InformerFactory is used to create Informer/Lister pairs for a schema.GroupVersionResource
+type InformerFactory interface {
+	// Get returns a synced Informer/Lister pair for the provided schema.GroupVersionResource.
+	Get(schema.GroupVersionResource) (cache.SharedIndexInformer, cache.GenericLister, error)
 }

--- a/apis/duck/typed.go
+++ b/apis/duck/typed.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package duck
+
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/knative/pkg/apis"
+)
+
+// TypedInformerFactory implements InformerFactory such that the elements
+// tracked by the informer/lister have the type of the canonical "obj".
+type TypedInformerFactory struct {
+	Client       dynamic.Interface
+	Type         apis.Listable
+	ResyncPeriod time.Duration
+	StopChannel  <-chan struct{}
+}
+
+// Check that TypedInformerFactory implements InformerFactory.
+var _ InformerFactory = (*TypedInformerFactory)(nil)
+
+// Get implements InformerFactory.
+func (dif *TypedInformerFactory) Get(gvr schema.GroupVersionResource) (cache.SharedIndexInformer, cache.GenericLister, error) {
+	listObj := dif.Type.GetListType()
+	lw := &cache.ListWatch{
+		ListFunc:  asStructuredLister(dif.Client.Resource(gvr).List, listObj),
+		WatchFunc: dif.Client.Resource(gvr).Watch,
+	}
+	inf := cache.NewSharedIndexInformer(lw, dif.Type, dif.ResyncPeriod, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+
+	lister := cache.NewGenericLister(inf.GetIndexer(), gvr.GroupResource())
+
+	go inf.Run(dif.StopChannel)
+
+	if ok := cache.WaitForCacheSync(dif.StopChannel, inf.HasSynced); !ok {
+		return nil, nil, fmt.Errorf("Failed starting shared index informer for %v with type %T", gvr, dif.Type)
+	}
+
+	return inf, lister, nil
+}
+
+type unstructuredLister func(metav1.ListOptions) (*unstructured.UnstructuredList, error)
+
+func asStructuredLister(ulist unstructuredLister, listObj runtime.Object) cache.ListFunc {
+	return func(opts metav1.ListOptions) (runtime.Object, error) {
+		ul, err := ulist(opts)
+		if err != nil {
+			return nil, err
+		}
+		res := listObj.DeepCopyObject()
+		if err := FromUnstructured(ul, res); err != nil {
+			return nil, err
+		}
+		return res, nil
+	}
+}

--- a/apis/duck/typed_test.go
+++ b/apis/duck/typed_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package duck_test
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/fake"
+
+	"github.com/knative/pkg/apis/duck"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	. "github.com/knative/pkg/testing"
+)
+
+func TestSimpleList(t *testing.T) {
+	scheme := runtime.NewScheme()
+	AddToScheme(scheme)
+	duckv1alpha1.AddToScheme(scheme)
+
+	namespace, name := "foo", "bar"
+	var want int64 = 1234
+	// Despite the signature allowing `...runtime.Object`, this method
+	// will not work properly unless the passed objects are `unstructured.Unstructured`
+	client := fake.NewSimpleDynamicClient(scheme, &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "pkg.knative.dev/v2",
+			"kind":       "Resource",
+			"metadata": map[string]interface{}{
+				"namespace": namespace,
+				"name":      name,
+			},
+			"spec": map[string]interface{}{
+				"generation": want,
+			},
+		},
+	})
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	tif := &duck.TypedInformerFactory{
+		Client:       client,
+		Type:         &duckv1alpha1.Generational{},
+		ResyncPeriod: 1 * time.Second,
+		StopChannel:  stopCh,
+	}
+
+	// This hangs without:
+	// https://github.com/kubernetes/kubernetes/pull/68552
+	_, lister, err := tif.Get(SchemeGroupVersion.WithResource("resources"))
+	if err != nil {
+		t.Fatalf("Get() = %v", err)
+	}
+
+	elt, err := lister.ByNamespace(namespace).Get(name)
+	if err != nil {
+		t.Fatalf("Get() = %v", err)
+	}
+
+	got, ok := elt.(*duckv1alpha1.Generational)
+	if !ok {
+		t.Fatalf("Get() = %T, wanted *duckv1alpha1.Generational", elt)
+	}
+
+	if want != int64(got.Spec.Generation) {
+		t.Errorf("Get().Spec.Generation = %v, wanted %v", got.Spec.Generation, want)
+	}
+
+	// TODO(mattmoor): Access through informer
+}

--- a/apis/duck/unstructured_test.go
+++ b/apis/duck/unstructured_test.go
@@ -29,12 +29,12 @@ import (
 func TestFromUnstructuredFooable(t *testing.T) {
 	tcs := []struct {
 		name      string
-		in        unstructured.Unstructured
+		in        Marshalable
 		want      FooStatus
 		wantError error
 	}{{
 		name: "Works with valid status",
-		in: unstructured.Unstructured{
+		in: &unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"apiVersion": "test",
 				"kind":       "test_kind",
@@ -54,7 +54,7 @@ func TestFromUnstructuredFooable(t *testing.T) {
 		wantError: nil,
 	}, {
 		name: "does not work with missing fooable status",
-		in: unstructured.Unstructured{
+		in: &unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"apiVersion": "test",
 				"kind":       "test_kind",
@@ -67,7 +67,7 @@ func TestFromUnstructuredFooable(t *testing.T) {
 		wantError: nil,
 	}, {
 		name:      "empty unstructured",
-		in:        unstructured.Unstructured{},
+		in:        &unstructured.Unstructured{},
 		want:      FooStatus{},
 		wantError: nil,
 	}}

--- a/hack/66078.patch
+++ b/hack/66078.patch
@@ -1,0 +1,46 @@
+diff --git a/vendor/k8s.io/client-go/dynamic/fake/simple.go b/vendor/k8s.io/client-go/dynamic/fake/simple.go
+index a71cec5..7be914c 100644
+--- a/vendor/k8s.io/client-go/dynamic/fake/simple.go
++++ b/vendor/k8s.io/client-go/dynamic/fake/simple.go
+@@ -33,6 +33,10 @@ import (
+ )
+ 
+ func NewSimpleDynamicClient(scheme *runtime.Scheme, objects ...runtime.Object) *FakeDynamicClient {
++	// In order to use List with this client, you have to have the v1.List registered in your scheme. Neat thing though
++	// it does NOT have to be the *same* list
++	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "fake-dynamic-client-group", Version: "v1", Kind: "List"}, &unstructured.UnstructuredList{})
++
+ 	codecs := serializer.NewCodecFactory(scheme)
+ 	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+ 	for _, obj := range objects {
+@@ -272,11 +276,11 @@ func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.Uns
+ 	switch {
+ 	case len(c.namespace) == 0:
+ 		obj, err = c.client.Fake.
+-			Invokes(testing.NewRootListAction(c.resource, schema.GroupVersionKind{Version: "v1", Kind: "List"}, opts), &metav1.Status{Status: "dynamic list fail"})
++			Invokes(testing.NewRootListAction(c.resource, schema.GroupVersionKind{Group: "fake-dynamic-client-group", Version: "v1", Kind: "" /*List is appended by the tracker automatically*/}, opts), &metav1.Status{Status: "dynamic list fail"})
+ 
+ 	case len(c.namespace) > 0:
+ 		obj, err = c.client.Fake.
+-			Invokes(testing.NewListAction(c.resource, schema.GroupVersionKind{Version: "v1", Kind: "List"}, c.namespace, opts), &metav1.Status{Status: "dynamic list fail"})
++			Invokes(testing.NewListAction(c.resource, schema.GroupVersionKind{Group: "fake-dynamic-client-group", Version: "v1", Kind: "" /*List is appended by the tracker automatically*/}, c.namespace, opts), &metav1.Status{Status: "dynamic list fail"})
+ 
+ 	}
+ 
+@@ -299,13 +303,14 @@ func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.Uns
+ 	}
+ 
+ 	list := &unstructured.UnstructuredList{}
+-	for _, item := range entireList.Items {
++	for i := range entireList.Items {
++		item := &entireList.Items[i]
+ 		metadata, err := meta.Accessor(item)
+ 		if err != nil {
+ 			return nil, err
+ 		}
+ 		if label.Matches(labels.Set(metadata.GetLabels())) {
+-			list.Items = append(list.Items, item)
++			list.Items = append(list.Items, *item)
+ 		}
+ 	}
+ 	return list, nil

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -27,3 +27,9 @@ dep ensure
 
 # Keep the only dir in knative/test-infra we're interested in
 find vendor/github.com/knative/test-infra -mindepth 1 -maxdepth 1 ! -name scripts -exec rm -fr {} \;
+
+# Patch the Kubernetes dynamic client to fix listing. This patch is from
+# https://github.com/kubernetes/kubernetes/pull/68552/files, which is a
+# cherrypick of #66078.  Remove this once that reaches a client version
+# we have pulled in.
+git apply ${REPO_ROOT_DIR}/hack/66078.patch

--- a/testing/register.go
+++ b/testing/register.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// SchemeGroupVersion is group version used to register these objects
+var SchemeGroupVersion = schema.GroupVersion{Group: "pkg.knative.dev", Version: "v2"}
+
+var (
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme   = SchemeBuilder.AddToScheme
+)
+
+// Adds the list of known types to Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
+		&Resource{},
+		(&Resource{}).GetListType(),
+	)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/vendor/k8s.io/client-go/dynamic/fake/simple.go
+++ b/vendor/k8s.io/client-go/dynamic/fake/simple.go
@@ -1,0 +1,368 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/testing"
+)
+
+func NewSimpleDynamicClient(scheme *runtime.Scheme, objects ...runtime.Object) *FakeDynamicClient {
+	// In order to use List with this client, you have to have the v1.List registered in your scheme. Neat thing though
+	// it does NOT have to be the *same* list
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "fake-dynamic-client-group", Version: "v1", Kind: "List"}, &unstructured.UnstructuredList{})
+
+	codecs := serializer.NewCodecFactory(scheme)
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &FakeDynamicClient{}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
+// Clientset implements clientset.Interface. Meant to be embedded into a
+// struct to get a default implementation. This makes faking out just the method
+// you want to test easier.
+type FakeDynamicClient struct {
+	testing.Fake
+	scheme *runtime.Scheme
+}
+
+type dynamicResourceClient struct {
+	client    *FakeDynamicClient
+	namespace string
+	resource  schema.GroupVersionResource
+}
+
+var _ dynamic.Interface = &FakeDynamicClient{}
+
+func (c *FakeDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource}
+}
+
+func (c *dynamicResourceClient) Namespace(ns string) dynamic.ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+func (c *dynamicResourceClient) Create(obj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateAction(c.resource, obj), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateSubresourceAction(c.resource, name, strings.Join(subresources, "/"), obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateAction(c.resource, c.namespace, obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateSubresourceAction(c.resource, name, strings.Join(subresources, "/"), c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Update(obj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateAction(c.resource, obj), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceAction(c.resource, strings.Join(subresources, "/"), obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateAction(c.resource, c.namespace, obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceAction(c.resource, strings.Join(subresources, "/"), c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceAction(c.resource, "status", obj), obj)
+
+	case len(c.namespace) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceAction(c.resource, "status", c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Delete(name string, opts *metav1.DeleteOptions, subresources ...string) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteAction(c.resource, name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteSubresourceAction(c.resource, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteAction(c.resource, c.namespace, name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteSubresourceAction(c.resource, strings.Join(subresources, "/"), c.namespace, name), &metav1.Status{Status: "dynamic delete fail"})
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) DeleteCollection(opts *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		action := testing.NewRootDeleteCollectionAction(c.resource, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	case len(c.namespace) > 0:
+		action := testing.NewDeleteCollectionAction(c.resource, c.namespace, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) Get(name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetAction(c.resource, name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetSubresourceAction(c.resource, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetAction(c.resource, c.namespace, name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetSubresourceAction(c.resource, c.namespace, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic get fail"})
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	var obj runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewRootListAction(c.resource, schema.GroupVersionKind{Group: "fake-dynamic-client-group", Version: "v1", Kind: "" /*List is appended by the tracker automatically*/}, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	case len(c.namespace) > 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewListAction(c.resource, schema.GroupVersionKind{Group: "fake-dynamic-client-group", Version: "v1", Kind: "" /*List is appended by the tracker automatically*/}, c.namespace, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	}
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+
+	retUnstructured := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(obj, retUnstructured, nil); err != nil {
+		return nil, err
+	}
+	entireList, err := retUnstructured.ToList()
+	if err != nil {
+		return nil, err
+	}
+
+	list := &unstructured.UnstructuredList{}
+	for i := range entireList.Items {
+		item := &entireList.Items[i]
+		metadata, err := meta.Accessor(item)
+		if err != nil {
+			return nil, err
+		}
+		if label.Matches(labels.Set(metadata.GetLabels())) {
+			list.Items = append(list.Items, *item)
+		}
+	}
+	return list, nil
+}
+
+func (c *dynamicResourceClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	switch {
+	case len(c.namespace) == 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewRootWatchAction(c.resource, opts))
+
+	case len(c.namespace) > 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewWatchAction(c.resource, c.namespace, opts))
+
+	}
+
+	panic("math broke")
+}
+
+func (c *dynamicResourceClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchAction(c.resource, name, data), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchSubresourceAction(c.resource, name, data, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchAction(c.resource, c.namespace, name, data), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchSubresourceAction(c.resource, c.namespace, name, data, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}

--- a/vendor/k8s.io/client-go/dynamic/interface.go
+++ b/vendor/k8s.io/client-go/dynamic/interface.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type Interface interface {
+	Resource(resource schema.GroupVersionResource) NamespaceableResourceInterface
+}
+
+type ResourceInterface interface {
+	Create(obj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error)
+	Update(obj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error)
+	UpdateStatus(obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
+	Delete(name string, options *metav1.DeleteOptions, subresources ...string) error
+	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
+	Get(name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error)
+	List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (*unstructured.Unstructured, error)
+}
+
+type NamespaceableResourceInterface interface {
+	Namespace(string) ResourceInterface
+	ResourceInterface
+}
+
+// APIPathResolverFunc knows how to convert a groupVersion to its API path. The Kind field is optional.
+// TODO find a better place to move this for existing callers
+type APIPathResolverFunc func(kind schema.GroupVersionKind) string
+
+// LegacyAPIPathResolverFunc can resolve paths properly with the legacy API.
+// TODO find a better place to move this for existing callers
+func LegacyAPIPathResolverFunc(kind schema.GroupVersionKind) string {
+	if len(kind.Group) == 0 {
+		return "/api"
+	}
+	return "/apis"
+}

--- a/vendor/k8s.io/client-go/dynamic/scheme.go
+++ b/vendor/k8s.io/client-go/dynamic/scheme.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
+)
+
+var watchScheme = runtime.NewScheme()
+var basicScheme = runtime.NewScheme()
+var deleteScheme = runtime.NewScheme()
+var parameterScheme = runtime.NewScheme()
+var deleteOptionsCodec = serializer.NewCodecFactory(deleteScheme)
+var dynamicParameterCodec = runtime.NewParameterCodec(parameterScheme)
+
+var versionV1 = schema.GroupVersion{Version: "v1"}
+
+func init() {
+	metav1.AddToGroupVersion(watchScheme, versionV1)
+	metav1.AddToGroupVersion(basicScheme, versionV1)
+	metav1.AddToGroupVersion(parameterScheme, versionV1)
+	metav1.AddToGroupVersion(deleteScheme, versionV1)
+}
+
+var watchJsonSerializerInfo = runtime.SerializerInfo{
+	MediaType:        "application/json",
+	EncodesAsText:    true,
+	Serializer:       json.NewSerializer(json.DefaultMetaFactory, watchScheme, watchScheme, false),
+	PrettySerializer: json.NewSerializer(json.DefaultMetaFactory, watchScheme, watchScheme, true),
+	StreamSerializer: &runtime.StreamSerializerInfo{
+		EncodesAsText: true,
+		Serializer:    json.NewSerializer(json.DefaultMetaFactory, watchScheme, watchScheme, false),
+		Framer:        json.Framer,
+	},
+}
+
+// watchNegotiatedSerializer is used to read the wrapper of the watch stream
+type watchNegotiatedSerializer struct{}
+
+var watchNegotiatedSerializerInstance = watchNegotiatedSerializer{}
+
+func (s watchNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{watchJsonSerializerInfo}
+}
+
+func (s watchNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return versioning.NewDefaultingCodecForScheme(watchScheme, encoder, nil, gv, nil)
+}
+
+func (s watchNegotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return versioning.NewDefaultingCodecForScheme(watchScheme, nil, decoder, nil, gv)
+}
+
+// basicNegotiatedSerializer is used to handle discovery and error handling serialization
+type basicNegotiatedSerializer struct{}
+
+func (s basicNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{
+		{
+			MediaType:        "application/json",
+			EncodesAsText:    true,
+			Serializer:       json.NewSerializer(json.DefaultMetaFactory, basicScheme, basicScheme, false),
+			PrettySerializer: json.NewSerializer(json.DefaultMetaFactory, basicScheme, basicScheme, true),
+			StreamSerializer: &runtime.StreamSerializerInfo{
+				EncodesAsText: true,
+				Serializer:    json.NewSerializer(json.DefaultMetaFactory, basicScheme, basicScheme, false),
+				Framer:        json.Framer,
+			},
+		},
+	}
+}
+
+func (s basicNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return versioning.NewDefaultingCodecForScheme(watchScheme, encoder, nil, gv, nil)
+}
+
+func (s basicNegotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return versioning.NewDefaultingCodecForScheme(watchScheme, nil, decoder, nil, gv)
+}

--- a/vendor/k8s.io/client-go/dynamic/simple.go
+++ b/vendor/k8s.io/client-go/dynamic/simple.go
@@ -1,0 +1,287 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"io"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+)
+
+type dynamicClient struct {
+	client *rest.RESTClient
+}
+
+var _ Interface = &dynamicClient{}
+
+func NewForConfig(inConfig *rest.Config) (Interface, error) {
+	config := rest.CopyConfig(inConfig)
+	// for serializing the options
+	config.GroupVersion = &schema.GroupVersion{}
+	config.APIPath = "/if-you-see-this-search-for-the-break"
+	config.AcceptContentTypes = "application/json"
+	config.ContentType = "application/json"
+	config.NegotiatedSerializer = basicNegotiatedSerializer{} // this gets used for discovery and error handling types
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	restClient, err := rest.RESTClientFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dynamicClient{client: restClient}, nil
+}
+
+type dynamicResourceClient struct {
+	client    *dynamicClient
+	namespace string
+	resource  schema.GroupVersionResource
+}
+
+func (c *dynamicClient) Resource(resource schema.GroupVersionResource) NamespaceableResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource}
+}
+
+func (c *dynamicResourceClient) Namespace(ns string) ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+func (c *dynamicResourceClient) Create(obj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error) {
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+	name := ""
+	if len(subresources) > 0 {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name = accessor.GetName()
+	}
+
+	result := c.client.client.Post().AbsPath(append(c.makeURLSegments(name), subresources...)...).Body(outBytes).Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) Update(obj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.Put().AbsPath(append(c.makeURLSegments(accessor.GetName()), subresources...)...).Body(outBytes).Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.Put().AbsPath(append(c.makeURLSegments(accessor.GetName()), "status")...).Body(outBytes).Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) Delete(name string, opts *metav1.DeleteOptions, subresources ...string) error {
+	if opts == nil {
+		opts = &metav1.DeleteOptions{}
+	}
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), opts)
+	if err != nil {
+		return err
+	}
+
+	result := c.client.client.Delete().AbsPath(append(c.makeURLSegments(name), subresources...)...).Body(deleteOptionsByte).Do()
+	return result.Error()
+}
+
+func (c *dynamicResourceClient) DeleteCollection(opts *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	if opts == nil {
+		opts = &metav1.DeleteOptions{}
+	}
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), opts)
+	if err != nil {
+		return err
+	}
+
+	result := c.client.client.Delete().AbsPath(c.makeURLSegments("")...).Body(deleteOptionsByte).SpecificallyVersionedParams(&listOptions, dynamicParameterCodec, versionV1).Do()
+	return result.Error()
+}
+
+func (c *dynamicResourceClient) Get(name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	result := c.client.client.Get().AbsPath(append(c.makeURLSegments(name), subresources...)...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	result := c.client.client.Get().AbsPath(c.makeURLSegments("")...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	if list, ok := uncastObj.(*unstructured.UnstructuredList); ok {
+		return list, nil
+	}
+
+	list, err := uncastObj.(*unstructured.Unstructured).ToList()
+	if err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
+func (c *dynamicResourceClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	internalGV := schema.GroupVersions{
+		{Group: c.resource.Group, Version: runtime.APIVersionInternal},
+		// always include the legacy group as a decoding target to handle non-error `Status` return types
+		{Group: "", Version: runtime.APIVersionInternal},
+	}
+	s := &rest.Serializers{
+		Encoder: watchNegotiatedSerializerInstance.EncoderForVersion(watchJsonSerializerInfo.Serializer, c.resource.GroupVersion()),
+		Decoder: watchNegotiatedSerializerInstance.DecoderToVersion(watchJsonSerializerInfo.Serializer, internalGV),
+
+		RenegotiatedDecoder: func(contentType string, params map[string]string) (runtime.Decoder, error) {
+			return watchNegotiatedSerializerInstance.DecoderToVersion(watchJsonSerializerInfo.Serializer, internalGV), nil
+		},
+		StreamingSerializer: watchJsonSerializerInfo.StreamSerializer.Serializer,
+		Framer:              watchJsonSerializerInfo.StreamSerializer.Framer,
+	}
+
+	wrappedDecoderFn := func(body io.ReadCloser) streaming.Decoder {
+		framer := s.Framer.NewFrameReader(body)
+		return streaming.NewDecoder(framer, s.StreamingSerializer)
+	}
+
+	opts.Watch = true
+	return c.client.client.Get().AbsPath(c.makeURLSegments("")...).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		WatchWithSpecificDecoders(wrappedDecoderFn, unstructured.UnstructuredJSONScheme)
+}
+
+func (c *dynamicResourceClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (*unstructured.Unstructured, error) {
+	result := c.client.client.Patch(pt).AbsPath(append(c.makeURLSegments(name), subresources...)...).Body(data).Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) makeURLSegments(name string) []string {
+	url := []string{}
+	if len(c.resource.Group) == 0 {
+		url = append(url, "api")
+	} else {
+		url = append(url, "apis", c.resource.Group)
+	}
+	url = append(url, c.resource.Version)
+
+	if len(c.namespace) > 0 {
+		url = append(url, "namespaces", c.namespace)
+	}
+	url = append(url, c.resource.Resource)
+
+	if len(name) > 0 {
+		url = append(url, name)
+	}
+
+	return url
+}


### PR DESCRIPTION
This starts to sketch common libraries for instantiating informers/listers for a particular GroupVersionResource as one of our duck types.

You can instantiate a duck.InformerFactory like so:
```go
        dynaClient, err := dynamic.NewForConfig(cfg)
        if err != nil {
                logger.Fatalf("Error building dynamic clientset: %v", err)
        }

        dif := &duck.CachedInformerFactory{
                Delegate: &duck.TypedInformerFactory{
                        Client:       dynaClient,
                        Type:         &duckv1alpha1.Target{},
                        ResyncPeriod: 30 * time.Second,
                        StopChannel:  stopCh,
                },
        }
```

Then, as you come across new GroupVersionResources that you want to handle:
```go
        informer, lister, err := dif.Get(gvr)
        if err != nil {
               logger.Fatalf("Error starting shared index informer: %v", err)
        }
```

With the `duck.TypedInformerFactory` the objects will be returned as the provided `Type:`, so in this example, you could safely write:
```go
        elt, err := lister.ByNamespace(ns).Get(name)
        if err != nil { ... }

        target := elt.(*duckv1alpha1.Target)
        // Stuff involving target.
```

WIP because I still need tests for the `TypedInformerFactory`.