### PR TITLE
Make "Severity: Error" conditions less scary.

### DIFF
--- a/apis/duck/v1alpha1/conditions_types.go
+++ b/apis/duck/v1alpha1/conditions_types.go
@@ -47,8 +47,10 @@ type ConditionSeverity string
 
 const (
 	// ConditionSeverityError specifies that a failure of a condition type
-	// should be viewed as an error.
-	ConditionSeverityError ConditionSeverity = "Error"
+	// should be viewed as an error.  As "Error" is the default for conditions
+	// we use the empty string (coupled with omitempty) to avoid confusion in
+	// the case where the condition is in state "True" (aka nothing is wrong).
+	ConditionSeverityError ConditionSeverity = ""
 	// ConditionSeverityWarning specifies that a failure of a condition type
 	// should be viewed as a warning, but that things could still work.
 	ConditionSeverityWarning ConditionSeverity = "Warning"


### PR DESCRIPTION
This restores the appearance of "terminal" conditions to what is was prior to the separation of "terminal" and "non-terminal" conditions.

Terminal conditions with an "Error" severity will simply omit the field.

This keeps coming up, and came to a head when both Evan and Ville bugged me about it in the same day.

Fixes: https://github.com/knative/serving/issues/2507

