### PR TITLE
Add missing CORS Policy to Istio HTTP route

### DIFF
--- a/apis/istio/v1alpha3/virtualservice_types.go
+++ b/apis/istio/v1alpha3/virtualservice_types.go
@@ -198,6 +198,9 @@ type HTTPRoute struct {
 
 	// Http headers to remove before returning the response to the caller
 	RemoveResponseHeaders map[string]string `json:"removeResponseHeaders,omitempty"`
+
+	// Cross-Origin Resource Sharing policy
+	CorsPolicy *CorsPolicy `json:"corsPolicy,omitempty"`
 }
 
 // HttpMatchRequest specifies a set of criterion to be met in order for the

--- a/apis/istio/v1alpha3/zz_generated.deepcopy.go
+++ b/apis/istio/v1alpha3/zz_generated.deepcopy.go
@@ -507,6 +507,11 @@ func (in *HTTPRoute) DeepCopyInto(out *HTTPRoute) {
 			(*out)[key] = val
 		}
 	}
+	if in.CorsPolicy != nil {
+		in, out := &in.CorsPolicy, &out.CorsPolicy
+		*out = new(CorsPolicy)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 


### PR DESCRIPTION
Hello,

The CORS policy was missing from the Istio HTTPRoute definition.

Signed-off-by: stefanprodan <stefan.prodan@gmail.com>
