### PR TITLE
Implement version check without dependence on go-internal.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -995,7 +995,9 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "cloud.google.com/go/compute/metadata",
     "contrib.go.opencensus.io/exporter/stackdriver",
+    "contrib.go.opencensus.io/exporter/stackdriver/monitoredresource",
     "github.com/davecgh/go-spew/spew",
     "github.com/evanphx/json-patch",
     "github.com/golang/glog",
@@ -1018,7 +1020,6 @@
     "go.uber.org/zap/zapcore",
     "go.uber.org/zap/zaptest",
     "golang.org/x/sync/errgroup",
-    "google.golang.org/genproto/googleapis/api/monitoredres",
     "k8s.io/api/admission/v1beta1",
     "k8s.io/api/admissionregistration/v1beta1",
     "k8s.io/api/apps/v1",
@@ -1041,6 +1042,7 @@
     "k8s.io/apimachinery/pkg/util/sets/types",
     "k8s.io/apimachinery/pkg/util/validation",
     "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apimachinery/pkg/version",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -18,37 +18,38 @@ package version
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/version"
 )
 
 type testVersioner struct {
-	version string
-	err     error
+	major string
+	minor string
+	err   error
 }
 
 func (t *testVersioner) ServerVersion() (*version.Info, error) {
-	return &version.Info{GitVersion: t.version}, t.err
+	return &version.Info{Major: t.major, Minor: t.minor}, t.err
 }
 
 func TestVersionCheck(t *testing.T) {
+	minimumVersion := fmt.Sprintf("v%d.%d", minimumMajor, minimumMinor)
+
 	tests := []struct {
 		name          string
 		actualVersion *testVersioner
 		wantError     bool
 	}{{
-		name:          "greater version (patch)",
-		actualVersion: &testVersioner{version: "v1.11.1"},
-	}, {
 		name:          "greater version (minor)",
-		actualVersion: &testVersioner{version: "v1.12.0"},
+		actualVersion: &testVersioner{major: "1", minor: "12"},
 	}, {
 		name:          "same version",
-		actualVersion: &testVersioner{version: "v1.11.0"},
+		actualVersion: &testVersioner{major: "1", minor: "11"},
 	}, {
 		name:          "smaller version",
-		actualVersion: &testVersioner{version: "v1.10.3"},
+		actualVersion: &testVersioner{major: "1", minor: "10"},
 		wantError:     true,
 	}, {
 		name:          "error while fetching",

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -52,6 +52,14 @@ func TestVersionCheck(t *testing.T) {
 		actualVersion: &testVersioner{major: "1", minor: "10"},
 		wantError:     true,
 	}, {
+		name:          "error while parsing major",
+		actualVersion: &testVersioner{major: "test", minor: "10"},
+		wantError:     true,
+	}, {
+		name:          "error while parsing minor",
+		actualVersion: &testVersioner{major: "10", minor: "test"},
+		wantError:     true,
+	}, {
 		name:          "error while fetching",
 		actualVersion: &testVersioner{err: errors.New("random error")},
 		wantError:     true,


### PR DESCRIPTION
The released version of go-internal that we transitively depend on does not contain a LICENSE file. Therefore I cannot include the currently implemented version into knative/serving for example, because license checks will fail.

Options are:
- Override the constraint for go-internal to a never commit. Felt unclean to me.
- Use a different package to parse SemVer. I tried https://github.com/blang/semver, it worked but it doesn't parse `v` prepended versions, so I had to sanitize the output of `GitVersion` from the Kubernetes server.

I, therefore, opted to implement it without any dependency on a SemVer tool and use the `Major`, `Minor` fields instead and compared manually.

I also forgot to run update-deps the last time round, so here we go.