### PR TITLE
golang format tools

### DIFF
--- a/test/zipkin/doc.go
+++ b/test/zipkin/doc.go
@@ -37,5 +37,5 @@ A general flow for a Test Suite to use Zipkin Tracing support is as follows:
 		2. Use SpoofingClient to make HTTP requests.
 		3. Call CleanupZipkinTracingSetup on cleanup after tests are executed.
 
- */
+*/
 package zipkin


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
