### PR TITLE
Add an example / test that we can Duck type Core K8s resources.

### DIFF
--- a/apis/duck/podspec_test.go
+++ b/apis/duck/podspec_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package duck_test
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/knative/pkg/apis/duck"
+)
+
+// PodSpecable is implemented by types containing a PodTemplateSpec
+// in the manner of ReplicaSet, Deployment, DaemonSet, StatefulSet.
+type PodSpecable corev1.PodTemplateSpec
+
+type WithPod struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec WithPodSpec `json:"spec,omitempty"`
+}
+
+type WithPodSpec struct {
+	Template PodSpecable `json:"template,omitempty"`
+}
+
+// Check that our canonical type implements PodSpecable.
+var _ = duck.VerifyType(&WithPod{}, &PodSpecable{})
+
+// Check that several Kubernetes built-in type implement PodSpecable.
+var _ = duck.VerifyType(&appsv1.ReplicaSet{}, &PodSpecable{})
+var _ = duck.VerifyType(&appsv1.Deployment{}, &PodSpecable{})
+var _ = duck.VerifyType(&appsv1.StatefulSet{}, &PodSpecable{})
+var _ = duck.VerifyType(&appsv1.DaemonSet{}, &PodSpecable{})
+var _ = duck.VerifyType(&batchv1.Job{}, &PodSpecable{})
+
+var _ duck.Populatable = (*WithPod)(nil)
+var _ duck.Implementable = (*PodSpecable)(nil)
+
+// GetFullType implements duck.Implementable
+func (_ *PodSpecable) GetFullType() duck.Populatable {
+	return &WithPod{}
+}
+
+// Populate implements duck.Populatable
+func (t *WithPod) Populate() {
+	t.Spec.Template = PodSpecable{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "container-name",
+				Image: "container-image:latest",
+			}},
+		},
+	}
+}
+
+func TestNothing(t *testing.T) {
+	// Don't test anything, this is simply a demonstration that we
+	// can Duck type core Kubernetes objects and initializing this
+	// package is sufficient to test that assertion.
+}


### PR DESCRIPTION
This defines a simple test duck type called PodSpecable, which has the same shape for embedding a corev1.PodTemplateSpec as numerous core Kubernetes resource: ReplicaSet, Deployment, StatefulSet, DaemonSet, and Job.