### PR TITLE
Prepare for global resync on ConfigMap changes

### DIFF
--- a/configmap/filter.go
+++ b/configmap/filter.go
@@ -21,7 +21,7 @@ import "reflect"
 // TypeFilter accepts instances of types to check against and returns a function transformer that would only let
 // the call to f through if value is assignable to any one of types of ts. Example:
 //
-// F := config.TypeFilter(&config.Domain{})(f)
+// F := configmap.TypeFilter(&config.Domain{})(f)
 //
 // The result is a function F(name string, value interface{}) that will call the underlying function
 // f(name, value) iff value is a *config.Domain

--- a/configmap/filter.go
+++ b/configmap/filter.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import "reflect"
+
+// TypeFilter accepts instances of types to check against and returns a function transformer that would only let
+// the call to f through if value is assignable to any one of types of ts. Example:
+//
+// F := config.TypeFilter(&config.Domain{})(f)
+//
+// The result is a function F(name string, value interface{}) that will call the underlying function
+// f(name, value) iff value is a *config.Domain
+func TypeFilter(ts ...interface{}) func(func(string, interface{})) func(string, interface{}) {
+	return func(f func(string, interface{})) func(string, interface{}) {
+		return func(name string, value interface{}) {
+			satisfies := false
+			for _, t := range ts {
+				t := reflect.TypeOf(t)
+				if reflect.TypeOf(value).AssignableTo(t) {
+					satisfies = true
+					break
+				}
+			}
+			if satisfies {
+				f(name, value)
+			}
+		}
+	}
+}

--- a/configmap/filter_test.go
+++ b/configmap/filter_test.go
@@ -1,0 +1,30 @@
+package configmap
+
+import "testing"
+
+type foo struct{}
+type bar struct{}
+
+func TestTypeFilter(t *testing.T) {
+	count := 0
+
+	var f = func(name string, value interface{}) {
+		count++
+	}
+
+	f("foo", &foo{})
+	f("bar", &bar{})
+
+	if want, got := 2, count; want != got {
+		t.Fatalf("plain call: count: want %v, got %v", want, got)
+	}
+
+	filtered := TypeFilter(&foo{})(f)
+
+	filtered("foo", &foo{})
+	filtered("bar", &bar{})
+
+	if want, got := 3, count; want != got {
+		t.Fatalf("filtered call: count: want %v, got %v", want, got)
+	}
+}

--- a/configmap/filter_test.go
+++ b/configmap/filter_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package configmap
 
 import "testing"

