### PR TITLE
Undo the patch sorting.

### DIFF
--- a/apis/duck/patch.go
+++ b/apis/duck/patch.go
@@ -18,7 +18,6 @@ package duck
 
 import (
 	"encoding/json"
-	"sort"
 
 	jsonmergepatch "github.com/evanphx/json-patch"
 	"github.com/mattbaird/jsonpatch"
@@ -51,20 +50,7 @@ func CreatePatch(before, after interface{}) (JSONPatch, error) {
 	if err != nil {
 		return nil, err
 	}
-	patch, err := jsonpatch.CreatePatch(rawBefore, rawAfter)
-	if err != nil {
-		return nil, err
-	}
-
-	// Give the patch a deterministic ordering.
-	sort.Slice(patch, func(i, j int) bool {
-		lhs, rhs := patch[i], patch[j]
-		if lhs.Operation != rhs.Operation {
-			return lhs.Operation < rhs.Operation
-		}
-		return lhs.Path < rhs.Path
-	})
-	return patch, nil
+	return jsonpatch.CreatePatch(rawBefore, rawAfter)
 }
 
 type JSONPatch []jsonpatch.JsonPatchOperation

--- a/apis/duck/patch_test.go
+++ b/apis/duck/patch_test.go
@@ -163,12 +163,12 @@ func TestCreatePatch(t *testing.T) {
 			},
 		},
 		want: JSONPatch{{
-			Operation: "remove",
-			Path:      "/status/patchable/field2",
-		}, {
 			Operation: "replace",
 			Path:      "/status/patchable/field1",
 			Value:     42.0,
+		}, {
+			Operation: "remove",
+			Path:      "/status/patchable/field2",
 		}},
 	}, {
 		name: "patch array",


### PR DESCRIPTION
My prior change added sorting to the duck.CreatePatch method to try and stabilize the result of jsonpatch.CreatePatch, which is otherwise non-deterministic (probably walking a map?).

My bad assumption was that the patch operations this generated wouldn't conflict, e.g. it should use `replace` vs. `remove` and `add`.

Clearly this was bad because we start getting really strange errors trying to import this into knative/serving, e.g.
https://gubernator.knative.dev/build/knative-prow/pr-logs/pull/knative_serving/2646/pull-knative-serving-integration-tests/1070435951391543298/

<!--
/lint
-->
