### PR TITLE
Make controller more responsive to events

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -516,7 +516,7 @@ func TestStartAndShutdownWithErroringWork(t *testing.T) {
 		t.Errorf("Requeue count = %v, wanted %v", got, want)
 	}
 
-	checkStats(t, reporter, 2, 0, 2, falseString)
+	checkStats(t, reporter, 3, 0, 3, falseString)
 }
 
 type PermanentErrorReconciler struct{}


### PR DESCRIPTION
Only delay the events when errors occur.

Also, clean up unnecessary code and misleading comments.
