### PR TITLE
Simplify and comment AppenRandomString

### DIFF
--- a/test/helpers/data.go
+++ b/test/helpers/data.go
@@ -3,7 +3,6 @@ package helpers
 import (
 	"math/rand"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -13,13 +12,8 @@ const (
 	sep           = "-"
 )
 
-var (
-	r        *rand.Rand
-	rndMutex sync.Mutex
-)
-
 func init() {
-	r = rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
+	rand.Seed(time.Now().UTC().UnixNano())
 }
 
 // AppendRandomString will generate a random string that begins with prefix.
@@ -31,11 +25,8 @@ func init() {
 func AppendRandomString(prefix string) string {
 	suffix := make([]byte, randSuffixLen)
 
-	rndMutex.Lock()
-	defer rndMutex.Unlock()
-
 	for i := range suffix {
-		suffix[i] = letterBytes[r.Intn(len(letterBytes))]
+		suffix[i] = letterBytes[rand.Intn(len(letterBytes))]
 	}
 
 	return strings.Join([]string{prefix, string(suffix)}, sep)

--- a/test/helpers/data.go
+++ b/test/helpers/data.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package helpers
 
 import (

--- a/test/helpers/data.go
+++ b/test/helpers/data.go
@@ -15,18 +15,20 @@ const (
 
 var (
 	r        *rand.Rand
-	rndMutex *sync.Mutex
-	once     sync.Once
+	rndMutex sync.Mutex
 )
 
-func initSeed() {
-	seed := time.Now().UTC().UnixNano()
-	r = rand.New(rand.NewSource(seed))
-	rndMutex = &sync.Mutex{}
+func init() {
+	r = rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 }
 
+// AppendRandomString will generate a random string that begins with prefix.
+// This is useful if you want to make sure that your tests can run at the same
+// time against the same environment without conflicting.
+// This method will use "-" as the separator between the prefix and
+// the random suffix.
+// This method will seed rand with the current time when the package is initialized.
 func AppendRandomString(prefix string) string {
-	once.Do(initSeed)
 	suffix := make([]byte, randSuffixLen)
 
 	rndMutex.Lock()

--- a/test/helpers/data_test.go
+++ b/test/helpers/data_test.go
@@ -1,0 +1,16 @@
+package helpers
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var matcher = regexp.MustCompile("abcd-[a-z]{8}")
+
+func ExampleAppendRandomString() {
+	const s = "abcd"
+	t := AppendRandomString(s)
+	o := AppendRandomString(s)
+	fmt.Println(matcher.MatchString(t), matcher.MatchString(o), o != t)
+	// Output: true true true
+}

--- a/test/helpers/data_test.go
+++ b/test/helpers/data_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package helpers
 
 import (


### PR DESCRIPTION
Port and rewrite the comment from the original.
Remove the sync.Once(). Initializing during package initialization is just as good.
Mutex doesn't have to be a pointer

/cc @mattmoor @srinivashegde86 