### PR TITLE
Merge FieldErrors into a single error when all but the path matches.

### DIFF
--- a/apis/field_error.go
+++ b/apis/field_error.go
@@ -21,8 +21,6 @@ import (
 	"sort"
 	"strings"
 
-	"k8s.io/kubernetes/pkg/util/slice"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
@@ -175,7 +173,7 @@ func flattenErrors(errors []FieldError) []FieldError {
 			// they match, merge the paths.
 			nextPaths := make([]string, 0, len(next.Paths))
 			for p := 0; p < len(next.Paths); p++ {
-				if slice.ContainsString(curr.Paths, next.Paths[p], nil) == false {
+				if containsString(curr.Paths, next.Paths[p]) == false {
 					nextPaths = append(nextPaths, next.Paths[p])
 				}
 			}
@@ -191,6 +189,15 @@ func flattenErrors(errors []FieldError) []FieldError {
 		newErrors = append(newErrors, curr)
 	}
 	return newErrors
+}
+
+func containsString(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
 }
 
 func asIndex(index int) string {

--- a/apis/field_error.go
+++ b/apis/field_error.go
@@ -145,14 +145,14 @@ func (fe *FieldError) getNormalizedErrors() []FieldError {
 		errors = append(errors, e.getNormalizedErrors()...)
 	}
 
-	errors = flattenErrors(errors)
+	errors = merge(errors)
 
 	return errors
 }
 
-// flattenErrors will combine errors that differ only in their paths.
+// merge will combine errors that differ only in their paths.
 // This assumes that errors has been normalized.
-func flattenErrors(errors []FieldError) []FieldError {
+func merge(errors []FieldError) []FieldError {
 	if len(errors) <= 1 {
 		return errors
 	}

--- a/apis/field_error_test.go
+++ b/apis/field_error_test.go
@@ -637,8 +637,9 @@ func TestFieldErrorPerformance(t *testing.T) {
 		withoutMerge = time.Since(then)
 	}
 
-	if withMerge.Nanoseconds() >= withoutMerge.Nanoseconds()*2 {
-		t.Errorf("Merge took too long. For %d, duration: merge %s vs no merge %s",
+	// only allow a 25% increase.
+	if withMerge.Nanoseconds() >= (withoutMerge.Nanoseconds()*125)/100 {
+		t.Errorf("Merge took too long. For %d, duration: merged %s vs unmerged %s",
 			count, withMerge, withoutMerge)
 	}
 }

--- a/apis/field_error_test.go
+++ b/apis/field_error_test.go
@@ -456,7 +456,7 @@ func TestAlsoStaysNil(t *testing.T) {
 	}
 }
 
-func TestFlattenFieldErrors(t *testing.T) {
+func TestMergeFieldErrors(t *testing.T) {
 	tests := []struct {
 		name     string
 		err      *FieldError


### PR DESCRIPTION
Implemented merge for squashing field errors together that are the same except for path.