### PR TITLE
Bump the sleep in the controller testing.

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -236,7 +236,7 @@ func TestEnqueues(t *testing.T) {
 			test.work(impl)
 
 			// The rate limit on our queue delays when things are added to the queue.
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(50 * time.Millisecond)
 			impl.WorkQueue.ShutDown()
 			gotQueue := drainWorkQueue(impl.WorkQueue)
 


### PR DESCRIPTION
The rate limiting queue makes the sleep necessary.  Locally I see 0-2 failures when this is run with -count=10000.  This bumps the sleep slightly to reduce this further.

Fixes: https://github.com/knative/pkg/issues/56
