### PR TITLE
Add a utility to check against a minimum required version number.

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+
+	"github.com/rogpeppe/go-internal/semver"
+	"k8s.io/apimachinery/pkg/version"
+)
+
+type serverVersion interface {
+	ServerVersion() (*version.Info, error)
+}
+
+var minimumVersion = "v1.11.0"
+
+// CheckMinimumVersion checks if the currently installed version of
+// Kubernetes is compatible with the minimum version required.
+// Returns an error if its not.
+//
+// A Kubernetes discovery client can be passed in as the versioner
+// like `CheckMinimumVersion(kubeClient.Discovery())`.
+func CheckMinimumVersion(versioner serverVersion) error {
+	v, err := versioner.ServerVersion()
+	if err != nil {
+		return err
+	}
+	currentVersion := semver.Canonical(v.String())
+
+	// Compare returns 1 if the first version is greater than the
+	// second version.
+	if semver.Compare(minimumVersion, currentVersion) == 1 {
+		return fmt.Errorf("kubernetes version %q is not compatible, need at least %q", currentVersion, minimumVersion)
+	}
+	return nil
+}

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,11 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 )
 
-type serverVersion interface {
+// ServerVersioner is an interface to mock the `ServerVersion`
+// method of the Kubernetes client's Discovery interface.
+// In an application `kubeClient.Discovery()` can be used to
+// suffice this interface.
+type ServerVersioner interface {
 	ServerVersion() (*version.Info, error)
 }
 
@@ -35,7 +39,7 @@ var minimumVersion = "v1.11.0"
 //
 // A Kubernetes discovery client can be passed in as the versioner
 // like `CheckMinimumVersion(kubeClient.Discovery())`.
-func CheckMinimumVersion(versioner serverVersion) error {
+func CheckMinimumVersion(versioner ServerVersioner) error {
 	v, err := versioner.ServerVersion()
 	if err != nil {
 		return err

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/version"
+)
+
+type testVersioner struct {
+	version string
+	err     error
+}
+
+func (t *testVersioner) ServerVersion() (*version.Info, error) {
+	return &version.Info{GitVersion: t.version}, t.err
+}
+
+func TestVersionCheck(t *testing.T) {
+	tests := []struct {
+		name          string
+		actualVersion *testVersioner
+		wantError     bool
+	}{{
+		name:          "greater version (patch)",
+		actualVersion: &testVersioner{version: "v1.11.1"},
+	}, {
+		name:          "greater version (minor)",
+		actualVersion: &testVersioner{version: "v1.12.0"},
+	}, {
+		name:          "same version",
+		actualVersion: &testVersioner{version: "v1.11.0"},
+	}, {
+		name:          "smaller version",
+		actualVersion: &testVersioner{version: "v1.10.3"},
+		wantError:     true,
+	}, {
+		name:          "error while fetching",
+		actualVersion: &testVersioner{err: errors.New("random error")},
+		wantError:     true,
+	}}
+
+	for _, test := range tests {
+		err := CheckMinimumVersion(test.actualVersion)
+		if err == nil && test.wantError {
+			t.Errorf("Expected an error for minimum: %q, actual: %v", minimumVersion, test.actualVersion)
+		}
+
+		if err != nil && !test.wantError {
+			t.Errorf("Expected no error but got %v for minimum: %q, actual: %v", err, minimumVersion, test.actualVersion)
+		}
+	}
+}


### PR DESCRIPTION
Knative meanwhile relies on at least Kubernetes 1.11 and I've been bitten by this requirement at least once. This utility can be built into each of our controllers, webhooks etc. to notify/crash if the version is not compatible.

Initially proposed at https://github.com/knative/build/pull/503.