### PR TITLE
Removing eventTime for required attrs.

### DIFF
--- a/cloudevents/event.go
+++ b/cloudevents/event.go
@@ -48,10 +48,10 @@ const (
 	// HeaderContentType is the standard HTTP header "Content-Type"
 	HeaderContentType = "Content-Type"
 
+	// required attributes
 	fieldCloudEventsVersion = "CloudEventsVersion"
 	fieldEventID            = "EventID"
 	fieldEventType          = "EventType"
-	fieldEventTime          = "EventTime"
 	fieldSource             = "Source"
 )
 


### PR DESCRIPTION
`fieldEventTime` was not used, not is it required on the fieldXy list of required attributes