### PR TITLE
Separate common monitoring methods into monitoring package

### DIFF
--- a/test/monitoring/doc.go
+++ b/test/monitoring/doc.go
@@ -19,6 +19,8 @@ Package monitoring provides common methods for all the monitoring components use
 
 This package exposes following methods:
 
+	CheckPortAvailability(port int) error
+		Checks if the given port is available
 	GetPods(kubeClientset *kubernetes.Clientset, app string) (*v1.PodList, error)
 		Gets the list of pods that satisfy the lable selector app=<app>
 	Cleanup(pid int) error

--- a/test/monitoring/doc.go
+++ b/test/monitoring/doc.go
@@ -19,9 +19,12 @@ Package monitoring provides common methods for all the monitoring components use
 
 This package exposes following methods:
 
-	SetupZipkinTracing(*kubernetes.Clientset) error
-		SetupZipkinTracing sets up zipkin tracing by setting up port-forwarding from
-		localhost to zipkin pod on the cluster. On successful setup this method sets
-		an internal flag zipkinTracingEnabled to true.
+	GetPods(kubeClientset *kubernetes.Clientset, app string) (*v1.PodList, error)
+		Gets the list of pods that satisfy the lable selector app=<app>
+	Cleanup(pid int) error
+		Kill the current port forwarding process running in the background
+	PortForward(logf logging.FormatLogger, podList *v1.PodList, localPort, remotePort int) (int, error)
+		Create a background process that will port forward the first pod from the local to remote port
+		It returns the process id for the background process created.
 */
 package monitoring

--- a/test/monitoring/doc.go
+++ b/test/monitoring/doc.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package monitoring provides common methods for all the monitoring components used in the tests
+
+This package exposes following methods:
+
+	SetupZipkinTracing(*kubernetes.Clientset) error
+		SetupZipkinTracing sets up zipkin tracing by setting up port-forwarding from
+		localhost to zipkin pod on the cluster. On successful setup this method sets
+		an internal flag zipkinTracingEnabled to true.
+*/
+package monitoring

--- a/test/monitoring/monitoring.go
+++ b/test/monitoring/monitoring.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/knative/pkg/test/logging"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	namespace = "istio-system"
+)
+
+// CheckPortAvailability checks to see if the port is available on the machine.
+func CheckPortAvailability(port int) error {
+	server, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		// Port is likely taken
+		return err
+	}
+	server.Close()
+
+	return nil
+}
+
+// GetPods retrieves the current existing podlist for the app in monitoring namespace
+// This uses app=<app> as labelselector for selecting pods
+func GetPods(kubeClientset *kubernetes.Clientset, app string) (*v1.PodList, error) {
+	pods, err := kubeClientset.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", app)})
+	if err == nil && len(pods.Items) == 0 {
+		err = fmt.Errorf("No %s Pod found on the cluster. Ensure monitoring is switched on for your Knative Setup", app)
+	}
+
+	return pods, err
+}
+
+// Cleanup will clean the background process used for port forwarding
+func Cleanup(pid int) error {
+	ps := os.Process{Pid: pid}
+	return ps.Kill()
+}
+
+// PortForward sets up local port forward to the pod specified by the "app" label in the given namespace
+func PortForward(logf logging.FormatLogger, podList *v1.PodList, localPort, remotePort int) (int, error) {
+	podName := podList.Items[0].Name
+	portFwdCmd := fmt.Sprintf("kubectl port-forward %s %d:%d -n %s", podName, localPort, remotePort, namespace)
+	portFwdProcess, err := executeCmdBackground(logf, portFwdCmd)
+
+	if err != nil {
+		return 0, fmt.Errorf("Failed to port forward: %v", err)
+	}
+
+	logf("running %s port-forward in background, pid = %d", podName, portFwdProcess.Pid)
+	return portFwdProcess.Pid, nil
+}
+
+// RunBackground starts a background process and returns the Process if succeed
+func executeCmdBackground(logf logging.FormatLogger, format string, args ...interface{}) (*os.Process, error) {
+	cmd := fmt.Sprintf(format, args...)
+	logf("Executing command: %s", cmd)
+	parts := strings.Split(cmd, " ")
+	c := exec.Command(parts[0], parts[1:]...) // #nosec
+	if err := c.Start(); err != nil {
+		return nil, fmt.Errorf("%s command failed: %v", cmd, err)
+	}
+	return c.Process, nil
+}

