### PR TITLE
Adding cloudevents lib to pkg

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -961,6 +961,7 @@
   analyzer-version = 1
   input-imports = [
     "contrib.go.opencensus.io/exporter/stackdriver",
+    "github.com/davecgh/go-spew/spew",
     "github.com/evanphx/json-patch",
     "github.com/golang/glog",
     "github.com/google/go-cmp/cmp",
@@ -969,6 +970,8 @@
     "github.com/markbates/inflect",
     "github.com/mattbaird/jsonpatch",
     "go.opencensus.io/exporter/prometheus",
+    "go.opencensus.io/plugin/ochttp",
+    "go.opencensus.io/plugin/ochttp/propagation/b3",
     "go.opencensus.io/stats",
     "go.opencensus.io/stats/view",
     "go.opencensus.io/tag",

--- a/cloudevents/doc.go
+++ b/cloudevents/doc.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cloudevents implements utilities for handling CloudEvents.
+// For information on the spec, see
+// https://github.com/cloudevents/spec/blob/v0.1/http-transport-binding.md
+// and
+// https://github.com/cloudevents/spec/blob/v0.1/spec.md
+
+package cloudevents

--- a/cloudevents/encoding_binary.go
+++ b/cloudevents/encoding_binary.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevents
+
+// TODO(inlined): must add header encoding/decoding
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	// HeaderCloudEventsVersion is the header for the version of Cloud Events
+	// used.
+	HeaderCloudEventsVersion = "CE-CloudEventsVersion"
+
+	// HeaderEventID is the header for the unique ID of this event.
+	HeaderEventID = "CE-EventID"
+
+	// HeaderEventTime is the OPTIONAL header for the time at which an event
+	// occurred.
+	HeaderEventTime = "CE-EventTime"
+
+	// HeaderEventType is the header for type of event represented. Value SHOULD
+	// be in reverse-dns form.
+	HeaderEventType = "CE-EventType"
+
+	// HeaderEventTypeVersion is the OPTIONAL header for the version of the
+	// scheme for the event type.
+	HeaderEventTypeVersion = "CE-EventTypeVersion"
+
+	// HeaderSchemaURL is the OPTIONAL header for the schema of the event data.
+	HeaderSchemaURL = "CE-SchemaURL"
+
+	// HeaderSource is the header for the source which emitted this event.
+	HeaderSource = "CE-Source"
+
+	// HeaderExtensions is the OPTIONAL header prefix for CloudEvents extensions
+	headerExtensionsPrefix = "CE-X-"
+
+	// Binary implements Binary encoding/decoding
+	Binary binary = 0
+)
+
+type binary int
+
+// FromRequest parses event data and context from an HTTP request.
+func (binary) FromRequest(data interface{}, r *http.Request) (*EventContext, error) {
+	var ctx EventContext
+	err := anyError(
+		getRequiredHeader(r.Header, HeaderEventID, &ctx.EventID),
+		getRequiredHeader(r.Header, HeaderEventType, &ctx.EventType),
+		getRequiredHeader(r.Header, HeaderSource, &ctx.Source),
+		getRequiredHeader(r.Header, HeaderContentType, &ctx.ContentType))
+	if err != nil {
+		return nil, err
+	}
+
+	ctx.CloudEventsVersion = r.Header.Get(HeaderCloudEventsVersion)
+	if timeStr := r.Header.Get(HeaderEventTime); timeStr != "" {
+		if ctx.EventTime, err = time.Parse(time.RFC3339Nano, timeStr); err != nil {
+			return nil, err
+		}
+	}
+	ctx.EventTypeVersion = r.Header.Get(HeaderEventTypeVersion)
+	ctx.SchemaURL = r.Header.Get(HeaderSchemaURL)
+	if ctx.CloudEventsVersion != CloudEventsVersion {
+		log.Printf("Received CloudEvent version %q; parsing as version %q",
+			ctx.CloudEventsVersion, CloudEventsVersion)
+	}
+
+	ctx.Extensions = make(map[string]interface{})
+	for k, v := range r.Header {
+		if strings.ToUpper(k)[:len(headerExtensionsPrefix)] != headerExtensionsPrefix {
+			continue
+		}
+		name := k[len(headerExtensionsPrefix):]
+		var val interface{}
+		if err := json.Unmarshal([]byte(v[0]), &val); err != nil {
+			// If this is not a JSON object, treat it as a string.
+			// It's not clear when we would treat this as Bytes.
+			ctx.Extensions[name] = v[0]
+		} else {
+			ctx.Extensions[name] = val
+		}
+	}
+
+	if err := unmarshalEventData(ctx.ContentType, r.Body, data); err != nil {
+		return nil, err
+	}
+
+	return &ctx, nil
+}
+
+// NewRequest creates an HTTP request for Binary content encoding.
+func (binary) NewRequest(urlString string, data interface{}, context EventContext) (*http.Request, error) {
+	url, err := url.Parse(urlString)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ensureRequiredFields(context); err != nil {
+		return nil, err
+	}
+	// Defaultable values:
+	ceVersion := context.CloudEventsVersion
+	if ceVersion == "" {
+		ceVersion = CloudEventsVersion
+	}
+	contentType := context.ContentType
+	if contentType == "" {
+		contentType = contentTypeJSON
+	}
+
+	// non-string values:
+	eventTime := ""
+	if !context.EventTime.IsZero() {
+		eventTime = context.EventTime.Format(time.RFC3339Nano)
+	}
+
+	h := http.Header{}
+	setHeader(h, HeaderCloudEventsVersion, ceVersion)
+	setHeader(h, HeaderEventID, context.EventID)
+	setHeader(h, HeaderEventTime, eventTime)
+	setHeader(h, HeaderEventType, context.EventType)
+	setHeader(h, HeaderEventTypeVersion, context.EventTypeVersion)
+	setHeader(h, HeaderSchemaURL, context.SchemaURL)
+	setHeader(h, HeaderContentType, contentType)
+	setHeader(h, HeaderSource, context.Source)
+	for name, value := range context.Extensions {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+		h[headerExtensionsPrefix+name] = []string{
+			string(encoded),
+		}
+	}
+
+	b, err := marshalEventData(contentType, data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Request{
+		Method: http.MethodPost,
+		URL:    url,
+		Header: h,
+		Body:   ioutil.NopCloser(bytes.NewReader(b)),
+	}, nil
+}
+
+// TODO(inlined) URI encoding/decoding of headers
+func getHeader(h http.Header, name string) string {
+	return h.Get(name)
+}
+
+func setHeader(h http.Header, name string, value string) {
+	if value != "" {
+		h.Set(name, value)
+	}
+}
+func getRequiredHeader(h http.Header, name string, value *string) error {
+	if *value = getHeader(h, name); *value == "" {
+		return fmt.Errorf("missing required header %q", name)
+	}
+	return nil
+}

--- a/cloudevents/encoding_structured.go
+++ b/cloudevents/encoding_structured.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevents
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	// Structured implements the JSON structured encoding/decoding
+	Structured structured = 0
+)
+
+type structured int
+
+type structuredEnvelope struct {
+	EventContext
+	RawData json.RawMessage `json:"data"`
+}
+
+// FromRequest parses a CloudEvent from structured content encoding.
+func (structured) FromRequest(data interface{}, r *http.Request) (*EventContext, error) {
+	var e structuredEnvelope
+	if err := json.NewDecoder(r.Body).Decode(&e); err != nil {
+		return nil, err
+	}
+
+	contentType := e.EventContext.ContentType
+	if contentType == "" {
+		contentType = contentTypeJSON
+	}
+	var reader io.Reader
+	if !isJSONEncoding(contentType) {
+		var jsonDecoded string
+		if err := json.Unmarshal(e.RawData, &jsonDecoded); err != nil {
+			return nil, fmt.Errorf("Could not JSON decode %q value %q", contentType, string(e.RawData))
+		}
+		reader = strings.NewReader(jsonDecoded)
+	} else {
+		reader = bytes.NewReader(e.RawData)
+	}
+	if e.EventContext.Extensions == nil {
+		e.EventContext.Extensions = make(map[string]interface{}, 0)
+	}
+	if err := unmarshalEventData(contentType, reader, data); err != nil {
+		return nil, err
+	}
+	return &e.EventContext, nil
+}
+
+// NewRequest creates an HTTP request for Structured content encoding.
+func (structured) NewRequest(urlString string, data interface{}, context EventContext) (*http.Request, error) {
+	url, err := url.Parse(urlString)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ensureRequiredFields(context); err != nil {
+		return nil, err
+	}
+
+	contentType := context.ContentType
+	if contentType == "" {
+		contentType = contentTypeJSON
+	}
+	e := structuredEnvelope{
+		EventContext: context,
+	}
+	dataBytes, err := marshalEventData(contentType, data)
+	if err != nil {
+		return nil, err
+	}
+	if isJSONEncoding(contentType) {
+		e.RawData = json.RawMessage(dataBytes)
+	} else {
+		e.RawData, err = json.Marshal(string(dataBytes))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	b, err := json.Marshal(e)
+	if err != nil {
+		return nil, err
+	}
+
+	h := http.Header{}
+	h.Set(HeaderContentType, ContentTypeStructuredJSON)
+	return &http.Request{
+		Method: http.MethodPost,
+		URL:    url,
+		Header: h,
+		Body:   ioutil.NopCloser(bytes.NewReader(b)),
+	}, nil
+}

--- a/cloudevents/event.go
+++ b/cloudevents/event.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevents
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"time"
+)
+
+const (
+	// CloudEventsVersion is the version of the CloudEvents spec targeted
+	// by this library.
+	CloudEventsVersion = "0.1"
+
+	// ContentTypeStructuredJSON is the content-type for "Structured" encoding
+	// where an event envelope is written in JSON and the body is arbitrary
+	// data which might be an alternate encoding.
+	ContentTypeStructuredJSON = "application/cloudevents+json"
+
+	// ContentTypeBinaryJSON is the content-type for "Binary" encoding where
+	// the event context is in HTTP headers and the body is a JSON event data.
+	ContentTypeBinaryJSON = "application/json"
+
+	// TODO(inlined) what about charset additions?
+	contentTypeJSON = "application/json"
+	contentTypeXML  = "application/xml"
+
+	// HeaderContentType is the standard HTTP header "Content-Type"
+	HeaderContentType = "Content-Type"
+
+	fieldCloudEventsVersion = "CloudEventsVersion"
+	fieldEventID            = "EventID"
+	fieldEventType          = "EventType"
+	fieldEventTime          = "EventTime"
+	fieldSource             = "Source"
+)
+
+// EventContext holds standard metadata about an event. See
+// https://github.com/cloudevents/spec/blob/v0.1/spec.md#context-attributes for
+// details on these fields.
+type EventContext struct {
+	// The version of the CloudEvents specification used by the event.
+	CloudEventsVersion string `json:"cloudEventsVersion,omitempty"`
+	// ID of the event; must be non-empty and unique within the scope of the producer.
+	EventID string `json:"eventID"`
+	// Timestamp when the event happened.
+	EventTime time.Time `json:"eventTime,omitempty"`
+	// Type of occurrence which has happened.
+	EventType string `json:"eventType"`
+	// The version of the `eventType`; this is producer-specific.
+	EventTypeVersion string `json:"eventTypeVersion,omitempty"`
+	// A link to the schema that the `data` attribute adheres to.
+	SchemaURL string `json:"schemaURL,omitempty"`
+	// A MIME (RFC 2046) string describing the media type of `data`.
+	// TODO: Should an empty string assume `application/json`, or auto-detect the content?
+	ContentType string `json:"contentType,omitempty"`
+	// A URI describing the event producer.
+	Source string `json:"source"`
+	// Additional metadata without a well-defined structure.
+	Extensions map[string]interface{} `json:"extensions,omitempty"`
+}
+
+// HTTPMarshaller implements a scheme for decoding CloudEvents over HTTP.
+// Implementations are Binary, Structured, and Any
+type HTTPMarshaller interface {
+	FromRequest(data interface{}, r *http.Request) (*EventContext, error)
+	NewRequest(urlString string, data interface{}, context EventContext) (*http.Request, error)
+}
+
+func anyError(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ensureRequiredFields(context EventContext) error {
+	return anyError(
+		require(fieldEventID, context.EventID),
+		require(fieldEventType, context.EventType),
+		require(fieldSource, context.Source))
+}
+
+func require(name string, value string) error {
+	if len(value) == 0 {
+		return fmt.Errorf("missing required field %q", name)
+	}
+	return nil
+}
+
+// The Cloud-Events spec allows two forms of JSON encoding:
+// 1. The overall message (Structured JSON encoding)
+// 2. Just the event data, where the context will be in HTTP headers instead
+//
+// Case #1 actually includes case #2. In structured binary encoding the JSON
+// HTTP body itself allows for cross-encoding of the "data" field.
+// This method is only intended for checking that inner JSON encoding type.
+func isJSONEncoding(encoding string) bool {
+	return encoding == contentTypeJSON || encoding == "text/json"
+}
+
+func isXMLEncoding(encoding string) bool {
+	return encoding == contentTypeXML || encoding == "text/xml"
+}
+
+func unmarshalEventData(encoding string, reader io.Reader, data interface{}) error {
+	// The Handler tools allow developers to not ask for event data;
+	// in this case, just don't unmarshal anything
+	if data == nil {
+		return nil
+	}
+
+	// If someone tried to marshal an event into an io.Reader, just assign our existing reader.
+	// (This is used by event.Mux to determine which type to unmarshal as)
+	readerPtrType := reflect.TypeOf((*io.Reader)(nil))
+	if reflect.TypeOf(data).ConvertibleTo(readerPtrType) {
+		reflect.ValueOf(data).Elem().Set(reflect.ValueOf(reader))
+		return nil
+	}
+	if isJSONEncoding(encoding) || encoding == "" {
+		return json.NewDecoder(reader).Decode(&data)
+	}
+
+	if isXMLEncoding(encoding) {
+		return xml.NewDecoder(reader).Decode(&data)
+	}
+
+	return fmt.Errorf("Cannot decode content type %q", encoding)
+}
+
+func marshalEventData(encoding string, data interface{}) ([]byte, error) {
+	var b []byte
+	var err error
+
+	if isJSONEncoding(encoding) {
+		b, err = json.Marshal(data)
+	} else if isXMLEncoding(encoding) {
+		b, err = xml.Marshal(data)
+	} else {
+		err = fmt.Errorf("Cannot encode content type %q", encoding)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// FromRequest parses a CloudEvent from any known encoding.
+func FromRequest(data interface{}, r *http.Request) (*EventContext, error) {
+	switch r.Header.Get(HeaderContentType) {
+	case ContentTypeStructuredJSON:
+		return Structured.FromRequest(data, r)
+	case ContentTypeBinaryJSON:
+		return Binary.FromRequest(data, r)
+	default:
+		// TODO: assume binary content mode
+		// (https://github.com/cloudevents/spec/blob/v0.1/http-transport-binding.md#3-http-message-mapping)
+		// and that data is ??? (io.Reader?, byte array?)
+		return nil, fmt.Errorf("Cannot handle encoding %q", r.Header.Get("Content-Type"))
+	}
+}
+
+// NewRequest craetes an HTTP request for Structured content encoding.
+func NewRequest(urlString string, data interface{}, context EventContext) (*http.Request, error) {
+	return Structured.NewRequest(urlString, data, context)
+}
+
+// Opaque key type used to store EventContexts in a context.Context
+type contextKeyType struct{}
+
+var contextKey = contextKeyType{}
+
+// FromContext loads an EventContext from a normal context.Context
+func FromContext(ctx context.Context) *EventContext {
+	return ctx.Value(contextKey).(*EventContext)
+}

--- a/cloudevents/event_test.go
+++ b/cloudevents/event_test.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevents_test
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/knative/pkg/cloudevents"
+)
+
+type FirestoreDocument struct {
+	Name       string                 `json:"name"`
+	Fields     map[string]interface{} `json:"fields"`
+	CreateTime time.Time              `json:"createTime"`
+	UpdateTime time.Time              `json:"updateTime"`
+}
+
+var (
+	webhook = "http://localhost/:sendEvent"
+)
+
+// Wrap the global functions in an HTTPMarshaller interface for table-driven testing:
+type defaultMarshaller int
+
+var Default defaultMarshaller = 0
+
+func (defaultMarshaller) FromRequest(data interface{}, r *http.Request) (*cloudevents.EventContext, error) {
+	return cloudevents.FromRequest(data, r)
+}
+func (defaultMarshaller) NewRequest(urlString string, data interface{}, context cloudevents.EventContext) (*http.Request, error) {
+	return cloudevents.NewRequest(urlString, data, context)
+}
+
+func TestValidRoundTrips(t *testing.T) {
+	doc := FirestoreDocument{
+		Name: "projects/demo/databases/default/documents/users/inlined",
+		Fields: map[string]interface{}{
+			"project": "eventing",
+			"handle":  "@inlined",
+		},
+		CreateTime: time.Date(1985, 6, 5, 12, 0, 0, 0, time.UTC),
+		UpdateTime: time.Now().UTC(),
+	}
+
+	service := "firestore.googleapis.com"
+
+	context := &cloudevents.EventContext{
+		CloudEventsVersion: "0.1",
+		EventID:            "eventid-123",
+		EventTime:          doc.UpdateTime,
+		EventType:          "google.firestore.document.create",
+		EventTypeVersion:   "v1beta2",
+		SchemaURL:          "http://type.googleapis.com/google.firestore.v1beta1.Document",
+		ContentType:        "application/json",
+		Source:             fmt.Sprintf("//%s/%s", service, doc.Name),
+		Extensions: map[string]interface{}{
+			"purpose": "tbd",
+		},
+	}
+	for _, test := range []struct {
+		name    string
+		encoder cloudevents.HTTPMarshaller
+		decoder cloudevents.HTTPMarshaller
+	}{
+		{
+			name:    "binary -> binary",
+			encoder: cloudevents.Binary,
+			decoder: cloudevents.Binary,
+		},
+		{
+			name:    "binary -> default",
+			encoder: cloudevents.Binary,
+			decoder: Default,
+		},
+		{
+			name:    "structured -> structured",
+			encoder: cloudevents.Structured,
+			decoder: cloudevents.Structured,
+		},
+		{
+			name:    "structured -> default",
+			encoder: cloudevents.Structured,
+			decoder: Default,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req, err := test.encoder.NewRequest(webhook, doc, *context)
+			if err != nil {
+				t.Fatalf("Failed to encode event %s", err)
+			}
+
+			var foundData FirestoreDocument
+			foundContext, err := test.decoder.FromRequest(&foundData, req)
+			if err != nil {
+				t.Fatalf("Failed to decode event %s", err)
+			}
+
+			if !reflect.DeepEqual(context, foundContext) {
+				t.Fatalf("Context was transcoded lossily: expected=%+v got=%+v", context, foundContext)
+			}
+			if !reflect.DeepEqual(doc, foundData) {
+				t.Fatalf("Data was transcoded lossily: expected=%+v got=%+v", doc, foundData)
+			}
+		})
+	}
+}
+
+type Address struct {
+	City, State string
+}
+type Person struct {
+	XMLName   xml.Name `xml:"person"`
+	Id        int      `xml:"id,attr"`
+	FirstName string   `xml:"name>first"`
+	LastName  string   `xml:"name>last"`
+	Age       int      `xml:"age"`
+	Height    float32  `xml:"height,omitempty"`
+	Married   bool
+	Address
+	Comment string `xml:",comment"`
+}
+
+func (Person) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("Person cannot be JSON encoded")
+}
+
+func (*Person) UnmarshalJSON([]byte) error {
+	return errors.New("Person cannot be JSON decoded")
+}
+
+func TestXmlStructuredDecoding(t *testing.T) {
+	person := &Person{
+		XMLName: xml.Name{
+			Local: "person",
+		},
+		Id:        13,
+		FirstName: "John",
+		LastName:  "Doe",
+		Age:       42,
+		Comment:   " Need more details. ",
+		Address:   Address{"Hanga Roa", "Easter Island"},
+	}
+
+	xmlPerson := `
+		<person id="13">
+			<name>
+				<first>John</first>
+				<last>Doe</last>
+			</name>
+			<age>42</age>
+			<Married>false</Married>
+			<City>Hanga Roa</City>
+			<State>Easter Island</State>
+			<!-- Need more details. -->
+		</person>`
+	xmlJsonSafe, err := json.Marshal(xmlPerson)
+	if err != nil {
+		t.Fatalf("Failed to create JSON encoded XML string: %s", err)
+	}
+
+	eventText := `
+	{
+		"eventID": "1234",
+		"eventType": "dev.eventing.test",
+		"source": "tests://TextXmlStructuredEncoding",
+		"contentType": "application/xml",
+		"data": ` + string(xmlJsonSafe) + `
+	}`
+
+	h := http.Header{}
+	h.Set(cloudevents.HeaderContentType, cloudevents.ContentTypeStructuredJSON)
+	req := &http.Request{
+		Header: h,
+		Body:   ioutil.NopCloser(strings.NewReader(eventText)),
+	}
+
+	var foundPerson Person
+	_, err = cloudevents.FromRequest(&foundPerson, req)
+	if err != nil {
+		t.Fatalf("Failed to parse cross-encoded request: %s", err)
+	}
+
+	if !reflect.DeepEqual(person, &foundPerson) {
+		t.Fatalf("Failed to parse xml-encoded data; wanted=%+v; got=%+v", person, foundPerson)
+	}
+}
+
+func TestExtensionsAreNeverNil(t *testing.T) {
+	r := &http.Request{
+		Header: http.Header{
+			cloudevents.HeaderContentType: []string{cloudevents.ContentTypeStructuredJSON},
+		},
+		Body: ioutil.NopCloser(strings.NewReader(`
+			{
+				"eventID": "1234",
+				"eventType": "dev.eventing.test",
+				"source": "tests://TextXmlStructuredEncoding",
+				"data": "hello, world"
+			}`)),
+	}
+
+	var data interface{}
+	ctx, err := cloudevents.FromRequest(&data, r)
+	if err != nil {
+		t.Fatal("Failed to parse request", err)
+	}
+	if ctx.Extensions == nil {
+		t.Fatal("Extensions should never be nil")
+	}
+}
+
+func TestExtensionExtraction(t *testing.T) {
+	h := http.Header{}
+	h.Set(cloudevents.HeaderContentType, cloudevents.ContentTypeBinaryJSON)
+	h.Set(cloudevents.HeaderEventID, "1234")
+	h.Set(cloudevents.HeaderEventType, "dev.eventing.test")
+	h.Set(cloudevents.HeaderSource, "tests://TestExtensionExtraction")
+	h.Set("CE-X-Prop1", "value1")
+	h.Set("CE-X-Prop2", `{"nestedProp":"nestedValue"}`)
+	b := strings.NewReader(`{"hello": "world"}`)
+
+	r := &http.Request{
+		Header: h,
+		Body:   ioutil.NopCloser(b),
+	}
+	var data interface{}
+	ctx, err := cloudevents.FromRequest(&data, r)
+	if err != nil {
+		t.Fatal("Failed to parse request", err)
+	}
+
+	expectedExtensions := map[string]interface{}{
+		"Prop1": "value1",
+		"Prop2": map[string]interface{}{
+			"nestedProp": "nestedValue",
+		},
+	}
+	if !reflect.DeepEqual(expectedExtensions, ctx.Extensions) {
+		t.Fatalf("Did not parse expected extensions. Wanted=%v; got=%v", expectedExtensions, ctx.Extensions)
+	}
+}

