### PR TITLE
Some clean ups in the FieldError code and its tests.

### DIFF
--- a/apis/field_error.go
+++ b/apis/field_error.go
@@ -133,21 +133,23 @@ func (fe *FieldError) isEmpty() bool {
 	return fe.Message == "" && fe.Details == "" && len(fe.errors) == 0 && len(fe.Paths) == 0
 }
 
-func (fe *FieldError) normalized() []FieldError {
+// normalized returns a flattened copy of all the errors.
+func (fe *FieldError) normalized() []*FieldError {
 	// In case we call normalized on a nil object, return just an empty
 	// list. This can happen when .Error() is called on a nil object.
 	if fe == nil {
-		return []FieldError(nil)
+		return []*FieldError(nil)
 	}
-	var errors []FieldError
-	// if this FieldError is a leaf,
+
+	// Allocate errors with at least as many objects as we'll get on the first pass.
+	errors := make([]*FieldError, 0, len(fe.errors)+1)
+	// If this FieldError is a leaf,
 	if fe.Message != "" {
-		err := FieldError{
+		errors = append(errors, &FieldError{
 			Message: fe.Message,
 			Paths:   fe.Paths,
 			Details: fe.Details,
-		}
-		errors = append(errors, err)
+		})
 	}
 	// and then collect all other errors recursively.
 	for _, e := range fe.errors {
@@ -235,19 +237,18 @@ func containsString(slice []string, s string) bool {
 // FiledErrors. FieldErrors have their Paths combined (and de-duped) if their
 // Message and Details are the same. Merge will not inspect FieldError.errors.
 // Merge will also sort the .Path slice, and the errors slice before returning.
-func merge(errs []FieldError) []FieldError {
+func merge(errs []*FieldError) []*FieldError {
 	// make a map big enough for all the errors.
-	m := make(map[string]FieldError, len(errs))
+	m := make(map[string]*FieldError, len(errs))
 
 	// Convert errs to a map where the key is <message>-<details> and the value
 	// is the error. If an error already exists in the map with the same key,
 	// then the paths will be merged.
 	for _, e := range errs {
-		k := key(&e)
+		k := key(e)
 		if v, ok := m[k]; ok {
 			// Found a match, merge the keys.
 			v.Paths = mergePaths(v.Paths, e.Paths)
-			m[k] = v
 		} else {
 			// Does not exist in the map, save the error.
 			m[k] = e
@@ -255,7 +256,7 @@ func merge(errs []FieldError) []FieldError {
 	}
 
 	// Take the map made previously and flatten it back out again.
-	newErrs := make([]FieldError, 0, len(m))
+	newErrs := make([]*FieldError, 0, len(m))
 	for _, v := range m {
 		// While we have access to the merged paths, sort them too.
 		sort.Slice(v.Paths, func(i, j int) bool { return v.Paths[i] < v.Paths[j] })

--- a/apis/field_error_test.go
+++ b/apis/field_error_test.go
@@ -226,9 +226,8 @@ Second: X, Y, Z`,
 				fe = fe.ViaField(prefix...)
 			}
 			if test.want != "" {
-				got := fe.Error()
-				if got != test.want {
-					t.Errorf("%s: Error() = %v, wanted %v", test.name, got, test.want)
+				if got, want := fe.Error(), test.want; got != want {
+					t.Errorf("%s: Error() = %v, wanted %v", test.name, got, want)
 				}
 			} else if fe != nil {
 				t.Errorf("%s: ViaField() = %v, wanted nil", test.name, fe)
@@ -421,9 +420,8 @@ can not use @, do not try`,
 			}
 
 			if test.want != "" {
-				got := fe.Error()
-				if got != test.want {
-					t.Errorf("%s: Error() = %v, wanted %v", test.name, got, test.want)
+				if got, want := fe.Error(), test.want; got != want {
+					t.Errorf("%s: Error() = %v, wanted %v", test.name, got, want)
 				}
 			} else if fe != nil {
 				t.Errorf("%s: ViaField() = %v, wanted nil", test.name, fe)
@@ -434,9 +432,7 @@ can not use @, do not try`,
 
 func TestNilError(t *testing.T) {
 	var err *FieldError
-	got := err.Error()
-	want := ""
-	if got != want {
+	if got, want := err.Error(), ""; got != want {
 		t.Errorf("got %v, wanted %v", got, want)
 	}
 }
@@ -512,9 +508,8 @@ not without this: bar.C`,
 			}
 
 			if test.want != "" {
-				got := fe.Error()
-				if got != test.want {
-					t.Errorf("%s: Error() = %v, wanted %v", test.name, got, test.want)
+				if got, want := fe.Error(), test.want; got != want {
+					t.Errorf("%s: Error() = %v, wanted %v", test.name, got, want)
 				}
 			} else if fe != nil {
 				t.Errorf("%s: ViaField() = %v, wanted nil", test.name, fe)
@@ -680,18 +675,15 @@ func TestFlatten(t *testing.T) {
 		indices: strings.Split("foo.[1].[0].bar", "."),
 		want:    "foo[1][0].bar",
 	}, {
-		name:    "err(bar).ViaIndex(0).ViaIndex[1].ViaField(foo)",
+		name:    "err(foo).ViaField(bar).ViaIndex[0].ViaField(baz)",
 		indices: []string{"foo", "bar.[0].baz"},
 		want:    "foo.bar[0].baz",
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
-			got := flatten(test.indices)
-
-			if got != test.want {
-				t.Errorf("got: %q, want %q", got, test.want)
+			if got, want := flatten(test.indices), test.want; got != want {
+				t.Errorf("got: %q, want %q", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
- rename FieldError.getNormalizedError to be normalized:
  - Go kind of discourages GetA() vs A()
  - it's an error, so normalizing itself is also an error, so
    normalizedError() is a tautology at this point
- flatten was doing a[x]=fmt.Sprintf("%s%s", a[x],y), which is a very
  expensive substitution for a[x]+=y
- some minor test cleanups (fix strings, streamline `got, want:=`
  pattern, etc.

<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:

Fixes: <LINK TO ISSUE>
-->
