### PR TITLE
This change implements a more generalized form of the BuildTracker.

### DIFF
--- a/tracker/doc.go
+++ b/tracker/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package tracker defines a utility to enable Reconcilers to trigger
+// reconciliations when objects that are cross-referenced change, so
+// that the level-based reconciliation can react to the change.  The
+// prototypical cross-reference in Kubernetes is corev1.ObjectReference.
+package tracker

--- a/tracker/enqueue.go
+++ b/tracker/enqueue.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracker
+
+import (
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+// New returns an implementation of Interface that lets a Reconciler
+// register a particular resource as watching an ObjectReference for
+// a particular lease duration.  This watch must be refreshed
+// periodically (e.g. by a controller resync) or it will expire.
+//
+// When OnChanged is called by the informer for a particular
+// GroupVersionKind, the provided callback is called with the "key"
+// of each object actively watching the changed object.
+func New(callback func(string), lease time.Duration) Interface {
+	return &impl{
+		leaseDuration: lease,
+		cb:            callback,
+	}
+}
+
+type impl struct {
+	m sync.Mutex
+	// mapping maps from an object reference to the set of
+	// keys for objects watching it.
+	mapping map[corev1.ObjectReference]set
+
+	// The amount of time that an object may watch another
+	// before having to renew the lease.
+	leaseDuration time.Duration
+
+	cb func(string)
+}
+
+// Check that impl implements Interface.
+var _ Interface = (*impl)(nil)
+
+// set is a map from keys to expirations
+type set map[string]time.Time
+
+// Track implements Interface.
+func (i *impl) Track(ref corev1.ObjectReference, obj interface{}) error {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return err
+	}
+
+	i.m.Lock()
+	defer i.m.Unlock()
+	if i.mapping == nil {
+		i.mapping = make(map[corev1.ObjectReference]set)
+	}
+
+	l, ok := i.mapping[ref]
+	if !ok {
+		l = set{}
+	}
+	// Overwrite the key with a new expiration.
+	l[key] = time.Now().Add(i.leaseDuration)
+
+	i.mapping[ref] = l
+	return nil
+}
+
+type accessor interface {
+	GroupVersionKind() schema.GroupVersionKind
+	GetNamespace() string
+	GetName() string
+}
+
+// OnChanged implements Interface.
+func (i *impl) OnChanged(obj interface{}) {
+	item, ok := obj.(accessor)
+	if !ok {
+		// TODO(mattmoor): We should consider logging here.
+		return
+	}
+
+	gvk := item.GroupVersionKind()
+	apiVersion, kind := gvk.ToAPIVersionAndKind()
+	or := corev1.ObjectReference{
+		APIVersion: apiVersion,
+		Kind:       kind,
+		Namespace:  item.GetNamespace(),
+		Name:       item.GetName(),
+	}
+
+	// TODO(mattmoor): Consider locking the mapping (global) for a
+	// smaller scope and leveraging a per-set lock to guard its access.
+	i.m.Lock()
+	defer i.m.Unlock()
+	s, ok := i.mapping[or]
+	if !ok {
+		// TODO(mattmoor): We should consider logging here.
+		return
+	}
+
+	for key, expiry := range s {
+		// If the expiration has lapsed, then delete the key.
+		if time.Now().After(expiry) {
+			delete(s, key)
+			continue
+		}
+		i.cb(key)
+	}
+}

