### PR TITLE
requeue keys on error in controller

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -37,10 +37,6 @@ import (
 const (
 	falseString = "false"
 	trueString  = "true"
-
-	// maxRetries is the number of times a key will be retried before it is dropped out of the queue.
-	// TODO(lichuqiang): make this configurable?
-	maxRetries = 15
 )
 
 // Reconciler is the interface that controller implementations are expected
@@ -299,9 +295,8 @@ func (c *Impl) processNextWorkItem() bool {
 }
 
 func (c *Impl) handleErr(err error, key interface{}) {
-	// Re-queue the key if it's an transient error,
-	// and have not reach the max retry number.
-	if !IsPermanentError(err) && c.WorkQueue.NumRequeues(key) < maxRetries {
+	// Re-queue the key if it's an transient error.
+	if !IsPermanentError(err) {
 		c.WorkQueue.AddRateLimited(key)
 		return
 	}


### PR DESCRIPTION
<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:


-->

Fixes: https://github.com/knative/serving/issues/2350

Here I also introduce an error wrapper `permanentError`, which allow users to decide to requeue/not requeue a key on certain error(I meant to make it `transientError`, but considering the fact we will have to wrap existing errors in serving controllers that way, I make it the opposite).

/assign @mattmoor @tcnghia 