### PR TITLE
golang format tools

### DIFF
--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/pkg/test/zipkin"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
