### PR TITLE
Exit when bootstrap http server of webhook error

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -308,12 +308,10 @@ func (ac *AdmissionController) Run(stop <-chan struct{}) error {
 
 	select {
 	case <-stop:
-		server.Close() // nolint: errcheck
+		return server.Close()
 	case <-serverBootstrapErrCh:
 		return errors.New("webhook server bootstrap failed")
 	}
-
-	return nil
 }
 
 // Unregister unregisters the external admission webhook

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -58,27 +58,6 @@ const (
 	testResourceName = "test-resource"
 )
 
-func newRunningTestAdmissionController(t *testing.T, options ControllerOptions) (
-	kubeClient *fakekubeclientset.Clientset,
-	ac *AdmissionController,
-	stopCh chan struct{}) {
-	// Create fake clients
-	kubeClient = fakekubeclientset.NewSimpleClientset()
-
-	ac, err := NewAdmissionController(kubeClient, options, TestLogger(t))
-	if err != nil {
-		t.Fatalf("Failed to create new admission controller: %s", err)
-	}
-	stopCh = make(chan struct{})
-	go func() {
-		if err := ac.Run(stopCh); err != nil {
-			t.Fatalf("Error running controller: %v", err)
-		}
-	}()
-	ac.Run(stopCh)
-	return
-}
-
 func newNonRunningTestAdmissionController(t *testing.T, options ControllerOptions) (
 	kubeClient *fakekubeclientset.Clientset,
 	ac *AdmissionController) {


### PR DESCRIPTION
Fixes: #130 

* Exit when bootstrap http server of webhook error
* Clean useless newRunningTestAdmissionController func

<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:


-->
