### PR TITLE
Remove images deletion step from e2e test / Update test-infra

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -258,11 +258,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4bf9fd75ac1fcff4d70f4185f9b3ef651d53ca92863bb95c919893afe3bd3fad"
+  digest = "1:09521a823a008f7df66962ac2637c22e1cdc842ebfcc7a083c444d35258986f7"
   name = "github.com/knative/test-infra"
   packages = ["tools/dep-collector"]
   pruneopts = "T"
-  revision = "213b8c44d0644af565a66e98dd857802a7e878a7"
+  revision = "7ed32409fa2c447a44a4281f0022ab25ce955f51"
 
 [[projects]]
   digest = "1:6abc0ac0adf962ae786cde04327a7207fe3dd0a7c48d9c5584b75f4c542eb5a0"
@@ -1000,6 +1000,7 @@
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/util/sets/types",
+    "k8s.io/apimachinery/pkg/util/validation",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",

--- a/vendor/github.com/knative/test-infra/Gopkg.lock
+++ b/vendor/github.com/knative/test-infra/Gopkg.lock
@@ -2,7 +2,134 @@
 
 
 [[projects]]
+  digest = "1:ffebc83d60ea84f7c18f4f1437a8f01ce49b7d93302db8af14ab1702d83d3fd8"
+  name = "cloud.google.com/go"
+  packages = [
+    "compute/metadata",
+    "iam",
+    "internal",
+    "internal/optional",
+    "internal/trace",
+    "internal/version",
+    "storage",
+  ]
+  pruneopts = "NUT"
+  revision = "74b12019e2aa53ec27882158f59192d7cd6d1998"
+  version = "v0.33.1"
+
+[[projects]]
+  digest = "1:5ee00c4f5c97178ae8d560e37d379d44a11a9044e329d914a200787c7b971dcb"
+  name = "fortio.org/fortio"
+  packages = [
+    "fhttp",
+    "fnet",
+    "log",
+    "periodic",
+    "stats",
+    "version",
+  ]
+  pruneopts = "NUT"
+  revision = "bf3f2d9ff07ed03ef16be56af20d58dc0300e60f"
+  version = "v1.3.0"
+
+[[projects]]
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = "NUT"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
+  digest = "1:32598368f409bbee79deb9d43569fcd92b9fb27f39155f5e166b3371217f051f"
+  name = "github.com/evanphx/json-patch"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "72bf35d0ff611848c1dc9df0f976c81192392fa5"
+  version = "v4.1.0"
+
+[[projects]]
+  digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
+  name = "github.com/ghodss/yaml"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:219b2e7d9a6cbe77079dddc3f26b77cbafaa2f23e5fc4eba4251d04f2a843202"
+  name = "github.com/gogo/protobuf"
+  packages = [
+    "proto",
+    "sortkeys",
+  ]
+  pruneopts = "NUT"
+  revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
+  version = "v1.1.1"
+
+[[projects]]
   branch = "master"
+  digest = "1:e2b86e41f3d669fc36b50d31d32d22c8ac656c75aa5ea89717ce7177e134ff2a"
+  name = "github.com/golang/glog"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
+
+[[projects]]
+  digest = "1:503ccff859e44ddf3d2901cb25ec0cac005856341abbcb70de4fffa731ecb8b3"
+  name = "github.com/golang/protobuf"
+  packages = [
+    "proto",
+    "protoc-gen-go/descriptor",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp",
+  ]
+  pruneopts = "NUT"
+  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
+  version = "v1.2.0"
+
+[[projects]]
+  digest = "1:21c8b3a5b2d66f5ba6731f12133ccbf970947a6f4e78f0d46b64c49f8a4034c1"
+  name = "github.com/google/go-cmp"
+  packages = [
+    "cmp",
+    "cmp/internal/diff",
+    "cmp/internal/function",
+    "cmp/internal/value",
+  ]
+  pruneopts = "NUT"
+  revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
+  version = "v0.2.0"
+
+[[projects]]
+  digest = "1:f4f203acd8b11b8747bdcd91696a01dbc95ccb9e2ca2db6abf81c3a4f5e950ce"
+  name = "github.com/google/go-github"
+  packages = ["github"]
+  pruneopts = "NUT"
+  revision = "f55b50f38167644bb7e4be03d9a2bde71d435239"
+  version = "v18.2.0"
+
+[[projects]]
+  digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
+  name = "github.com/google/go-querystring"
+  packages = ["query"]
+  pruneopts = "NUT"
+  revision = "44c6ddd0a2342c386950e880b658017258da92fc"
+  version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:52c5834e2bebac9030c97cc0798ac11c3aa8a39f098aeb419f142533da6cd3cc"
+  name = "github.com/google/gofuzz"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:fa44e3e20bd07c0f2ae762d01e7acb9f4b988411c5e8c00ec77d587b0c0465dc"
   name = "github.com/google/licenseclassifier"
   packages = [
     ".",
@@ -10,19 +137,411 @@
     "stringclassifier",
     "stringclassifier/internal/pq",
     "stringclassifier/searchset",
-    "stringclassifier/searchset/tokenizer"
+    "stringclassifier/searchset/tokenizer",
   ]
+  pruneopts = "UT"
   revision = "3c8ad1f0b0644b6646210ee9cf2f34ff907e2e18"
 
 [[projects]]
+  digest = "1:fb9f5147a9d6fc69057d05b0739bcd79562c55db143c3bdacfe1c9c6129461f6"
+  name = "github.com/googleapis/gax-go"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "b001040cd31805261cbd978842099e326dfa857b"
+  version = "v2.0.2"
+
+[[projects]]
+  digest = "1:b42cde0e1f3c816dd57f57f7bbcf05ca40263ad96f168714c130c611fc0856a6"
+  name = "github.com/hashicorp/golang-lru"
+  packages = [
+    ".",
+    "simplelru",
+  ]
+  pruneopts = "NUT"
+  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
+  version = "v0.5.0"
+
+[[projects]]
+  digest = "1:8e36686e8b139f8fe240c1d5cf3a145bc675c22ff8e707857cdd3ae17b00d728"
+  name = "github.com/json-iterator/go"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "1624edc4454b8682399def8740d46db5e4362ba4"
+  version = "v1.1.5"
+
+[[projects]]
+  digest = "1:41290f810d4fe2d98e7fcba582bcb6b593a37da307c22b252dcbf0573dba95ef"
+  name = "github.com/knative/build"
+  packages = [
+    "pkg/apis/build",
+    "pkg/apis/build/v1alpha1",
+  ]
+  pruneopts = "NUT"
+  revision = "94859753e2c6724df2be86f6a254f810895fa3eb"
+  version = "v0.2.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:c9b80529d8bd72a4c142629b765bd241cb43eb68f205a6a8e683efb2c5dae7f2"
+  name = "github.com/knative/pkg"
+  packages = [
+    "apis",
+    "apis/duck",
+    "apis/duck/v1alpha1",
+    "kmeta",
+  ]
+  pruneopts = "NUT"
+  revision = "acfd173abd8d2063ddceedb3487599f97ac93db8"
+
+[[projects]]
+  digest = "1:ffcf923a4041d861db53b7b8abd834325da3fbac6cc21ba041a472d770fef63b"
+  name = "github.com/knative/serving"
+  packages = [
+    "pkg/apis/autoscaling",
+    "pkg/apis/networking",
+    "pkg/apis/networking/v1alpha1",
+    "pkg/apis/serving",
+    "pkg/apis/serving/v1alpha1",
+  ]
+  pruneopts = "NUT"
+  revision = "f69d5efe522edecc5ff5bc3e23f1a7ff206a7726"
+  version = "v0.2.2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:0e9bfc47ab9941ecc3344e580baca5deb4091177e84dd9773b48b38ec26b93d5"
+  name = "github.com/mattbaird/jsonpatch"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "81af80346b1a01caae0cbc27fd3c1ba5b11e189f"
+
+[[projects]]
+  digest = "1:2f42fa12d6911c7b7659738758631bec870b7e9b4c6be5444f963cdcfccc191f"
+  name = "github.com/modern-go/concurrent"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
+  version = "1.0.3"
+
+[[projects]]
+  digest = "1:c6aca19413b13dc59c220ad7430329e2ec454cc310bc6d8de2c7e2b93c18a0f6"
+  name = "github.com/modern-go/reflect2"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
+  version = "1.0.1"
+
+[[projects]]
+  digest = "1:d917313f309bda80d27274d53985bc65651f81a5b66b820749ac7f8ef061fd04"
   name = "github.com/sergi/go-diff"
   packages = ["diffmatchpatch"]
+  pruneopts = "NUT"
   revision = "1744e2970ca51c86172c8190fadad617561ed6e7"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:27f79b0258eaf8c1ca1f5c806e649e1c4b988b23d7befe667e9457abaaacc8d0"
