### PR TITLE
CloudEvents v0.2 support, step 1: interfaces and versioned types.

### DIFF
--- a/cloudevents/doc.go
+++ b/cloudevents/doc.go
@@ -19,5 +19,4 @@ limitations under the License.
 // https://github.com/cloudevents/spec/blob/v0.1/http-transport-binding.md
 // and
 // https://github.com/cloudevents/spec/blob/v0.1/spec.md
-
 package cloudevents

--- a/cloudevents/encoding_binary.go
+++ b/cloudevents/encoding_binary.go
@@ -20,14 +20,9 @@ package cloudevents
 
 import (
 	"bytes"
-	"encoding/json"
-	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
-	"strings"
-	"time"
 )
 
 const (
@@ -56,7 +51,7 @@ const (
 	// HeaderSource is the header for the source which emitted this event.
 	HeaderSource = "CE-Source"
 
-	// HeaderExtensions is the OPTIONAL header prefix for CloudEvents extensions
+	// HeaderExtensionsPrefix is the OPTIONAL header prefix for CloudEvents extensions
 	HeaderExtensionsPrefix = "CE-X-"
 
 	// Binary implements Binary encoding/decoding
@@ -65,68 +60,46 @@ const (
 
 type binary int
 
+// BinarySender implements an interface for sending an EventContext as
+// (possibly one of several versions) as a binary encoding HTTP request.
+type BinarySender interface {
+	// AsHeaders converts this EventContext to a set of HTTP headers.
+	AsHeaders() http.Header
+}
+
+// BinaryLoader implements an interface for translating a binary encoding HTTP
+// request or response to a an EventContext (possibly one of several versions).
+type BinaryLoader interface {
+	// FromHeaders copies data from the supplied HTTP headers into the object.
+	// Values will be defaulted if necessary.
+	FromHeaders(in http.Header) error
+}
+
 // FromRequest parses event data and context from an HTTP request.
 func (binary) FromRequest(data interface{}, r *http.Request) (*EventContext, error) {
-	var ctx EventContext
-	err := anyError(
-		getRequiredHeader(r.Header, HeaderEventID, &ctx.EventID),
-		getRequiredHeader(r.Header, HeaderEventType, &ctx.EventType),
-		getRequiredHeader(r.Header, HeaderSource, &ctx.Source),
-		getRequiredHeader(r.Header, HeaderContentType, &ctx.ContentType))
-	if err != nil {
+	// TODO: detect version and create correct VXXEventContext
+	ec := &EventContext{}
+	if err := ec.FromHeaders(r.Header); err != nil {
 		return nil, err
 	}
 
-	ctx.CloudEventsVersion = r.Header.Get(HeaderCloudEventsVersion)
-	if timeStr := r.Header.Get(HeaderEventTime); timeStr != "" {
-		if ctx.EventTime, err = time.Parse(time.RFC3339Nano, timeStr); err != nil {
-			return nil, err
-		}
-	}
-	ctx.EventTypeVersion = r.Header.Get(HeaderEventTypeVersion)
-	ctx.SchemaURL = r.Header.Get(HeaderSchemaURL)
-	if ctx.CloudEventsVersion != CloudEventsVersion {
-		log.Printf("Received CloudEvent version %q; parsing as version %q",
-			ctx.CloudEventsVersion, CloudEventsVersion)
-	}
-
-	ctx.Extensions = make(map[string]interface{})
-	for k, v := range r.Header {
-		if strings.ToUpper(k)[:len(HeaderExtensionsPrefix)] != HeaderExtensionsPrefix {
-			continue
-		}
-		name := k[len(HeaderExtensionsPrefix):]
-		var val interface{}
-		if err := json.Unmarshal([]byte(v[0]), &val); err != nil {
-			// If this is not a JSON object, treat it as a string.
-			// It's not clear when we would treat this as Bytes.
-			ctx.Extensions[name] = v[0]
-		} else {
-			ctx.Extensions[name] = val
-		}
-	}
-
-	if err := unmarshalEventData(ctx.ContentType, r.Body, data); err != nil {
+	if err := unmarshalEventData(ec.ContentType, r.Body, data); err != nil {
 		return nil, err
 	}
 
-	return &ctx, nil
+	return ec, nil
 }
 
 // NewRequest creates an HTTP request for Binary content encoding.
-func (t binary) NewRequest(urlString string, data interface{}, context EventContext) (*http.Request, error) {
+func (t binary) NewRequest(urlString string, data interface{}, context SendContext) (*http.Request, error) {
 	url, err := url.Parse(urlString)
 	if err != nil {
 		return nil, err
 	}
 
-	h := http.Header{}
-	err = t.ToHeaders(&context, h)
-	if err != nil {
-		return nil, err
-	}
+	h := context.AsHeaders()
 
-	b, err := marshalEventData(context.ContentType, data)
+	b, err := marshalEventData(h.Get("Content-Type"), data)
 	if err != nil {
 		return nil, err
 	}
@@ -137,65 +110,4 @@ func (t binary) NewRequest(urlString string, data interface{}, context EventCont
 		Header: h,
 		Body:   ioutil.NopCloser(bytes.NewReader(b)),
 	}, nil
-}
-
-func (binary) ToHeaders(context *EventContext, h http.Header) error {
-	if context == nil || h == nil {
-		return nil
-	}
-	if err := ensureRequiredFields(*context); err != nil {
-		return err
-	}
-	// Defaultable values:
-	ceVersion := context.CloudEventsVersion
-	if ceVersion == "" {
-		ceVersion = CloudEventsVersion
-	}
-	contentType := context.ContentType
-	if contentType == "" {
-		contentType = contentTypeJSON
-	}
-
-	// non-string values:
-	eventTime := ""
-	if !context.EventTime.IsZero() {
-		eventTime = context.EventTime.Format(time.RFC3339Nano)
-	}
-
-	setHeader(h, HeaderCloudEventsVersion, ceVersion)
-	setHeader(h, HeaderEventID, context.EventID)
-	setHeader(h, HeaderEventTime, eventTime)
-	setHeader(h, HeaderEventType, context.EventType)
-	setHeader(h, HeaderEventTypeVersion, context.EventTypeVersion)
-	setHeader(h, HeaderSchemaURL, context.SchemaURL)
-	setHeader(h, HeaderContentType, contentType)
-	setHeader(h, HeaderSource, context.Source)
-	for name, value := range context.Extensions {
-		encoded, err := json.Marshal(value)
-		if err != nil {
-			return err
-		}
-		h[HeaderExtensionsPrefix+name] = []string{
-			string(encoded),
-		}
-	}
-
-	return nil
-}
-
-// TODO(inlined) URI encoding/decoding of headers
-func getHeader(h http.Header, name string) string {
-	return h.Get(name)
-}
-
-func setHeader(h http.Header, name string, value string) {
-	if value != "" {
-		h.Set(name, value)
-	}
-}
-func getRequiredHeader(h http.Header, name string, value *string) error {
-	if *value = getHeader(h, name); *value == "" {
-		return fmt.Errorf("missing required header %q", name)
-	}
-	return nil
 }

--- a/cloudevents/encoding_structured.go
+++ b/cloudevents/encoding_structured.go
@@ -34,73 +34,94 @@ const (
 
 type structured int
 
-type structuredEnvelope struct {
-	EventContext
-	RawData json.RawMessage `json:"data"`
+// StructuredSender implements an interface for translating an EventContext
+// (possibly one of severals versions) to a structured encoding HTTP request.
+type StructuredSender interface {
+	// AsJSON encodes the object into a map from string to JSON data, which
+	// allows additional keys to be encoded later.
+	AsJSON() (map[string]json.RawMessage, error)
+	// DataContentType returns the MIME content type for encoding data.
+	DataContentType() string
+}
+
+// StructuredLoader implements an interface for translating a structured
+// encoding HTTP request or response to a an EventContext (possibly one of
+// several versions).
+type StructuredLoader interface {
+	// FromJSON assumes that the object has already been decoded into a raw map
+	// from string to json.RawMessage, because this is needed to extract the
+	// CloudEvents version.
+	FromJSON(map[string]json.RawMessage) error
 }
 
 // FromRequest parses a CloudEvent from structured content encoding.
 func (structured) FromRequest(data interface{}, r *http.Request) (*EventContext, error) {
-	var e structuredEnvelope
-	if err := json.NewDecoder(r.Body).Decode(&e); err != nil {
+	raw := make(map[string]json.RawMessage)
+	if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
 		return nil, err
 	}
 
-	contentType := e.EventContext.ContentType
+	rawData := raw["data"]
+	delete(raw, "data")
+
+	// TODO: support both v01 and v02 encoding
+	ec := &EventContext{}
+	if err := ec.FromJSON(raw); err != nil {
+		return nil, err
+	}
+
+	contentType := ec.ContentType
 	if contentType == "" {
 		contentType = contentTypeJSON
 	}
 	var reader io.Reader
 	if !isJSONEncoding(contentType) {
 		var jsonDecoded string
-		if err := json.Unmarshal(e.RawData, &jsonDecoded); err != nil {
-			return nil, fmt.Errorf("Could not JSON decode %q value %q", contentType, string(e.RawData))
+		if err := json.Unmarshal(rawData, &jsonDecoded); err != nil {
+			return nil, fmt.Errorf("Could not JSON decode %q value %q", contentType, rawData)
 		}
 		reader = strings.NewReader(jsonDecoded)
 	} else {
-		reader = bytes.NewReader(e.RawData)
-	}
-	if e.EventContext.Extensions == nil {
-		e.EventContext.Extensions = make(map[string]interface{}, 0)
+		reader = bytes.NewReader(rawData)
 	}
 	if err := unmarshalEventData(contentType, reader, data); err != nil {
 		return nil, err
 	}
-	return &e.EventContext, nil
+	return ec, nil
 }
 
 // NewRequest creates an HTTP request for Structured content encoding.
-func (structured) NewRequest(urlString string, data interface{}, context EventContext) (*http.Request, error) {
+func (structured) NewRequest(urlString string, data interface{}, context SendContext) (*http.Request, error) {
 	url, err := url.Parse(urlString)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := ensureRequiredFields(context); err != nil {
+	fields, err := context.AsJSON()
+	if err != nil {
 		return nil, err
 	}
 
-	contentType := context.ContentType
+	// TODO: remove this defaulting?
+	contentType := context.DataContentType()
 	if contentType == "" {
 		contentType = contentTypeJSON
 	}
-	e := structuredEnvelope{
-		EventContext: context,
-	}
+
 	dataBytes, err := marshalEventData(contentType, data)
 	if err != nil {
 		return nil, err
 	}
 	if isJSONEncoding(contentType) {
-		e.RawData = json.RawMessage(dataBytes)
+		fields["data"] = json.RawMessage(dataBytes)
 	} else {
-		e.RawData, err = json.Marshal(string(dataBytes))
+		fields["data"], err = json.Marshal(string(dataBytes))
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	b, err := json.Marshal(e)
+	b, err := json.Marshal(fields)
 	if err != nil {
 		return nil, err
 	}

--- a/cloudevents/event.go
+++ b/cloudevents/event.go
@@ -24,14 +24,9 @@ import (
 	"io"
 	"net/http"
 	"reflect"
-	"time"
 )
 
 const (
-	// CloudEventsVersion is the version of the CloudEvents spec targeted
-	// by this library.
-	CloudEventsVersion = "0.1"
-
 	// ContentTypeStructuredJSON is the content-type for "Structured" encoding
 	// where an event envelope is written in JSON and the body is arbitrary
 	// data which might be an alternate encoding.
@@ -48,43 +43,48 @@ const (
 	// HeaderContentType is the standard HTTP header "Content-Type"
 	HeaderContentType = "Content-Type"
 
-	// required attributes
-	fieldCloudEventsVersion = "CloudEventsVersion"
-	fieldEventID            = "EventID"
-	fieldEventType          = "EventType"
-	fieldSource             = "Source"
+	// CloudEventsVersion is a legacy alias of V01CloudEventsVersion, for compatibility.
+	CloudEventsVersion = V01CloudEventsVersion
 )
 
-// EventContext holds standard metadata about an event. See
-// https://github.com/cloudevents/spec/blob/v0.1/spec.md#context-attributes for
-// details on these fields.
-type EventContext struct {
-	// The version of the CloudEvents specification used by the event.
-	CloudEventsVersion string `json:"cloudEventsVersion,omitempty"`
-	// ID of the event; must be non-empty and unique within the scope of the producer.
-	EventID string `json:"eventID"`
-	// Timestamp when the event happened.
-	EventTime time.Time `json:"eventTime,omitempty"`
-	// Type of occurrence which has happened.
-	EventType string `json:"eventType"`
-	// The version of the `eventType`; this is producer-specific.
-	EventTypeVersion string `json:"eventTypeVersion,omitempty"`
-	// A link to the schema that the `data` attribute adheres to.
-	SchemaURL string `json:"schemaURL,omitempty"`
-	// A MIME (RFC 2046) string describing the media type of `data`.
-	// TODO: Should an empty string assume `application/json`, or auto-detect the content?
-	ContentType string `json:"contentType,omitempty"`
-	// A URI describing the event producer.
-	Source string `json:"source"`
-	// Additional metadata without a well-defined structure.
-	Extensions map[string]interface{} `json:"extensions,omitempty"`
-}
+// EventContext is a legacy un-versioned alias, from when we thought that field names would stay the same.
+type EventContext = V01EventContext
 
 // HTTPMarshaller implements a scheme for decoding CloudEvents over HTTP.
 // Implementations are Binary, Structured, and Any
 type HTTPMarshaller interface {
 	FromRequest(data interface{}, r *http.Request) (*EventContext, error)
-	NewRequest(urlString string, data interface{}, context EventContext) (*http.Request, error)
+	NewRequest(urlString string, data interface{}, context SendContext) (*http.Request, error)
+}
+
+// SendContext provides an interface for extracting information from an
+// EventContext (the set of non-data event attributes of a CloudEvent).
+type SendContext interface {
+	StructuredSender
+	BinarySender
+}
+
+// LoadContext provides an interface for extracting information from an
+// EventContext (the set of non-data event attributes of a CloudEvent).
+//
+// LoadContext also provides a set of translation methods between the
+// versions of the CloudEvents spec, which allows programs to interoperate with
+// different versions of the CloudEvents spec at the same time.
+type LoadContext interface {
+	StructuredLoader
+	BinaryLoader
+
+	// AsV01 provides a translation from whatever the "native" encoding of the
+	// CloudEvent was to the equivalent in v0.1 field names, moving fields to or
+	// from extensions as necessary.
+	AsV01() V01EventContext
+}
+
+// ContextType is a unified interface for both sending and loading the
+// CloudEvent data across versions.
+type ContextType interface {
+	SendContext
+	LoadContext
 }
 
 func anyError(errs ...error) error {
@@ -94,13 +94,6 @@ func anyError(errs ...error) error {
 		}
 	}
 	return nil
-}
-
-func ensureRequiredFields(context EventContext) error {
-	return anyError(
-		require(fieldEventID, context.EventID),
-		require(fieldEventType, context.EventType),
-		require(fieldSource, context.Source))
 }
 
 func require(name string, value string) error {
@@ -184,16 +177,16 @@ func FromRequest(data interface{}, r *http.Request) (*EventContext, error) {
 }
 
 // NewRequest craetes an HTTP request for Structured content encoding.
-func NewRequest(urlString string, data interface{}, context EventContext) (*http.Request, error) {
+func NewRequest(urlString string, data interface{}, context SendContext) (*http.Request, error) {
 	return Structured.NewRequest(urlString, data, context)
 }
 
-// Opaque key type used to store EventContexts in a context.Context
+// Opaque key type used to store V01EventContexts in a context.Context
 type contextKeyType struct{}
 
 var contextKey = contextKeyType{}
 
-// FromContext loads an EventContext from a normal context.Context
-func FromContext(ctx context.Context) *EventContext {
-	return ctx.Value(contextKey).(*EventContext)
+// FromContext loads an V01EventContext from a normal context.Context
+func FromContext(ctx context.Context) *V01EventContext {
+	return ctx.Value(contextKey).(*V01EventContext)
 }

--- a/cloudevents/event_test.go
+++ b/cloudevents/event_test.go
@@ -50,7 +50,7 @@ var Default defaultMarshaller = 0
 func (defaultMarshaller) FromRequest(data interface{}, r *http.Request) (*cloudevents.EventContext, error) {
 	return cloudevents.FromRequest(data, r)
 }
-func (defaultMarshaller) NewRequest(urlString string, data interface{}, context cloudevents.EventContext) (*http.Request, error) {
+func (defaultMarshaller) NewRequest(urlString string, data interface{}, context cloudevents.SendContext) (*http.Request, error) {
 	return cloudevents.NewRequest(urlString, data, context)
 }
 
@@ -183,6 +183,7 @@ func TestXmlStructuredDecoding(t *testing.T) {
 
 	eventText := `
 	{
+		"cloudEventsVersion": "0.1",
 		"eventID": "1234",
 		"eventType": "dev.eventing.test",
 		"source": "tests://TextXmlStructuredEncoding",
@@ -215,6 +216,7 @@ func TestExtensionsAreNeverNil(t *testing.T) {
 		},
 		Body: ioutil.NopCloser(strings.NewReader(`
 			{
+				"cloudEventsVersion": "0.1",
 				"eventID": "1234",
 				"eventType": "dev.eventing.test",
 				"source": "tests://TextXmlStructuredEncoding",
@@ -234,6 +236,7 @@ func TestExtensionsAreNeverNil(t *testing.T) {
 
 func TestExtensionExtraction(t *testing.T) {
 	h := http.Header{}
+	h.Set(cloudevents.HeaderCloudEventsVersion, cloudevents.V01CloudEventsVersion)
 	h.Set(cloudevents.HeaderContentType, cloudevents.ContentTypeBinaryJSON)
 	h.Set(cloudevents.HeaderEventID, "1234")
 	h.Set(cloudevents.HeaderEventType, "dev.eventing.test")

--- a/cloudevents/event_v01.go
+++ b/cloudevents/event_v01.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevents
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	// V01CloudEventsVersion is the version of the CloudEvents spec targeted
+	// by this library.
+	V01CloudEventsVersion = "0.1"
+
+	// v0.1 field names
+	fieldCloudEventsVersion = "CloudEventsVersion"
+	fieldEventID            = "EventID"
+	fieldEventType          = "EventType"
+)
+
+// V01EventContext holds standard metadata about an event. See
+// https://github.com/cloudevents/spec/blob/v0.1/spec.md#context-attributes for
+// details on these fields.
+type V01EventContext struct {
+	// The version of the CloudEvents specification used by the event.
+	CloudEventsVersion string `json:"cloudEventsVersion,omitempty"`
+	// ID of the event; must be non-empty and unique within the scope of the producer.
+	EventID string `json:"eventID"`
+	// Timestamp when the event happened.
+	EventTime time.Time `json:"eventTime,omitempty"`
+	// Type of occurrence which has happened.
+	EventType string `json:"eventType"`
+	// The version of the `eventType`; this is producer-specific.
+	EventTypeVersion string `json:"eventTypeVersion,omitempty"`
+	// A link to the schema that the `data` attribute adheres to.
+	SchemaURL string `json:"schemaURL,omitempty"`
+	// A MIME (RFC 2046) string describing the media type of `data`.
+	// TODO: Should an empty string assume `application/json`, or auto-detect the content?
+	ContentType string `json:"contentType,omitempty"`
+	// A URI describing the event producer.
+	Source string `json:"source"`
+	// Additional metadata without a well-defined structure.
+	Extensions map[string]interface{} `json:"extensions,omitempty"`
+}
+
+// AsV01 implements the LoadContext interface.
+func (ec V01EventContext) AsV01() V01EventContext {
+	return ec
+}
+
+// AsHeaders implements the BinarySender interface.
+func (ec V01EventContext) AsHeaders() http.Header {
+	h := http.Header{}
+	h.Set("CE-CloudEventsVersion", ec.CloudEventsVersion)
+	h.Set("CE-EventID", ec.EventID)
+	h.Set("CE-EventType", ec.EventType)
+	h.Set("CE-Source", ec.Source)
+	if ec.CloudEventsVersion == "" {
+		h.Set("CE-CloudEventsVersion", V01CloudEventsVersion)
+	}
+	if !ec.EventTime.IsZero() {
+		h.Set("CE-EventTime", ec.EventTime.Format(time.RFC3339Nano))
+	}
+	if ec.EventTypeVersion != "" {
+		h.Set("CE-EventTypeVersion", ec.EventTypeVersion)
+	}
+	if ec.SchemaURL != "" {
+		h.Set("CE-SchemaUrl", ec.SchemaURL)
+	}
+	if ec.ContentType != "" {
+		h.Set("Content-Type", ec.ContentType)
+	}
+	for k, v := range ec.Extensions {
+		data := fmt.Sprint(v)
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			data = string(encoded)
+		}
+		h["CE-X-"+k] = []string{data}
+	}
+	return h
+}
+
+// FromHeaders implements the BinaryContext interface
+func (ec *V01EventContext) FromHeaders(in http.Header) error {
+	missingField := func(name string) error {
+		if in.Get("CE-"+name) == "" {
+			return fmt.Errorf("Missing field %q in %v: %q", "CE-"+name, in, in.Get("CE-"+name))
+		}
+		return nil
+	}
+	err := anyError(
+		missingField("CloudEventsVersion"),
+		missingField("EventID"),
+		missingField("EventType"),
+		missingField("Source"),
+	)
+	if err != nil {
+		return err
+	}
+	data := V01EventContext{
+		CloudEventsVersion: in.Get("CE-CloudEventsVersion"),
+		EventID:            in.Get("CE-EventID"),
+		EventType:          in.Get("CE-EventType"),
+		EventTypeVersion:   in.Get("CE-EventTypeVersion"),
+		SchemaURL:          in.Get("CE-SchemaURL"),
+		ContentType:        in.Get("Content-Type"),
+		Source:             in.Get("CE-Source"),
+		Extensions:         make(map[string]interface{}),
+	}
+	if timeStr := in.Get("CE-EventTime"); timeStr != "" {
+		if data.EventTime, err = time.Parse(time.RFC3339Nano, timeStr); err != nil {
+			return err
+		}
+	}
+	for k, v := range in {
+		if strings.EqualFold(k[:len("CE-X-")], "CE-X-") {
+			key := k[len("CE-X-"):]
+			var tmp interface{}
+			if err = json.Unmarshal([]byte(v[0]), &tmp); err == nil {
+				data.Extensions[key] = tmp
+			} else {
+				// If we can't unmarshall the data, treat it as a string
+				data.Extensions[key] = v[0]
+			}
+		}
+	}
+	*ec = data
+	return nil
+}
+
+// AsJSON implements the StructuredSender interface
+func (ec V01EventContext) AsJSON() (map[string]json.RawMessage, error) {
+	ret := make(map[string]json.RawMessage)
+	err := anyError(
+		encodeKey(&ret, "cloudEventsVersion", ec.CloudEventsVersion),
+		encodeKey(&ret, "eventID", ec.EventID),
+		encodeKey(&ret, "eventTime", ec.EventTime),
+		encodeKey(&ret, "eventType", ec.EventType),
+		encodeKey(&ret, "eventTypeVersion", ec.EventTypeVersion),
+		encodeKey(&ret, "schemaURL", ec.SchemaURL),
+		encodeKey(&ret, "contentType", ec.ContentType),
+		encodeKey(&ret, "source", ec.Source),
+		encodeKey(&ret, "extensions", ec.Extensions))
+	return ret, err
+}
+
+// DataContentType implements the StructuredSender interface
+func (ec V01EventContext) DataContentType() string {
+	return ec.ContentType
+}
+
+// FromJSON implements the StructuredContext interface
+func (ec *V01EventContext) FromJSON(in map[string]json.RawMessage) error {
+	data := V01EventContext{
+		CloudEventsVersion: extractKey(in, "cloudEventsVersion"),
+		EventID:            extractKey(in, "eventID"),
+		EventType:          extractKey(in, "eventType"),
+		Source:             extractKey(in, "source"),
+	}
+	var err error
+	timeStr := extractKey(in, "eventTime")
+	if timeStr != "" {
+		if data.EventTime, err = time.Parse(time.RFC3339Nano, timeStr); err != nil {
+			return err
+		}
+	}
+	extractKeyTo(in, "eventTypeVersion", &data.EventTypeVersion)
+	extractKeyTo(in, "schemaURL", &data.SchemaURL)
+	extractKeyTo(in, "contentType", &data.ContentType)
+	if len(in["extensions"]) == 0 {
+		in["extensions"] = []byte("{}")
+	}
+	err = json.Unmarshal(in["extensions"], &data.Extensions)
+	if err != nil {
+		return err
+	}
+	*ec = data
+	return nil
+}
+
+func encodeKey(out *map[string]json.RawMessage, key string, value interface{}) (err error) {
+	if s, ok := value.(string); s == "" && ok {
+		// Skip empty strings
+		return nil
+	}
+	(*out)[key], err = json.Marshal(value)
+	return
+}
+
+func extractKey(in map[string]json.RawMessage, key string) (s string) {
+	extractKeyTo(in, key, &s)
+	return
+}
+
+func extractKeyTo(in map[string]json.RawMessage, key string, out *string) error {
+	tmp := in[key]
+	delete(in, key)
+	return json.Unmarshal(tmp, out)
+}


### PR DESCRIPTION
In-progress: #193 

This PR renames `CloudEventsVersion` and `EventContext` to `V01...`, and leaves legacy aliases to allow seamless upgrades.

Additional changes:
* Introduces `SendContext`/`LoadContext` interfaces to support read/write of arbitrary CloudEvents versions.
* Makes `CloudEventsVersion` required per v0.1 spec.

The next step is to change the return type on `FromRequest` to `(LoadContext, error)` and introduce the `V02EventContext` file. This will also necessitate changing the tests (and therefore downstream code), so I'd prefer to do this in a separate PR (see 366 in `handler.go` for an example of the work needed -- basically calling `AsV01()` or `AsV02()` in locations which expect a particular version).