--- a/configmap/store.go
+++ b/configmap/store.go
@@ -69,6 +69,13 @@ type UntypedStore struct {
 // These functions can return any type along with an error.
 // If the function definition differs then NewUntypedStore
 // will panic.
+//
+// onAfterStore is a variadic list of callbacks to run
+// after the ConfigMap has been transformed (via the appropriate Constructor)
+// and stored. These callbacks run sequentially (in the argument order) in a
+// separate go-routine and are of type func(name string, value interface{})
+// where name is the config-map name and value is the object that has been
+// constructed from the config-map and stored.
 func NewUntypedStore(
 	name string,
 	logger Logger,

--- a/configmap/store.go
+++ b/configmap/store.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import (
+	"reflect"
+	"sync/atomic"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// The UntypedStore expects a logger that conforms to this interface
+// The store will log when updates succeed or fail
+type Logger interface {
+	Infof(string, ...interface{})
+	Fatalf(string, ...interface{})
+	Errorf(string, ...interface{})
+}
+
+// Constructors is a map for specifying config names to
+// their function constructors
+//
+// The values of this map must be functions with the definition
+//
+// func(*k8s.io/api/core/v1.ConfigMap) (... , error)
+//
+// These functions can return any type along with an error
+type Constructors map[string]interface{}
+
+// An UntypedStore is a responsible for storing and
+// constructing configs from Kubernetes ConfigMaps
+//
+// WatchConfigs should be used with a configmap,Watcher
+// in order for this store to remain up to date
+type UntypedStore struct {
+	name   string
+	logger Logger
+
+	storages     map[string]*atomic.Value
+	constructors map[string]reflect.Value
+
+	onAfterStore []func(name string, value interface{})
+}
+
+// NewUntypedStore creates an UntypedStore with given name,
+// Logger and Constructors
+//
+// The Logger must not be nil
+//
+// The values in the Constructors map must be functions with
+// the definition
+//
+// func(*k8s.io/api/core/v1.ConfigMap) (... , error)
+//
+// These functions can return any type along with an error.
+// If the function definition differs then NewUntypedStore
+// will panic.
+func NewUntypedStore(
+	name string,
+	logger Logger,
+	constructors Constructors,
+	onAfterStore ...func(name string, value interface{})) *UntypedStore {
+
+	store := &UntypedStore{
+		name:         name,
+		logger:       logger,
+		storages:     make(map[string]*atomic.Value),
+		constructors: make(map[string]reflect.Value),
+		onAfterStore: onAfterStore,
+	}
+
+	for configName, constructor := range constructors {
+		store.registerConfig(configName, constructor)
+	}
+
+	return store
+}
+
+func (s *UntypedStore) registerConfig(name string, constructor interface{}) {
+	cType := reflect.TypeOf(constructor)
+
+	if cType.Kind() != reflect.Func {
+		panic("config constructor must be a function")
+	}
+
+	if cType.NumIn() != 1 || cType.In(0) != reflect.TypeOf(&corev1.ConfigMap{}) {
+		panic("config constructor must be of the type func(*k8s.io/api/core/v1/ConfigMap) (..., error)")
+	}
+
+	errorType := reflect.TypeOf((*error)(nil)).Elem()
+
+	if cType.NumOut() != 2 || !cType.Out(1).Implements(errorType) {
+		panic("config constructor must be of the type func(*k8s.io/api/core/v1/ConfigMap) (..., error)")
+	}
+
+	s.storages[name] = &atomic.Value{}
+	s.constructors[name] = reflect.ValueOf(constructor)
+}
+
+// WatchConfigs uses the provided configmap.Watcher
+// to setup watches for the config names provided in the
+// Constructors map
+func (s *UntypedStore) WatchConfigs(w Watcher) {
+	for configMapName := range s.constructors {
+		w.Watch(configMapName, s.OnConfigChanged)
+	}
+}
+
+// UntypedLoad will return the constructed value for a given
+// ConfigMap name
+func (s *UntypedStore) UntypedLoad(name string) interface{} {
+	storage := s.storages[name]
+	return storage.Load()
+}
+
+// OnConfigChanged will invoke the mapped constructor against
+// a Kubernetes ConfigMap. If successful it will be stored.
+// If construction fails during the first appearance the store
+// will log a fatal error. If construction fails while updating
+// the store will log an error message.
+func (s *UntypedStore) OnConfigChanged(c *corev1.ConfigMap) {
+	name := c.ObjectMeta.Name
+
+	storage := s.storages[name]
+	constructor := s.constructors[name]
+
+	inputs := []reflect.Value{
+		reflect.ValueOf(c),
+	}
+
+	outputs := constructor.Call(inputs)
+	result := outputs[0].Interface()
+	errVal := outputs[1]
+
+	if !errVal.IsNil() {
+		err := errVal.Interface()
+		if storage.Load() != nil {
+			s.logger.Errorf("Error updating %s config %q: %q", s.name, name, err)
+		} else {
+			s.logger.Fatalf("Error initializing %s config %q: %q", s.name, name, err)
+		}
+		return
+	}
+
+	s.logger.Infof("%s config %q config was added or updated: %v", s.name, name, result)
+	storage.Store(result)
+
+	go func() {
+		for _, f := range s.onAfterStore {
+			f(name, result)
+		}
+	}()
+}

--- a/configmap/store.go
+++ b/configmap/store.go
@@ -23,8 +23,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// The UntypedStore expects a logger that conforms to this interface
-// The store will log when updates succeed or fail
+// Logger is the interface that UntypedStore expects its logger to conform to.
+// UntypedStore will log when updates succeed or fail.
 type Logger interface {
 	Infof(string, ...interface{})
 	Fatalf(string, ...interface{})

--- a/configmap/store_test.go
+++ b/configmap/store_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/knative/pkg/logging/testing"
+)
+
+func TestStoreBadConstructors(t *testing.T) {
+	tests := []struct {
+		name        string
+		constructor interface{}
+	}{{
+		name:        "not a function",
+		constructor: "i'm pretending to be a function",
+	}, {
+		name:        "no function arguments",
+		constructor: func() (bool, error) { return true, nil },
+	}, {
+		name:        "single argument is not a configmap",
+		constructor: func(bool) (bool, error) { return true, nil },
+	}, {
+		name:        "single return",
+		constructor: func(*corev1.ConfigMap) error { return nil },
+	}, {
+		name:        "wrong second return",
+		constructor: func(*corev1.ConfigMap) (bool, bool) { return true, true },
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Error("expected NewUntypedStore to panic")
+				}
+			}()
+
+			NewUntypedStore("store", nil, Constructors{
+				"test": test.constructor,
+			})
+		})
+	}
+}
+
+func TestStoreWatchConfigs(t *testing.T) {
+	constructor := func(c *corev1.ConfigMap) (interface{}, error) {
+		return c.Name, nil
+	}
+
+	store := NewUntypedStore(
+		"name",
+		TestLogger(t),
+		Constructors{
+			"config-name-1": constructor,
+			"config-name-2": constructor,
+		},
+	)
+
+	watcher := &mockWatcher{}
+	store.WatchConfigs(watcher)
+
+	want := []string{
+		"config-name-1",
+		"config-name-2",
+	}
+
+	got := watcher.watches
+
+	if diff := cmp.Diff(want, got, sortStrings); diff != "" {
+		t.Errorf("Unexpected configmap watches (-want, +got): %v", diff)
+	}
+}
+
+func TestStoreConfigChange(t *testing.T) {
+	constructor := func(c *corev1.ConfigMap) (interface{}, error) {
+		return c.Name, nil
+	}
+
+	store := NewUntypedStore(
+		"name",
+		TestLogger(t),
+		Constructors{
+			"config-name-1": constructor,
+			"config-name-2": constructor,
+		},
+	)
+
+	store.OnConfigChanged(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config-name-1",
+		},
+	})
+
+	result := store.UntypedLoad("config-name-1")
+
+	if diff := cmp.Diff(result, "config-name-1"); diff != "" {
+		t.Errorf("Expected loaded value diff: %s", diff)
+	}
+
+	result = store.UntypedLoad("config-name-2")
+
+	if diff := cmp.Diff(result, nil); diff != "" {
+		t.Errorf("Unexpected loaded value diff: %s", diff)
+	}
+
+	store.OnConfigChanged(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config-name-2",
+		},
+	})
+
+	result = store.UntypedLoad("config-name-2")
+
+	if diff := cmp.Diff(result, "config-name-2"); diff != "" {
+		t.Errorf("Expected loaded value diff: %s", diff)
+	}
+}
+
+func TestStoreFailedFirstConversionCrashes(t *testing.T) {
+	if os.Getenv("CRASH") == "1" {
+		constructor := func(c *corev1.ConfigMap) (interface{}, error) {
+			return nil, errors.New("failure")
+		}
+
+		store := NewUntypedStore("name", TestLogger(t),
+			Constructors{"config-name-1": constructor},
+		)
+
+		store.OnConfigChanged(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "config-name-1",
+			},
+		})
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
+	cmd.Env = append(os.Environ(), "CRASH=1")
+	err := cmd.Run()
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Fatalf("process should have exited with status 1 - err %v", err)
+}
+
+func TestStoreFailedUpdate(t *testing.T) {
+	induceConstructorFailure := false
+
+	constructor := func(c *corev1.ConfigMap) (interface{}, error) {
+		if induceConstructorFailure {
+			return nil, errors.New("failure")
+		}
+
+		return time.Now().String(), nil
+	}
+
+	store := NewUntypedStore("name", TestLogger(t),
+		Constructors{"config-name-1": constructor},
+	)
+
+	store.OnConfigChanged(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config-name-1",
+		},
+	})
+
+	firstLoad := store.UntypedLoad("config-name-1")
+
+	induceConstructorFailure = true
+	store.OnConfigChanged(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config-name-1",
+		},
+	})
+
+	secondLoad := store.UntypedLoad("config-name-1")
+
+	if diff := cmp.Diff(firstLoad, secondLoad); diff != "" {
+		t.Errorf("Expected loaded value to remain the same dff: %s", diff)
+	}
+}
+
+type mockWatcher struct {
+	watches []string
+}
+
+func (w *mockWatcher) Watch(config string, o Observer) {
+	w.watches = append(w.watches, config)
+}
+
+func (*mockWatcher) Start(<-chan struct{}) error { return nil }
+
+var _ Watcher = (*mockWatcher)(nil)
+
+var sortStrings = cmpopts.SortSlices(func(x, y string) bool {
+	return x < y
+})

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -216,3 +216,11 @@ func (c *Impl) processNextWorkItem() bool {
 
 	return true
 }
+
+// GlobalResync enqueues all objects from the passed SharedInformer
+func (c *Impl) GlobalResync(si cache.SharedInformer) {
+	store := si.GetStore()
+	for _, obj := range store.List() {
+		c.Enqueue(obj)
+	}
+}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -219,8 +219,7 @@ func (c *Impl) processNextWorkItem() bool {
 
 // GlobalResync enqueues all objects from the passed SharedInformer
 func (c *Impl) GlobalResync(si cache.SharedInformer) {
-	store := si.GetStore()
-	for _, obj := range store.List() {
-		c.Enqueue(obj)
+	for _, key := range si.GetStore().ListKeys() {
+		c.EnqueueKey(key)
 	}
 }


### PR DESCRIPTION
- Add GlobalResync(cache.SharedInformer) method to *controller.Impl (knative/serving#2182)
- Move UntypedStore from serving/pkg/config to pkg/configmap (knative/serving#2184)
- Add onAfterStore callbacks to UntypedStore
- Add TypeFilter to enable composable construction of such callbacks
