### PR TITLE
Adding support for Zipkin tracing in SpoofClient

### DIFF
--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ package spoof
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -47,6 +46,9 @@ const (
 	// TODO(tcnghia): These probably shouldn't be hard-coded here?
 	istioIngressNamespace = "istio-system"
 	istioIngressName      = "istio-ingressgateway"
+	// Name of the temporary HTTP header that is added to http.Request to indicate that
+	// it is a SpoofClient.Poll request. This header is removed before making call to backend.
+	pollReqHeader = "X-Kn-Poll-Request-Do-Not-Trace"
 )
 
 // Response is a stripped down subset of http.Response. The is primarily useful
@@ -185,6 +187,12 @@ func (sc *SpoofingClient) Do(req *http.Request) (*Response, error) {
 	traceContext, span := trace.StartSpan(req.Context(), "SpoofingClient-Trace")
 	defer span.End()
 
+	// Check to see if the call to this method is coming from a Poll call.
+	logZipkinTrace := true
+	if req.Header.Get(pollReqHeader) != "" {
+		req.Header.Del(pollReqHeader)
+		logZipkinTrace = false
+	}
 	resp, err := sc.Client.Do(req.WithContext(traceContext))
 	if err != nil {
 		return nil, err
@@ -198,12 +206,18 @@ func (sc *SpoofingClient) Do(req *http.Request) (*Response, error) {
 		return nil, err
 	}
 
-	return &Response{
+	spoofResp := &Response{
 		Status:     resp.Status,
 		StatusCode: resp.StatusCode,
 		Header:     resp.Header,
 		Body:       body,
-	}, nil
+	}
+
+	if logZipkinTrace {
+		sc.logZipkinTrace(spoofResp)
+	}
+
+	return spoofResp, nil
 }
 
 // Poll executes an http request until it satisfies the inState condition or encounters an error.
@@ -214,6 +228,10 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker) (*Res
 	)
 
 	err = wait.PollImmediate(sc.RequestInterval, sc.RequestTimeout, func() (bool, error) {
+		// As we may do multiple Do calls as part of a single Poll we add this temporary header
+		// to the request to indicate to Do method not to log Zipkin trace, instead it is
+		// handled by this method itself.
+		req.Header.Add(pollReqHeader, "True")
 		resp, err = sc.Do(req)
 		if err != nil {
 			if err, ok := err.(net.Error); ok && err.Timeout() {
@@ -226,13 +244,24 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker) (*Res
 		return inState(resp)
 	})
 
+	if resp != nil {
+		sc.logZipkinTrace(resp)
+	}
+
 	return resp, err
 }
 
-// LogZipkinTrace provides support to log Zipkin Trace for param: traceID
-func (sc *SpoofingClient) LogZipkinTrace(traceID string) error {
+// logZipkinTrace provides support to log Zipkin Trace for param: spoofResponse
+// We only log Zipkin trace for HTTP server errors i.e for HTTP status codes between 500 to 600
+func (sc *SpoofingClient) logZipkinTrace(spoofResp *Response) {
+	if !zipkin.ZipkinTracingEnabled || spoofResp.StatusCode < http.StatusInternalServerError || spoofResp.StatusCode >= 600 {
+		return
+	}
+
+	traceID := spoofResp.Header.Get(zipkin.ZipkinTraceIDHeader)
 	if err := zipkin.CheckZipkinPortAvailability(); err == nil {
-		return errors.New("port-forwarding for Zipkin is not-setup. Failing Zipkin Trace retrieval")
+		sc.logf("port-forwarding for Zipkin is not-setup. Failing Zipkin Trace retrieval")
+		return
 	}
 
 	sc.logf("Logging Zipkin Trace: %s", traceID)
@@ -242,20 +271,21 @@ func (sc *SpoofingClient) LogZipkinTrace(traceID string) error {
 	time.Sleep(5 * time.Second)
 	resp, err := http.Get(zipkinTraceEndpoint)
 	if err != nil {
-		return fmt.Errorf("Error retrieving Zipkin trace: %v", err)
+		sc.logf("Error retrieving Zipkin trace: %v", err)
+		return
 	}
 	defer resp.Body.Close()
 
 	trace, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("Error reading Zipkin trace response: %v", err)
+		sc.logf("Error reading Zipkin trace response: %v", err)
+		return
 	}
 
 	var prettyJSON bytes.Buffer
 	if error := json.Indent(&prettyJSON, trace, "", "\t"); error != nil {
-		return fmt.Errorf("JSON Parser Error while trying for Pretty-Format: %v, Original Response: %s", error, string(trace))
+		sc.logf("JSON Parser Error while trying for Pretty-Format: %v, Original Response: %s", error, string(trace))
+		return
 	}
 	sc.logf("%s", prettyJSON.String())
-
-	return nil
 }

--- a/test/zipkin/doc.go
+++ b/test/zipkin/doc.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package zipkin adds Zipkin tracing support that can be used in conjunction with
+SpoofingClient to log zipkin traces for requests that have encountered server errors
+i.e HTTP request that have HTTP status between 500 to 600.
+
+This package exposes following methods:
+
+	SetupZipkinTracing(*kubernetes.Clientset) error
+		SetupZipkinTracing sets up zipkin tracing by setting up port-forwarding from
+		localhost to zipkin pod on the cluster. On successful setup this method sets
+		an internal flag zipkinTracingEnabled to true.
+
+	CleanupZipkinTracingSetup() error
+		CleanupZipkinTracingSetup cleans up zipkin tracing setup by cleaning up the
+		port-forwarding setup by call to SetupZipkinTracing. This method also sets
+		zipkinTracingEnabled flag to false.
+
+A general flow for a Test Suite to use Zipkin Tracing support is as follows:
+
+		1. Call SetupZipkinTracing(*kubernetes.Clientset) in TestMain.
+		2. Use SpoofingClient to make HTTP requests.
+		3. Call CleanupZipkinTracingSetup on cleanup after tests are executed.
+
+ */
+package zipkin


### PR DESCRIPTION
Existing support for Zipkin tracing pushes the responsibility of logging zipkin traces to individual tests. This change moves the responsibility to SpoofClient, so that all tests get it by default. Individual tests
can disable this functionality by just disabling a ZipkinTracingEnabled flag in zipkin package.

Zipkin tracing in Spoofing client checks to see if the ZipkinTracingEnabled flag is enabled and only logs traces for requests that have encountered Server errors i.e if the http.Response.StatusCode between 500 to 599.

For SpoofingClient.Poll calls we only log trace of the final SpoofingClient.Do made.