### PR TITLE
Allow unknown JSON fields

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -503,7 +503,6 @@ func (ac *AdmissionController) mutate(ctx context.Context, kind metav1.GroupVers
 
 	if len(newBytes) != 0 {
 		newDecoder := json.NewDecoder(bytes.NewBuffer(newBytes))
-		newDecoder.DisallowUnknownFields()
 		if err := newDecoder.Decode(&newObj); err != nil {
 			return nil, fmt.Errorf("cannot decode incoming new object: %v", err)
 		}
@@ -514,7 +513,6 @@ func (ac *AdmissionController) mutate(ctx context.Context, kind metav1.GroupVers
 
 	if len(oldBytes) != 0 {
 		oldDecoder := json.NewDecoder(bytes.NewBuffer(oldBytes))
-		oldDecoder.DisallowUnknownFields()
 		if err := oldDecoder.Decode(&oldObj); err != nil {
 			return nil, fmt.Errorf("cannot decode incoming old object: %v", err)
 		}


### PR DESCRIPTION
This enables us to make additive changes without breaking downgrades.

Unfortunate side effect is that we don't get a nice typo checker in the
webhook :(

Fixes: #128
