### PR TITLE
Simplify init function for metrics config used in unit tests

### DIFF
--- a/controller/stats_reporter_test.go
+++ b/controller/stats_reporter_test.go
@@ -21,15 +21,12 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/knative/pkg/logging/testing"
 	"github.com/knative/pkg/metrics"
 	"go.opencensus.io/stats/view"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestNewStatsReporterErrors(t *testing.T) {
-	initMetricsConfig(t)
+	metrics.SetTestingMetricsConfig()
 	// These are invalid as defined by the current OpenCensus library.
 	invalidTagValues := []string{
 		"naïve",                  // Includes non-ASCII character.
@@ -46,7 +43,7 @@ func TestNewStatsReporterErrors(t *testing.T) {
 }
 
 func TestReportQueueDepth(t *testing.T) {
-	initMetricsConfig(t)
+	metrics.SetTestingMetricsConfig()
 	r1 := &reporter{}
 	if err := r1.ReportQueueDepth(10); err == nil {
 		t.Error("Reporter.Report() expected an error for Report call before init. Got success.")
@@ -69,7 +66,7 @@ func TestReportQueueDepth(t *testing.T) {
 }
 
 func TestReportReconcile(t *testing.T) {
-	initMetricsConfig(t)
+	metrics.SetTestingMetricsConfig()
 	r, _ := NewStatsReporter("testreconciler")
 	wantTags := map[string]string{
 		"reconciler": "testreconciler",
@@ -84,16 +81,6 @@ func TestReportReconcile(t *testing.T) {
 	expectSuccess(t, func() error { return r.ReportReconcile(time.Duration(15*time.Millisecond), "test/key", "true") })
 	checkCountData(t, "reconcile_count", wantTags, 2)
 	checkDistributionData(t, "reconcile_latency", wantTags, 25)
-}
-
-func initMetricsConfig(t *testing.T) {
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "config-observability",
-		},
-		Data: map[string]string{},
-	}
-	metrics.UpdateExporterFromConfigMap("testDomain", "testComponent", TestLogger(t))(cm)
 }
 
 func expectSuccess(t *testing.T, f func() error) {

--- a/metrics/stackdriver_exporter_test.go
+++ b/metrics/stackdriver_exporter_test.go
@@ -16,7 +16,6 @@ import (
 	"path"
 	"testing"
 
-	"contrib.go.opencensus.io/exporter/stackdriver"
 	. "github.com/knative/pkg/logging/testing"
 	"github.com/knative/pkg/metrics/metricskey"
 	"go.opencensus.io/stats"
@@ -25,12 +24,6 @@ import (
 )
 
 var (
-	testGcpMetadata = gcpMetadata{
-		project:  "test-project",
-		location: "test-location",
-		cluster:  "test-cluster",
-	}
-
 	supportedMetricsTestCases = []struct {
 		name       string
 		domain     string
@@ -70,18 +63,6 @@ var (
 		metricName: "unsupported",
 	}}
 )
-
-func fakeGcpMetadataFun() *gcpMetadata {
-	return &testGcpMetadata
-}
-
-type fakeExporter struct{}
-
-func (fe *fakeExporter) ExportView(vd *view.Data) {}
-
-func newFakeExporter(o stackdriver.Options) (view.Exporter, error) {
-	return &fakeExporter{}, nil
-}
 
 func TestGetMonitoredResourceFunc_UseKnativeRevision(t *testing.T) {
 	for _, testCase := range supportedMetricsTestCases {

--- a/metrics/testing.go
+++ b/metrics/testing.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"contrib.go.opencensus.io/exporter/stackdriver"
+	"go.opencensus.io/stats/view"
+)
+
+var (
+	testGcpMetadata = gcpMetadata{
+		project:  "test-project",
+		location: "test-location",
+		cluster:  "test-cluster",
+	}
+)
+
+// SetTestingMetricsConfig initialize the package level config with a empty value
+// for unit tests.
+func SetTestingMetricsConfig() {
+	setCurMetricsConfig(&metricsConfig{})
+}
+
+func fakeGcpMetadataFun() *gcpMetadata {
+	return &testGcpMetadata
+}
+
+type fakeExporter struct{}
+
+func (fe *fakeExporter) ExportView(vd *view.Data) {}
+
+func newFakeExporter(o stackdriver.Options) (view.Exporter, error) {
+	return &fakeExporter{}, nil
+}


### PR DESCRIPTION
Simplify init function for metrics config used in unit tests and move it to `metrics` package so that it can be shared.

Also move fake objects relative to unit tests to `testing.go` file.