### PR TITLE
Don't close the http.Request body

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -435,8 +435,6 @@ func (ac *AdmissionController) register(
 // ServeHTTP implements the external admission webhook for mutating
 // serving resources.
 func (ac *AdmissionController) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
 	logger := ac.Logger
 	logger.Infof("Webhook ServeHTTP request=%#v", r)
 


### PR DESCRIPTION
As per net.http package for `http.Request.Body`

```
The Server will close the request body. The ServeHTTP
Handler does not need to.
```

<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:

Fixes: <LINK TO ISSUE>
-->
