### PR TITLE
Add timeKey so time is actually logged in e2e tests.

### DIFF
--- a/test/logging/logging.go
+++ b/test/logging/logging.go
@@ -77,17 +77,18 @@ func newLogger(logLevel string) *BaseLogger {
 	  "outputPaths": ["stdout"],
 	  "errorOutputPaths": ["stderr"],
 	  "encoderConfig": {
+	    "timeKey": "ts",
 	    "messageKey": "message",
-			"levelKey": "level",
-			"nameKey": "logger",
-			"callerKey": "caller",
-			"messageKey": "msg",
-      "stacktraceKey": "stacktrace",
-      "lineEnding": "",
-      "levelEncoder": "",
-      "timeEncoder": "iso8601",
-      "durationEncoder": "",
-      "callerEncoder": ""
+	    "levelKey": "level",
+	    "nameKey": "logger",
+	    "callerKey": "caller",
+	    "messageKey": "msg",
+	    "stacktraceKey": "stacktrace",
+	    "lineEnding": "",
+	    "levelEncoder": "",
+	    "timeEncoder": "",
+	    "durationEncoder": "iso8601",
+	    "callerEncoder": ""
 	  }
 	}`
 	configJSON := fmt.Sprintf(configJSONTemplate, logLevel)

--- a/test/logging/logging.go
+++ b/test/logging/logging.go
@@ -86,8 +86,8 @@ func newLogger(logLevel string) *BaseLogger {
 	    "stacktraceKey": "stacktrace",
 	    "lineEnding": "",
 	    "levelEncoder": "",
-	    "timeEncoder": "",
-	    "durationEncoder": "iso8601",
+	    "timeEncoder": "iso8601",
+	    "durationEncoder": "",
 	    "callerEncoder": ""
 	  }
 	}`


### PR DESCRIPTION
<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:

Fixes: <LINK TO ISSUE>
-->

@mdemirhan It seems like the zap logger needs a key defined for a field for it to be printed, even when using the console encoder.