### PR TITLE
golang format tools

### DIFF
--- a/test/logging/logging.go
+++ b/test/logging/logging.go
@@ -73,7 +73,7 @@ func (e *zapMetricExporter) ExportView(vd *view.Data) {
 // GetEmitableSpan starts and returns a trace.Span with a name that
 // is used by the ExportSpan method to emit the span.
 func GetEmitableSpan(ctx context.Context, metricName string) *trace.Span {
-	_, span := trace.StartSpan(ctx, emitableSpanNamePrefix + metricName)
+	_, span := trace.StartSpan(ctx, emitableSpanNamePrefix+metricName)
 	return span
 }
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
