### PR TITLE
Don't rate-limit normal events

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -200,7 +200,7 @@ func (c *Impl) EnqueueLabelOfClusterScopedResource(nameLabel string) func(obj in
 
 // EnqueueKey takes a namespace/name string and puts it onto the work queue.
 func (c *Impl) EnqueueKey(key string) {
-	c.WorkQueue.AddRateLimited(key)
+	c.WorkQueue.Add(key)
 }
 
 // Run starts the controller's worker threads, the number of which is threadiness.


### PR DESCRIPTION
<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:

Fixes: <LINK TO ISSUE>
-->

This is a performance improvement for all Knative controllers. We will stop rate-limiting normal events added to the workqueue and only rate-limit errors. Note: apiserver rate-limiting is still in place via the controller's k8s client/REST config.

This change is most noticeable when there are lots of controlled objects and during a re-sync, when every controlled object is being added to the workqueue at the same time.

I set up an ad-hoc test, creating 100 Knative Services and waiting until they were all ready. The time for this test was cut in half by this change:

- knative/master: 100.615508012s
- with my change: 44.856111381s

To answer the question of whether this is a reasonable change or not, most k8s controllers do not rate-limit on normal enqueues. Here are a few examples:
https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/statefulset/stateful_set.go#L382
https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/replicaset/replica_set.go#L411
https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/deployment/deployment_controller.go#L136

/cc @mattmoor 
/cc @alculquicondor 