### PR TITLE
golang format tools

### DIFF
--- a/test/monitoring/monitoring.go
+++ b/test/monitoring/monitoring.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"github.com/knative/pkg/test/logging"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
