### PR TITLE
Make clientAuth of webhook server into a configuration option

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -94,6 +94,11 @@ type ControllerOptions struct {
 	// potential races where registration completes and k8s apiserver
 	// invokes the webhook before the HTTP server is started.
 	RegistrationDelay time.Duration
+
+	// ClientAuthType declares the policy the webhook server will follow for
+	// TLS Client Authentication.
+	// The default value is tls.NoClientCert.
+	ClientAuth tls.ClientAuthType
 }
 
 // ResourceCallback defines a signature for resource specific (Route, Configuration, etc.)
@@ -142,7 +147,7 @@ func getAPIServerExtensionCACert(cl kubernetes.Interface) ([]byte, error) {
 }
 
 // MakeTLSConfig makes a TLS configuration suitable for use with the server
-func makeTLSConfig(serverCert, serverKey, caCert []byte) (*tls.Config, error) {
+func makeTLSConfig(serverCert, serverKey, caCert []byte, clientAuthType tls.ClientAuthType) (*tls.Config, error) {
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)
 	cert, err := tls.X509KeyPair(serverCert, serverKey)
@@ -152,11 +157,7 @@ func makeTLSConfig(serverCert, serverKey, caCert []byte) (*tls.Config, error) {
 	return &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		ClientCAs:    caCertPool,
-		ClientAuth:   tls.NoClientCert,
-		// Note on GKE there apparently is no client cert sent, so this
-		// does not work on GKE.
-		// TODO: make this into a configuration option.
-		//		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientAuth:   clientAuthType,
 	}, nil
 }
 
@@ -234,16 +235,20 @@ func SetDefaults(ctx context.Context) ResourceDefaulter {
 }
 
 func configureCerts(ctx context.Context, client kubernetes.Interface, options *ControllerOptions) (*tls.Config, []byte, error) {
-	apiServerCACert, err := getAPIServerExtensionCACert(client)
+	var apiServerCACert []byte
+	if options.ClientAuth >= tls.VerifyClientCertIfGiven {
+		var err error
+		apiServerCACert, err = getAPIServerExtensionCACert(client)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	serverKey, serverCert, caCert, err := getOrGenerateKeyCertsFromSecret(ctx, client, options)
 	if err != nil {
 		return nil, nil, err
 	}
-	serverKey, serverCert, caCert, err := getOrGenerateKeyCertsFromSecret(
-		ctx, client, options)
-	if err != nil {
-		return nil, nil, err
-	}
-	tlsConfig, err := makeTLSConfig(serverCert, serverKey, apiServerCACert)
+	tlsConfig, err := makeTLSConfig(serverCert, serverKey, apiServerCACert, options.ClientAuth)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -284,7 +284,7 @@ func TestRegistrationForAlreadyExistingWebhook(t *testing.T) {
 		t.Fatal("Expected webhook controller to fail")
 	}
 
-	if !strings.Contains(err.Error(), "configmaps") {
+	if ac.Options.ClientAuth >= tls.VerifyClientCertIfGiven && !strings.Contains(err.Error(), "configmaps") {
 		t.Fatal("Expected error msg to contain configmap key missing error")
 	}
 }
@@ -364,6 +364,14 @@ func TestCertConfigurationForGeneratedSecret(t *testing.T) {
 	}
 	if p.Type != "CERTIFICATE" {
 		t.Fatalf("Expectet type to be CERTIFICATE but got %s", string(p.Type))
+	}
+}
+
+func TestSettingWebhookClientAuth(t *testing.T) {
+	opts := newDefaultOptions()
+	if opts.ClientAuth != tls.NoClientCert {
+		t.Fatalf("Expected default ClientAuth to be NoClientCert (%v) but got (%v)",
+			tls.NoClientCert, opts.ClientAuth)
 	}
 }
 


### PR DESCRIPTION
Fixes: #124 

Make clientAuth of webhook server into a configuration option

<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:

Fixes: <LINK TO ISSUE>
-->
