### PR TITLE
Move the `getObject` method into `kmeta`

### DIFF
--- a/kmeta/accessor.go
+++ b/kmeta/accessor.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kmeta
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// DeletionHandlingAccessor tries to get runtime Object from given interface in the way of Accessor first;
+// and to handle deletion, it try to fetch info from DeletedFinalStateUnknown on failure.
+// The name is a reference to cache.DeletionHandlingMetaNamespaceKeyFunc
+func DeletionHandlingAccessor(obj interface{}) (metav1.Object, error) {
+	object, err := meta.Accessor(obj)
+	if err != nil {
+		// To handle obj deletion, try to fetch info from DeletedFinalStateUnknown.
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return nil, fmt.Errorf("Couldn't get object from tombstone %#v", obj)
+		}
+		object, ok = tombstone.Obj.(metav1.Object)
+		if !ok {
+			return nil, fmt.Errorf("The object that Tombstone contained is not of metav1.Object %#v", obj)
+		}
+	}
+
+	return object, nil
+}

--- a/kmeta/accessor_test.go
+++ b/kmeta/accessor_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kmeta
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	. "github.com/knative/pkg/testing"
+)
+
+func TestAccessor(t *testing.T) {
+	goodResource := &Resource{}
+	goodAccessor, _ := meta.Accessor(goodResource)
+
+	tests := []struct {
+		name string
+		o    interface{}
+		want metav1.Object
+	}{{
+		name: "bad object returns error",
+		o:    struct{}{},
+	}, {
+		name: "deleted with bad final state",
+		o: cache.DeletedFinalStateUnknown{
+			Obj: struct{}{},
+		},
+	}, {
+		name: "good object",
+		o:    goodResource,
+		want: goodAccessor,
+	}, {
+		name: "deleted with good final state",
+		o: cache.DeletedFinalStateUnknown{
+			Obj: goodResource,
+		},
+		want: goodAccessor,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.want == nil {
+				got, err := DeletionHandlingAccessor(test.o)
+				if err == nil {
+					t.Errorf("DeletionHandlingAccessor() = %v, wanted error", got)
+				}
+			} else {
+				got, err := DeletionHandlingAccessor(test.o)
+				if err != nil {
+					t.Errorf("DeletionHandlingAccessor() = %v", err)
+				}
+				if diff := cmp.Diff(got, test.want); diff != "" {
+					t.Errorf("DeletionHandlingAccessor = %s", diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This promotes the private deletion-handling helper wrapping `meta.Accessor` into `kmeta`.  The wordy name is based on the wordier `cache.DeletionHandlingMetaNamespaceKeyFunc`, since it serves a similar purpose.

<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:

/lint
-->