--- a/cloudevents/handler.go
+++ b/cloudevents/handler.go
@@ -1,0 +1,353 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"reflect"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+type handler struct {
+	numIn    int
+	fnValue  reflect.Value
+	dataType reflect.Type
+}
+
+type failedHandler struct {
+	err error
+}
+
+type errAndHandler interface {
+	http.Handler
+	error
+}
+
+const (
+	inParamUsage  = "Expected a function taking either no parameters, a context.Context, or (context.Context, any)"
+	outParamUsage = "Expected a function returning either nothing, an error, or (any, error)"
+)
+
+var (
+	// FYI: Getting the type of an interface is a bit hard in Go because of nil is special:
+	// 1. Structs & pointers have concrete types, whereas interfaces are actually tuples of
+	//    [implementation vtable, pointer].
+	// 2. Literals (such as nil) can be cast to any relevant type.
+	// Because TypeOf takes an interface{}, a nil interface reference would cast lossily when
+	// it leaves this stack frame. The workaround is to pass a pointer to an interface and then
+	// get the type of its reference.
+	// For example, see: https://play.golang.org/p/_dxLvdkvqvg
+	contextType = reflect.TypeOf((*context.Context)(nil)).Elem()
+	errorType   = reflect.TypeOf((*error)(nil)).Elem()
+)
+
+// Verifies that the inputs to a function have a valid signature; panics otherwise.
+// Valid input signatures:
+// (), (context.Context), (context.Context, any)
+func validateInParamSignature(fnType reflect.Type) error {
+	switch fnType.NumIn() {
+	case 2:
+		fallthrough
+	case 1:
+		if !fnType.In(0).ConvertibleTo(contextType) {
+			return fmt.Errorf("%s; cannot convert parameter 0 from %s to context.Context", inParamUsage, fnType.In(0))
+		}
+		fallthrough
+	case 0:
+		return nil
+	default:
+		return fmt.Errorf("%s; function has too many parameters (%d)", inParamUsage, fnType.NumIn())
+	}
+}
+
+// Verifies that the outputs of a function have a valid signature; panics otherwise.
+// Valid output signatures:
+// (), (error), (any, error)
+func validateOutParamSignature(fnType reflect.Type) error {
+	switch fnType.NumOut() {
+	case 2:
+		fallthrough
+	case 1:
+		paramNo := fnType.NumOut() - 1
+		paramType := fnType.Out(paramNo)
+		if !paramType.ConvertibleTo(errorType) {
+			return fmt.Errorf("%s; cannot convert return type %d from %s to error", outParamUsage, paramNo, paramType)
+		}
+		fallthrough
+	case 0:
+		return nil
+	default:
+		return fmt.Errorf("%s; function has too many return types (%d)", outParamUsage, fnType.NumOut())
+	}
+}
+
+// Verifies that a function has the right number of in and out params and that they are
+// of allowed types. If successful, returns the expected in-param type, otherwise panics.
+func validateFunction(fnType reflect.Type) errAndHandler {
+	if fnType.Kind() != reflect.Func {
+		return &failedHandler{err: fmt.Errorf("Must pass a function to handle events")}
+	}
+	err := anyError(
+		validateInParamSignature(fnType),
+		validateOutParamSignature(fnType))
+	if err != nil {
+		return &failedHandler{err: err}
+	}
+	return nil
+}
+
+// Alocates a new instance of type t and returns:
+// asPtr is of type t if t is a pointer type and of type &t otherwise (used for unmarshalling)
+// asValue is a Value of type t pointing to the same data as asPtr
+func allocate(t reflect.Type) (asPtr interface{}, asValue reflect.Value) {
+	if t == nil {
+		return nil, reflect.Value{}
+	}
+	if t.Kind() == reflect.Ptr {
+		reflectPtr := reflect.New(t.Elem())
+		asPtr = reflectPtr.Interface()
+		asValue = reflectPtr
+	} else {
+		reflectPtr := reflect.New(t)
+		asPtr = reflectPtr.Interface()
+		asValue = reflectPtr.Elem()
+	}
+	return
+}
+
+func unwrapReturnValues(res []reflect.Value) (interface{}, error) {
+	switch len(res) {
+	case 0:
+		return nil, nil
+	case 1:
+		if res[0].IsNil() {
+			return nil, nil
+		}
+		// Should be a safe cast due to assertEventHandler()
+		return nil, res[0].Interface().(error)
+	case 2:
+		if res[1].IsNil() {
+			return res[0].Interface(), nil
+		}
+		// Should be a safe cast due to assertEventHandler()
+		return nil, res[1].Interface().(error)
+	default:
+		// Should never happen due to assertEventHandler()
+		panic("Cannot unmarshal more than 2 return values")
+	}
+}
+
+// Accepts the results from a handler functions and translates them to an HTTP response
+func respondHTTP(outparams []reflect.Value, w http.ResponseWriter) {
+	res, err := unwrapReturnValues(outparams)
+
+	if err != nil {
+		log.Print("Failed to handle event: ", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`Internal server error`))
+		return
+	}
+
+	if res != nil {
+		json, err := json.Marshal(res)
+		if err != nil {
+			log.Printf("Failed to marshal return value %+v: %s", res, err)
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`Internal server error`))
+		} else {
+			w.Write(json)
+		}
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Handler creates an EventHandler that implements http.Handler
+// If the fn parameter is not a valid type, will produce an http.Handler that also conforms
+// to error and will respond to all HTTP requests with that error. Valid types of fn are:
+//
+// * func()
+// * func() error
+// * func() (anything, error)
+// * func(context.Context)
+// * func(context.Context) error
+// * func(context.Context) (anything, error)
+// * func(context.Context, anything)
+// * func(context.Context, anything) error
+// * func(context.Context, anything) (anything, error)
+//
+// CloudEvent contexts are available from the context.Context parameter
+// CloudEvent data will be deserialized into the "anything" parameter.
+// The library supports native decoding with both XML and JSON encoding.
+// To accept another advanced type, pass an io.Reader as the input parameter.
+//
+// HTTP responses are generated based on the return value of fn:
+// * any error return value will cause a StatusInternalServerError response
+// * a function with no return type or a function returning nil will cause a StatusNoContent response
+// * a function that returns a value will cause a StatusOK and render the response as JSON
+func Handler(fn interface{}) http.Handler {
+	fnType := reflect.TypeOf(fn)
+	err := validateFunction(fnType)
+	if err != nil {
+		return err
+	}
+	var dataType reflect.Type
+	if fnType.NumIn() == 2 {
+		dataType = fnType.In(1)
+	}
+
+	return &handler{
+		numIn:    fnType.NumIn(),
+		dataType: dataType,
+		fnValue:  reflect.ValueOf(fn),
+	}
+}
+
+// ServeHTTP implements http.Handler
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	args := make([]reflect.Value, 0, 2)
+
+	if h.numIn > 0 {
+		dataPtr, dataArg := allocate(h.dataType)
+		eventContext, err := FromRequest(dataPtr, r)
+		if err != nil {
+			log.Printf("Failed to handle request %s; error %s", spew.Sdump(r), err)
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`Invalid request`))
+			return
+		}
+
+		ctx := r.Context()
+		ctx = context.WithValue(ctx, contextKey, eventContext)
+		args = append(args, reflect.ValueOf(ctx))
+
+		if h.numIn == 2 {
+			args = append(args, dataArg)
+		}
+	}
+
+	res := h.fnValue.Call(args)
+	respondHTTP(res, w)
+}
+
+func (h failedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	log.Print("Failed to handle event: ", h.Error())
+	w.WriteHeader(http.StatusNotImplemented)
+	w.Write([]byte(`Internal server error`))
+}
+
+func (h failedHandler) Error() string {
+	return h.err.Error()
+}
+
+// Mux allows developers to handle logically related groups of
+// functionality multiplexed based on the event type.
+// TODO: Consider dropping Mux or figure out how to handle non-JSON encoding.
+type Mux map[string]*handler
+
+// NewMux creates a new Mux
+func NewMux() Mux {
+	return make(map[string]*handler)
+}
+
+// Handle adds a new handler for a specific event type
+// If the fn parameter is not a valid type, the endpoint will respond to all HTTP requests
+// with that error. Valid types of fn are:
+//
+// * func()
+// * func() error
+// * func() (anything, error)
+// * func(context.Context)
+// * func(context.Context) error
+// * func(context.Context) (anything, error)
+// * func(context.Context, anything)
+// * func(context.Context, anything) error
+// * func(context.Context, anything) (anything, error)
+//
+// CloudEvent contexts are available from the context.Context parameter
+// CloudEvent data will be deserialized into the "anything" parameter.
+// The library supports native decoding with both XML and JSON encoding.
+// To accept another advanced type, pass an io.Reader as the input parameter.
+//
+// HTTP responses are generated based on the return value of fn:
+// * any error return value will cause a StatusInternalServerError response
+// * a function with no return type or a function returning nil will cause a StatusNoContent response
+// * a function that returns a value will cause a StatusOK and render the response as JSON
+func (m Mux) Handle(eventType string, fn interface{}) error {
+	fnType := reflect.TypeOf(fn)
+	err := validateFunction(fnType)
+	if err != nil {
+		return err
+	}
+	var dataType reflect.Type
+	if fnType.NumIn() == 2 {
+		dataType = fnType.In(1)
+	}
+	m[eventType] = &handler{
+		numIn:    fnType.NumIn(),
+		dataType: dataType,
+		fnValue:  reflect.ValueOf(fn),
+	}
+	return nil
+}
+
+// ServeHTTP implements http.Handler
+func (m Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var rawData io.Reader
+	eventContext, err := FromRequest(&rawData, r)
+	if err != nil {
+		log.Printf("Failed to handle request: %s %s", err, spew.Sdump(r))
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`Invalid request`))
+		return
+	}
+
+	h := m[eventContext.EventType]
+	if h == nil {
+		log.Print("Cloud not find handler for event type", eventContext.EventType)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(fmt.Sprintf("Event type %q is not supported", eventContext.EventType)))
+		return
+	}
+
+	args := make([]reflect.Value, 0, 2)
+	if h.numIn > 0 {
+		ctx := r.Context()
+		ctx = context.WithValue(ctx, contextKey, eventContext)
+		args = append(args, reflect.ValueOf(ctx))
+	}
+	if h.numIn == 2 {
+		dataPtr, dataArg := allocate(h.dataType)
+		if err := unmarshalEventData(eventContext.ContentType, rawData, dataPtr); err != nil {
+			log.Print("Failed to parse event data", err)
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`Invalid request`))
+			return
+		}
+		args = append(args, dataArg)
+	}
+
+	res := h.fnValue.Call(args)
+	respondHTTP(res, w)
+}

