### PR TITLE
golang format tools

### DIFF
--- a/apis/field_error_test.go
+++ b/apis/field_error_test.go
@@ -429,7 +429,7 @@ can not use @, do not try`,
 
 			if test.want != "" {
 				if got, want := fe.Error(), test.want; got != want {
-t.Errorf("%s: Error() = %q, wanted %q, diff: %s", test.name, got, want, cmp.Diff(got, want))
+					t.Errorf("%s: Error() = %q, wanted %q, diff: %s", test.name, got, want, cmp.Diff(got, want))
 				}
 			} else if fe != nil {
 				t.Errorf("%s: ViaField() = %v, wanted nil", test.name, fe)

--- a/cloudevents/client_test.go
+++ b/cloudevents/client_test.go
@@ -380,7 +380,7 @@ func canonicalizeHeaders(rvs ...requestValidation) {
 		for n, v := range headers {
 			delete(headers, n)
 			ln := strings.ToLower(n)
-			if !unimportantHeaders.Has(ln){
+			if !unimportantHeaders.Has(ln) {
 				headers[ln] = v
 			}
 		}

--- a/cloudevents/handler.go
+++ b/cloudevents/handler.go
@@ -60,8 +60,8 @@ var (
 	// it leaves this stack frame. The workaround is to pass a pointer to an interface and then
 	// get the type of its reference.
 	// For example, see: https://play.golang.org/p/_dxLvdkvqvg
-	contextType      = reflect.TypeOf((*context.Context)(nil)).Elem()
-	errorType        = reflect.TypeOf((*error)(nil)).Elem()
+	contextType     = reflect.TypeOf((*context.Context)(nil)).Elem()
+	errorType       = reflect.TypeOf((*error)(nil)).Elem()
 	sendContextType = reflect.TypeOf((*SendContext)(nil)).Elem()
 )
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
