### PR TITLE
This exempts defaulting from the rules governing field immutability.

### DIFF
--- a/apis/duck/patch.go
+++ b/apis/duck/patch.go
@@ -18,6 +18,7 @@ package duck
 
 import (
 	"encoding/json"
+	"sort"
 
 	jsonmergepatch "github.com/evanphx/json-patch"
 	"github.com/mattbaird/jsonpatch"
@@ -50,7 +51,20 @@ func CreatePatch(before, after interface{}) (JSONPatch, error) {
 	if err != nil {
 		return nil, err
 	}
-	return jsonpatch.CreatePatch(rawBefore, rawAfter)
+	patch, err := jsonpatch.CreatePatch(rawBefore, rawAfter)
+	if err != nil {
+		return nil, err
+	}
+
+	// Give the patch a deterministic ordering.
+	sort.Slice(patch, func(i, j int) bool {
+		lhs, rhs := patch[i], patch[j]
+		if lhs.Operation != rhs.Operation {
+			return lhs.Operation < rhs.Operation
+		}
+		return lhs.Path < rhs.Path
+	})
+	return patch, nil
 }
 
 type JSONPatch []jsonpatch.JsonPatchOperation

--- a/apis/duck/patch_test.go
+++ b/apis/duck/patch_test.go
@@ -163,12 +163,12 @@ func TestCreatePatch(t *testing.T) {
 			},
 		},
 		want: JSONPatch{{
+			Operation: "remove",
+			Path:      "/status/patchable/field2",
+		}, {
 			Operation: "replace",
 			Path:      "/status/patchable/field1",
 			Value:     42.0,
-		}, {
-			Operation: "remove",
-			Path:      "/status/patchable/field2",
 		}},
 	}, {
 		name: "patch array",

--- a/testing/resource.go
+++ b/testing/resource.go
@@ -45,9 +45,10 @@ var _ apis.Listable = (*Resource)(nil)
 type ResourceSpec struct {
 	Generation int64 `json:"generation,omitempty"`
 
-	FieldWithDefault    string `json:"fieldWithDefault,omitempty"`
-	FieldWithValidation string `json:"fieldWithValidation,omitempty"`
-	FieldThatsImmutable string `json:"fieldThatsImmutable,omitempty"`
+	FieldWithDefault               string `json:"fieldWithDefault,omitempty"`
+	FieldWithValidation            string `json:"fieldWithValidation,omitempty"`
+	FieldThatsImmutable            string `json:"fieldThatsImmutable,omitempty"`
+	FieldThatsImmutableWithDefault string `json:"fieldThatsImmutableWithDefault,omitempty"`
 }
 
 func (c *Resource) SetDefaults() {
@@ -57,6 +58,9 @@ func (c *Resource) SetDefaults() {
 func (cs *ResourceSpec) SetDefaults() {
 	if cs.FieldWithDefault == "" {
 		cs.FieldWithDefault = "I'm a default."
+	}
+	if cs.FieldThatsImmutableWithDefault == "" {
+		cs.FieldThatsImmutableWithDefault = "this is another default value"
 	}
 }
 
@@ -83,6 +87,15 @@ func (current *Resource) CheckImmutableFields(og apis.Immutable) *apis.FieldErro
 			Paths:   []string{"spec.fieldThatsImmutable"},
 			Details: fmt.Sprintf("got: %v, want: %v", current.Spec.FieldThatsImmutable,
 				original.Spec.FieldThatsImmutable),
+		}
+	}
+
+	if original.Spec.FieldThatsImmutableWithDefault != current.Spec.FieldThatsImmutableWithDefault {
+		return &apis.FieldError{
+			Message: "Immutable field changed",
+			Paths:   []string{"spec.fieldThatsImmutableWithDefault"},
+			Details: fmt.Sprintf("got: %v, want: %v", current.Spec.FieldThatsImmutableWithDefault,
+				original.Spec.FieldThatsImmutableWithDefault),
 		}
 	}
 	return nil


### PR DESCRIPTION
Immutable fields with default values may now be changed iff they change is to populate their default value.  This is to support defaulting in the scenario where an object was created long ago and a new field (with a default!) is added.  When controllers attempt to mutate the object status today, this would create a webhook rejection!  With this change, we compare against a freshly defaulted "old" object to exclude newly defaulted fields from the immutability check.

We saw this in knative/serving for the newly added TimeoutSeconds field in Revision (otherwise immutable), which I believe it leading to upgrade testing flakes since post-upgrade Revision status updates will fail.

<!--
/lint
-->
