### PR TITLE
Stackdriver resource label change for knative_revision resource type

### DIFF
--- a/metrics/metricskey/constants.go
+++ b/metrics/metricskey/constants.go
@@ -18,7 +18,7 @@ const (
 	ResourceTypeKnativeRevision = "knative_revision"
 
 	// LabelProject is the label for project (e.g. GCP GAIA ID, AWS project name)
-	LabelProject = "project"
+	LabelProject = "project_id"
 
 	// LabelLocation is the label for location (e.g. GCE zone, AWS region) where the service is deployed
 	LabelLocation = "location"


### PR DESCRIPTION
Change the label sent to Stackdriver `knative_revision` resource type from `project` to `project_id`. The later is the actual key defined in Stackdriver.