### PR TITLE
Read metrics backend from environment variable

### DIFF
--- a/metrics/config.go
+++ b/metrics/config.go
@@ -70,8 +70,7 @@ func getMetricsConfig(m map[string]string, domain string, component string, logg
 		backend = string(Prometheus)
 	}
 	// Override backend if it is setting in config map.
-	backendFromConfig, ok := m[backendDestinationKey]
-	if ok {
+	if backendFromConfig, ok := m[backendDestinationKey]; ok {
 		backend = backendFromConfig
 	}
 	lb := metricsBackend(strings.ToLower(backend))

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -41,6 +42,8 @@ const (
 	Stackdriver metricsBackend = "stackdriver"
 	// Prometheus is used for Prometheus backend
 	Prometheus metricsBackend = "prometheus"
+
+	defaultBackendEnvName = "DEFAULT_METRICS_BACKEND"
 )
 
 type metricsConfig struct {
@@ -60,9 +63,16 @@ type metricsConfig struct {
 
 func getMetricsConfig(m map[string]string, domain string, component string, logger *zap.SugaredLogger) (*metricsConfig, error) {
 	var mc metricsConfig
-	backend, ok := m[backendDestinationKey]
-	if !ok {
+	// Read backend setting from environment variable first
+	backend := os.Getenv(defaultBackendEnvName)
+	if backend == "" {
+		// Use Prometheus if DEFAULT_METRICS_BACKEND does not exist or is empty
 		backend = string(Prometheus)
+	}
+	// Override backend if it is setting in config map.
+	backendFromConfig, ok := m[backendDestinationKey]
+	if ok {
+		backend = backendFromConfig
 	}
 	lb := metricsBackend(strings.ToLower(backend))
 	switch lb {
@@ -116,14 +126,13 @@ func UpdateExporterFromConfigMap(domain string, component string, logger *zap.Su
 	return func(configMap *corev1.ConfigMap) {
 		newConfig, err := getMetricsConfig(configMap.Data, domain, component, logger)
 		if err != nil {
-			ce := getCurMetricsExporter()
-			if ce == nil {
+			if ce := getCurMetricsExporter(); ce == nil {
 				// Fail the process if there doesn't exist an exporter.
-				logger.Fatal("Failed to get a valid metrics config")
+				logger.Error("Failed to get a valid metrics config", zap.Error(err))
 			} else {
 				logger.Error("Failed to get a valid metrics config; Skip updating the metrics exporter", zap.Error(err))
-				return
 			}
+			return
 		}
 
 		if isMetricsConfigChanged(newConfig) {


### PR DESCRIPTION
Propose:

1. Set metrics backend to the value from an environment variable first. Then override it to the value from config map, if any. This gives the ability to set metrics backend when rolling out a new knative serving components while keep existing config map unchanged.

1. Do not panic the process if the backend is not supported. Activator and autoscaler should continute to work without emitting metrics to any backend.
