### PR TITLE
Format markdown

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -77,7 +77,8 @@ These metrics will be emitted by the test if the test is run with
 
 You can record arbitrary metrics with
 [`stats.Record`](https://github.com/census-instrumentation/opencensus-go#stats)
-or measure latency by creating a instance of [`trace.Span`](https://github.com/census-instrumentation/opencensus-go#traces)
+or measure latency by creating a instance of
+[`trace.Span`](https://github.com/census-instrumentation/opencensus-go#traces)
 by using the helper method [`logging.GetEmitableSpan()`](../logging/logger.go)
 
 ```go


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`