### PR TITLE
Use different reporting periods based on the metrics backend

### DIFF
--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
-	"time"
 
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	"go.opencensus.io/exporter/prometheus"
@@ -137,7 +136,7 @@ func setCurMetricsExporterAndConfig(e view.Exporter, c *metricsConfig) {
 	metricsMux.Lock()
 	defer metricsMux.Unlock()
 	view.RegisterExporter(e)
-	view.SetReportingPeriod(60 * time.Second)
+	view.SetReportingPeriod(c.reportingPeriod)
 	curMetricsExporter = e
 	curMetricsConfig = c
 }


### PR DESCRIPTION
Use different reporting periods based on the metrics backend. Original implementation was setting this value to 1 min to accommodate the minimum allowed value for stackdriver, but that is a sub optimal behavior for Prometheus. The change also allows operator to override the default values.

<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:

Fixes: <LINK TO ISSUE>
-->
