### PR TITLE
Add ping message verification to the websocket connection.

### DIFF
--- a/websocket/connection.go
+++ b/websocket/connection.go
@@ -185,6 +185,10 @@ func (c *ManagedConnection) connect() error {
 				return false, nil
 			}
 
+			// Setting the read deadline will cause NextReader in read
+			// to fail if it is exceeded. This deadline is reset each
+			// time we receive a pong message so we know the connection
+			// is still intact.
 			conn.SetReadDeadline(time.Now().Add(pongTimeout))
 			conn.SetPongHandler(func(string) error {
 				conn.SetReadDeadline(time.Now().Add(pongTimeout))

--- a/websocket/connection.go
+++ b/websocket/connection.go
@@ -140,6 +140,7 @@ func NewDurableConnection(target string, messageChan chan []byte, logger *zap.Su
 	// Keep sending pings 3 times per pongTimeout interval.
 	go func() {
 		ticker := time.NewTicker(pongTimeout / 3)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:


### PR DESCRIPTION
<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:

Fixes: <LINK TO ISSUE>
-->

This should further increase the durability of our websocket connections. See https://github.com/knative/serving/issues/3138

Ping messages are sent to actively probe the websocket connection. By default, the websocket servers we use send a pong message back. This can be used to break indefinite read calls.