--- a/tracker/enqueue_test.go
+++ b/tracker/enqueue_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracker
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/knative/pkg/testing"
+)
+
+// Ensure our resource satisfies the interface.
+var _ accessor = (*Resource)(nil)
+
+func TestFoo(t *testing.T) {
+	calls := 0
+	f := func(key string) {
+		calls = calls + 1
+	}
+
+	trk := New(f, 10*time.Millisecond)
+
+	objRef := corev1.ObjectReference{
+		APIVersion: "ref.knative.dev/v1alpha1",
+		Kind:       "Thing1",
+		Namespace:  "ns",
+		Name:       "foo",
+	}
+
+	thing1 := &Resource{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: objRef.APIVersion,
+			Kind:       objRef.Kind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: objRef.Namespace,
+			Name:      objRef.Name,
+		},
+	}
+
+	thing2 := &Resource{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "reffer.knative.dev/v1alpha1",
+			Kind:       "Thing2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "bar",
+		},
+	}
+
+	t.Run("Not tracked yet", func(t *testing.T) {
+		trk.OnChanged(thing1)
+		if got, want := calls, 0; got != want {
+			t.Errorf("OnChanged() = %v, wanted %v", got, want)
+		}
+	})
+
+	t.Run("Tracked gets called", func(t *testing.T) {
+		if err := trk.Track(objRef, thing2); err != nil {
+			t.Errorf("Track() = %v", err)
+		}
+
+		trk.OnChanged(thing1)
+		if got, want := calls, 1; got != want {
+			t.Errorf("OnChanged() = %v, wanted %v", got, want)
+		}
+	})
+
+	t.Run("Still gets called", func(t *testing.T) {
+		trk.OnChanged(thing1)
+		if got, want := calls, 2; got != want {
+			t.Errorf("OnChanged() = %v, wanted %v", got, want)
+		}
+	})
+
+	// Check that after the sleep duration, we stop getting called.
+	time.Sleep(20 * time.Millisecond)
+	t.Run("Stops getting called", func(t *testing.T) {
+		trk.OnChanged(thing1)
+		if got, want := calls, 2; got != want {
+			t.Errorf("OnChanged() = %v, wanted %v", got, want)
+		}
+	})
+
+	t.Run("Starts getting called again", func(t *testing.T) {
+		if err := trk.Track(objRef, thing2); err != nil {
+			t.Errorf("Track() = %v", err)
+		}
+
+		trk.OnChanged(thing1)
+		if got, want := calls, 3; got != want {
+			t.Errorf("OnChanged() = %v, wanted %v", got, want)
+		}
+	})
+
+	t.Run("OnChanged non-accessor", func(t *testing.T) {
+		// Check that passing in a resource that doesn't implement
+		// accessor won't panic.
+		trk.OnChanged("not an accessor")
+
+		if got, want := calls, 3; got != want {
+			t.Errorf("OnChanged() = %v, wanted %v", got, want)
+		}
+	})
+
+	t.Run("Track bad object", func(t *testing.T) {
+		if err := trk.Track(objRef, struct{}{}); err == nil {
+			t.Error("Track() = nil, wanted error")
+		}
+	})
+}

--- a/tracker/interface.go
+++ b/tracker/interface.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracker
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Interface defines the interface through which an object can register
+// that it is tracking another object by reference.
+type Interface interface {
+	// Track tells us that "obj" is tracking changes to the
+	// referenced object.
+	Track(ref corev1.ObjectReference, obj interface{}) error
+
+	// OnChanged is a callback to register with the InformerFactory
+	// so that we are notified for appropriate object changes.
+	OnChanged(obj interface{})
+}


### PR DESCRIPTION
To use this with a typical informer, e.g. the way `Route` would monitor `Configurations` and `Revisions`, you'd do something like:
```go
	c := &Reconciler{
		Base:                 reconciler.NewBase(opt, controllerAgentName),
		...
	}
	impl := controller.NewImpl(c, c.Logger, "Routes")

        t := tracker.New(impl.EnqueueKey, 30*time.Minute)
        configInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
                AddFunc:    t.OnChanged,
                UpdateFunc: controller.PassNew(t.OnChanged),
        })
        revisionInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
                AddFunc:    t.OnChanged,
                UpdateFunc: controller.PassNew(t.OnChanged),
        })

        // Now use c.tracker.Track(revisionRef, route) or c.tracker.Track(configRef, route)
        // each Reconcile(route) to refresh the cross-object leases.
        c.tracker = t
```

To use this with a `duck.InformerFactory`, e.g. the way `Revision` will monitor `BuildRef`s you'd do something like:
```go
	c := &Reconciler{
		Base:             reconciler.NewBase(opt, controllerAgentName),
		...
	}
	impl := controller.NewImpl(c, c.Logger, "Revisions")

        t := tracker.New(impl.EnqueueKey, 30*time.Minute)
        cif := &duck.CachedInformerFactory{
                Delegate: &duck.EnqueueInformerFactory{
                        Delegate: buildInformerFactory,
                        EventHandler: cache.ResourceEventHandlerFuncs{
                                AddFunc:    t.OnChanged,
                                UpdateFunc: controller.PassNew(t.OnChanged),
                        },
                },
        }

        // Now use: `c.buildInformerFactory.Get()` to access ObjectReferences.
        c.buildInformerFactory = buildInformerFactory

        // Now use: `c.tracker.Track(rev.Spec.BuildRef, rev)` to queue `rev`
        // each time `rev.Spec.BuildRef` changes (expires 30 minutes after BuildRef
        // points to something else).
        c.tracker = t
```

Fixes: https://github.com/knative/pkg/issues/94

<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:

Fixes: <LINK TO ISSUE>
-->
