### PR TITLE
Fix to add defer Close in Spoof Client zipkin tracing

### DIFF
--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -240,6 +240,7 @@ func (sc *SpoofingClient) LogZipkinTrace(traceID string) error {
 	if err != nil {
 		return fmt.Errorf("Error retrieving Zipkin trace: %v", err)
 	}
+	defer resp.Body.Close()
 
 	trace, err := ioutil.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
Utility method to retrieve zipkin traces had missed a defer Close call. This change fixes that
