### PR TITLE
🦆 Duck Typing - add a ConformsToType helper

### DIFF
--- a/apis/duck/verify.go
+++ b/apis/duck/verify.go
@@ -56,23 +56,8 @@ func VerifyType(instance interface{}, iface Implementable) error {
 	// that we will compare at the end.
 	input, output := iface.GetFullType(), iface.GetFullType()
 
-	// Populate our input resource with values we will roundtrip.
-	input.Populate()
-
-	// Serialize the input to JSON and deserialize that into the provided instance
-	// of the type that we are checking.
-	if before, err := json.Marshal(input); err != nil {
-		return fmt.Errorf("error serializing duck type %T", input)
-	} else if err := json.Unmarshal(before, instance); err != nil {
-		return fmt.Errorf("error deserializing duck type %T into %T", input, instance)
-	}
-
-	// Serialize the instance we are checking to JSON and deserialize that into the
-	// output resource.
-	if after, err := json.Marshal(instance); err != nil {
-		return fmt.Errorf("error serializing %T", instance)
-	} else if err := json.Unmarshal(after, output); err != nil {
-		return fmt.Errorf("error deserializing %T into dock type %T", instance, output)
+	if err := roundTrip(instance, input, output); err != nil {
+		return err
 	}
 
 	// Now verify that we were able to roundtrip all of our fields through the type
@@ -81,5 +66,43 @@ func VerifyType(instance interface{}, iface Implementable) error {
 		return fmt.Errorf("%T does not implement the duck type %T, the following fields were lost: %s",
 			instance, iface, diff)
 	}
+	return nil
+}
+
+// ConformsToType will return true or false depending on whether a
+// concrete resource properly implements the provided Implementable
+// duck type.
+//
+// It will return an error if marshal/unmarshalling fails
+func ConformsToType(instance interface{}, iface Implementable) (bool, error) {
+	input, output := iface.GetFullType(), iface.GetFullType()
+
+	if err := roundTrip(instance, input, output); err != nil {
+		return false, err
+	}
+
+	return cmp.Equal(input, output), nil
+}
+
+func roundTrip(instance interface{}, input, output Populatable) error {
+	// Populate our input resource with values we will roundtrip.
+	input.Populate()
+
+	// Serialize the input to JSON and deserialize that into the provided instance
+	// of the type that we are checking.
+	if before, err := json.Marshal(input); err != nil {
+		return fmt.Errorf("error serializing duck type %T error: %s", input, err)
+	} else if err := json.Unmarshal(before, instance); err != nil {
+		return fmt.Errorf("error deserializing duck type %T into %T error: %s", input, instance, err)
+	}
+
+	// Serialize the instance we are checking to JSON and deserialize that into the
+	// output resource.
+	if after, err := json.Marshal(instance); err != nil {
+		return fmt.Errorf("error serializing %T error: %s", instance, err)
+	} else if err := json.Unmarshal(after, output); err != nil {
+		return fmt.Errorf("error deserializing %T into duck type %T error: %s", instance, output, err)
+	}
+
 	return nil
 }

--- a/apis/duck/verify.go
+++ b/apis/duck/verify.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/knative/pkg/kmp"
 )
 
 // Implementable is implemented by the Fooable duck type that consumers
@@ -62,7 +62,9 @@ func VerifyType(instance interface{}, iface Implementable) error {
 
 	// Now verify that we were able to roundtrip all of our fields through the type
 	// we are checking.
-	if diff := cmp.Diff(input, output); diff != "" {
+	if diff, err := kmp.SafeDiff(input, output); err != nil {
+		return err
+	} else if diff != "" {
 		return fmt.Errorf("%T does not implement the duck type %T, the following fields were lost: %s",
 			instance, iface, diff)
 	}
@@ -81,7 +83,7 @@ func ConformsToType(instance interface{}, iface Implementable) (bool, error) {
 		return false, err
 	}
 
-	return cmp.Equal(input, output), nil
+	return kmp.SafeEqual(input, output)
 }
 
 func roundTrip(instance interface{}, input, output Populatable) error {

--- a/apis/duck/verify_test.go
+++ b/apis/duck/verify_test.go
@@ -169,7 +169,7 @@ func TestMismatches(t *testing.T) {
 	}
 }
 
-func TestMarshallingErrors(t *testing.T) {
+func TestErrors(t *testing.T) {
 	tests := []struct {
 		name     string
 		instance interface{}
@@ -190,6 +190,10 @@ func TestMarshallingErrors(t *testing.T) {
 		name:     "instance - fails to marshal",
 		instance: &UnableToMarshal{},
 		iface:    &Fooable{},
+	}, {
+		name:     "duck type - unexported fields",
+		instance: &Foo{},
+		iface:    &UnexportedFields{},
 	}}
 
 	for _, test := range tests {
@@ -325,7 +329,7 @@ func (u *UnableToMarshal) MarshalJSON() ([]byte, error) {
 }
 
 // For testing this doubles as the 'Implementable'
-// and 'Populataable'
+// and 'Populatable'
 type UnableToUnmarshal struct{}
 
 var _ Implementable = (*UnableToUnmarshal)(nil)
@@ -341,4 +345,22 @@ func (u *UnableToUnmarshal) Populate() {
 
 func (u *UnableToUnmarshal) UnmarshalJSON([]byte) error {
 	return errors.New("I will never unmarshal for you")
+}
+
+// For testing this doubles as the 'Implementable'
+// and 'Populatable'
+type UnexportedFields struct {
+	a string
+}
+
+var _ Implementable = (*UnexportedFields)(nil)
+var _ Populatable = (*UnexportedFields)(nil)
+
+func (u *UnexportedFields) GetFullType() Populatable {
+	return &UnexportedFields{}
+}
+
+func (u *UnexportedFields) Populate() {
+	u.a = "hello"
+	return
 }

--- a/kmp/diff.go
+++ b/kmp/diff.go
@@ -49,3 +49,17 @@ func SafeDiff(x, y interface{}, opts ...cmp.Option) (diff string, err error) {
 
 	return
 }
+
+func SafeEqual(x, y interface{}, opts ...cmp.Option) (equal bool, err error) {
+	// cmp.Equal will panic if we miss something; return error instead of crashing.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("recovered in kmp.SafeEqual: %v", r)
+		}
+	}()
+
+	opts = append(opts, defaultOpts...)
+	equal = cmp.Equal(x, y, opts...)
+
+	return
+}


### PR DESCRIPTION
Unlike `VerifyType`, `ConformsToType` will return the following:
- an error when any marshalling/unmarshalling fails
- false when the concrete type does not implement the duck type
- true when the concrete type implements the duck type
