### PR TITLE
Format markdown

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -46,7 +46,8 @@ _See [e2e_flags.go](./e2e_flags.go)._
 [When tests are run with `--logverbose` option](README.md#output-verbose-logs),
 debug logs will be emitted to stdout.
 
-We are using a generic [FormatLogger](https://github.com/knative/pkg/blob/master/test/logging/logging.go#L49)
+We are using a generic
+[FormatLogger](https://github.com/knative/pkg/blob/master/test/logging/logging.go#L49)
 that can be passed in any existing logger that satisfies it. Test can use the
 generic [logging methods](https://golang.org/pkg/testing/#T) to log info and
 error logs. All the common methods accept generic FormatLogger as a parameter


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`