### PR TITLE
Add static endpoint override to test/spoof

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -250,9 +250,9 @@ go test ./test --emitmetrics
 ```
 
 - To add additional metrics to a test, see
-  [emitting metrics](adding_tests.md#emit-metrics).
+  [emitting metrics](https://github.com/knative/pkg/tree/master/test#emit-metrics).
 - For more info on the format of the metrics, see
-  [metric format](adding_tests.md#metric-format).
+  [metric format](https://github.com/knative/pkg/tree/master/test#emit-metrics).
 
 [minikube]: https://kubernetes.io/docs/setup/minikube/
 

--- a/test/README.md
+++ b/test/README.md
@@ -213,6 +213,16 @@ The current cluster names can be obtained by running:
 kubectl config get-clusters
 ```
 
+### Specifying ingress endpoint
+
+The `--ingressendpoint` argument lets you specify a static url to use as the
+ingress server during tests. This is useful for Kubernetes configurations which
+do not provide external IPs.
+
+```bash
+go test ./test --ingressendpoint <k8s-controller-ip>:32380
+```
+
 ### Specifying namespace
 
 The `--namespace` argument lets you specify the namespace to use for the tests.

--- a/test/clients.go
+++ b/test/clients.go
@@ -35,7 +35,7 @@ type KubeClient struct {
 
 // NewSpoofingClient returns a spoofing client to make requests
 func NewSpoofingClient(client *KubeClient, logger *logging.BaseLogger, domain string, resolvable bool) (*spoof.SpoofingClient, error) {
-	return spoof.New(client.Kube, logger, domain, resolvable)
+	return spoof.New(client.Kube, logger, domain, resolvable, Flags.IngressEndpoint)
 }
 
 // NewKubeClient instantiates and returns several clientsets required for making request to the

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -32,11 +32,12 @@ var Flags = initializeFlags()
 
 // EnvironmentFlags define the flags that are needed to run the e2e tests.
 type EnvironmentFlags struct {
-	Cluster     string // K8s cluster (defaults to $K8S_CLUSTER_OVERRIDE)
-	Kubeconfig  string // Path to kubeconfig (defaults to ./kube/config)
-	Namespace   string // K8s namespace (blank by default, to be overwritten by test suite)
-	LogVerbose  bool   // Enable verbose logging
-	EmitMetrics bool   // Emit metrics
+	Cluster         string // K8s cluster (defaults to $K8S_CLUSTER_OVERRIDE)
+	Kubeconfig      string // Path to kubeconfig (defaults to ./kube/config)
+	Namespace       string // K8s namespace (blank by default, to be overwritten by test suite)
+	IngressEndpoint string // Host to use for ingress endpoint
+	LogVerbose      bool   // Enable verbose logging
+	EmitMetrics     bool   // Emit metrics
 }
 
 func initializeFlags() *EnvironmentFlags {
@@ -55,6 +56,8 @@ func initializeFlags() *EnvironmentFlags {
 
 	flag.StringVar(&f.Namespace, "namespace", "",
 		"Provide the namespace you would like to use for these tests.")
+
+	flag.StringVar(&f.IngressEndpoint, "ingressendpoint", "", "Provide a static endpoint url to the ingress server used during tests.")
 
 	flag.BoolVar(&f.LogVerbose, "logverbose", false,
 		"Set this flag to true if you would like to see verbose logging.")


### PR DESCRIPTION
When testing locally its common to use a cluster which both does not
have resolvable dns for ksvcs and does not have public IPs. Support
overriding the endpoint for knative's ingress controller to a static
value which can be set to e.g. the knative-ingressgateway nodeport.

<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:

Fixes: <LINK TO ISSUE>
-->
