### PR TITLE
Increase pod termination wait time a little bit.

### DIFF
--- a/test/kube_checks.go
+++ b/test/kube_checks.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	interval   = 1 * time.Second
-	podTimeout = 5 * time.Minute
+	podTimeout = 8 * time.Minute
 )
 
 // WaitForDeploymentState polls the status of the Deployment called name


### PR DESCRIPTION
In some cases, pods have entered 'Terminating' state, and we're only
waiting for K8s to kill the pods which unfortunately could go over the
5 minutes timeout here.