### PR TITLE
Consistently log the full response on errors in tests.

### DIFF
--- a/test/request.go
+++ b/test/request.go
@@ -60,7 +60,7 @@ func IsOneOfStatusCodes(codes ...int) spoof.ResponseChecker {
 			}
 		}
 
-		return true, fmt.Errorf("status = %d, want one of: %v, body = %s", resp.StatusCode, codes, string(resp.Body))
+		return true, fmt.Errorf("status = %d, want one of: %v", resp.StatusCode, codes)
 	}
 }
 
@@ -74,7 +74,7 @@ func MatchesBody(expected string) spoof.ResponseChecker {
 	return func(resp *spoof.Response) (bool, error) {
 		if !strings.Contains(string(resp.Body), expected) {
 			// Returning (true, err) causes SpoofingClient.Poll to fail.
-			return true, fmt.Errorf("body mismatch: got %q, want %q", string(resp.Body), expected)
+			return true, fmt.Errorf("body = %s, want: %s", string(resp.Body), expected)
 		}
 
 		return true, nil

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -252,7 +252,7 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker) (*Res
 	}
 
 	if err != nil {
-		return resp, errors.Wrapf(err, "response: %s did not pass checks", resp.String())
+		return resp, errors.Wrapf(err, "response: %s did not pass checks", resp)
 	}
 	return resp, nil
 }

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/knative/pkg/test/logging"
 	"github.com/knative/pkg/test/zipkin"
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -60,6 +61,10 @@ type Response struct {
 	StatusCode int
 	Header     http.Header
 	Body       []byte
+}
+
+func (r *Response) String() string {
+	return fmt.Sprintf("status: %d, body: %s, headers: %v", r.StatusCode, string(r.Body), r.Header)
 }
 
 // Interface defines the actions that can be performed by the spoofing client.
@@ -246,7 +251,10 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker) (*Res
 		sc.logZipkinTrace(resp)
 	}
 
-	return resp, err
+	if err != nil {
+		return resp, errors.Wrapf(err, "response: %s did not pass checks", resp.String())
+	}
+	return resp, nil
 }
 
 // logZipkinTrace provides support to log Zipkin Trace for param: spoofResponse


### PR DESCRIPTION
See knative/serving#3396 for in-context use of this. When an error occurs in a test using `client.Poll` we usually want to report all the information we can on the failed request.
