### PR TITLE
Format markdown

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,8 +9,8 @@ to Knative `pkg`. Also take a look at:
 ## Getting started
 
 1. Create [a GitHub account](https://github.com/join)
-1. Setup [GitHub access via
-   SSH](https://help.github.com/articles/connecting-to-github-with-ssh/)
+1. Setup
+   [GitHub access via SSH](https://help.github.com/articles/connecting-to-github-with-ssh/)
 1. Install [requirements](#requirements)
 1. Set up your [shell environment](#environment-setup)
 1. [Create and checkout a repo fork](#checkout-your-fork)
@@ -21,7 +21,8 @@ Before submitting a PR, see also [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 You must install these tools:
 
-1. [`go`](https://golang.org/doc/install): The language Knative `pkg` is built in
+1. [`go`](https://golang.org/doc/install): The language Knative `pkg` is built
+   in
 1. [`git`](https://help.github.com/articles/set-up-git/): For source control
 1. [`dep`](https://github.com/golang/dep): For managing external dependencies.
 
@@ -44,13 +45,14 @@ export PATH="${PATH}:${GOPATH}/bin"
 
 ### Checkout your fork
 
-The Go tools require that you clone the repository to the `src/github.com/knative/pkg` directory
-in your [`GOPATH`](https://github.com/golang/go/wiki/SettingGOPATH).
+The Go tools require that you clone the repository to the
+`src/github.com/knative/pkg` directory in your
+[`GOPATH`](https://github.com/golang/go/wiki/SettingGOPATH).
 
 To check out this repository:
 
-1. Create your own [fork of this
-   repo](https://help.github.com/articles/fork-a-repo/)
+1. Create your own
+   [fork of this repo](https://help.github.com/articles/fork-a-repo/)
 1. Clone it to your machine:
 
 ```shell
@@ -62,7 +64,8 @@ git remote add upstream git@github.com:knative/pkg.git
 git remote set-url --push upstream no_push
 ```
 
-_Adding the `upstream` remote sets you up nicely for regularly [syncing your
-fork](https://help.github.com/articles/syncing-a-fork/)._
+_Adding the `upstream` remote sets you up nicely for regularly
+[syncing your fork](https://help.github.com/articles/syncing-a-fork/)._
 
-Once you reach this point you are ready to do a full build and deploy as described below.
+Once you reach this point you are ready to do a full build and deploy as
+described below.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![GoDoc](https://godoc.org/github.com/knative/pkg?status.svg)](https://godoc.org/github.com/knative/pkg)
 [![Go Report Card](https://goreportcard.com/badge/knative/pkg)](https://goreportcard.com/report/knative/pkg)
 
-Knative `pkg` provides a place for sharing common Knative packages across
-the Knative repos.
+Knative `pkg` provides a place for sharing common Knative packages across the
+Knative repos.
 
 To learn more about Knative, please visit our
 [Knative docs](https://github.com/knative/docs) repository.

--- a/apis/istio/v1alpha3/README.md
+++ b/apis/istio/v1alpha3/README.md
@@ -6,12 +6,12 @@ https://github.com/istio/api/tree/master/networking/v1alpha3 .
 # Why do we hand-translate from proto? i.e Why can't we vendor these?
 
 Istio needs to run on many platforms and as a reason they represent their
-objects internally as proto. On Kubernetes, their API take in JSON objects
-and convert to proto before processing them.
+objects internally as proto. On Kubernetes, their API take in JSON objects and
+convert to proto before processing them.
 
 So they have nothing we can vendor, except for the Go files that are generated
 by the proto compiler, which is not compatible with K8s API code-generator at
 all.
 
-We may be able to donate our translation so they can maintain it themselves.
-See https://github.com/istio/istio/issues/6084.
+We may be able to donate our translation so they can maintain it themselves. See
+https://github.com/istio/istio/issues/6084.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -5,9 +5,9 @@
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-education, socio-economic status, nationality, personal appearance, race,
-religion, or sexual identity and orientation.
+size, disability, ethnicity, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
 
 ## Our Standards
 
@@ -37,11 +37,11 @@ Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
 response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
 
 ## Scope
 
@@ -54,14 +54,13 @@ further defined and clarified by project maintainers.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior
-may be reported by contacting the project team at
-knative-code-of-conduct@googlegroups.com. All complaints will be reviewed
-and investigated and will result in a response that is deemed
-necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of
-an incident. Further details of specific enforcement policies may be
-posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at
+knative-code-of-conduct@googlegroups.com. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
@@ -69,7 +68,8 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 [homepage]: https://www.contributor-covenant.org

--- a/test/README.md
+++ b/test/README.md
@@ -2,9 +2,11 @@
 
 This directory contains tests and testing docs.
 
-- [Test library](#test-library) contains code you can use in your `knative` tests
+- [Test library](#test-library) contains code you can use in your `knative`
+  tests
 - [Flags](#flags) added by [the test library](#test-library)
-- [Unit tests](#running-unit-tests) currently reside in the codebase alongside the code they test
+- [Unit tests](#running-unit-tests) currently reside in the codebase alongside
+  the code they test
 
 ## Running unit tests
 
@@ -25,11 +27,13 @@ You can use the test library in this dir to:
 
 ### Use common test flags
 
-These flags are useful for running against an existing cluster, making use of your existing
+These flags are useful for running against an existing cluster, making use of
+your existing
 [environment setup](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#environment-setup).
 
-By importing `github.com/knative/pkg/test` you get access to a global variable called
-`test.Flags` which holds the values of [the command line flags](/test/README.md#flags).
+By importing `github.com/knative/pkg/test` you get access to a global variable
+called `test.Flags` which holds the values of
+[the command line flags](/test/README.md#flags).
 
 ```go
 logger.Infof("Using namespace %s", test.Flags.Namespace)
@@ -39,19 +43,21 @@ _See [e2e_flags.go](./e2e_flags.go)._
 
 ### Output logs
 
-[When tests are run with `--logverbose`
-option](README.md#output-verbose-logs), debug logs will be emitted to stdout.
+[When tests are run with `--logverbose` option](README.md#output-verbose-logs),
+debug logs will be emitted to stdout.
 
-We are using the common [e2e logging library](logging/logging.go) that uses the [Knative logging library](../logging/) for structured logging.
-It is built on top of [zap](https://github.com/uber-go/zap). Tests should initialize the global logger to use a test specifc context with `logging.GetContextLogger`:
+We are using the common [e2e logging library](logging/logging.go) that uses the
+[Knative logging library](../logging/) for structured logging. It is built on
+top of [zap](https://github.com/uber-go/zap). Tests should initialize the global
+logger to use a test specifc context with `logging.GetContextLogger`:
 
 ```go
 // The convention is for the name of the logger to match the name of the test.
 logging.GetContextLogger("TestHelloWorld")
 ```
 
-Logs can then be emitted using the `logger` object which is required by
-many functions in the test library. To emit logs:
+Logs can then be emitted using the `logger` object which is required by many
+functions in the test library. To emit logs:
 
 ```go
 logger.Infof("Creating a new Route %s and Configuration %s", route, configuration)
@@ -62,28 +68,32 @@ _See [logging.go](./logging/logging.go)._
 
 ### Emit metrics
 
-You can emit metrics from your tests using [the opencensus
-library](https://github.com/census-instrumentation/opencensus-go), which [is being
-used inside Knative as well](https://github.com/knative/serving/blob/master/docs/telemetry.md).
-These metrics will be emitted by the test if the test is run with [the `--emitmetrics` option](#metrics-flag).
+You can emit metrics from your tests using
+[the opencensus library](https://github.com/census-instrumentation/opencensus-go),
+which
+[is being used inside Knative as well](https://github.com/knative/serving/blob/master/docs/telemetry.md).
+These metrics will be emitted by the test if the test is run with
+[the `--emitmetrics` option](#metrics-flag).
 
 You can record arbitrary metrics with
-[`stats.Record`](https://github.com/census-instrumentation/opencensus-go#stats) or
-measure latency with [`trace.StartSpan`](https://github.com/census-instrumentation/opencensus-go#traces):
+[`stats.Record`](https://github.com/census-instrumentation/opencensus-go#stats)
+or measure latency with
+[`trace.StartSpan`](https://github.com/census-instrumentation/opencensus-go#traces):
 
 ```go
 ctx, span := trace.StartSpan(context.Background(), "MyMetric")
 ```
 
-- These traces will be emitted automatically by [the generic crd polling
-  functions](#check-knative-serving-resources).
+- These traces will be emitted automatically by
+  [the generic crd polling functions](#check-knative-serving-resources).
 - The traces are emitted by [a custom metric exporter](./logging/logging.go)
   that uses the global logger instance.
 
 #### Metric format
 
-When a `trace` metric is emitted, the format is `metric <name> <startTime> <endTime> <duration>`. The name
-of the metric is arbitrary and can be any string. The values are:
+When a `trace` metric is emitted, the format is
+`metric <name> <startTime> <endTime> <duration>`. The name of the metric is
+arbitrary and can be any string. The values are:
 
 - `metric` - Indicates this log is a metric
 - `<name>` - Arbitrary string indentifying the metric
@@ -97,31 +107,36 @@ For example:
 metric WaitForConfigurationState/prodxiparjxt/ConfigurationUpdatedWithRevision 1529980772357637397 1529980772431586609 73.949212ms
 ```
 
-_The [`Wait` methods](#check-knative-serving-resources) (which poll resources) will
-prefix the metric names with the name of the function, and if applicable, the name of the resource,
-separated by `/`. In the example above, `WaitForConfigurationState` is the name of
-the function, and `prodxiparjxt` is the name of the configuration resource being polled.
-`ConfigurationUpdatedWithRevision` is the string passed to `WaitForConfigurationState` by
-the caller to identify what state is being polled for._
+_The [`Wait` methods](#check-knative-serving-resources) (which poll resources)
+will prefix the metric names with the name of the function, and if applicable,
+the name of the resource, separated by `/`. In the example above,
+`WaitForConfigurationState` is the name of the function, and `prodxiparjxt` is
+the name of the configuration resource being polled.
+`ConfigurationUpdatedWithRevision` is the string passed to
+`WaitForConfigurationState` by the caller to identify what state is being polled
+for._
 
 ### Check Knative Serving resources
 
 _WARNING: this code also exists in
 [`knative/serving`](https://github.com/knative/serving/blob/master/test/adding_tests.md#make-requests-against-deployed-services)._
 
-After creating Knative Serving resources or making changes to them, you will need to wait for the system
-to realize those changes. You can use the Knative Serving CRD check and polling methods to check the
-resources are either in or reach the desired state.
+After creating Knative Serving resources or making changes to them, you will
+need to wait for the system to realize those changes. You can use the Knative
+Serving CRD check and polling methods to check the resources are either in or
+reach the desired state.
 
-The `WaitFor*` functions use the kubernetes [`wait` package](https://godoc.org/k8s.io/apimachinery/pkg/util/wait).
-To poll they use [`PollImmediate`](https://godoc.org/k8s.io/apimachinery/pkg/util/wait#PollImmediate)
+The `WaitFor*` functions use the kubernetes
+[`wait` package](https://godoc.org/k8s.io/apimachinery/pkg/util/wait). To poll
+they use
+[`PollImmediate`](https://godoc.org/k8s.io/apimachinery/pkg/util/wait#PollImmediate)
 and the return values of the function you provide behave the same as
 [`ConditionFunc`](https://godoc.org/k8s.io/apimachinery/pkg/util/wait#ConditionFunc):
-a `bool` to indicate if the function should stop or continue polling, and an `error` to indicate if
-there has been an error.
+a `bool` to indicate if the function should stop or continue polling, and an
+`error` to indicate if there has been an error.
 
-For example, you can poll a `Configuration` object to find the name of the `Revision` that was created
-for it:
+For example, you can poll a `Configuration` object to find the name of the
+`Revision` that was created for it:
 
 ```go
 var revisionName string
@@ -134,14 +149,16 @@ err := test.WaitForConfigurationState(clients.ServingClient, configName, func(c 
 }, "ConfigurationUpdatedWithRevision")
 ```
 
-_[Metrics will be emitted](#emit-metrics) for these `Wait` method tracking how long test poll for._
+_[Metrics will be emitted](#emit-metrics) for these `Wait` method tracking how
+long test poll for._
 
 _See [kube_checks.go](./kube_checks.go)._
 
 ### Ensure test cleanup
 
-To ensure your test is cleaned up, you should defer cleanup to execute after your
-test completes and also ensure the cleanup occurs if the test is interrupted:
+To ensure your test is cleaned up, you should defer cleanup to execute after
+your test completes and also ensure the cleanup occurs if the test is
+interrupted:
 
 ```go
 defer tearDown(clients)
@@ -152,10 +169,11 @@ _See [cleanup.go](./cleanup.go)._
 
 ## Flags
 
-Importing [the test library](#test-library) adds flags that are useful for end to end tests that
-need to run against a cluster.
+Importing [the test library](#test-library) adds flags that are useful for end
+to end tests that need to run against a cluster.
 
-Tests importing [`github.com/knative/pkg/test`](#test-library) recognize these flags:
+Tests importing [`github.com/knative/pkg/test`](#test-library) recognize these
+flags:
 
 - [`--kubeconfig`](#specifying-kubeconfig)
 - [`--cluster`](#specifying-cluster)
@@ -165,10 +183,11 @@ Tests importing [`github.com/knative/pkg/test`](#test-library) recognize these f
 
 ### Specifying kubeconfig
 
-By default the tests will use the [kubeconfig
-file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
-at `~/.kube/config`. If there is an error getting the current user, it will use `kubeconfig` instead as the default value.
-You can specify a different config file with the argument `--kubeconfig`.
+By default the tests will use the
+[kubeconfig file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
+at `~/.kube/config`. If there is an error getting the current user, it will use
+`kubeconfig` instead as the default value. You can specify a different config
+file with the argument `--kubeconfig`.
 
 To run tests with a non-default kubeconfig file:
 
@@ -178,9 +197,10 @@ go test ./test --kubeconfig /my/path/kubeconfig
 
 ### Specifying cluster
 
-The `--cluster` argument lets you use a different cluster than [your specified
-kubeconfig's](#specifying-kubeconfig) active context. This will default to the value
-of your [`K8S_CLUSTER_OVERRIDE` environment variable](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#environment-setup)
+The `--cluster` argument lets you use a different cluster than
+[your specified kubeconfig's](#specifying-kubeconfig) active context. This will
+default to the value of your
+[`K8S_CLUSTER_OVERRIDE` environment variable](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#environment-setup)
 if not specified.
 
 ```bash
@@ -195,8 +215,8 @@ kubectl config get-clusters
 
 ### Specifying namespace
 
-The `--namespace` argument lets you specify the namespace to use for the
-tests. By default, tests will use `serving-tests`.
+The `--namespace` argument lets you specify the namespace to use for the tests.
+By default, tests will use `serving-tests`.
 
 ```bash
 go test ./test --namespace your-namespace-name
@@ -212,15 +232,17 @@ go test ./test --logverbose
 
 ### Metrics flag
 
-Running tests with the `--emitmetrics` argument will cause latency metrics to be emitted by
-the tests.
+Running tests with the `--emitmetrics` argument will cause latency metrics to be
+emitted by the tests.
 
 ```bash
 go test ./test --emitmetrics
 ```
 
-- To add additional metrics to a test, see [emitting metrics](adding_tests.md#emit-metrics).
-- For more info on the format of the metrics, see [metric format](adding_tests.md#metric-format).
+- To add additional metrics to a test, see
+  [emitting metrics](adding_tests.md#emit-metrics).
+- For more info on the format of the metrics, see
+  [metric format](adding_tests.md#metric-format).
 
 [minikube]: https://kubernetes.io/docs/setup/minikube/
 


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`