### PR TITLE
Format markdown

### DIFF
--- a/.github/issue-template.md
+++ b/.github/issue-template.md
@@ -21,14 +21,10 @@ Classify what kind of issue this is:
 
 ## Expected Behavior
 
-
 ## Actual Behavior
-
 
 ## Steps to Reproduce the Problem
 
-  1.
-  2.
-  3.
+1. 2. 3.
 
 ## Additional Info

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@ This doc explains how to setup a development environment so you can get started
 [contributing](https://github.com/knative/docs/blob/master/community/CONTRIBUTING.md)
 to Knative `pkg`. Also take a look at:
 
-* [The pull request workflow](https://github.com/knative/docs/blob/master/community/CONTRIBUTING.md#pull-requests)
+- [The pull request workflow](https://github.com/knative/docs/blob/master/community/CONTRIBUTING.md#pull-requests)
 
 ## Getting started
 
@@ -31,9 +31,9 @@ To get started you'll need to set these environment variables (we recommend
 adding them to your `.bashrc`):
 
 1. `GOPATH`: If you don't have one, simply pick a directory and add
-`export GOPATH=...`
+   `export GOPATH=...`
 1. `$GOPATH/bin` on `PATH`: This is so that tooling installed via `go get` will
-work properly.
+   work properly.
 
 `.bashrc` example:
 
@@ -50,17 +50,17 @@ in your [`GOPATH`](https://github.com/golang/go/wiki/SettingGOPATH).
 To check out this repository:
 
 1. Create your own [fork of this
-  repo](https://help.github.com/articles/fork-a-repo/)
+   repo](https://help.github.com/articles/fork-a-repo/)
 1. Clone it to your machine:
 
-  ```shell
-  mkdir -p ${GOPATH}/src/github.com/knative
-  cd ${GOPATH}/src/github.com/knative
-  git clone git@github.com:${YOUR_GITHUB_USERNAME}/pkg.git
-  cd pkg
-  git remote add upstream git@github.com:knative/pkg.git
-  git remote set-url --push upstream no_push
-  ```
+```shell
+mkdir -p ${GOPATH}/src/github.com/knative
+cd ${GOPATH}/src/github.com/knative
+git clone git@github.com:${YOUR_GITHUB_USERNAME}/pkg.git
+cd pkg
+git remote add upstream git@github.com:knative/pkg.git
+git remote set-url --push upstream no_push
+```
 
 _Adding the `upstream` remote sets you up nicely for regularly [syncing your
 fork](https://help.github.com/articles/syncing-a-fork/)._

--- a/apis/istio/v1alpha3/README.md
+++ b/apis/istio/v1alpha3/README.md
@@ -1,11 +1,12 @@
 # What are these files?
 
-These are Go structs for Istio CRD.  We translated them from proto files in
+These are Go structs for Istio CRD. We translated them from proto files in
 https://github.com/istio/api/tree/master/networking/v1alpha3 .
 
-# Why do we hand-translate from proto?  i.e Why can't we vendor these?
+# Why do we hand-translate from proto? i.e Why can't we vendor these?
+
 Istio needs to run on many platforms and as a reason they represent their
-objects internally as proto.  On Kubernetes, their API take in JSON objects
+objects internally as proto. On Kubernetes, their API take in JSON objects
 and convert to proto before processing them.
 
 So they have nothing we can vendor, except for the Go files that are generated

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -14,21 +14,21 @@ religion, or sexual identity and orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
+- The use of sexualized language or imagery and unwelcome sexual attention or
   advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
   address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Our Responsibilities
@@ -60,7 +60,7 @@ knative-code-of-conduct@googlegroups.com. All complaints will be reviewed
 and investigated and will result in a response that is deemed
 necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of
-an incident.  Further details of specific enforcement policies may be
+an incident. Further details of specific enforcement policies may be
 posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
@@ -73,4 +73,3 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage], versi
 available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 [homepage]: https://www.contributor-covenant.org
-

--- a/test/README.md
+++ b/test/README.md
@@ -2,9 +2,9 @@
 
 This directory contains tests and testing docs.
 
-* [Test library](#test-library) contains code you can use in your `knative` tests
-* [Flags](#flags) added by [the test library](#test-library)
-* [Unit tests](#running-unit-tests) currently reside in the codebase alongside the code they test
+- [Test library](#test-library) contains code you can use in your `knative` tests
+- [Flags](#flags) added by [the test library](#test-library)
+- [Unit tests](#running-unit-tests) currently reside in the codebase alongside the code they test
 
 ## Running unit tests
 
@@ -18,10 +18,10 @@ go test ./...
 
 You can use the test library in this dir to:
 
-* [Use common test flags](#use-common-test-flags)
-* [Output logs](#output-logs)
-* [Emit metrics](#emit-metrics)
-* [Ensure test cleanup](#ensure-test-cleanup)
+- [Use common test flags](#use-common-test-flags)
+- [Output logs](#output-logs)
+- [Emit metrics](#emit-metrics)
+- [Ensure test cleanup](#ensure-test-cleanup)
 
 ### Use common test flags
 
@@ -37,13 +37,12 @@ logger.Infof("Using namespace %s", test.Flags.Namespace)
 
 _See [e2e_flags.go](./e2e_flags.go)._
 
-
 ### Output logs
 
 [When tests are run with `--logverbose`
 option](README.md#output-verbose-logs), debug logs will be emitted to stdout.
 
-We are using the common [e2e logging library](logging/logging.go) that uses the [Knative logging library](../logging/) for structured logging. 
+We are using the common [e2e logging library](logging/logging.go) that uses the [Knative logging library](../logging/) for structured logging.
 It is built on top of [zap](https://github.com/uber-go/zap). Tests should initialize the global logger to use a test specifc context with `logging.GetContextLogger`:
 
 ```go
@@ -76,9 +75,9 @@ measure latency with [`trace.StartSpan`](https://github.com/census-instrumentati
 ctx, span := trace.StartSpan(context.Background(), "MyMetric")
 ```
 
-* These traces will be emitted automatically by [the generic crd polling
+- These traces will be emitted automatically by [the generic crd polling
   functions](#check-knative-serving-resources).
-* The traces are emitted by [a custom metric exporter](./logging/logging.go)
+- The traces are emitted by [a custom metric exporter](./logging/logging.go)
   that uses the global logger instance.
 
 #### Metric format
@@ -86,11 +85,11 @@ ctx, span := trace.StartSpan(context.Background(), "MyMetric")
 When a `trace` metric is emitted, the format is `metric <name> <startTime> <endTime> <duration>`. The name
 of the metric is arbitrary and can be any string. The values are:
 
-* `metric` - Indicates this log is a metric
-* `<name>` - Arbitrary string indentifying the metric
-* `<startTime>` - Unix time in nanoseconds when measurement started
-* `<endTime>` - Unix time in nanoseconds when measurement ended
-* `<duration>` - The difference in ms between the startTime and endTime
+- `metric` - Indicates this log is a metric
+- `<name>` - Arbitrary string indentifying the metric
+- `<startTime>` - Unix time in nanoseconds when measurement started
+- `<endTime>` - Unix time in nanoseconds when measurement ended
+- `<duration>` - The difference in ms between the startTime and endTime
 
 For example:
 
@@ -158,11 +157,11 @@ need to run against a cluster.
 
 Tests importing [`github.com/knative/pkg/test`](#test-library) recognize these flags:
 
-* [`--kubeconfig`](#specifying-kubeconfig)
-* [`--cluster`](#specifying-cluster)
-* [`--namespace`](#specifying-namespace)
-* [`--logverbose`](#output-verbose-logs)
-* [`--emitmetrics`](#metrics-flag)
+- [`--kubeconfig`](#specifying-kubeconfig)
+- [`--cluster`](#specifying-cluster)
+- [`--namespace`](#specifying-namespace)
+- [`--logverbose`](#output-verbose-logs)
+- [`--emitmetrics`](#metrics-flag)
 
 ### Specifying kubeconfig
 
@@ -220,10 +219,10 @@ the tests.
 go test ./test --emitmetrics
 ```
 
-* To add additional metrics to a test, see [emitting metrics](adding_tests.md#emit-metrics).
-* For more info on the format of the metrics, see [metric format](adding_tests.md#metric-format).
+- To add additional metrics to a test, see [emitting metrics](adding_tests.md#emit-metrics).
+- For more info on the format of the metrics, see [metric format](adding_tests.md#metric-format).
 
-[Minikube]: https://kubernetes.io/docs/setup/minikube/
+[minikube]: https://kubernetes.io/docs/setup/minikube/
 
 ---
 


### PR DESCRIPTION
Produced via: `prettier --write $(find -name '*.md' | grep -v vendor)`