### PR TITLE
Add `AtIndex` method to deal to attach index at the current error.

### DIFF
--- a/apis/field_error.go
+++ b/apis/field_error.go
@@ -73,7 +73,7 @@ func (fe *FieldError) ViaField(prefix ...string) *FieldError {
 	return newErr
 }
 
-// ViaIndex is used to attach an index to the *next* ViaField provided.
+// ViaIndex is used to attach an index to the next ViaField provided.
 // For example, if a type recursively validates a parameter that has a collection:
 //  for i, c := range spec.Collection {
 //    if err := doValidation(c); err != nil {
@@ -82,19 +82,6 @@ func (fe *FieldError) ViaField(prefix ...string) *FieldError {
 //  }
 func (fe *FieldError) ViaIndex(index int) *FieldError {
 	return fe.ViaField(asIndex(index))
-}
-
-
-// AtIndex is used to attach an index to the *previous* ViaField provided.
-func (fe *FieldError) AtIndex(index int) *FieldError {
-	if fe == nil {
-		return nil
-	}
-	ai := asIndex(index)
-	for i := range fe.Paths {
-		fe.Paths[i] = flatten([]string{fe.Paths[i], ai})
-	}
-	return fe
 }
 
 

--- a/apis/field_error.go
+++ b/apis/field_error.go
@@ -84,6 +84,20 @@ func (fe *FieldError) ViaIndex(index int) *FieldError {
 	return fe.ViaField(asIndex(index))
 }
 
+// AtIndex attaches the index to the current field.
+// Which is different from ViaIndex, that attaches index to the
+// next field.
+func (fe *FieldError) AtIndex(index int) *FieldError {
+	if fe == nil {
+		return nil
+	}
+	ai := asIndex(index)
+	for i := range fe.Paths {
+		fe.Paths[i] = flatten([]string{fe.Paths[i], ai})
+	}
+	return fe
+}
+
 // ViaFieldIndex is the short way to chain: err.ViaIndex(bar).ViaField(foo)
 func (fe *FieldError) ViaFieldIndex(field string, index int) *FieldError {
 	return fe.ViaIndex(index).ViaField(field)
@@ -192,7 +206,7 @@ func asKey(key string) string {
 //   err([0]).ViaField(bar).ViaField(foo) -> foo.bar.[0] converts to foo.bar[0]
 //   err(bar).ViaIndex(0).ViaField(foo) -> foo.[0].bar converts to foo[0].bar
 //   err(bar).ViaField(foo).ViaIndex(0) -> [0].foo.bar converts to [0].foo.bar
-//   err(bar).ViaIndex(0).ViaIndex[1].ViaField(foo) -> foo.[1].[0].bar converts to foo[1][0].bar
+//   err(bar).ViaIndex(0).ViaIndex(1).ViaField(foo) -> foo.[1].[0].bar converts to foo[1][0].bar
 func flatten(path []string) string {
 	var newPath []string
 	for _, part := range path {

--- a/apis/field_error.go
+++ b/apis/field_error.go
@@ -84,7 +84,6 @@ func (fe *FieldError) ViaIndex(index int) *FieldError {
 	return fe.ViaField(asIndex(index))
 }
 
-
 // ViaFieldIndex is the short way to chain: err.ViaIndex(bar).ViaField(foo)
 func (fe *FieldError) ViaFieldIndex(field string, index int) *FieldError {
 	return fe.ViaIndex(index).ViaField(field)

--- a/apis/field_error.go
+++ b/apis/field_error.go
@@ -73,7 +73,7 @@ func (fe *FieldError) ViaField(prefix ...string) *FieldError {
 	return newErr
 }
 
-// ViaIndex is used to attach an index to the next ViaField provided.
+// ViaIndex is used to attach an index to the *next* ViaField provided.
 // For example, if a type recursively validates a parameter that has a collection:
 //  for i, c := range spec.Collection {
 //    if err := doValidation(c); err != nil {
@@ -84,9 +84,8 @@ func (fe *FieldError) ViaIndex(index int) *FieldError {
 	return fe.ViaField(asIndex(index))
 }
 
-// AtIndex attaches the index to the current field.
-// Which is different from ViaIndex, that attaches index to the
-// next field.
+
+// AtIndex is used to attach an index to the *previous* ViaField provided.
 func (fe *FieldError) AtIndex(index int) *FieldError {
 	if fe == nil {
 		return nil
@@ -97,6 +96,7 @@ func (fe *FieldError) AtIndex(index int) *FieldError {
 	}
 	return fe
 }
+
 
 // ViaFieldIndex is the short way to chain: err.ViaIndex(bar).ViaField(foo)
 func (fe *FieldError) ViaFieldIndex(field string, index int) *FieldError {
@@ -312,6 +312,12 @@ func ErrDisallowedFields(fieldPaths ...string) *FieldError {
 		Message: "must not set the field(s)",
 		Paths:   fieldPaths,
 	}
+}
+
+// ErrInvalidArrayValue consturcts a FieldError for a repetetive `field`
+// at `index` that has received an invalid string value.
+func ErrInvalidArrayValue(value, field string, index int) *FieldError {
+	return ErrInvalidValue(value, CurrentField).ViaFieldIndex(field, index)
 }
 
 // ErrInvalidValue constructs a FieldError for a field that has received an

--- a/apis/field_error_test.go
+++ b/apis/field_error_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package apis
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"fmt"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFieldError(t *testing.T) {

--- a/apis/field_error_test.go
+++ b/apis/field_error_test.go
@@ -17,12 +17,11 @@ limitations under the License.
 package apis
 
 import (
+	"github.com/google/go-cmp/cmp"
 	"fmt"
 	"strconv"
 	"strings"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestFieldError(t *testing.T) {
@@ -340,55 +339,26 @@ can not use @, do not try`,
 			// }
 			// --> I expect path to be myList[i].foo
 
-			return (&FieldError{
-				Message: "invalid field(s)",
-				Paths:   []string{"foo"},
-			}).ViaIndex(0).ViaField("bar").ViaIndex(2).ViaIndex(1).ViaField("baz").ViaIndex(3).ViaIndex(4).ViaField("boof")
-		}(),
-		want: "invalid field(s): boof[4][3].baz[1][2].bar[0].foo",
-	}, {
-		name: "manual index, using ViaFieldIndex",
-		err: func() *FieldError {
-			// Example, return an error in a loop:
-			// for i, item := spec.myList {
-			//   err := item.validate().ViaIndex(i).ViaField("myList")
-			//   if err != nil {
-			// 		return err
-			//   }
-			// }
-			// --> I expect path to be myList[i].foo
-
-			return (&FieldError{
-				Message: "invalid field(s)",
-				Paths:   []string{"foo"},
-			}).ViaFieldIndex("bar", 0).ViaIndex(2).ViaFieldIndex("baz", 1).ViaIndex(3).ViaFieldIndex("boof", 4)
-		}(),
-		want: "invalid field(s): boof[4][3].baz[1][2].bar[0].foo",
-	}, {
-		name: "atIndex",
-		err: func() *FieldError {
-			return (&FieldError{Message: "broken at index 5", Paths: []string{"foo"}}).AtIndex(5)
-		}(),
-		want: "broken at index 5: foo[5]",
-	}, {
-		name: "atIndex, nil",
-		err: func() *FieldError {
-			var fe *FieldError
-			return fe.AtIndex(5)
-		}(),
-	}, {
-		name: "atIndex; 2d",
-		err: func() *FieldError {
-			return (&FieldError{Message: "broken at index[5][3]", Paths: []string{"foo"}}).AtIndex(5).AtIndex(3)
-		}(),
-		want: "broken at index[5][3]: foo[5][3]",
-	}, {
-		name: "manual multiple index",
-		err: func() *FieldError {
 			err := &FieldError{
 				Message: "invalid field(s)",
 				Paths:   []string{"foo"},
 			}
+
+			err = err.ViaIndex(0).ViaField("bar")
+			err = err.ViaIndex(2).ViaIndex(1).ViaField("baz")
+			err = err.ViaIndex(3).ViaIndex(4).ViaField("boof")
+			return err
+		}(),
+		want: "invalid field(s): boof[4][3].baz[1][2].bar[0].foo",
+	}, {
+		name: "manual multiple index",
+		err: func() *FieldError {
+
+			err := &FieldError{
+				Message: "invalid field(s)",
+				Paths:   []string{"foo"},
+			}
+
 			err = err.ViaField("bear", "[1]", "[2]", "[3]", "baz", "]xxx[").ViaField("bar")
 			return err
 		}(),
@@ -396,10 +366,13 @@ can not use @, do not try`,
 	}, {
 		name: "manual keys",
 		err: func() *FieldError {
-			err := (&FieldError{
+			err := &FieldError{
 				Message: "invalid field(s)",
 				Paths:   []string{"foo"},
-			}).ViaKey("A").ViaField("bar").ViaKey("CCC").ViaKey("BB").ViaField("baz")
+			}
+
+			err = err.ViaKey("A").ViaField("bar")
+			err = err.ViaKey("CCC").ViaKey("BB").ViaField("baz")
 			err = err.ViaKey("E").ViaKey("F").ViaField("jar")
 			return err
 		}(),
@@ -407,12 +380,22 @@ can not use @, do not try`,
 	}, {
 		name: "manual index and keys",
 		err: func() *FieldError {
-			return (&FieldError{
+			err := &FieldError{
 				Message: "invalid field(s)",
 				Paths:   []string{"foo", "faa"},
-			}).ViaKey("A").ViaField("bar").ViaIndex(1).ViaField("baz").ViaKey("E").ViaIndex(0).ViaField("jar")
+			}
+			err = err.ViaKey("A").ViaField("bar")
+			err = err.ViaIndex(1).ViaField("baz")
+			err = err.ViaKey("E").ViaIndex(0).ViaField("jar")
+			return err
 		}(),
 		want: "invalid field(s): jar[0][E].baz[1].bar[A].faa, jar[0][E].baz[1].bar[A].foo",
+	}, {
+		name: "leaf field error with index",
+		err: func() *FieldError {
+			return ErrInvalidArrayValue("kapot", "indexed", 5)
+		}(),
+		want: `invalid value "kapot": indexed[5]`,
 	}, {
 		name:     "nil propagation",
 		err:      nil,
@@ -445,7 +428,7 @@ can not use @, do not try`,
 
 			if test.want != "" {
 				if got, want := fe.Error(), test.want; got != want {
-					t.Errorf("%s: Error() = %q, wanted %q, diff: %s", test.name, got, want, cmp.Diff(got, want))
+t.Errorf("%s: Error() = %q, wanted %q, diff: %s", test.name, got, want, cmp.Diff(got, want))
 				}
 			} else if fe != nil {
 				t.Errorf("%s: ViaField() = %v, wanted nil", test.name, fe)


### PR DESCRIPTION
This is useful when we are dealing with primite leaf list (e.g.
a list of strings).
The alternative are
a) creating dummy error and then executing ViaFieldIndex(), which is
plain ugly
b) implementing Validate() on the primitive type via type aliasing and
then collecting errors, which seems an overkill.

In addition it seems ViaFieldIndex was not covered by unit tests,
so I've added one to take care of that.

/cc @evankanderson 