### PR TITLE
Conditions implementation no longer mutates the underlying dependents array

### DIFF
--- a/apis/duck/v1alpha1/condition_set.go
+++ b/apis/duck/v1alpha1/condition_set.go
@@ -212,11 +212,16 @@ func (r conditionsImpl) SetCondition(new Condition) {
 }
 
 func (r conditionsImpl) isTerminal(t ConditionType) bool {
-	for _, cond := range append(r.dependents, r.happy) {
+	for _, cond := range r.dependents {
 		if cond == t {
 			return true
 		}
 	}
+
+	if t == r.happy {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
Addresses: https://github.com/knative/serving/issues/2849

This is because the condition set in serving is a global variable.