### PR TITLE
Remove baselogger and use FormatLogger everywhere

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -46,22 +46,16 @@ _See [e2e_flags.go](./e2e_flags.go)._
 [When tests are run with `--logverbose` option](README.md#output-verbose-logs),
 debug logs will be emitted to stdout.
 
-We are using the common [e2e logging library](logging/logging.go) that uses the
-[Knative logging library](../logging/) for structured logging. It is built on
-top of [zap](https://github.com/uber-go/zap). Tests should initialize the global
-logger to use a test specifc context with `logging.GetContextLogger`:
+We are using a generic [FormatLogger]](https://github.com/knative/pkg/blob/master/test/logging/logging.go#L49) 
+that can be passed in any existing logger that satisfies it. Test can use the generic 
+[logging methods](https://golang.org/pkg/testing/#T) to log info and error logs. All the common methods 
+accept generic FormatLogger as a parameter and tests can pass in `t.Logf` like this:
 
 ```go
-// The convention is for the name of the logger to match the name of the test.
-logging.GetContextLogger("TestHelloWorld")
-```
-
-Logs can then be emitted using the `logger` object which is required by many
-functions in the test library. To emit logs:
-
-```go
-logger.Infof("Creating a new Route %s and Configuration %s", route, configuration)
-logger.Debugf("The LogURL is %s, not yet verifying", logURL)
+_, err = pkgTest.WaitForEndpointState(
+    clients.KubeClient,
+    t.Logf,
+    ...),
 ```
 
 _See [logging.go](./logging/logging.go)._

--- a/test/README.md
+++ b/test/README.md
@@ -46,10 +46,11 @@ _See [e2e_flags.go](./e2e_flags.go)._
 [When tests are run with `--logverbose` option](README.md#output-verbose-logs),
 debug logs will be emitted to stdout.
 
-We are using a generic [FormatLogger]](https://github.com/knative/pkg/blob/master/test/logging/logging.go#L49)
-that can be passed in any existing logger that satisfies it. Test can use the generic
-[logging methods](https://golang.org/pkg/testing/#T) to log info and error logs. All the common methods
-accept generic FormatLogger as a parameter and tests can pass in `t.Logf` like this:
+We are using a generic [FormatLogger](https://github.com/knative/pkg/blob/master/test/logging/logging.go#L49)
+that can be passed in any existing logger that satisfies it. Test can use the
+generic [logging methods](https://golang.org/pkg/testing/#T) to log info and
+error logs. All the common methods accept generic FormatLogger as a parameter
+and tests can pass in `t.Logf` like this:
 
 ```go
 _, err = pkgTest.WaitForEndpointState(
@@ -135,13 +136,14 @@ For example, you can poll a `Configuration` object to find the name of the
 
 ```go
 var revisionName string
-err := test.WaitForConfigurationState(clients.ServingClient, configName, func(c *v1alpha1.Configuration) (bool, error) {
-    if c.Status.LatestCreatedRevisionName != "" {
-        revisionName = c.Status.LatestCreatedRevisionName
-        return true, nil
-    }
-    return false, nil
-}, "ConfigurationUpdatedWithRevision")
+err := test.WaitForConfigurationState(
+    clients.ServingClient, configName, func(c *v1alpha1.Configuration) (bool, error) {
+        if c.Status.LatestCreatedRevisionName != "" {
+            revisionName = c.Status.LatestCreatedRevisionName
+            return true, nil
+        }
+        return false, nil
+    }, "ConfigurationUpdatedWithRevision")
 ```
 
 _[Metrics will be emitted](#emit-metrics) for these `Wait` method tracking how

--- a/test/README.md
+++ b/test/README.md
@@ -46,9 +46,9 @@ _See [e2e_flags.go](./e2e_flags.go)._
 [When tests are run with `--logverbose` option](README.md#output-verbose-logs),
 debug logs will be emitted to stdout.
 
-We are using a generic [FormatLogger]](https://github.com/knative/pkg/blob/master/test/logging/logging.go#L49) 
-that can be passed in any existing logger that satisfies it. Test can use the generic 
-[logging methods](https://golang.org/pkg/testing/#T) to log info and error logs. All the common methods 
+We are using a generic [FormatLogger]](https://github.com/knative/pkg/blob/master/test/logging/logging.go#L49)
+that can be passed in any existing logger that satisfies it. Test can use the generic
+[logging methods](https://golang.org/pkg/testing/#T) to log info and error logs. All the common methods
 accept generic FormatLogger as a parameter and tests can pass in `t.Logf` like this:
 
 ```go

--- a/test/cleanup.go
+++ b/test/cleanup.go
@@ -27,12 +27,12 @@ import (
 )
 
 // CleanupOnInterrupt will execute the function cleanup if an interrupt signal is caught
-func CleanupOnInterrupt(cleanup func(), logger *logging.BaseLogger) {
+func CleanupOnInterrupt(cleanup func(), logf logging.FormatLogger) {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	go func() {
 		for range c {
-			logger.Info("Test interrupted, cleaning up.")
+			logf("Test interrupted, cleaning up.")
 			cleanup()
 			os.Exit(1)
 		}

--- a/test/clients.go
+++ b/test/clients.go
@@ -19,6 +19,7 @@ limitations under the License.
 package test
 
 import (
+	"github.com/knative/pkg/test/logging"
 	"github.com/knative/pkg/test/spoof"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -33,7 +34,7 @@ type KubeClient struct {
 }
 
 // NewSpoofingClient returns a spoofing client to make requests
-func NewSpoofingClient(client *KubeClient, logf spoof.FormatLogger, domain string, resolvable bool) (*spoof.SpoofingClient, error) {
+func NewSpoofingClient(client *KubeClient, logf logging.FormatLogger, domain string, resolvable bool) (*spoof.SpoofingClient, error) {
 	return spoof.New(client.Kube, logf, domain, resolvable, Flags.IngressEndpoint)
 }
 

--- a/test/logging/logging.go
+++ b/test/logging/logging.go
@@ -46,7 +46,10 @@ const (
 	emitableSpanNamePrefix = "emitspan-"
 )
 
-var baseLogger *BaseLogger
+// FormatLogger is a printf style function for logging in the Spoof client.
+type FormatLogger func(template string, args ...interface{})
+
+var logger *zap.SugaredLogger
 
 var exporter *zapMetricExporter
 
@@ -55,11 +58,6 @@ var exporter *zapMetricExporter
 // It conforms to the view.Exporter and trace.Exporter interfaces.
 type zapMetricExporter struct {
 	logger *zap.SugaredLogger
-}
-
-// BaseLogger is a common knative test files logger.
-type BaseLogger struct {
-	Logger *zap.SugaredLogger
 }
 
 // ExportView will emit the view data vd (i.e. the stats that have been
@@ -87,7 +85,7 @@ func (e *zapMetricExporter) ExportSpan(vd *trace.SpanData) {
 	}
 }
 
-func newLogger(logLevel string) *BaseLogger {
+func newLogger(logLevel string) *zap.SugaredLogger {
 	configJSONTemplate := `{
 	  "level": "%s",
 	  "encoding": "console",
@@ -110,13 +108,26 @@ func newLogger(logLevel string) *BaseLogger {
 	}`
 	configJSON := fmt.Sprintf(configJSONTemplate, logLevel)
 	l, _ := logging.NewLogger(string(configJSON), logLevel, zap.AddCallerSkip(1))
-	return &BaseLogger{Logger: l}
+	return l
 }
 
 // InitializeMetricExporter initializes the metric exporter logger
-func InitializeMetricExporter() {
-	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+func InitializeMetricExporter(context string) {
+	// If there was a previously registered exporter, unregister it so we only emit
+	// the metrics in the current context.
+	if exporter != nil {
+		view.UnregisterExporter(exporter)
+		trace.UnregisterExporter(exporter)
+	}
+
+	logger := logger.Named(context)
+
+	exporter = &zapMetricExporter{logger: logger}
+	view.RegisterExporter(exporter)
+	trace.RegisterExporter(exporter)
+
 	view.SetReportingPeriod(metricViewReportingPeriod)
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 }
 
 // InitializeLogger initializes the base logger
@@ -130,66 +141,6 @@ func InitializeLogger(logVerbose bool) {
 
 		logLevel = "debug"
 	}
-	baseLogger = newLogger(logLevel)
-}
 
-// GetContextLogger creates a Named logger (https://godoc.org/go.uber.org/zap#Logger.Named)
-// using the provided context as a name. This will also register the logger as a metric exporter,
-// which is unfortunately global, so calling `GetContextLogger` will have the side effect of
-// changing the context in which all metrics are logged from that point forward.
-func GetContextLogger(context string) *BaseLogger {
-	// If there was a previously registered exporter, unregister it so we only emit
-	// the metrics in the current context.
-	if exporter != nil {
-		view.UnregisterExporter(exporter)
-		trace.UnregisterExporter(exporter)
-	}
-
-	logger := baseLogger.Logger.Named(context)
-
-	exporter = &zapMetricExporter{logger: logger}
-	view.RegisterExporter(exporter)
-	trace.RegisterExporter(exporter)
-
-	return &BaseLogger{Logger: logger}
-}
-
-// Infof logs a templated message.
-func (b *BaseLogger) Infof(template string, args ...interface{}) {
-	b.Logger.Infof(template, args...)
-}
-
-// Info logs an info message.
-func (b *BaseLogger) Info(args ...interface{}) {
-	b.Logger.Info(args...)
-}
-
-// Fatal logs a fatal message.
-func (b *BaseLogger) Fatal(args ...interface{}) {
-	b.Logger.Fatal(args...)
-}
-
-// Fatalf logs a templated fatal message.
-func (b *BaseLogger) Fatalf(template string, args ...interface{}) {
-	b.Logger.Fatalf(template, args...)
-}
-
-// Debugf logs a templated debug message.
-func (b *BaseLogger) Debugf(template string, args ...interface{}) {
-	b.Logger.Debugf(template, args...)
-}
-
-// Debug logs a debug message.
-func (b *BaseLogger) Debug(args ...interface{}) {
-	b.Logger.Debug(args...)
-}
-
-// Errorf logs a templated error message.
-func (b *BaseLogger) Errorf(template string, args ...interface{}) {
-	b.Logger.Errorf(template, args...)
-}
-
-// Error logs an error message.
-func (b *BaseLogger) Error(args ...interface{}) {
-	b.Logger.Error(args...)
+	logger = newLogger(logLevel)
 }

--- a/test/logging/logging.go
+++ b/test/logging/logging.go
@@ -46,7 +46,7 @@ const (
 	emitableSpanNamePrefix = "emitspan-"
 )
 
-// FormatLogger is a printf style function for logging in the Spoof client.
+// FormatLogger is a printf style function for logging in tests.
 type FormatLogger func(template string, args ...interface{})
 
 var logger *zap.SugaredLogger

--- a/test/request.go
+++ b/test/request.go
@@ -119,7 +119,7 @@ func MatchesAllOf(checkers ...spoof.ResponseChecker) spoof.ResponseChecker {
 // the domain in the request headers, otherwise it will make the request directly to domain.
 // desc will be used to name the metric that is emitted to track how long it took for the
 // domain to get into the state checked by inState.  Commas in `desc` must be escaped.
-func WaitForEndpointState(kubeClient *KubeClient, logf spoof.FormatLogger, domain string, inState spoof.ResponseChecker, desc string, resolvable bool) (*spoof.Response, error) {
+func WaitForEndpointState(kubeClient *KubeClient, logf logging.FormatLogger, domain string, inState spoof.ResponseChecker, desc string, resolvable bool) (*spoof.Response, error) {
 	return WaitForEndpointStateWithTimeout(kubeClient, logf, domain, inState, desc, resolvable, spoof.RequestTimeout)
 }
 
@@ -130,7 +130,7 @@ func WaitForEndpointState(kubeClient *KubeClient, logf spoof.FormatLogger, domai
 // desc will be used to name the metric that is emitted to track how long it took for the
 // domain to get into the state checked by inState.  Commas in `desc` must be escaped.
 func WaitForEndpointStateWithTimeout(
-	kubeClient *KubeClient, logf spoof.FormatLogger, domain string, inState spoof.ResponseChecker,
+	kubeClient *KubeClient, logf logging.FormatLogger, domain string, inState spoof.ResponseChecker,
 	desc string, resolvable bool, timeout time.Duration) (*spoof.Response, error) {
 	defer logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForEndpointState/%s", desc)).End()
 

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/knative/pkg/test/logging"
 	"github.com/knative/pkg/test/zipkin"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,9 +78,6 @@ var _ Interface = (*SpoofingClient)(nil)
 // https://github.com/kubernetes/apimachinery/blob/cf7ae2f57dabc02a3d215f15ca61ae1446f3be8f/pkg/util/wait/wait.go#L172
 type ResponseChecker func(resp *Response) (done bool, err error)
 
-// FormatLogger is a printf style function for logging in the Spoof client.
-type FormatLogger func(template string, args ...interface{})
-
 // SpoofingClient is a minimal HTTP client wrapper that spoofs the domain of requests
 // for non-resolvable domains.
 type SpoofingClient struct {
@@ -90,7 +88,7 @@ type SpoofingClient struct {
 	endpoint string
 	domain   string
 
-	logf FormatLogger
+	logf logging.FormatLogger
 }
 
 // New returns a SpoofingClient that rewrites requests if the target domain is not `resolveable`.
@@ -98,7 +96,7 @@ type SpoofingClient struct {
 // follow the ingress if it moves (or if there are multiple ingresses).
 //
 // If that's a problem, see test/request.go#WaitForEndpointState for oneshot spoofing.
-func New(kubeClientset *kubernetes.Clientset, logf FormatLogger, domain string, resolvable bool, endpointOverride string) (*SpoofingClient, error) {
+func New(kubeClientset *kubernetes.Clientset, logf logging.FormatLogger, domain string, resolvable bool, endpointOverride string) (*SpoofingClient, error) {
 	sc := SpoofingClient{
 		Client:          &http.Client{Transport: &ochttp.Transport{Propagation: &b3.HTTPFormat{}}}, // Using ochttp Transport required for zipkin-tracing
 		RequestInterval: requestInterval,


### PR DESCRIPTION
This also moves the FormatLogger from spoof to logging package

Part of https://github.com/knative/test-infra/issues/530