### PR TITLE
fix very annoying logging in the integration tests

### DIFF
--- a/test/logging/logging.go
+++ b/test/logging/logging.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/glog"
 	"github.com/knative/pkg/logging"
 	"go.opencensus.io/stats/view"
@@ -58,9 +59,9 @@ type BaseLogger struct {
 // ExportView will emit the view data vd (i.e. the stats that have been
 // recorded) to the zap logger.
 func (e *zapMetricExporter) ExportView(vd *view.Data) {
-	// We are not curretnly consuming these metrics, so for now we'll juse
+	// We are not currently consuming these metrics, so for now we'll juse
 	// dump the view.Data object as is.
-	e.logger.Info(vd)
+	e.logger.Debug(spew.Sprint(vd))
 }
 
 // ExportSpan will emit the trace data to the zap logger.


### PR DESCRIPTION
this logging is very annoying and useless.
This makes logging more useful and still can be turned on via flags.

/cc @markusthoemmes @mattmoor 