### PR TITLE
Update the ConditionSet to support non-terminal conditions.

### DIFF
--- a/apis/duck/v1alpha1/condition_set_test.go
+++ b/apis/duck/v1alpha1/condition_set_test.go
@@ -18,6 +18,8 @@ package v1alpha1
 
 import (
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestNewLivingConditionSet(t *testing.T) {
@@ -83,5 +85,35 @@ func TestNewBatchConditionSet(t *testing.T) {
 				t.Errorf("%q expected: %v got: %v", tc.name, e, a)
 			}
 		})
+	}
+}
+
+func TestNonTerminalCondition(t *testing.T) {
+	set := NewLivingConditionSet("Foo")
+	status := &KResourceStatus{}
+
+	manager := set.Manage(status)
+	manager.InitializeConditions()
+
+	if got, want := len(status.Conditions), 2; got != want {
+		t.Errorf("InitializeConditions() = %v, wanted %v", got, want)
+	}
+
+	// Setting the other "terminal" condition makes Ready true.
+	manager.MarkTrue("Foo")
+	if got, want := manager.GetCondition("Ready").Status, corev1.ConditionTrue; got != want {
+		t.Errorf("MarkTrue(Foo) = %v, wanted %v", got, want)
+	}
+
+	// Setting a "non-terminal" condition, doesn't change Ready.
+	manager.MarkUnknown("Bar", "", "")
+	if got, want := manager.GetCondition("Ready").Status, corev1.ConditionTrue; got != want {
+		t.Errorf("MarkUnknown(Foo) = %v, wanted %v", got, want)
+	}
+
+	// Setting a "non-terminal" condition, doesn't change Ready.
+	manager.MarkFalse("Bar", "", "")
+	if got, want := manager.GetCondition("Ready").Status, corev1.ConditionTrue; got != want {
+		t.Errorf("MarkFalse(Foo) = %v, wanted %v", got, want)
 	}
 }

--- a/apis/duck/v1alpha1/conditions_types.go
+++ b/apis/duck/v1alpha1/conditions_types.go
@@ -42,6 +42,21 @@ const (
 	ConditionSucceeded ConditionType = "Succeeded"
 )
 
+// ConditionSeverity expresses the severity of a Condition Type failing.
+type ConditionSeverity string
+
+const (
+	// ConditionSeverityError specifies that a failure of a condition type
+	// should be viewed as an error.
+	ConditionSeverityError ConditionSeverity = "Error"
+	// ConditionSeverityWarning specifies that a failure of a condition type
+	// should be viewed as a warning, but that things could still work.
+	ConditionSeverityWarning ConditionSeverity = "Warning"
+	// ConditionSeverityInfo specifies that a failure of a condition type
+	// should be viewed as purely informational, and that things could still work.
+	ConditionSeverityInfo ConditionSeverity = "Info"
+)
+
 // Conditions defines a readiness condition for a Knative resource.
 // See: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties
 // +k8s:deepcopy-gen=true
@@ -53,6 +68,11 @@ type Condition struct {
 	// Status of the condition, one of True, False, Unknown.
 	// +required
 	Status corev1.ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown"`
+
+	// Severity with which to treat failures of this type of condition.
+	// When this is not specified, it defaults to Error.
+	// +optional
+	Severity ConditionSeverity `json:"severity,omitempty" description:"how to interpret failures of this condition, one of Error, Warning, Info"`
 
 	// LastTransitionTime is the last time the condition transitioned from one status to another.
 	// We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
@@ -92,7 +112,6 @@ func (c *Condition) IsUnknown() bool {
 	}
 	return c.Status == corev1.ConditionUnknown
 }
-
 
 // Conditions is an Implementable "duck type".
 var _ duck.Implementable = (*Conditions)(nil)


### PR DESCRIPTION
This change updates the `ConditionSet` datatype to treat the set of conditions that it is initially supplied with as the set of "terminal" conditions, where as before:
1. If all `True`, results in `Ready=True`
2. If any `False`, results in `Ready=False`
3. Otherwise, `Ready=Unknown`

However, in additional to this initial "terminal" set, other conditions may be set that are "non-terminal" and have no influence over the "happy" condition (e.g. `Ready`).

Related to: https://github.com/knative/serving/issues/2394

<!--
/lint
/hold
-->

I'm putting a `/hold` on this until we discuss at next week's API WG.