--- a/test/zipkin/util.go
+++ b/test/zipkin/util.go
@@ -19,15 +19,11 @@ limitations under the License.
 package zipkin
 
 import (
-	"fmt"
-	"net"
-	"os"
-	"os/exec"
 	"sync"
 
 	"github.com/knative/pkg/test/logging"
+	"github.com/knative/pkg/test/monitoring"
 	"go.opencensus.io/trace"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -35,16 +31,16 @@ const (
 	//ZipkinTraceIDHeader HTTP response header key to be used to store Zipkin Trace ID.
 	ZipkinTraceIDHeader = "ZIPKIN_TRACE_ID"
 
-	// ZipkinPort port exposed by the Zipkin Pod
+	// ZipkinPort is port exposed by the Zipkin Pod
 	// https://github.com/knative/serving/blob/master/config/monitoring/200-common/100-zipkin.yaml#L25 configures the Zipkin Port on the cluster.
 	ZipkinPort = 9411
 
 	// ZipkinTraceEndpoint port-forwarded zipkin endpoint
 	ZipkinTraceEndpoint = "http://localhost:9411/api/v2/trace/"
 
-	// ZipkinNamespace namespace where zipkin pod runs.
-	// https://github.com/knative/serving/blob/master/config/monitoring/200-common/100-zipkin.yaml#L19 configures the namespace for zipkin.
-	ZipkinNamespace = "istio-system"
+	// App is the name of this component.
+	// This will be used as a label selector
+	app = "zipkin"
 )
 
 var (
@@ -66,28 +62,23 @@ var (
 // 2. Enable AlwaysSample config for tracing.
 func SetupZipkinTracing(kubeClientset *kubernetes.Clientset, logf logging.FormatLogger) {
 	setupOnce.Do(func() {
-		if err := CheckZipkinPortAvailability(); err != nil {
+		if err := monitoring.CheckPortAvailability(ZipkinPort); err != nil {
 			logf("Zipkin port not available on the machine: %v", err)
 			return
 		}
 
-		zipkinPods, err := kubeClientset.CoreV1().Pods(ZipkinNamespace).List(metav1.ListOptions{LabelSelector: "app=zipkin"})
+		zipkinPods, err := monitoring.GetPods(kubeClientset, app)
 		if err != nil {
 			logf("Error retrieving Zipkin pod details: %v", err)
 			return
 		}
 
-		if len(zipkinPods.Items) == 0 {
-			logf("No Zipkin Pod found on the cluster. Ensure monitoring is switched on for your Knative Setup")
-			return
-		}
-
-		portForwardCmd := exec.Command("kubectl", "port-forward", "--namespace="+ZipkinNamespace, zipkinPods.Items[0].Name, fmt.Sprintf("%d:%d", ZipkinPort, ZipkinPort))
-		if err = portForwardCmd.Start(); err != nil {
+		zipkinPortForwardPID, err = monitoring.PortForward(logf, zipkinPods, ZipkinPort, ZipkinPort)
+		if err != nil {
 			logf("Error starting kubectl port-forward command: %v", err)
 			return
 		}
-		zipkinPortForwardPID = portForwardCmd.Process.Pid
+
 		logf("Zipkin port-forward process started with PID: %d", zipkinPortForwardPID)
 
 		// Applying AlwaysSample config to ensure we propagate zipkin header for every request made by this client.
@@ -104,26 +95,11 @@ func CleanupZipkinTracingSetup(logf logging.FormatLogger) {
 			return
 		}
 
-		ps := os.Process{Pid: zipkinPortForwardPID}
-		if err := ps.Kill(); err != nil {
+		if err := monitoring.Cleanup(zipkinPortForwardPID); err != nil {
 			logf("Encountered error killing port-forward process in CleanupZipkingTracingSetup() : %v", err)
 			return
 		}
 
-		logf("Successfully killed Zipkin port-forward process")
 		ZipkinTracingEnabled = false
 	})
-}
-
-// CheckZipkinPortAvailability checks to see if Zipkin Port is available on the machine.
-// returns error if the port is not available.
-func CheckZipkinPortAvailability() error {
-	server, err := net.Listen("tcp", fmt.Sprintf(":%d", ZipkinPort))
-	if err != nil {
-		// Port is likely taken
-		return err
-	}
-	server.Close()
-
-	return nil
 }

--- a/test/zipkin/util.go
+++ b/test/zipkin/util.go
@@ -103,3 +103,9 @@ func CleanupZipkinTracingSetup(logf logging.FormatLogger) {
 		ZipkinTracingEnabled = false
 	})
 }
+
+// CheckZipkinPortAvailability checks to see if Zipkin Port is available on the machine.
+// returns error if the port is not available.
+func CheckZipkinPortAvailability() error {
+	return monitoring.CheckPortAvailability(ZipkinPort)
+}


### PR DESCRIPTION
Part of https://github.com/knative/test-infra/issues/540

This removes some things from the zipkin package into a separate monitoring package that can be used for all monitoring components like the prometheus package as well. This will help us consolidate things for monitorng usage in our tests