--- a/cloudevents/handler_test.go
+++ b/cloudevents/handler_test.go
@@ -1,0 +1,461 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevents_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/knative/pkg/cloudevents"
+)
+
+func TestHandlerTypeErrors(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		param interface{}
+		err   string
+	}{
+		{
+			name:  "non-func",
+			param: 5,
+			err:   "Must pass a function to handle events",
+		},
+		{
+			name:  "wrong param count",
+			param: func(context.Context, interface{}, interface{}) {},
+			err:   "Expected a function taking either no parameters, a context.Context, or (context.Context, any); function has too many parameters (3)",
+		},
+		{
+			name:  "wrong first parameter type",
+			param: func(int) {},
+			err:   "Expected a function taking either no parameters, a context.Context, or (context.Context, any); cannot convert parameter 0 from int to context.Context",
+		},
+		{
+			name:  "wrong return count",
+			param: func() (interface{}, error, interface{}) { return nil, nil, nil },
+			err:   "Expected a function returning either nothing, an error, or (any, error); function has too many return types (3)",
+		},
+		{
+			name:  "invalid return type",
+			param: func() interface{} { return nil },
+			err:   "Expected a function returning either nothing, an error, or (any, error); cannot convert return type 0 from interface {} to error",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := cloudevents.Handler(test.param)
+			err, ok := h.(error)
+			if !ok {
+				t.Fatalf("Expected Handler() to fail with %v, passed", test.err)
+			}
+			if !strings.Contains(err.Error(), test.err) {
+				t.Errorf("Expected Handler() to fail. want %q, got %v", test.err, err)
+			}
+
+			// Attempt to call the returned Handler to verify it fails.
+			srv := httptest.NewServer(h)
+			defer srv.Close()
+			type E struct{}
+			req, err := cloudevents.NewRequest(srv.URL, E{}, cloudevents.EventContext{
+				EventID: "1", EventType: "a", Source: "one"})
+			if err != nil {
+				t.Errorf("Couldn't construct request: %v", err)
+			}
+			if resp, err := srv.Client().Do(req); err != nil {
+				t.Errorf("Failed to Post event: %v", resp)
+			} else if resp.StatusCode != http.StatusNotImplemented {
+				t.Errorf("Expected error status. got %d, got %d", resp.StatusCode, http.StatusNotImplemented)
+			}
+		})
+	}
+}
+
+func TestHandlerValidTypes(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		f    interface{}
+	}{
+		{
+			name: "no in, no out",
+			f:    func() {},
+		}, {
+			name: "one in, no out",
+			f:    func(context.Context) {},
+		}, {
+			name: "interface in, no out",
+			f:    func(context.Context, io.Reader) {},
+		}, {
+			name: "value-type in, no out",
+			f:    func(context.Context, int) {},
+		}, {
+			name: "pointer-type in, no out",
+			f:    func(context.Context, *int) {},
+		}, {
+			name: "no in, one out",
+			f:    func() error { return nil },
+		}, {
+			name: "one in, one out",
+			f:    func(context.Context) error { return nil },
+		}, {
+			name: "two in, one out",
+			f:    func(context.Context, string) error { return nil },
+		}, {
+			name: "no in, two out",
+			f:    func() (string, error) { return "", nil },
+		}, {
+			name: "one in, two out",
+			f:    func(context.Context) (map[string]interface{}, error) { return nil, nil },
+		}, {
+			name: "two in, two out",
+			f:    func(context.Context, io.Reader) (interface{}, error) { return nil, nil },
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err, ok := cloudevents.Handler(test.f).(error); ok {
+				t.Errorf("%q failed: %v", test.name, err)
+			}
+		})
+	}
+}
+
+func TestParameterMarsahlling(t *testing.T) {
+	type Data struct {
+		Message string
+	}
+	expectedData := Data{Message: "Hello, world!"}
+	expectedContext := &cloudevents.EventContext{
+		CloudEventsVersion: cloudevents.CloudEventsVersion,
+		EventID:            "1234",
+		Source:             "tests:TestUndtypedHandling",
+		EventType:          "dev.eventing.test",
+		EventTime:          time.Now().UTC(),
+		ContentType:        "application/json",
+		Extensions:         map[string]interface{}{},
+	}
+	var wasCalled = false
+	for _, marshaller := range []struct {
+		name string
+		val  cloudevents.HTTPMarshaller
+	}{
+		{
+			name: "structured",
+			val:  cloudevents.Structured,
+		}, {
+			name: "binary",
+			val:  cloudevents.Binary,
+		},
+	} {
+		for _, test := range []struct {
+			name      string
+			generator func(t *testing.T) http.Handler
+		}{
+			{
+				name: "no parameters",
+				generator: func(t *testing.T) http.Handler {
+					return cloudevents.Handler(func() {
+						wasCalled = true
+					})
+				},
+			},
+			{
+				name: "one parameter",
+				generator: func(t *testing.T) http.Handler {
+					return cloudevents.Handler(func(ctx context.Context) {
+						eventContext := cloudevents.FromContext(ctx)
+						if !reflect.DeepEqual(expectedContext, eventContext) {
+							t.Fatalf("Did not get expected context; wanted=%s; got=%s", spew.Sdump(expectedContext), spew.Sdump(eventContext))
+						}
+						wasCalled = true
+					})
+				},
+			}, {
+				name: "two parameters (struct type)",
+				generator: func(t *testing.T) http.Handler {
+					return cloudevents.Handler(func(ctx context.Context, data Data) {
+						eventContext := cloudevents.FromContext(ctx)
+						if !reflect.DeepEqual(expectedContext, eventContext) {
+							t.Fatalf("Did not get expected context; wanted=%s; got=%s", spew.Sdump(expectedContext), spew.Sdump(eventContext))
+						}
+						if !reflect.DeepEqual(expectedData, data) {
+							t.Fatalf("Did not get expected data; wanted=%s; got=%s", spew.Sdump(expectedData), spew.Sdump(data))
+						}
+						wasCalled = true
+					})
+				},
+			}, {
+				name: "two parameters (pointer type)",
+				generator: func(t *testing.T) http.Handler {
+					return cloudevents.Handler(func(ctx context.Context, data *Data) {
+						eventContext := cloudevents.FromContext(ctx)
+						if !reflect.DeepEqual(expectedContext, eventContext) {
+							t.Fatalf("Did not get expected context; wanted=%s; got=%s", spew.Sdump(expectedContext), spew.Sdump(eventContext))
+						}
+						if !reflect.DeepEqual(expectedData, *data) {
+							t.Fatalf("Did not get expected data; wanted=%s; got=%s", spew.Sdump(&expectedData), spew.Sdump(data))
+						}
+						wasCalled = true
+					})
+				},
+			}, {
+				name: "two parameters (untyped)",
+				generator: func(t *testing.T) http.Handler {
+					return cloudevents.Handler(func(ctx context.Context, data map[string]interface{}) {
+						eventContext := cloudevents.FromContext(ctx)
+						if !reflect.DeepEqual(expectedContext, eventContext) {
+							t.Fatalf("Did not get expected context; wanted=%s; got=%s", spew.Sdump(expectedContext), spew.Sdump(eventContext))
+						}
+						b, err := json.Marshal(expectedData)
+						if err != nil {
+							t.Fatal("Failed to serialize expected data", err)
+						}
+						var expectedUntyped map[string]interface{}
+						err = json.Unmarshal(b, &expectedUntyped)
+						if err != nil {
+							t.Fatal("Failed to deserialize expected data", err)
+						}
+						if !reflect.DeepEqual(expectedUntyped, data) {
+							t.Fatalf("Did not get expected data; wanted=%s; got=%s", spew.Sdump(expectedUntyped), spew.Sdump(data))
+						}
+						wasCalled = true
+					})
+				},
+			},
+		} {
+			t.Run(fmt.Sprintf("%s: %s", marshaller.name, test.name), func(t *testing.T) {
+				wasCalled = false
+				handler := test.generator(t)
+				if err, ok := handler.(error); ok {
+					t.Errorf("Handler() failed: %v", err)
+					return
+				}
+				srv := httptest.NewServer(handler)
+				defer srv.Close()
+				req, err := marshaller.val.NewRequest(srv.URL, expectedData, *expectedContext)
+				if err != nil {
+					t.Fatal("Failed to marshal request ", err)
+				}
+				res, err := srv.Client().Do(req)
+				if err != nil {
+					t.Fatal("Failed to send request")
+				}
+				if res.StatusCode/100 != 2 {
+					t.Fatal("Got non-successful response: ", res.StatusCode)
+				}
+				if !wasCalled {
+					t.Fatal("Handler was never called")
+				}
+			})
+		}
+	}
+}
+
+func TestReturnTypeRendering(t *testing.T) {
+	eventData := map[string]interface{}{
+		"unused": "data",
+	}
+	type RetVal struct {
+		ID interface{}
+	}
+	eventContext := cloudevents.EventContext{
+		CloudEventsVersion: cloudevents.CloudEventsVersion,
+		EventID:            "1234",
+		Source:             "tests:TestUndtypedHandling",
+		EventType:          "dev.eventing.test",
+		Extensions:         map[string]interface{}{},
+	}
+	for _, test := range []struct {
+		name             string
+		expectedStatus   int
+		expectedResponse string
+		handler          http.Handler
+	}{
+		{
+			name:           "no return",
+			expectedStatus: http.StatusNoContent,
+			handler:        cloudevents.Handler(func() {}),
+		}, {
+			name:           "nil error return",
+			expectedStatus: http.StatusNoContent,
+			handler: cloudevents.Handler(func() error {
+				return nil
+			}),
+		}, {
+			name:           "non-nil error return (one return type)",
+			expectedStatus: http.StatusInternalServerError,
+			handler: cloudevents.Handler(func() error {
+				return errors.New("Some error")
+			}),
+			expectedResponse: "Internal server error",
+		}, {
+			name:           "successful return",
+			expectedStatus: http.StatusOK,
+			handler: cloudevents.Handler(func() (map[string]interface{}, error) {
+				return map[string]interface{}{"hello": "world"}, nil
+			}),
+			expectedResponse: `{"hello":"world"}`,
+		}, {
+			name:           "non-nil error return (two return types)",
+			expectedStatus: http.StatusInternalServerError,
+			handler: cloudevents.Handler(func() (map[string]interface{}, error) {
+				return map[string]interface{}{"hello": "world"}, errors.New("Errors take precedence")
+			}),
+			expectedResponse: "Internal server error",
+		},
+		{
+			name:           "non-nil content return",
+			expectedStatus: http.StatusOK,
+			handler: cloudevents.Handler(func() (map[string]interface{}, error) {
+				return map[string]interface{}{"hello": "world"}, nil
+			}),
+			expectedResponse: `{"hello":"world"}`,
+		},
+		{
+			name:           "bad JSON content",
+			expectedStatus: http.StatusInternalServerError,
+			handler: cloudevents.Handler(func() (RetVal, error) {
+				return RetVal{ID: func() {}}, nil
+			}),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err, ok := test.handler.(error); ok {
+				t.Errorf("Handler() failed: %v", err)
+				return
+			}
+			srv := httptest.NewServer(test.handler)
+			defer srv.Close()
+			req, err := cloudevents.NewRequest(srv.URL, eventData, eventContext)
+			if err != nil {
+				t.Fatal("Failed to marshal request ", err)
+			}
+			res, err := srv.Client().Do(req)
+			if err != nil {
+				t.Fatal("Failed to send request")
+			}
+			defer res.Body.Close()
+			if test.expectedStatus != res.StatusCode {
+				t.Fatalf("Wrong status code from event handler; wanted=%d; got=%d", test.expectedStatus, res.StatusCode)
+			}
+			if test.expectedResponse != "" {
+				b, err := ioutil.ReadAll(res.Body)
+				if err != nil {
+					t.Fatal("Failed to read response body:", err)
+				}
+				resBody := string(b)
+				if test.expectedResponse != resBody {
+					t.Fatalf("Got unexpected respnose string; wanted=%q; got=%q", test.expectedResponse, resBody)
+				}
+			}
+		})
+	}
+}
+
+func TestMux(t *testing.T) {
+	type TypeA struct {
+		Greeting string
+	}
+	type TypeB struct {
+		Farewell string
+	}
+
+	eventA := TypeA{
+		Greeting: "Hello, world!",
+	}
+	eventB := TypeB{
+		Farewell: "Hasta la vista",
+	}
+
+	contextA := &cloudevents.EventContext{
+		EventID:     "1234",
+		EventType:   "org.A.test",
+		Source:      "test:TestMux",
+		ContentType: "application/json",
+		Extensions:  map[string]interface{}{},
+	}
+	contextB := &cloudevents.EventContext{
+		EventID:     "5678",
+		EventType:   "org.B.test",
+		Source:      "test:TestMux",
+		ContentType: "application/json",
+		Extensions:  map[string]interface{}{},
+	}
+	sawA, sawB := false, false
+
+	mux := cloudevents.NewMux()
+	err := mux.Handle("org.A.test", func(ctx context.Context, data TypeA) error {
+		sawA = true
+		context := cloudevents.FromContext(ctx)
+		if !reflect.DeepEqual(eventA, data) {
+			t.Fatalf("Got wrong data for event A; wanted=%s; got=%s", eventA, data)
+		}
+		if !reflect.DeepEqual(contextA, context) {
+			t.Fatalf("Got wrong context for event A; wanted=%s; got=%s", contextA, context)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("mux.Handle('org.A.test') failed: %v", err)
+	}
+	err = mux.Handle("org.B.test", func(ctx context.Context, data TypeB) error {
+		sawB = true
+		context := cloudevents.FromContext(ctx)
+		if !reflect.DeepEqual(eventB, data) {
+			t.Fatalf("Got wrong data for event A; wanted=%s; got=%s", eventB, data)
+		}
+		if !reflect.DeepEqual(contextB, context) {
+			t.Fatalf("Got wrong context for event A; wanted=%s; got=%s", contextB, context)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("mux.Handle('org.B.test') failed: %v", err)
+	}
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	req, err := cloudevents.NewRequest(srv.URL, eventA, *contextA)
+	if err != nil {
+		t.Fatal("Failed to marshal request for eventA", err)
+	}
+	if _, err := srv.Client().Do(req); err != nil {
+		t.Fatal("Failed to send eventA", err)
+	}
+	req, err = cloudevents.NewRequest(srv.URL, eventB, *contextB)
+	if err != nil {
+		t.Fatal("Failed to marshal request for eventB", err)
+	}
+	if _, err := srv.Client().Do(req); err != nil {
+		t.Fatal("Failed to send eventB", err)
+	}
+
+	if !sawA {
+		t.Fatal("Handler for eventA never called")
+	}
+	if !sawB {
+		t.Fatal("Handler for eventB never called")
+	}
+}


### PR DESCRIPTION
Adding cloudevents sdk for working with cloud event producers and consumers.

This will be used in `knative/eventing` and `knative/eventing-sources`.