### PR TITLE
Check error condition when setting default kubeconfig

### DIFF
--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -45,8 +45,10 @@ func initializeFlags() *EnvironmentFlags {
 	flag.StringVar(&f.Cluster, "cluster", defaultCluster,
 		"Provide the cluster to test against. Defaults to $K8S_CLUSTER_OVERRIDE, then current cluster in kubeconfig if $K8S_CLUSTER_OVERRIDE is unset.")
 
-	usr, _ := user.Current()
-	defaultKubeconfig := path.Join(usr.HomeDir, ".kube/config")
+	var defaultKubeconfig string
+	if usr, err := user.Current(); err == nil {
+		defaultKubeconfig = path.Join(usr.HomeDir, ".kube/config")
+	}
 
 	flag.StringVar(&f.Kubeconfig, "kubeconfig", defaultKubeconfig,
 		"Provide the path to the `kubeconfig` file you'd like to use for these tests. The `current-context` will be used.")


### PR DESCRIPTION
Avoid segmentation fault when the user is not returned correctly. This might happen when the tests are run from within a Docker container which runs as a non-root user and entries in /etc/passwd or /etc/group are not set. This is common when running on OpenShift. 
If the default kubeconfig is not set correctly the user can still pass their own config through the kubeconfig flag.

