### PR TITLE
Clean test loggers

### DIFF
--- a/logging/testing/util.go
+++ b/logging/testing/util.go
@@ -54,6 +54,14 @@ func TestLogger(t *testing.T) *zap.SugaredLogger {
 	return logger
 }
 
+// ClearAll removes all the testing loggers.
+// `go test -count=X` executes runs in the same process, thus the map
+// persists between the runs, but the `t` will no longer be valid and will
+// cause a panic deep inside testing code.
+func ClearAll() {
+	loggers = make(map[string]*zap.SugaredLogger)
+}
+
 // TestContextWithLogger returns a context with a logger to be used in tests
 func TestContextWithLogger(t *testing.T) context.Context {
 	return logging.WithLogger(context.TODO(), TestLogger(t))

--- a/test/logging/logging.go
+++ b/test/logging/logging.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/glog"
 	"github.com/knative/pkg/logging"
 	"go.opencensus.io/stats/view"
@@ -58,9 +59,9 @@ type BaseLogger struct {
 // ExportView will emit the view data vd (i.e. the stats that have been
 // recorded) to the zap logger.
 func (e *zapMetricExporter) ExportView(vd *view.Data) {
-	// We are not curretnly consuming these metrics, so for now we'll juse
+	// We are not currently consuming these metrics, so for now we'll juse
 	// dump the view.Data object as is.
-	e.logger.Info(vd)
+	e.logger.Debug(spew.Sprint(vd))
 }
 
 // ExportSpan will emit the trace data to the zap logger.


### PR DESCRIPTION
This helps with running tests with `-count=X`, since test loggers hog T objects and they are not reusable.

/cc @mattmoor 