### PR TITLE
Add Generation variants of kmeta/labels.go

### DIFF
--- a/kmeta/labels_test.go
+++ b/kmeta/labels_test.go
@@ -114,3 +114,96 @@ func TestMakeOldVersionLabelSelector(t *testing.T) {
 		})
 	}
 }
+
+func TestMakeGenerationLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		om   metav1.ObjectMeta
+		s    string
+	}{{
+		name: "simple translation",
+		om: metav1.ObjectMeta{
+			UID:        "1234",
+			Generation: 5,
+		},
+		s: "controller=1234,generation=00005",
+	}, {
+		name: "another simple translation",
+		om: metav1.ObjectMeta{
+			UID:        "abcd",
+			Generation: 5432,
+		},
+		s: "controller=abcd,generation=05432",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ls := MakeGenerationLabels(&test.om)
+			if want, got := test.s, ls.String(); got != want {
+				t.Errorf("MakeGenerationLabels() = %v, wanted %v", got, want)
+			}
+		})
+	}
+}
+
+func TestMakeGenerationLabelSelector(t *testing.T) {
+	tests := []struct {
+		name string
+		om   metav1.ObjectMeta
+		s    string
+	}{{
+		name: "simple translation",
+		om: metav1.ObjectMeta{
+			UID:        "1234",
+			Generation: 5,
+		},
+		s: "controller=1234,generation=00005",
+	}, {
+		name: "another simple translation",
+		om: metav1.ObjectMeta{
+			UID:        "abcd",
+			Generation: 5432,
+		},
+		s: "controller=abcd,generation=05432",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ls := MakeGenerationLabelSelector(&test.om)
+			if want, got := test.s, ls.String(); got != want {
+				t.Errorf("MakeGenerationLabelSelector() = %v, wanted %v", got, want)
+			}
+		})
+	}
+}
+
+func TestMakeOldGenerationLabelSelector(t *testing.T) {
+	tests := []struct {
+		name string
+		om   metav1.ObjectMeta
+		s    string
+	}{{
+		name: "simple translation",
+		om: metav1.ObjectMeta{
+			UID:        "1234",
+			Generation: 5,
+		},
+		s: "controller=1234,generation!=00005",
+	}, {
+		name: "another simple translation",
+		om: metav1.ObjectMeta{
+			UID:        "abcd",
+			Generation: 5432,
+		},
+		s: "controller=abcd,generation!=05432",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ls := MakeOldGenerationLabelSelector(&test.om)
+			if want, got := test.s, ls.String(); got != want {
+				t.Errorf("MakeOldGenerationLabelSelector() = %v, wanted %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Unlike `ResourceVersion`, which changes whenever the resource changes at all (including `/status` which can be high churn), `Generation` only changes when the `/spec` of a CRD changes (for CRDs starting in 1.11, right now they are locked at `generation: 1`).

These methods are useful for interacting with K8s resource now, and will be useful for CRDs soon.

Fixes: https://github.com/knative/pkg/issues/116

<!--
/lint
-->
