### PR TITLE
test/helpers module to store AppendRandomString helper fn

### DIFF
--- a/test/helpers/data.go
+++ b/test/helpers/data.go
@@ -1,0 +1,39 @@
+package helpers
+
+import (
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	letterBytes   = "abcdefghijklmnopqrstuvwxyz"
+	randSuffixLen = 8
+	sep = "-"
+)
+
+var (
+	r        *rand.Rand
+	rndMutex *sync.Mutex
+	once     sync.Once
+)
+
+func initSeed() {
+	seed := time.Now().UTC().UnixNano()
+	r = rand.New(rand.NewSource(seed))
+	rndMutex = &sync.Mutex{}
+}
+
+func AppendRandomString(prefix string) string {
+	once.Do(initSeed)
+	suffix := make([]byte, randSuffixLen)
+
+	rndMutex.Lock()
+	for i := range suffix {
+		suffix[i] = letterBytes[r.Intn(len(letterBytes))]
+	}
+	rndMutex.Unlock()
+
+	return strings.Join([]string{prefix, string(suffix)}, sep)
+}

--- a/test/helpers/data.go
+++ b/test/helpers/data.go
@@ -30,10 +30,11 @@ func AppendRandomString(prefix string) string {
 	suffix := make([]byte, randSuffixLen)
 
 	rndMutex.Lock()
+	defer rndMutex.Unlock()
+
 	for i := range suffix {
 		suffix[i] = letterBytes[r.Intn(len(letterBytes))]
 	}
-	rndMutex.Unlock()
 
 	return strings.Join([]string{prefix, string(suffix)}, sep)
 }


### PR DESCRIPTION
<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description: 
-->

Fixes: #226

I have added the helper function`AppendRandomString` into `test/helpers` module (helpers being a new module), sample usage:

```go
package pkg

import (
	"github.com/knative/pkg/test/helpers"
	"testing"
	"strings"
)


func TestAppendRandomString(t *testing.T) {
	s := helpers.AppendRandomString("myprefix")

	if !strings.HasPrefix(s, "myprefix") {
		t.Fatalf("Failed to verify prefix: %s", s)
	}

	if len(s) != 18 {
		t.Fatalf("Failed to verify string size: %d", len(s))
	}

	t.Logf("---%s---", s)
}
```

I was looking for a first good issue and this one looked simple enough :)