### PR TITLE
golang format tools

### DIFF
--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/knative/pkg/test/logging"
 	zipkin "github.com/knative/pkg/test/zipkin"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -35,6 +35,7 @@ import (
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
+
 	// corev1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
