### PR TITLE
Adding Zipkin tracing support for SpoofingClient

### DIFF
--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -19,6 +19,9 @@ limitations under the License.
 package spoof
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -26,9 +29,14 @@ import (
 	"time"
 
 	"github.com/knative/pkg/test/logging"
+	zipkin "github.com/knative/pkg/test/zipkin"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/plugin/ochttp/propagation/b3"
+	"go.opencensus.io/trace"
 )
 
 const (
@@ -82,7 +90,7 @@ type SpoofingClient struct {
 // If that's a problem, see test/request.go#WaitForEndpointState for oneshot spoofing.
 func New(kubeClientset *kubernetes.Clientset, logger *logging.BaseLogger, domain string, resolvable bool) (*SpoofingClient, error) {
 	sc := SpoofingClient{
-		Client:          http.DefaultClient,
+		Client:          &http.Client{Transport: &ochttp.Transport{Propagation: &b3.HTTPFormat{}}}, // Using ochttp Transport required for zipkin-tracing
 		RequestInterval: requestInterval,
 		RequestTimeout:  requestTimeout,
 		logger:          logger,
@@ -127,6 +135,7 @@ func New(kubeClientset *kubernetes.Clientset, logger *logging.BaseLogger, domain
 
 // Do dispatches to the underlying http.Client.Do, spoofing domains as needed
 // and transforming the http.Response into a spoof.Response.
+// Each response is augmented with "ZipkinTraceID" header that identifies the zipkin trace corresponding to the request.
 func (sc *SpoofingClient) Do(req *http.Request) (*Response, error) {
 	// Controls the Host header, for spoofing.
 	if sc.domain != "" {
@@ -138,12 +147,18 @@ func (sc *SpoofingClient) Do(req *http.Request) (*Response, error) {
 		req.URL.Host = sc.endpoint
 	}
 
-	resp, err := sc.Client.Do(req)
+	// Starting span to capture zipkin trace.
+	traceContext, span := trace.StartSpan(req.Context(), "SpoofingClient-Trace")
+	defer span.End()
+
+	resp, err := sc.Client.Do(req.WithContext(traceContext))
 	if err != nil {
 		return nil, err
 	}
 
 	defer resp.Body.Close()
+
+	resp.Header.Add(zipkin.ZipkinTraceIDHeader, span.SpanContext().TraceID.String())
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
@@ -178,4 +193,35 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker) (*Res
 	})
 
 	return resp, err
+}
+
+// LogZipkinTrace provides support to log Zipkin Trace for param: traceID
+func (sc *SpoofingClient) LogZipkinTrace(traceID string) error {
+	if err := zipkin.CheckZipkinPortAvailability(); err == nil {
+		return errors.New("port-forwarding for Zipkin is not-setup. Failing Zipkin Trace retrieval")
+	}
+
+	sc.logger.Infof("Logging Zipkin Trace: %s", traceID)
+
+	zipkinTraceEndpoint := zipkin.ZipkinTraceEndpoint + traceID
+	// Sleep to ensure all traces are correctly pushed on the backend.
+	time.Sleep(5 * time.Second)
+	resp, err := http.Get(zipkinTraceEndpoint)
+	if err != nil {
+		return fmt.Errorf("Error retrieving Zipkin trace: %v", err)
+	}
+
+	trace, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("Error reading Zipkin trace response: %v", err)
+	}
+
+	var prettyJSON bytes.Buffer
+	error := json.Indent(&prettyJSON, trace, "", "\t")
+	if error != nil {
+		return fmt.Errorf("JSON Parser Error while trying for Pretty-Format: %v, Original Response: %s", error, string(trace))
+	}
+	sc.logger.Infof(prettyJSON.String())
+
+	return nil
 }

--- a/test/zipkin/util.go
+++ b/test/zipkin/util.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//util has constants and helper methods useful for zipkin tracing support.
+
+package zipkin
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+
+	"github.com/knative/pkg/test/logging"
+	"go.opencensus.io/trace"
+	"k8s.io/client-go/kubernetes"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+
+	//ZipkinTraceIDHeader HTTP response header key to be used to store Zipkin Trace ID.
+	ZipkinTraceIDHeader = "ZIPKIN_TRACE_ID"
+
+	// ZipkinPort port exposed by the Zipkin Pod
+	// https://github.com/knative/serving/blob/master/config/monitoring/200-common/100-zipkin.yaml#L25 configures the Zipkin Port on the cluster.
+	ZipkinPort = 9411
+
+	// ZipkinTraceEndpoint port-forwarded zipkin endpoint
+	ZipkinTraceEndpoint = "http://localhost:9411/api/v2/trace/"
+
+	// ZipkinNamespace namespace where zipkin pod runs.
+	// https://github.com/knative/serving/blob/master/config/monitoring/200-common/100-zipkin.yaml#L19 configures the namespace for zipkin.
+	ZipkinNamespace = "istio-system"
+)
+
+var zipkinPortForwardPID int
+
+// SetupZipkinTracing sets up zipkin tracing which involves a) Setting up port-forwarding from localhost to zipkin pod on the cluster (pid of the process doing Port-Forward is stored in a global variable).
+// b) enable AlwaysSample config for tracing.
+func SetupZipkinTracing(kubeClientset *kubernetes.Clientset) error {
+	logger := logging.GetContextLogger("SpoofUtil")
+
+	if err := CheckZipkinPortAvailability(); err != nil {
+		return fmt.Errorf("Zipkin port not available on the machine: %v", err)
+	}
+
+	zipkinPods, err := kubeClientset.CoreV1().Pods(ZipkinNamespace).List(metav1.ListOptions{LabelSelector: "app=zipkin"})
+	if err != nil {
+		return fmt.Errorf("Error retrieving Zipkin pod details : %v", err)
+	}
+
+	if len(zipkinPods.Items) == 0 {
+		return errors.New("No Zipkin Pod found on the cluster. Ensure monitoring is switched on for your Knative Setup")
+	}
+
+	portForwardCmd := exec.Command("kubectl", "port-forward", "--namespace=" + ZipkinNamespace, zipkinPods.Items[0].Name, fmt.Sprintf("%d:%d", ZipkinPort, ZipkinPort))
+	if err = portForwardCmd.Start(); err != nil {
+		return fmt.Errorf("Error starting kubectl port-forward command : %v", err)
+
+	}
+	zipkinPortForwardPID = portForwardCmd.Process.Pid
+	logger.Infof("Zipkin port-forward process started with PID: %d", zipkinPortForwardPID)
+
+	// Applying AlwaysSample config to ensure we propagate zipkin header for every request made by this client.
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+
+	logger.Infof("Successfully setup SpoofingClient for Zipkin Tracing")
+
+	return nil
+}
+
+// CleanupZipkinTracingSetup cleans up the Zipkin tracing setup on the machine. This involves killing the process performing port-forward.
+func CleanupZipkinTracingSetup() error {
+	logger := logging.GetContextLogger("SpoofUtil")
+
+	ps := os.Process{Pid: zipkinPortForwardPID}
+	if err := ps.Kill(); err != nil {
+		return fmt.Errorf("Encoutered error killing port-forward process in CleanupZipkingTracingSetup() : %v", err)
+	}
+
+	logger.Infof("Successfully killed Zipkin port-forward process")
+	return nil
+}
+
+// CheckZipkinPortAvailability checks to see if Zipkin Port is available on the machine.
+// returns error if the port is not available.
+func CheckZipkinPortAvailability() error {
+	server, err := net.Listen("tcp", fmt.Sprintf(":%d", ZipkinPort))
+	if err != nil {
+		// Port is likely taken
+		return err
+	}
+	server.Close()
+	return nil
+}


### PR DESCRIPTION
Change adds Zipkin Tracing header to each HTTP request made through
SpoofingClient to knit together Zipkin traces on the backend to requests
made through the client. To use the support tests needs to call into
SetupZipkinTracing(..) in their Setup method to setup Zipkin tracing.
This method setups Port-Forwarding from the machine(Port 9411) where tests are run
to Zipkin Pod on the Knative setup.  TearDown/Cleanup method needs to call KillZipkinPortFowardingProcess(..) to cleanup Zipkin tracing setup.

<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:

Fixes: https://github.com/knative/test-infra/issues/89
-->
