### PR TITLE
Allow event type to be overridden in cloudevent client.

### DIFF
--- a/cloudevents/builder.go
+++ b/cloudevents/builder.go
@@ -58,12 +58,6 @@ type Builder struct {
 // send a pre-assembled cloud event to the given target. The target is assumed
 // to be a URL with a scheme, ie: "http://localhost:8080"
 func (b *Builder) Build(target string, data interface{}, overrides ...SendContext) (*http.Request, error) {
-	if b.Source == "" {
-		return nil, fmt.Errorf("Build.Source is empty")
-	}
-	if b.EventType == "" {
-		return nil, fmt.Errorf("Build.EventType is empty")
-	}
 	if len(overrides) > 1 {
 		return nil, fmt.Errorf("Build was called with more than one override")
 	}
@@ -80,6 +74,13 @@ func (b *Builder) Build(target string, data interface{}, overrides ...SendContex
 	}
 	// TODO: when V02 is supported this will have to shuffle a little.
 	ctx := b.cloudEventsContextV01(overridesV01)
+
+	if ctx.Source == "" {
+		return nil, fmt.Errorf("ctx.Source resolved empty")
+	}
+	if b.EventType == "" {
+		return nil, fmt.Errorf("ctx.EventType resolved empty")
+	}
 
 	switch b.Encoding {
 	case BinaryV01:
@@ -111,6 +112,9 @@ func (b *Builder) cloudEventsContextV01(overrides *V01EventContext) V01EventCont
 		}
 		if overrides.EventID != "" {
 			ctx.EventID = overrides.EventID
+		}
+		if overrides.EventType != "" {
+			ctx.EventType = overrides.EventType
 		}
 		if !overrides.EventTime.IsZero() {
 			ctx.EventTime = overrides.EventTime

--- a/cloudevents/builder_context_test.go
+++ b/cloudevents/builder_context_test.go
@@ -144,6 +144,22 @@ func TestCloudEventsContextV01(t *testing.T) {
 			},
 			opt: cmpopts.IgnoreFields(V01EventContext{}, "EventID", "EventTime"),
 		}, {
+			name: "override event type",
+			b: Builder{
+				Source:    "source",
+				EventType: "event.type",
+			},
+			override: &V01EventContext{
+				EventType: "override.event.type",
+			},
+			want: V01EventContext{
+				CloudEventsVersion: "0.1",
+				EventType:          "override.event.type",
+				ContentType:        "application/json",
+				Source:             "source",
+			},
+			opt: cmpopts.IgnoreFields(V01EventContext{}, "EventID", "EventTime"),
+		}, {
 			name: "override extensions",
 			b: Builder{
 				Source:           "source",

--- a/cloudevents/builder_test.go
+++ b/cloudevents/builder_test.go
@@ -36,16 +36,28 @@ func TestBuilderBuildValidation(t *testing.T) {
 		{
 			name:    "Source is empty",
 			b:       cloudevents.Builder{},
-			errText: "Build.Source is empty",
-		},
-		{
+			errText: "Source resolved empty",
+		}, {
 			name: "EventType is empty",
 			b: cloudevents.Builder{
 				Source: "source",
 			},
-			errText: "Build.EventType is empty",
-		},
-		{
+			errText: "EventType resolved empty",
+		}, {
+			name: "source from overrides, EventType is empty",
+			b:    cloudevents.Builder{},
+			overrides: []cloudevents.SendContext{cloudevents.V01EventContext{
+				Source: "source",
+			}},
+			errText: "EventType resolved empty",
+		}, {
+			name: "valid, source and event type from overrides",
+			b:    cloudevents.Builder{},
+			overrides: []cloudevents.SendContext{cloudevents.V01EventContext{
+				Source:    "source",
+				EventType: "event.type",
+			}},
+		}, {
 			name: "too many overrides",
 			b: cloudevents.Builder{
 				Source:    "source",
@@ -53,8 +65,7 @@ func TestBuilderBuildValidation(t *testing.T) {
 			},
 			overrides: []cloudevents.SendContext{cloudevents.V01EventContext{}, cloudevents.V01EventContext{}},
 			errText:   "Build was called with more than one override",
-		},
-		{
+		}, {
 			name: "override is wrong type",
 			b: cloudevents.Builder{
 				Source:    "source",

--- a/cloudevents/client_test.go
+++ b/cloudevents/client_test.go
@@ -251,7 +251,7 @@ func TestClientSend(t *testing.T) {
 				return *client
 			}(),
 			override: &cloudevents.V01EventContext{},
-			errText:  "Build.EventType is empty",
+			errText:  "EventType resolved empty",
 		}, {
 			name: "request not accepted",
 			client: func() cloudevents.Client {


### PR DESCRIPTION
Allow event type to be overridden in cloudevent client.

Also fix issue where context was not tested after overrides.
fixes: https://github.com/knative/pkg/issues/249