+  name = "go.opencensus.io"
+  packages = [
+    ".",
+    "exemplar",
+    "internal",
+    "internal/tagencoding",
+    "plugin/ochttp",
+    "plugin/ochttp/propagation/b3",
+    "stats",
+    "stats/internal",
+    "stats/view",
+    "tag",
+    "trace",
+    "trace/internal",
+    "trace/propagation",
+    "trace/tracestate",
+  ]
+  pruneopts = "NUT"
+  revision = "b7bf3cdb64150a8c8c53b769fdeb2ba581bd4d4b"
+  version = "v0.18.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
+  name = "golang.org/x/crypto"
+  packages = ["ssh/terminal"]
+  pruneopts = "NUT"
+  revision = "3d3f9f413869b949e48070b5bc593aa22cc2b8f2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:e780fc0b3262496ffe4052749545209866b89af1653ff09a01e228e01f2184ee"
+  name = "golang.org/x/net"
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "trace",
+  ]
+  pruneopts = "NUT"
+  revision = "adae6a3d119ae4890b46832a2e88a95adc62b8e7"
+
+[[projects]]
+  branch = "master"
+  digest = "1:288dab78eb80eb8ace4e427ddc27186d3c675e50ae26c50c52719520f71e536f"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "google",
+    "internal",
+    "jws",
+    "jwt",
+  ]
+  pruneopts = "NUT"
+  revision = "8f65e3013ebad444f13bc19536f7865efc793816"
+
+[[projects]]
+  branch = "master"
+  digest = "1:af8c93dac5d132eebc86de1565df19a7bf88cbe11ce57bc4e5a2ebe627b3350b"
+  name = "golang.org/x/sys"
+  packages = [
+    "unix",
+    "windows",
+  ]
+  pruneopts = "NUT"
+  revision = "0cf1ed9e522b7dbb416f080a5c8003de9b702bf4"
+
+[[projects]]
+  digest = "1:a0f29009397dc27c9dc8440f0945d49e5cbb9b72d0b0fc745474d9bfdea2d9f8"
+  name = "golang.org/x/text"
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+  ]
+  pruneopts = "NUT"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:9fdc2b55e8e0fafe4b41884091e51e77344f7dc511c5acedcfd98200003bff90"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  pruneopts = "NUT"
+  revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
+
+[[projects]]
+  branch = "master"
+  digest = "1:04c1f65b6a942ad67673950e530d6e7a43de578429d5ed9f08dca96f7ee55356"
+  name = "google.golang.org/api"
+  packages = [
+    "gensupport",
+    "googleapi",
+    "googleapi/internal/uritemplates",
+    "googleapi/transport",
+    "internal",
+    "iterator",
+    "option",
+    "storage/v1",
+    "transport/http",
+    "transport/http/internal/propagation",
+  ]
+  pruneopts = "NUT"
+  revision = "faade3cbb06a30202f2da53a8a5e3c4afe60b0c2"
+
+[[projects]]
+  digest = "1:441d97368658ab6125cd88aa973e2bfa0585e4119d437b09f8fd40e5c5c76aa9"
+  name = "google.golang.org/appengine"
+  packages = [
+    ".",
+    "internal",
+    "internal/app_identity",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/modules",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch",
+  ]
+  pruneopts = "NUT"
+  revision = "4a4468ece617fc8205e99368fa2200e9d1fad421"
+  version = "v1.3.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:1d2211bed775b5fd4f419ab4f1fcd3e5117b1bd5b8ff2c54e6fb19ca295cbe9d"
+  name = "google.golang.org/genproto"
+  packages = [
+    "googleapis/api/annotations",
+    "googleapis/iam/v1",
+    "googleapis/rpc/code",
+    "googleapis/rpc/status",
+  ]
+  pruneopts = "NUT"
+  revision = "b5d43981345bdb2c233eb4bf3277847b48c6fdc6"
+
+[[projects]]
+  digest = "1:eaba4c1cb24e1a60617767bc7e6ea30b3274e4fe56363413238f124a5ac60044"
+  name = "google.golang.org/grpc"
+  packages = [
+    ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "codes",
+    "connectivity",
+    "credentials",
+    "encoding",
+    "encoding/proto",
+    "grpclog",
+    "internal",
+    "internal/backoff",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/transport",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "stats",
+    "status",
+    "tap",
+  ]
+  pruneopts = "NUT"
+  revision = "2e463a05d100327ca47ac218281906921038fd95"
+  version = "v1.16.0"
+
+[[projects]]
+  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
+  name = "gopkg.in/inf.v0"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
+  version = "v0.9.1"
+
+[[projects]]
+  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
+
+[[projects]]
+  digest = "1:fa7cb0588ebe949022922fa7c6cc4417e3fc048b809f1d849ecd051fcbe88db5"
+  name = "k8s.io/api"
+  packages = ["core/v1"]
+  pruneopts = "NUT"
+  revision = "4e7be11eab3ffcfc1876898b8272df53785a9504"
+  version = "kubernetes-1.11.3"
+
+[[projects]]
+  digest = "1:8f3fab5d5b634e33e38a1e9f0b72c4ed58c04014ada241483fa747f993f2e349"
+  name = "k8s.io/apimachinery"
+  packages = [
+    "pkg/api/equality",
+    "pkg/api/errors",
+    "pkg/api/meta",
+    "pkg/api/resource",
+    "pkg/apis/meta/internalversion",
+    "pkg/apis/meta/v1",
+    "pkg/apis/meta/v1/unstructured",
+    "pkg/apis/meta/v1beta1",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/runtime/serializer",
+    "pkg/runtime/serializer/json",
+    "pkg/runtime/serializer/protobuf",
+    "pkg/runtime/serializer/recognizer",
+    "pkg/runtime/serializer/streaming",
+    "pkg/runtime/serializer/versioning",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/cache",
+    "pkg/util/clock",
+    "pkg/util/diff",
+    "pkg/util/errors",
+    "pkg/util/framer",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/net",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/wait",
+    "pkg/util/yaml",
+    "pkg/version",
+    "pkg/watch",
+    "third_party/forked/golang/reflect",
+  ]
+  pruneopts = "NUT"
+  revision = "def12e63c512da17043b4f0293f52d1006603d9f"
+  version = "kubernetes-1.11.3"
+
+[[projects]]
+  digest = "1:1e184b5ee1723cd4aeb90ceda3f4f31ec12098dc9525f7f221b355bc0b1673e0"
+  name = "k8s.io/client-go"
+  packages = [
+    "dynamic",
+    "pkg/apis/clientauthentication",
+    "pkg/apis/clientauthentication/v1alpha1",
+    "pkg/apis/clientauthentication/v1beta1",
+    "pkg/version",
+    "plugin/pkg/client/auth/exec",
+    "rest",
+    "rest/watch",
+    "tools/cache",
+    "tools/clientcmd/api",
+    "tools/metrics",
+    "tools/pager",
+    "transport",
+    "util/buffer",
+    "util/cert",
+    "util/connrotation",
+    "util/flowcontrol",
+    "util/integer",
+    "util/retry",
+  ]
+  pruneopts = "NUT"
+  revision = "2cefa64ff137e128daeddbd1775cd775708a05bf"
+  version = "kubernetes-1.11.3"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "aea50f9014005bedc3dc202c5fbf9d2d8c7a6f7beac2337fd863b23f411c4125"
+  input-imports = [
+    "cloud.google.com/go/storage",
+    "fortio.org/fortio/fhttp",
+    "fortio.org/fortio/periodic",
+    "fortio.org/fortio/stats",
+    "github.com/golang/glog",
+    "github.com/google/go-github/github",
+    "github.com/google/licenseclassifier",
+    "github.com/knative/serving/pkg/apis/serving/v1alpha1",
+    "google.golang.org/api/option",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/knative/test-infra/Gopkg.toml
+++ b/vendor/github.com/knative/test-infra/Gopkg.toml
@@ -1,8 +1,7 @@
 # Refer to https://golang.github.io/dep/docs/Gopkg.toml.html
 # for detailed Gopkg.toml documentation.
 
-required = [
-  "github.com/google/licenseclassifier/licenses",
+required = [  
 ]
 
 # TODO(mattmoor): Find a way to bundle the licenseclassifier's
@@ -12,3 +11,7 @@ required = [
   go-tests = true
   unused-packages = true
   non-go = true
+
+[[prune.project]]
+  name = "github.com/google/licenseclassifier"
+  non-go = false

--- a/vendor/github.com/knative/test-infra/OWNERS
+++ b/vendor/github.com/knative/test-infra/OWNERS
@@ -2,6 +2,8 @@
 
 approvers:
 - adrcunha
+- dushyanthsc
+- ericKlawitter
 - jessiezcc
 - srinivashegde86
 - steuhs

--- a/vendor/github.com/knative/test-infra/ci/prow/config.yaml
+++ b/vendor/github.com/knative/test-infra/ci/prow/config.yaml
@@ -206,7 +206,45 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
-        - "--integration-tests"
+        - "--run-test"
+        - "./test/e2e-tests.sh"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "1Gi"
+
+  - name: pull-knative-serving-upgrade-tests
+    agent: kubernetes
+    context: pull-knative-serving-upgrade-tests
+    always_run: true
+    rerun_command: "/test pull-knative-serving-upgrade-tests"
+    trigger: "(?m)^/test (all|pull-knative-serving-upgrade-tests),?(\\s+|$)"
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+    skip_branches:  # Skip these branches, as test isn't available.
+    - release-0.1
+    - release-0.2
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+        imagePullPolicy: Always
+        args:
+        - "--scenario=kubernetes_execute_bazel"
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://knative-prow/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-upgrade-tests.sh"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -236,7 +274,7 @@ presubmits:
         - "--postsubmit-job-name=post-knative-serving-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
-        - "--cov-target=./pkg/"
+        - "--cov-target=."
         - "--cov-threshold-percentage=50"
         - "--github-token=/etc/github-token/token"
         volumeMounts:
@@ -270,7 +308,7 @@ presubmits:
         - "--postsubmit-job-name=post-knative-serving-go-coverage"
         - "--profile-name=coverage_profile.txt"
         - "--artifacts=$(ARTIFACTS)"
-        - "--cov-target=./pkg/"
+        - "--cov-target=."
         - "--cov-threshold-percentage=81"
         - "--github-token=/etc/github-token/token"
         volumeMounts:
@@ -359,6 +397,7 @@ presubmits:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
       preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:latest
@@ -404,7 +443,7 @@ presubmits:
         - "--postsubmit-job-name=post-knative-build-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
-        - "--cov-target=./pkg/"
+        - "--cov-target=."
         - "--cov-threshold-percentage=50"
         - "--github-token=/etc/github-token/token"
         volumeMounts:
@@ -672,7 +711,7 @@ presubmits:
         - "--postsubmit-job-name=post-knative-eventing-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
-        - "--cov-target=./pkg/"
+        - "--cov-target=."
         - "--cov-threshold-percentage=50"
         - "--github-token=/etc/github-token/token"
         volumeMounts:
@@ -806,7 +845,7 @@ presubmits:
         - "--postsubmit-job-name=post-knative-eventing-sources-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
-        - "--cov-target=./pkg/"
+        - "--cov-target=."
         - "--cov-threshold-percentage=50"
         - "--github-token=/etc/github-token/token"
         volumeMounts:
@@ -940,7 +979,7 @@ presubmits:
         - "--postsubmit-job-name=post-knative-docs-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
-        - "--cov-target=./pkg/"
+        - "--cov-target=."
         - "--cov-threshold-percentage=50"
         - "--github-token=/etc/github-token/token"
         volumeMounts:
@@ -1408,7 +1447,7 @@ presubmits:
         - "--postsubmit-job-name=post-knative-caching-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
-        - "--cov-target=./pkg/"
+        - "--cov-target=."
         - "--cov-threshold-percentage=50"
         - "--github-token=/etc/github-token/token"
         volumeMounts:
@@ -1446,6 +1485,38 @@ periodics:
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
+      # Bazel needs privileged mode in order to sandbox builds.
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "1Gi"
+- cron: "15 8 * * *" # Run at 01:15PST every day (08:15 UTC)
+  name: ci-knative-serving-0.2-continuous
+  agent: kubernetes
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      imagePullPolicy: Always
+      args:
+      - "--scenario=kubernetes_execute_bazel"
+      - "--clean"
+      - "--job=$(JOB_NAME)"
+      - "--repo=github.com/knative/serving=release-0.2"
+      - "--root=/go/src"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://knative-prow/logs"
+      - "--timeout=50" # Avoid overrun
+      - "--" # end bootstrap args, scenario args below
+      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
       # Bazel needs privileged mode in order to sandbox builds.
       securityContext:
         privileged: true
@@ -1572,7 +1643,7 @@ periodics:
       args:
       - "--artifacts=$(ARTIFACTS)"
       - "--profile-name=coverage_profile.txt"
-      - "--cov-target=./pkg/"
+      - "--cov-target=."
       - "--cov-threshold-percentage=80"
 - cron: "0 1 * * *" # Run at 01:00 every day
   name: ci-knative-serving-performance
@@ -1706,7 +1777,28 @@ periodics:
       args:
       - "--artifacts=$(ARTIFACTS)"
       - "--profile-name=coverage_profile.txt"
-      - "--cov-target=./pkg/"
+      - "--cov-target=."
+      - "--cov-threshold-percentage=80"
+
+- cron: "0 1 * * *" # Run at 01:00 every day
+  name: ci-knative-build-pipeline-go-coverage
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: build
+    base_ref: master
+    clone_uri: "https://github.com/knative/build-pipeline.git"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/coverage:latest
+      imagePullPolicy: Always
+      command:
+      - "/coverage"
+      args:
+      - "--artifacts=$(ARTIFACTS)"
+      - "--profile-name=coverage_profile.txt"
+      - "--cov-target=."
       - "--cov-threshold-percentage=80"
 
 - cron: "50 * * * *" # Run every hour and 50 minutes
@@ -1757,7 +1849,7 @@ periodics:
       args:
       - "--artifacts=$(ARTIFACTS)"
       - "--profile-name=coverage_profile.txt"
-      - "--cov-target=./pkg/"
+      - "--cov-target=."
       - "--cov-threshold-percentage=80"
 
 - cron: "30 * * * *" # Run every hour and 30 minutes
@@ -1839,7 +1931,7 @@ periodics:
       args:
       - "--artifacts=$(ARTIFACTS)"
       - "--profile-name=coverage_profile.txt"
-      - "--cov-target=./pkg/"
+      - "--cov-target=."
       - "--cov-threshold-percentage=80"
 
 - cron: "30 * * * *" # Run every hour and 30 minutes
@@ -1921,7 +2013,7 @@ periodics:
       args:
       - "--artifacts=$(ARTIFACTS)"
       - "--profile-name=coverage_profile.txt"
-      - "--cov-target=./pkg/"
+      - "--cov-target=."
       - "--cov-threshold-percentage=80"
 
 - cron: "40 * * * *" # Run every hour and 40 minutes
@@ -2054,7 +2146,7 @@ periodics:
       args:
       - "--artifacts=$(ARTIFACTS)"
       - "--profile-name=coverage_profile.txt"
-      - "--cov-target=./pkg/"
+      - "--cov-target=."
       - "--cov-threshold-percentage=80"
 
 postsubmits:
@@ -2074,7 +2166,7 @@ postsubmits:
         args:
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
-        - "--cov-target=./pkg/"
+        - "--cov-target=."
         - "--cov-threshold-percentage=0"
   - name: post-knative-serving-go-coverage-dev
     branches:
@@ -2091,7 +2183,7 @@ postsubmits:
         args:
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
-        - "--cov-target=./pkg/"
+        - "--cov-target=."
         - "--cov-threshold-percentage=0"
 
   knative/build:
@@ -2110,7 +2202,26 @@ postsubmits:
         args:
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
-        - "--cov-target=./pkg/"
+        - "--cov-target=."
+        - "--cov-threshold-percentage=0"
+
+  knative/build-pipeline:
+  - name: post-knative-build-pipeline-go-coverage
+    branches:
+    - master
+    agent: kubernetes
+    decorate: true
+    clone_uri: "https://github.com/knative/build-pipeline.git"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
+        imagePullPolicy: Always
+        command:
+        - "/coverage"
+        args:
+        - "--artifacts=$(ARTIFACTS)"
+        - "--profile-name=coverage_profile.txt"
+        - "--cov-target=."
         - "--cov-threshold-percentage=0"
 
   knative/docs:
@@ -2129,7 +2240,7 @@ postsubmits:
         args:
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
-        - "--cov-target=./pkg/"
+        - "--cov-target=."
         - "--cov-threshold-percentage=0"
 
   knative/eventing:
@@ -2148,7 +2259,7 @@ postsubmits:
         args:
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
-        - "--cov-target=./pkg/"
+        - "--cov-target=."
         - "--cov-threshold-percentage=0"
 
   knative/eventing-sources:
@@ -2167,7 +2278,7 @@ postsubmits:
         args:
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
-        - "--cov-target=./pkg/"
+        - "--cov-target=."
         - "--cov-threshold-percentage=0"
 
   knative/pkg:
@@ -2205,6 +2316,5 @@ postsubmits:
         args:
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
-        - "--cov-target=./pkg/"
+        - "--cov-target=."
         - "--cov-threshold-percentage=0"
-

--- a/vendor/github.com/knative/test-infra/ci/prow/plugins.yaml
+++ b/vendor/github.com/knative/test-infra/ci/prow/plugins.yaml
@@ -18,6 +18,15 @@ approve:
   implicit_self_approve: true
   review_acts_as_approve: true
 
+repo_milestone:
+  # Default maintainer
+  '':
+    # You can curl the following endpoint in order to determine the github ID of
+    # your team responsible for maintaining the milestones:
+    # curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
+    maintainers_id: 3012514
+    maintainers_team: knative-milestone-maintainers
+
 plugins:
   knative:
   - approve
@@ -33,6 +42,7 @@ plugins:
   - label
   - lgtm
   - lifecycle
+  - milestone
   - shrug
   - size
   - skip

--- a/vendor/github.com/knative/test-infra/ci/testgrid/config.yaml
+++ b/vendor/github.com/knative/test-infra/ci/testgrid/config.yaml
@@ -23,7 +23,7 @@ default_test_group:
   num_columns_recent: 10         # The number of columns to consider "recent" for a variety of purposes
   use_kubernetes_client: true    # ** This field is deprecated and should always be true **
   is_external: true              # ** This field is deprecated and should always be true **
-  alert_stale_results_hours: 0   # Don't alert for staleness by default
+  alert_stale_results_hours: 24  # Alert if tests haven't run for a day
   num_failures_to_alert: 3       # Consider a test failed if it has 3 or more consecutive failures
   num_passes_to_disable_alert: 1 # Consider a failing test passing if it has 1 or more consecutive passes
 
@@ -49,16 +49,24 @@ default_dashboard_tab:
   num_columns_recent: 10
   code_search_url_template:      # The URL template to visit when searching for changelists
     url: https://github.com/knative/serving/compare/<start-custom-0>...<end-custom-0>
+  alert_options:
+    alert_mail_to_addresses: ' knative-productivity-dev@googlegroups.com'
 
+#################################################################
 # Test groups
+#################################################################
 
 test_groups:
+
+## Master branch (head)
+
 - name: ci-knative-serving-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-continuous
 - name: ci-knative-serving-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-release
 - name: ci-knative-serving-playground
   gcs_prefix: knative-prow/logs/ci-knative-serving-playground
+  alert_stale_results_hours: 168  # Alert if playground haven't been updated for a week
 - name: pull-knative-serving-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-serving-go-coverage
   short_text_metric: coverage
@@ -68,6 +76,9 @@ test_groups:
 - name: ci-knative-serving-api-coverage
   gcs_prefix: knative-prow/logs/ci-knative-serving-api-coverage
   short_text_metric: api_coverage
+- name: ci-knative-serving-performance
+  gcs_prefix: knative-prow/logs/ci-knative-serving-performance
+  short_text_metric: perf_latency
 - name: ci-knative-build-continuous
   gcs_prefix: knative-prow/logs/ci-knative-build-continuous
 - name: ci-knative-build-release
@@ -80,6 +91,8 @@ test_groups:
   short_text_metric: latency
 - name: ci-knative-build-templates-continuous
   gcs_prefix: knative-prow/logs/ci-knative-build-templates-continuous
+- name: ci-knative-build-pipeline-release
+  gcs_prefix: knative-prow/logs/ci-knative-build-pipeline-release
 - name: pull-knative-build-pipeline-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-build-pipeline-go-coverage
   short_text_metric: coverage
@@ -113,9 +126,19 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-caching-go-coverage
   short_text_metric: coverage
 
+## release-0.2 branch
+
+- name: ci-knative-serving-0.2-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.2-continuous
+
+#################################################################
 # Dashboards
+#################################################################
 
 dashboards:
+
+## Master branch (head)
+
 - name: knative-serving
   dashboard_tab:
   - name: continuous
@@ -134,6 +157,12 @@ dashboards:
   - name: api-coverage
     test_group_name: ci-knative-serving-api-coverage
     description: 'Conformance tests API coverage.'
+    base_options: 'exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name='
+  - name: conformance-tests
+    test_group_name: ci-knative-serving-continuous
+    base_options: 'include-filter-by-regex=//knative/serving/test/conformance:&sort-by-name='
+  - name: performance
+    test_group_name: ci-knative-serving-performance
     base_options: 'exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name='
 - name: knative-build
   dashboard_tab:
@@ -154,6 +183,8 @@ dashboards:
     test_group_name: ci-knative-build-templates-continuous
 - name: knative-build-pipeline
   dashboard_tab:
+  - name: release
+    test_group_name: ci-knative-build-pipeline-release
   - name: coverage
     test_group_name: pull-knative-build-pipeline-test-coverage
     base_options: 'exclude-filter-by-regex=Overall&group-by-directory=&expand-groups=&sort-by-name='
@@ -197,7 +228,16 @@ dashboards:
     test_group_name: pull-knative-caching-test-coverage
     base_options: 'exclude-filter-by-regex=Overall&group-by-directory=&expand-groups=&sort-by-name='
 
+## release-0.2 branch
+
+- name: knative-serving-0.2
+  dashboard_tab:
+  - name: continuous
+    test_group_name: ci-knative-serving-0.2-continuous
+
+#################################################################
 # Dashboard groups
+#################################################################
 
 dashboard_groups:
 - name: knative
@@ -211,3 +251,6 @@ dashboard_groups:
   - knative-docs
   - knative-pkg
   - knative-caching
+- name: knative-0.2
+  dashboard_names:
+  - knative-serving-0.2

--- a/vendor/github.com/knative/test-infra/dummy.go
+++ b/vendor/github.com/knative/test-infra/dummy.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("This is a dummy go file so `go dep` can be used with knative/test-infra repo")
+	fmt.Println("This file can be removed once the repo contains real, useful go code in the root dir")
+}
+

--- a/vendor/github.com/knative/test-infra/images/prow-tests/Dockerfile
+++ b/vendor/github.com/knative/test-infra/images/prow-tests/Dockerfile
@@ -29,8 +29,6 @@ RUN docker-credential-gcr configure-docker
 RUN apt-get install -y uuid-runtime  # for uuidgen
 RUN apt-get install -y npm  # for markdown-link-check
 RUN apt-get install -y rubygems  # for mdl
-RUN apt-get install -y build-essential libssl-dev # for wrk
-RUN apt-get install -y netbase # sets up /etc/services needed for wrk
 
 # Extra tools through go get
 RUN go get -u github.com/google/go-containerregistry/cmd/ko
@@ -44,11 +42,8 @@ RUN npm install -g markdown-link-check
 RUN gem install mixlib-config -v 2.2.4  # required because ruby is 2.1
 RUN gem install mdl
 
-# Install wrk
-RUN git clone https://github.com/wg/wrk.git wrk
-RUN make -C wrk/
-RUN cp wrk/wrk /usr/local/bin
+ADD . /go/src/github.com/knative/test-infra
 
 # Extra custom tools
-ADD githubhelper .
-ADD dep-collector .
+RUN cp /go/src/github.com/knative/test-infra/tools/githubhelper/githubhelper .
+RUN go install github.com/knative/test-infra/tools/dep-collector

--- a/vendor/github.com/knative/test-infra/scripts/dummy.go
+++ b/vendor/github.com/knative/test-infra/scripts/dummy.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scripts
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("This is a dummy go file so `go dep` can be used with knative/test-infra/scripts")
+	fmt.Println("This file can be safely removed if one day this directory contains real, useful go code")
+}

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -45,23 +45,19 @@ readonly E2E_CLUSTER_NODES=3
 readonly E2E_CLUSTER_MACHINE=n1-standard-4
 readonly TEST_RESULT_FILE=/tmp/${E2E_BASE_NAME}-e2e-result
 
+# Flag whether test is using a boskos GCP project
+IS_BOSKOS=0
+
 # Tear down the test resources.
 function teardown_test_resources() {
   header "Tearing down test environment"
   # Free resources in GCP project.
-  if (( ! USING_EXISTING_CLUSTER )) && [[ "$(type -t teardown)" == "function" ]]; then
+  if (( ! USING_EXISTING_CLUSTER )) && function_exists teardown; then
     teardown
   fi
 
-  # Delete Knative Serving images when using prow.
-  if (( IS_PROW )); then
-    echo "Images in ${DOCKER_REPO_OVERRIDE}:"
-    gcloud container images list --repository=${DOCKER_REPO_OVERRIDE}
-    delete_gcr_images ${DOCKER_REPO_OVERRIDE}
-  else
-    # Delete the kubernetes source downloaded by kubetest
-    rm -fr kubernetes kubernetes.tar.gz
-  fi
+  # Delete the kubernetes source downloaded by kubetest
+  rm -fr kubernetes kubernetes.tar.gz
 }
 
 # Exit test, dumping current state info.
@@ -72,30 +68,36 @@ function fail_test() {
   exit 1
 }
 
-# Run the given E2E tests (must be tagged as such).
+# Run the given E2E tests. Assume tests are tagged e2e, unless `-tags=XXX` is passed.
 # Parameters: $1..$n - any go test flags, then directories containing the tests to run.
 function go_test_e2e() {
-  local options=""
-  (( EMIT_METRICS )) && options="-emitmetrics"
-  report_go_test -v -tags=e2e -count=1 $@ ${options}
+  local test_options=""
+  local go_options=""
+  (( EMIT_METRICS )) && test_options="-emitmetrics"
+  [[ ! " $@" == *" -tags="* ]] && go_options="-tags=e2e"
+  report_go_test -v -count=1 ${go_options} $@ ${test_options}
 }
 
 # Download the k8s binaries required by kubetest.
+# Parameters: $1 - GCP project that will host the test cluster.
 function download_k8s() {
-  local version=${SERVING_GKE_VERSION}
+  local version=${E2E_CLUSTER_VERSION}
+  # Fetch valid versions
+  local versions="$(gcloud container get-server-config \
+      --project=$1 \
+      --format='value(validMasterVersions)' \
+      --region=${E2E_CLUSTER_REGION})"
+  local gke_versions=(`echo -n ${versions//;/ /}`)
+  echo "Valid GKE versions are [${versions//;/, }]"
   if [[ "${version}" == "latest" ]]; then
-    # Fetch latest valid version
-    local versions="$(gcloud container get-server-config \
-        --project=${GCP_PROJECT} \
-        --format='value(validMasterVersions)' \
-        --region=${E2E_CLUSTER_REGION})"
-    local gke_versions=(`echo -n ${versions//;/ /}`)
     # Get first (latest) version, excluding the "-gke.#" suffix
     version="${gke_versions[0]%-*}"
-    echo "Latest GKE is ${version}, from [${versions//;/, }]"
+    echo "Using latest version, ${version}"
   elif [[ "${version}" == "default" ]]; then
     echo "ERROR: `default` GKE version is not supported yet"
     return 1
+  else
+    echo "Using command-line supplied version ${version}"
   fi
   # Download k8s to staging dir
   version=v${version}
@@ -113,6 +115,7 @@ function download_k8s() {
     mv kubernetes/client/kubernetes-client-*.tar.gz .
     rm -fr kubernetes
     # Create an empty kubernetes test tarball; we don't use it but kubetest will fetch it
+    # As of August 21 2018 this means avoiding a useless 1.2GB download
     tar -czf kubernetes-test.tar.gz -T /dev/null
   fi
   popd
@@ -123,7 +126,7 @@ function download_k8s() {
 # This is intended to be called when a test fails to provide debugging information.
 function dump_cluster_state() {
   echo "***************************************"
-  echo "***           TEST FAILED           ***"
+  echo "***         E2E TEST FAILED         ***"
   echo "***    Start of information dump    ***"
   echo "***************************************"
   echo ">>> All resources:"
@@ -132,9 +135,9 @@ function dump_cluster_state() {
   kubectl get services --all-namespaces
   echo ">>> Events:"
   kubectl get events --all-namespaces
-  [[ "$(type -t dump_extra_cluster_state)" == "function" ]] && dump_extra_cluster_state
+  function_exists dump_extra_cluster_state && dump_extra_cluster_state
   echo "***************************************"
-  echo "***           TEST FAILED           ***"
+  echo "***         E2E TEST FAILED         ***"
   echo "***     End of information dump     ***"
   echo "***************************************"
 }
@@ -157,10 +160,10 @@ function create_test_cluster() {
     --gcp-network="${E2E_NETWORK_NAME}"
     --gke-environment=prod
   )
-  if (( ! IS_PROW )); then
-    CLUSTER_CREATION_ARGS+=(--gcp-project=${PROJECT_ID:?"PROJECT_ID must be set to the GCP project where the tests are run."})
-  else
+  if (( IS_BOSKOS )); then
     CLUSTER_CREATION_ARGS+=(--gcp-service-account=/etc/service-account/service-account.json)
+  else
+    CLUSTER_CREATION_ARGS+=(--gcp-project=${GCP_PROJECT})
   fi
   # SSH keys are not used, but kubetest checks for their existence.
   # Touch them so if they don't exist, empty files are create to satisfy the check.
@@ -172,45 +175,52 @@ function create_test_cluster() {
   # be a writeable docker repo.
   export K8S_USER_OVERRIDE=
   export K8S_CLUSTER_OVERRIDE=
-  # Get the current GCP project
-  export GCP_PROJECT=${PROJECT_ID}
-  [[ -z ${GCP_PROJECT} ]] && export GCP_PROJECT=$(gcloud config get-value project)
   # Assume test failed (see more details at the end of this script).
   echo -n "1"> ${TEST_RESULT_FILE}
   local test_cmd_args="--run-tests"
   (( EMIT_METRICS )) && test_cmd_args+=" --emit-metrics"
+  [[ -n "${GCP_PROJECT}" ]] && test_cmd_args+=" --gcp-project ${GCP_PROJECT}"
+  # Get the current GCP project for downloading kubernetes
+  local gcloud_project="${GCP_PROJECT}"
+  [[ -z "${gcloud_project}" ]] && gcloud_project="$(gcloud config get-value project)"
+  echo "gcloud project is ${gcloud_project}"
+  (( IS_BOSKOS )) && echo "Using boskos for the test cluster"
+  [[ -n "${GCP_PROJECT}" ]] && echo "GCP project for test cluster is ${GCP_PROJECT}"
   echo "Test script is ${E2E_SCRIPT}"
-  download_k8s || return 1
+  download_k8s ${gcloud_project} || return 1
   # Don't fail test for kubetest, as it might incorrectly report test failure
   # if teardown fails (for details, see success() below)
   set +o errexit
-  kubetest "${CLUSTER_CREATION_ARGS[@]}" \
+  run_go_tool k8s.io/test-infra/kubetest \
+    kubetest "${CLUSTER_CREATION_ARGS[@]}" \
     --up \
     --down \
     --extract local \
-    --gcp-node-image ${SERVING_GKE_IMAGE} \
+    --gcp-node-image "${SERVING_GKE_IMAGE}" \
     --test-cmd "${E2E_SCRIPT}" \
     --test-cmd-args "${test_cmd_args}"
   echo "Test subprocess exited with code $?"
   # Ignore any errors below, this is a best-effort cleanup and shouldn't affect the test result.
   set +o errexit
+  # Ensure we're using the GCP project used by kubetest
+  gcloud_project="$(gcloud config get-value project)"
   # Delete target pools and health checks that might have leaked.
   # See https://github.com/knative/serving/issues/959 for details.
   # TODO(adrcunha): Remove once the leak issue is resolved.
   local http_health_checks="$(gcloud compute target-pools list \
-    --project=${GCP_PROJECT} --format='value(healthChecks)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
+    --project=${gcloud_project} --format='value(healthChecks)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
     grep httpHealthChecks | tr '\n' ' ')"
   local target_pools="$(gcloud compute target-pools list \
-    --project=${GCP_PROJECT} --format='value(name)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
+    --project=${gcloud_project} --format='value(name)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
     tr '\n' ' ')"
   if [[ -n "${target_pools}" ]]; then
     echo "Found leaked target pools, deleting"
-    gcloud compute forwarding-rules delete -q --project=${GCP_PROJECT} --region=${E2E_CLUSTER_REGION} ${target_pools}
-    gcloud compute target-pools delete -q --project=${GCP_PROJECT} --region=${E2E_CLUSTER_REGION} ${target_pools}
+    gcloud compute forwarding-rules delete -q --project=${gcloud_project} --region=${E2E_CLUSTER_REGION} ${target_pools}
+    gcloud compute target-pools delete -q --project=${gcloud_project} --region=${E2E_CLUSTER_REGION} ${target_pools}
   fi
   if [[ -n "${http_health_checks}" ]]; then
     echo "Found leaked health checks, deleting"
-    gcloud compute http-health-checks delete -q --project=${GCP_PROJECT} ${http_health_checks}
+    gcloud compute http-health-checks delete -q --project=${gcloud_project} ${http_health_checks}
   fi
   local result="$(cat ${TEST_RESULT_FILE})"
   echo "Test result code is $result"
@@ -246,9 +256,11 @@ function setup_test_cluster() {
   echo "- User is ${K8S_USER_OVERRIDE}"
   echo "- Docker is ${DOCKER_REPO_OVERRIDE}"
 
+  export KO_DOCKER_REPO="${DOCKER_REPO_OVERRIDE}"
+
   trap teardown_test_resources EXIT
 
-  if (( USING_EXISTING_CLUSTER )) && [[ "$(type -t teardown)" == "function" ]]; then
+  if (( USING_EXISTING_CLUSTER )) && function_exists teardown; then
     echo "Deleting any previous SUT instance"
     teardown
   fi
@@ -270,7 +282,7 @@ function success() {
   # TODO(adrcunha): Get rid of this workaround.
   echo -n "0"> ${TEST_RESULT_FILE}
   echo "**************************************"
-  echo "***        ALL TESTS PASSED        ***"
+  echo "***        E2E TESTS PASSED        ***"
   echo "**************************************"
   exit 0
 }
@@ -278,7 +290,14 @@ function success() {
 RUN_TESTS=0
 EMIT_METRICS=0
 USING_EXISTING_CLUSTER=1
+GCP_PROJECT=""
 E2E_SCRIPT=""
+E2E_CLUSTER_VERSION=""
+
+function abort() {
+  echo "error: $@"
+  exit 1
+}
 
 # Parse flags and initialize the test cluster.
 function initialize() {
@@ -288,11 +307,13 @@ function initialize() {
   E2E_SCRIPT="$(cd ${E2E_SCRIPT%/*} && echo $PWD/${E2E_SCRIPT##*/})"
   readonly E2E_SCRIPT
 
+  E2E_CLUSTER_VERSION="${SERVING_GKE_VERSION}"
+
   cd ${REPO_ROOT_DIR}
   while [[ $# -ne 0 ]]; do
     local parameter=$1
     # Try parsing flag as a custom one.
-    if [[ "$(type -t parse_flags)" == "function" ]]; then
+    if function_exists parse_flags; then
       parse_flags $@
       local skip=$?
       if [[ ${skip} -ne 0 ]]; then
@@ -305,16 +326,47 @@ function initialize() {
     case $parameter in
       --run-tests) RUN_TESTS=1 ;;
       --emit-metrics) EMIT_METRICS=1 ;;
+      --gcp-project)
+        shift
+        [[ $# -ge 1 ]] || abort "missing project name after --gcp-project"
+        GCP_PROJECT=$1
+        ;;
+      --cluster-version)
+        shift
+        [[ $# -ge 1 ]] || abort "missing version after --cluster-version"
+        [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || abort "kubernetes version must be 'X.Y.Z'"
+        E2E_CLUSTER_VERSION=$1
+        ;;
       *)
-        echo "error: unknown option ${parameter}"
-        echo "usage: $0 [--run-tests][--emit-metrics]"
-        exit 1
+        echo "usage: $0 [--run-tests][--emit-metrics][--cluster-version X.Y.Z][--gcp-project name]"
+        abort "unknown option ${parameter}"
         ;;
     esac
     shift
   done
+
+  # Use PROJECT_ID if set, unless --gcp-project was used.
+  if [[ -n "${PROJECT_ID:-}" && -z "${GCP_PROJECT}" ]]; then
+    echo "\$PROJECT_ID is set to '${PROJECT_ID}', using it to run the tests"
+    GCP_PROJECT="${PROJECT_ID}"
+  fi
+  if (( ! IS_PROW )) && [[ -z "${GCP_PROJECT}" ]]; then
+    abort "set \$PROJECT_ID or use --gcp-project to select the GCP project where the tests are run"
+  fi
+
+  (( IS_PROW )) && [[ -z "${GCP_PROJECT}" ]] && IS_BOSKOS=1
+
+  # Safety checks
+
+  if [[ "${DOCKER_REPO_OVERRIDE}" =~ ^gcr.io/knative-(releases|nightly)/?$ ]]; then
+    abort "\$DOCKER_REPO_OVERRIDE is set to ${DOCKER_REPO_OVERRIDE}, which is forbidden"
+  fi
+
   readonly RUN_TESTS
   readonly EMIT_METRICS
+  readonly E2E_CLUSTER_VERSION
+  readonly GCP_PROJECT
+  readonly IS_BOSKOS
 
   if (( ! RUN_TESTS )); then
     create_test_cluster

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -22,11 +22,12 @@
 readonly SERVING_GKE_VERSION=latest
 readonly SERVING_GKE_IMAGE=cos
 
-# Public images and yaml files.
-readonly KNATIVE_ISTIO_YAML=https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml
-readonly KNATIVE_SERVING_RELEASE=https://storage.googleapis.com/knative-releases/serving/latest/release.yaml
-readonly KNATIVE_BUILD_RELEASE=https://storage.googleapis.com/knative-releases/build/latest/release.yaml
-readonly KNATIVE_EVENTING_RELEASE=https://storage.googleapis.com/knative-releases/eventing/latest/release.yaml
+# Public latest stable nightly images and yaml files.
+readonly KNATIVE_ISTIO_CRD_YAML=https://storage.googleapis.com/knative-nightly/serving/latest/istio-crds.yaml
+readonly KNATIVE_ISTIO_YAML=https://storage.googleapis.com/knative-nightly/serving/latest/istio.yaml
+readonly KNATIVE_SERVING_RELEASE=https://storage.googleapis.com/knative-nightly/serving/latest/release.yaml
+readonly KNATIVE_BUILD_RELEASE=https://storage.googleapis.com/knative-nightly/build/latest/release.yaml
+readonly KNATIVE_EVENTING_RELEASE=https://storage.googleapis.com/knative-nightly/eventing/latest/release.yaml
 
 # Conveniently set GOPATH if unset
 if [[ -z "${GOPATH:-}" ]]; then
@@ -46,7 +47,7 @@ readonly REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 #             $2 - banner message.
 function make_banner() {
     local msg="$1$1$1$1 $2 $1$1$1$1"
-    local border="${msg//[-0-9A-Za-z _.,]/$1}"
+    local border="${msg//[-0-9A-Za-z _.,\/]/$1}"
     echo -e "${border}\n${msg}\n${border}"
 }
 
@@ -64,6 +65,11 @@ function subheader() {
 # Simple warning banner for logging purposes.
 function warning() {
   make_banner "!" "$1"
+}
+
+# Checks whether the given function exists.
+function function_exists() {
+  [[ "$(type -t $1)" == "function" ]]
 }
 
 # Remove ALL images in the given GCR repository.
@@ -94,7 +100,10 @@ function wait_until_object_does_not_exist() {
   fi
   echo -n "Waiting until ${DESCRIPTION} does not exist"
   for i in {1..150}; do  # timeout after 5 minutes
-    kubectl ${KUBECTL_ARGS} > /dev/null 2>&1 || return 0
+    if kubectl ${KUBECTL_ARGS} > /dev/null 2>&1; then
+      echo "\n${DESCRIPTION} does not exist"
+      return 0
+    fi
     echo -n "."
     sleep 2
   done
@@ -172,13 +181,21 @@ function wait_until_routable() {
   return 1
 }
 
-# Returns the name of the pod of the given app.
+# Returns the name of the first pod of the given app.
 # Parameters: $1 - app name.
 #             $2 - namespace (optional).
 function get_app_pod() {
+  local pods=($(get_app_pods $1 $2))
+  echo "${pods[0]}"
+}
+
+# Returns the name of all pods of the given app.
+# Parameters: $1 - app name.
+#             $2 - namespace (optional).
+function get_app_pods() {
   local namespace=""
   [[ -n $2 ]] && namespace="-n $2"
-  kubectl get pods ${namespace} --selector=app=$1 --output=jsonpath="{.items[0].metadata.name}"
+  kubectl get pods ${namespace} --selector=app=$1 --output=jsonpath="{.items[*].metadata.name}"
 }
 
 # Sets the given user as cluster admin.
@@ -220,8 +237,8 @@ function acquire_cluster_admin_role() {
 function report_go_test() {
   # Run tests in verbose mode to capture details.
   # go doesn't like repeating -v, so remove if passed.
-  local args=("${@/-v}")
-  local go_test="go test -race -v ${args[@]}"
+  local args=" $@ "
+  local go_test="go test -race -v ${args/ -v / }"
   # Just run regular go tests if not on Prow.
   if (( ! IS_PROW )); then
     ${go_test}
@@ -231,6 +248,7 @@ function report_go_test() {
   local report=$(mktemp)
   local failed=0
   local test_count=0
+  local tests_failed=0
   ${go_test} > ${report} || failed=$?
   echo "Finished run, return code is ${failed}"
   # Tests didn't run.
@@ -283,6 +301,7 @@ function report_go_test() {
         local src="${name}.sh"
         echo "exit 0" > ${src}
         if [[ "${field1}" == "FAIL:" ]]; then
+          tests_failed=$(( tests_failed + 1 ))
           [[ -z "${error}" ]] && read error
           echo "cat <<ERROR-EOF" > ${src}
           echo "${error}" >> ${src}
@@ -309,13 +328,13 @@ function report_go_test() {
       fi
     fi
   done < ${report}
-  echo "Done parsing ${test_count} tests"
+  echo "Done parsing ${test_count} tests, ${tests_failed} tests failed"
   # If any test failed, show the detailed report.
   # Otherwise, we already shown the summary.
   # Exception: when emitting metrics, dump the full report.
   if (( failed )) || [[ "$@" == *" -emitmetrics"* ]]; then
     if (( failed )); then
-      echo "At least one test failed, full log:"
+      echo "There were ${tests_failed} test failures, full log:"
     else
       echo "Dumping full log as metrics were requested:"
     fi
@@ -330,6 +349,7 @@ function report_go_test() {
 function start_latest_knative_serving() {
   header "Starting Knative Serving"
   subheader "Installing Istio"
+  kubectl apply -f ${KNATIVE_ISTIO_CRD_YAML} || return 1
   kubectl apply -f ${KNATIVE_ISTIO_YAML} || return 1
   wait_until_pods_running istio-system || return 1
   kubectl label namespace default istio-injection=enabled || return 1
@@ -351,16 +371,18 @@ function start_latest_knative_build() {
 }
 
 # Run a go tool, installing it first if necessary.
-# Parameters: $1 - tool to run.
-#             $2 - tool package for go get.
+# Parameters: $1 - tool package/dir for go get/install.
+#             $2 - tool to run.
 #             $3..$n - parameters passed to the tool.
 function run_go_tool() {
-  local tool=$1
+  local tool=$2
   if [[ -z "$(which ${tool})" ]]; then
-    go install $2
+    local action=get
+    [[ $1 =~ ^[\./].* ]] && action=install
+    go ${action} $1
   fi
   shift 2
-  ${tool} $@
+  ${tool} "$@"
 }
 
 # Run dep-collector to update licenses.
@@ -370,7 +392,7 @@ function update_licenses() {
   cd ${REPO_ROOT_DIR} || return 1
   local dst=$1
   shift
-  run_go_tool dep-collector ./vendor/github.com/knative/test-infra/tools/dep-collector $@ > ./${dst}
+  run_go_tool ./vendor/github.com/knative/test-infra/tools/dep-collector dep-collector $@ > ./${dst}
 }
 
 # Run dep-collector to check for forbidden liceses.
@@ -379,7 +401,7 @@ function check_licenses() {
   # Fetch the google/licenseclassifier for its license db
   go get -u github.com/google/licenseclassifier
   # Check that we don't have any forbidden licenses in our images.
-  run_go_tool dep-collector ./vendor/github.com/knative/test-infra/tools/dep-collector -check $@
+  run_go_tool ./vendor/github.com/knative/test-infra/tools/dep-collector dep-collector -check $@
 }
 
 # Run the given linter on the given files, checking it exists first.

--- a/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
@@ -14,26 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is a helper script to run the presubmit tests. To use it:
-# 1. Source this script.
-# 2. Define the functions build_tests(), unit_tests() and
-#    integration_tests(). They should run all tests (i.e., not fail
-#    fast), and return 0 if all passed, 1 if a failure occurred.
-#    The environment variables RUN_BUILD_TESTS, RUN_UNIT_TESTS and
-#    RUN_INTEGRATION_TESTS are set to 0 (false) or 1 (true) accordingly.
-#    If --emit-metrics is passed, EMIT_METRICS will be set to 1.
-# 3. Call the main() function passing $@ (without quotes).
-#
-# Running the script without parameters, or with the --all-tests
-# flag, causes all tests to be executed, in the right order.
-# Use the flags --build-tests, --unit-tests and --integration-tests
-# to run a specific set of tests. The flag --emit-metrics is used
-# to emit metrics when running the tests.
+# This is a helper script for Knative presubmit test scripts.
+# See README.md for instructions on how to use it.
 
 source $(dirname ${BASH_SOURCE})/library.sh
 
 # Extensions or file patterns that don't require presubmit tests.
-readonly NO_PRESUBMIT_FILES=(\.md \.png ^OWNERS)
+readonly NO_PRESUBMIT_FILES=(\.md \.png ^OWNERS ^OWNERS_ALIASES)
 
 # Options set by command-line flags.
 RUN_BUILD_TESTS=0
@@ -61,6 +48,11 @@ function exit_if_presubmit_not_required() {
   fi
 }
 
+function abort() {
+  echo "error: $@"
+  exit 1
+}
+
 # Process flags and run tests accordingly.
 function main() {
   exit_if_presubmit_not_required
@@ -76,60 +68,94 @@ function main() {
     kubectl version
     echo ">> go version"
     go version
+    echo ">> git version"
+    git version
   fi
 
-  local all_parameters=$@
-  [[ -z $1 ]] && all_parameters="--all-tests"
+  [[ -z $1 ]] && set -- "--all-tests"
 
-  for parameter in ${all_parameters}; do
+  local TEST_TO_RUN=""
+
+  while [[ $# -ne 0 ]]; do
+    local parameter=$1
     case ${parameter} in
+      --build-tests) RUN_BUILD_TESTS=1 ;;
+      --unit-tests) RUN_UNIT_TESTS=1 ;;
+      --integration-tests) RUN_INTEGRATION_TESTS=1 ;;
+      --emit-metrics) EMIT_METRICS=1 ;;
       --all-tests)
         RUN_BUILD_TESTS=1
         RUN_UNIT_TESTS=1
         RUN_INTEGRATION_TESTS=1
+        ;;
+      --run-test)
         shift
+        [[ $# -ge 1 ]] || abort "missing executable after --run-test"
+        TEST_TO_RUN=$1
         ;;
-      --build-tests)
-        RUN_BUILD_TESTS=1
-        shift
-        ;;
-      --unit-tests)
-        RUN_UNIT_TESTS=1
-        shift
-        ;;
-      --integration-tests)
-        RUN_INTEGRATION_TESTS=1
-        shift
-        ;;
-      --emit-metrics)
-        EMIT_METRICS=1
-        shift
-        ;;
-      *)
-        echo "error: unknown option ${parameter}"
-        exit 1
-        ;;
+      *) abort "error: unknown option ${parameter}" ;;
     esac
+    shift
   done
 
   readonly RUN_BUILD_TESTS
   readonly RUN_UNIT_TESTS
   readonly RUN_INTEGRATION_TESTS
   readonly EMIT_METRICS
+  readonly TEST_TO_RUN
 
   cd ${REPO_ROOT_DIR}
 
   # Tests to be performed, in the right order if --all-tests is passed.
 
-  local result=0
+  local failed=0
+
+  if [[ -n "${TEST_TO_RUN}" ]]; then
+    if (( RUN_BUILD_TESTS || RUN_UNIT_TESTS || RUN_INTEGRATION_TESTS )); then
+      abort "--run-test must be used alone"
+    fi
+    ${TEST_TO_RUN} || failed=1
+  fi
+
   if (( RUN_BUILD_TESTS )); then
-    build_tests || result=1
+    build_tests || failed=1
   fi
   if (( RUN_UNIT_TESTS )); then
-    unit_tests || result=1
+    unit_tests || failed=1
   fi
   if (( RUN_INTEGRATION_TESTS )); then
-    integration_tests || result=1
+    local e2e_failed=0
+    # Run pre-integration tests, if any
+    if function_exists pre_integration_tests; then
+      if ! pre_integration_tests; then
+        failed=1
+        e2e_failed=1
+      fi
+    fi
+    # Don't run integration tests if pre-integration tests failed
+    if (( ! e2e_failed )); then
+      if function_exists integration_tests; then
+        if ! integration_tests; then
+          failed=1
+          e2e_failed=1
+        fi
+      else
+       local options=""
+       (( EMIT_METRICS )) && options="--emit-metrics"
+       for e2e_test in ./test/e2e-*tests.sh; do
+         echo "Running integration test ${e2e_test}"
+         if ! ${e2e_test} ${options}; then
+           failed=1
+           e2e_failed=1
+         fi
+       done
+      fi
+    fi
+    # Don't run post-integration
+    if (( ! e2e_failed )) && function_exists post_integration_tests; then
+      post_integration_tests || failed=1
+    fi
   fi
-  exit ${result}
+
+  exit ${failed}
 }

--- a/vendor/github.com/knative/test-infra/scripts/release.sh
+++ b/vendor/github.com/knative/test-infra/scripts/release.sh
@@ -31,8 +31,10 @@ function banner() {
 #             $3 - tag to apply (optional).
 function tag_images_in_yaml() {
   [[ -z $3 ]] && return 0
-  echo "Tagging images with $3"
-  for image in $(grep -o "$2/[a-z\./-]\+@sha256:[0-9a-f]\+" $1); do
+  local src_dir="${GOPATH}/src/"
+  local BASE_PATH="${REPO_ROOT_DIR/$src_dir}"
+  echo "Tagging images under '${BASE_PATH}' with $3"
+  for image in $(grep -o "$2/${BASE_PATH}/[a-z\./-]\+@sha256:[0-9a-f]\+" $1); do
     gcloud -q container images add-tag ${image} ${image%%@*}:$3
   done
 }
@@ -68,7 +70,7 @@ function parse_flags() {
   RELEASE_VERSION=""
   RELEASE_NOTES=""
   RELEASE_BRANCH=""
-  KO_FLAGS="-P -L"
+  KO_FLAGS="-P"
   cd ${REPO_ROOT_DIR}
   while [[ $# -ne 0 ]]; do
     local parameter=$1
@@ -76,16 +78,8 @@ function parse_flags() {
       --skip-tests) SKIP_TESTS=1 ;;
       --tag-release) TAG_RELEASE=1 ;;
       --notag-release) TAG_RELEASE=0 ;;
-      --publish)
-        PUBLISH_RELEASE=1
-        # Remove -L from ko flags
-        KO_FLAGS="${KO_FLAGS/-L}"
-        ;;
-      --nopublish)
-        PUBLISH_RELEASE=0
-        # Add -L to ko flags
-        KO_FLAGS="-L ${KO_FLAGS}"
-        ;;
+      --publish) PUBLISH_RELEASE=1 ;;
+      --nopublish) PUBLISH_RELEASE=0 ;;
       --version)
         shift
         [[ $# -ge 1 ]] || abort "missing version after --version"
@@ -109,9 +103,16 @@ function parse_flags() {
     shift
   done
 
+  # Update KO_DOCKER_REPO and KO_FLAGS if we're not publishing.
+  if (( ! PUBLISH_RELEASE )); then
+    KO_DOCKER_REPO="ko.local"
+    KO_FLAGS="-L ${KO_FLAGS}"
+  fi
+
   if (( TAG_RELEASE )); then
-    # Currently we're not considering the tags in refs/tags namespace.
-    commit=$(git describe --always --dirty)
+    # Get the commit, excluding any tags but keeping the "dirty" flag
+    local commit="$(git describe --always --dirty --match '^$')"
+    [[ -n "${commit}" ]] || abort "Error getting the current commit"
     # Like kubernetes, image tag is vYYYYMMDD-commit
     TAG="v$(date +%Y%m%d)-${commit}"
   fi
@@ -138,7 +139,10 @@ function run_validation_tests() {
   if (( ! SKIP_TESTS )); then
     banner "Running release validation tests"
     # Run tests.
-    $1
+    if ! $1; then
+      banner "Release validation tests failed, aborting"
+      exit 1
+    fi
   fi
 }
 
@@ -147,7 +151,7 @@ function initialize() {
   parse_flags $@
   # Checkout specific branch, if necessary
   if (( BRANCH_RELEASE )); then
-    git checkout --track upstream/${RELEASE_BRANCH} || abort "cannot checkout branch ${RELEASE_BRANCH}"
+    git checkout upstream/${RELEASE_BRANCH} || abort "cannot checkout branch ${RELEASE_BRANCH}"
   fi
 }
 
@@ -157,18 +161,23 @@ function initialize() {
 function branch_release() {
   (( BRANCH_RELEASE )) || return 0
   local title="$1 release ${TAG}"
-  local yamls="$2"
-  local attach="--attach=${yamls// / --attach=}"
+  local attachments=()
   local description="$(mktemp)"
+  local attachments_dir="$(mktemp -d)"
+  # Copy each YAML to a separate dir
+  for yaml in $2; do
+    cp ${yaml} ${attachments_dir}/
+    attachments+=("--attach=${yaml}#$(basename ${yaml})")
+  done
   echo -e "${title}\n" > ${description}
   if [[ -n "${RELEASE_NOTES}" ]]; then
     cat ${RELEASE_NOTES} >> ${description}
   fi
   git tag -a ${TAG} -m "${title}"
   git push $(git remote get-url upstream) tag ${TAG}
-  run_go_tool hub github.com/github/hub release create \
+  run_go_tool github.com/github/hub hub release create \
       --prerelease \
-      ${attach} \
+      ${attachments[@]} \
       --file=${description} \
       --commitish=${RELEASE_BRANCH} \
       ${TAG}

--- a/vendor/github.com/knative/test-infra/test/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/test/presubmit-tests.sh
@@ -29,7 +29,7 @@ function build_tests() {
   make -C ci/prow test || failed=1
   make -C ci/testgrid test || failed=1
   for script in scripts/*.sh; do
-    echo "Checking integrity of ${script}"
+    subheader "Checking integrity of ${script}"
     bash -c "source ${script}" || failed=1
   done
   return ${failed}
@@ -38,15 +38,14 @@ function build_tests() {
 function unit_tests() {
   header "Running unit tests"
   local failed=0
-  for test in library release; do
-    ./test/${test}-tests.sh || failed=1
+  for test in ./test/unit/*-tests.sh; do
+    subheader "Running tests in ${test}"
+    ${test} || failed=1
   done
+  go test -count=1 ./... || failed=1
   return ${failed}
 }
 
-function integration_tests() {
-  ./test/e2e-tests.sh --smoke-test-custom-flag-passed
-  ./test/e2e-tests.sh
-}
+# We use the default integration test runner.
 
 main $@

--- a/vendor/github.com/knative/test-infra/test/unit/e2e-custom-flag-tests.sh
+++ b/vendor/github.com/knative/test-infra/test/unit/e2e-custom-flag-tests.sh
@@ -23,15 +23,17 @@
 # Calling this script without arguments will create a new cluster in
 # project $PROJECT_ID, run the tests and delete the cluster.
 
-source $(dirname $0)/../scripts/e2e-tests.sh
+source $(dirname $0)/../../scripts/e2e-tests.sh
+
+function parse_flags() {
+  if [[ "$1" == "--smoke-test-custom-flag" ]]; then
+    echo ">> All tests passed"
+    exit 0
+  fi
+  fail_test "Unexpected flag $1 passed"
+}
 
 # Script entry point.
 
-initialize $@
-
-start_latest_knative_serving || fail_test "Knative Serving is not up"
-
-# This is actually a unit test, but it does exercise the necessary helper functions.
-go_test_e2e -run TestE2ESucceeds ./test || fail_test
-
-success
+echo ">> Testing e2e custom flag"
+initialize --smoke-test-custom-flag

--- a/vendor/github.com/knative/test-infra/test/unit/library-tests.sh
+++ b/vendor/github.com/knative/test-infra/test/unit/library-tests.sh
@@ -17,13 +17,13 @@
 # Fake we're in a Prow job, if running locally.
 [[ -z "${PROW_JOB_ID:-}" ]] && PROW_JOB_ID=123
 
-source $(dirname $0)/../scripts/library.sh
+source $(dirname $0)/../../scripts/library.sh
 
 set -e
 
 function test_report() {
   local REPORT="$(mktemp)"
-  report_go_test -run $1 ./test > ${REPORT} || true
+  report_go_test -tags=library -run $1 ./test > ${REPORT} || true
   cat ${REPORT}
   grep "$2" ${REPORT} > /dev/null
   grep "Done parsing 1 tests" ${REPORT} > /dev/null
@@ -36,15 +36,15 @@ function cleanup_bazel() {
 
 trap cleanup_bazel EXIT
 
-header "Testing report_go_test"
+echo ">> Testing report_go_test"
 
-subheader "Test pass"
+echo ">> Test that test passes"
 test_report TestSucceeds "^- TestSucceeds :PASS:"
 
-subheader "Test fails with fatal"
+echo ">> Testing that test fails with fatal"
 test_report TestFailsWithFatal "^- TestFailsWithFatal :FAIL:"
 
-subheader "Test fails with SIGQUIT"
+echo ">> Testing that test fails with SIGQUIT"
 test_report TestFailsWithSigQuit "^- TestFailsWithSigQuit :FAIL:"
 
-header "All tests passed"
+echo ">> All tests passed"

--- a/vendor/github.com/knative/test-infra/test/unit/presubmit-full-custom-integration-tests.sh
+++ b/vendor/github.com/knative/test-infra/test/unit/presubmit-full-custom-integration-tests.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2018 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,23 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMG = gcr.io/knative-tests/test-infra/prow-tests
-TAG := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty --match '^$')
+source $(dirname $0)/presubmit-integration-tests-common.sh
 
-all: build
+function check_results() {
+  (( PRE_INTEGRATION_TESTS )) || failed "Pre integration tests did not run"
+  (( CUSTOM_INTEGRATION_TESTS )) || failed "Custom integration tests did not run"
+  (( POST_INTEGRATION_TESTS )) || failed "Post integration tests did not run"
+  echo ">> All tests passed"
+}
 
-build:
-	make -C ../../tools/githubhelper
-	docker build -t $(IMG):$(TAG) -f Dockerfile ../..
-	docker tag $(IMG):$(TAG) $(IMG):latest
+echo ">> Testing all custom test integration functions"
 
-push_versioned: build
-	docker push $(IMG):$(TAG)
-
-push_latest: build
-	docker push $(IMG):latest
-
-clean:
-	rm -fr githubhelper dep-collector
-
-push: push_versioned push_latest clean
+main $@

--- a/vendor/github.com/knative/test-infra/test/unit/presubmit-integration-tests-common.sh
+++ b/vendor/github.com/knative/test-infra/test/unit/presubmit-integration-tests-common.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2018 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,23 +14,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMG = gcr.io/knative-tests/test-infra/prow-tests
-TAG := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty --match '^$')
+source $(dirname $0)/../../scripts/presubmit-tests.sh
 
-all: build
+function failed() {
+  echo $1
+  exit 1
+}
 
-build:
-	make -C ../../tools/githubhelper
-	docker build -t $(IMG):$(TAG) -f Dockerfile ../..
-	docker tag $(IMG):$(TAG) $(IMG):latest
+function pre_integration_tests() {
+  PRE_INTEGRATION_TESTS=1
+}
 
-push_versioned: build
-	docker push $(IMG):$(TAG)
+function integration_tests() {
+  CUSTOM_INTEGRATION_TESTS=1
+}
 
-push_latest: build
-	docker push $(IMG):latest
+function post_integration_tests() {
+  POST_INTEGRATION_TESTS=1
+}
 
-clean:
-	rm -fr githubhelper dep-collector
+function build_tests() {
+  return 0
+}
 
-push: push_versioned push_latest clean
+function unit_tests() {
+  return 0
+}
+
+PRE_INTEGRATION_TESTS=0
+CUSTOM_INTEGRATION_TESTS=0
+POST_INTEGRATION_TESTS=0
+
+trap check_results EXIT

--- a/vendor/github.com/knative/test-infra/tools/apicoverage/apicoverage.go
+++ b/vendor/github.com/knative/test-infra/tools/apicoverage/apicoverage.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	logDir         = "logs/ci-knative-serving-continuous/"
+	logDir         = "logs/ci-knative-serving-continuous"
 	buildFile      = "build-log.txt"
 	apiCoverage    = "api_coverage"
 	overallRoute   = "OverallRoute"

--- a/vendor/github.com/knative/test-infra/tools/dep-collector/imports.go
+++ b/vendor/github.com/knative/test-infra/tools/dep-collector/imports.go
@@ -62,7 +62,7 @@ func CollectTransitiveImports(binaries []string) ([]string, error) {
 func qualifyLocalImport(ip string) (string, error) {
 	gopathsrc := filepath.Join(gb.Default.GOPATH, "src")
 	if !strings.HasPrefix(WorkingDir, gopathsrc) {
-		return "", fmt.Errorf("working directory must be on ${GOPATH}/src = ", gopathsrc)
+		return "", fmt.Errorf("working directory must be on ${GOPATH}/src = %s", gopathsrc)
 	}
 	return filepath.Join(strings.TrimPrefix(WorkingDir, gopathsrc+string(filepath.Separator)), ip), nil
 }

--- a/vendor/github.com/knative/test-infra/tools/gcs/gcs.go
+++ b/vendor/github.com/knative/test-infra/tools/gcs/gcs.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	bucketName = "knative-prow"
-	latest     = "latest-build.txt"
+	latest     = "/latest-build.txt"
 )
 
 var client *storage.Client
@@ -50,7 +50,9 @@ func createStorageObject(filename string) *storage.ObjectHandle {
 
 // GetLatestBuildNumber gets the latest build number for the specified log directory
 func GetLatestBuildNumber(ctx context.Context, logDir string, sa string) (int, error) {
-	contents, err := ReadGcsFile(ctx, logDir+latest, sa)
+	logFilePath := logDir + latest
+	log.Printf("Using %s to get latest build number", logFilePath)
+	contents, err := ReadGcsFile(ctx, logFilePath, sa)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Old images cleanup is no longer part of e2e test, this functionality will be moved to a separate job runs periodically.

## Proposed Changes
  *This part is done in knative/test-infra, updating dependencies in this repo to include this update.

Link to the issue in test-infra: knative/test-infra#276
