### PR TITLE
Record metrics if config is nil

### DIFF
--- a/metrics/record.go
+++ b/metrics/record.go
@@ -26,10 +26,10 @@ import (
 
 // Record decides whether to record one measurement via OpenCensus based on the
 // following conditions:
-//   1) No package level metrics config. Users must ensure metrics config are set
-//      to get expected behavior. Otherwise it just proxies to OpenCensus based
-//      on the assumption that users intend to record metric when they call this
-//      function.
+//   1) No package level metrics config. In this case it just proxies to OpenCensus
+//      based on the assumption that users expect the metrics to be recorded when
+//      they call this function. Users must ensure metrics config are set before
+//      using this function to get expected behavior.
 //   2) The backend is not Stackdriver.
 //   3) The backend is Stackdriver and it is allowed to use custom metrics.
 //   4) The backend is Stackdriver and the metric is "knative_revison" built-in metric.

--- a/metrics/record.go
+++ b/metrics/record.go
@@ -20,27 +20,32 @@ import (
 	"context"
 	"path"
 
-	"github.com/knative/pkg/logging"
 	"github.com/knative/pkg/metrics/metricskey"
 	"go.opencensus.io/stats"
 )
 
-// Record decides whether to record one measurement based on current
-// metrics config. If yes, it records measurements via OpenCensus.
+// Record decides whether to record one measurement via OpenCensus based on the
+// following conditions:
+//   1) No package level metrics config. User must ensure metrics config are set
+//      to get expected behavior.
+//   2) The backend is not Stackdriver.
+//   3) The backend is Stackdriver and it is allowed to use custom metrics.
+//   4) The backend is Stackdriver and the metric is "knative_revison" built-in metric.
 func Record(ctx context.Context, ms stats.Measurement) {
 	mc := getCurMetricsConfig()
+
+	// Condition 1)
 	if mc == nil {
-		logging.FromContext(ctx).Warn("The current metrics config has not been successfully set yet, not record the metric %v.", ms)
+		stats.Record(ctx, ms)
 		return
 	}
-	// Should record if one of the following conditions satisfies:
-	// 1) the backend is not Stackdriver
-	// 2) the backend is Stackdriver and it is allowed to use custom metrics
-	// 3) the backend is Stackdriver and the metric is "knative_revison" built-in metric.
+
 	if !mc.isStackdriverBackend || mc.allowStackdriverCustomMetrics {
+		// Condition 2) and 3)
 		stats.Record(ctx, ms)
 	} else {
 		metricType := path.Join(mc.stackdriverMetricTypePrefix, ms.Measure().Name())
+		// Condition 4)
 		if metricskey.KnativeRevisionMetrics.Has(metricType) {
 			stats.Record(ctx, ms)
 		}

--- a/metrics/record.go
+++ b/metrics/record.go
@@ -42,14 +42,15 @@ func Record(ctx context.Context, ms stats.Measurement) {
 		return
 	}
 
+	// Condition 2) and 3)
 	if !mc.isStackdriverBackend || mc.allowStackdriverCustomMetrics {
-		// Condition 2) and 3)
 		stats.Record(ctx, ms)
-	} else {
-		metricType := path.Join(mc.stackdriverMetricTypePrefix, ms.Measure().Name())
-		// Condition 4)
-		if metricskey.KnativeRevisionMetrics.Has(metricType) {
-			stats.Record(ctx, ms)
-		}
+		return
+	}
+
+	// Condition 4)
+	metricType := path.Join(mc.stackdriverMetricTypePrefix, ms.Measure().Name())
+	if metricskey.KnativeRevisionMetrics.Has(metricType) {
+		stats.Record(ctx, ms)
 	}
 }

--- a/metrics/record.go
+++ b/metrics/record.go
@@ -26,8 +26,10 @@ import (
 
 // Record decides whether to record one measurement via OpenCensus based on the
 // following conditions:
-//   1) No package level metrics config. User must ensure metrics config are set
-//      to get expected behavior.
+//   1) No package level metrics config. Users must ensure metrics config are set
+//      to get expected behavior. Otherwise it just proxies to OpenCensus based
+//      on the assumption that users intend to record metric when they call this
+//      function.
 //   2) The backend is not Stackdriver.
 //   3) The backend is Stackdriver and it is allowed to use custom metrics.
 //   4) The backend is Stackdriver and the metric is "knative_revison" built-in metric.

--- a/metrics/record_test.go
+++ b/metrics/record_test.go
@@ -60,6 +60,9 @@ func TestRecord(t *testing.T) {
 				allowStackdriverCustomMetrics: true,
 			},
 			measurement: measure.M(3),
+		}, {
+			name:        "empty metricsConfig",
+			measurement: measure.M(4),
 		},
 	}
 
@@ -81,9 +84,6 @@ func TestRecord(t *testing.T) {
 				isStackdriverBackend:        true,
 				stackdriverMetricTypePrefix: "knative.dev/unsupported",
 			},
-			measurement: measure.M(4),
-		}, {
-			name:        "empty metricsConfig",
 			measurement: measure.M(5),
 		},
 	}
@@ -91,7 +91,7 @@ func TestRecord(t *testing.T) {
 	for _, test := range shouldNotReportCases {
 		setCurMetricsConfig(test.metricsConfig)
 		Record(ctx, test.measurement)
-		checkLastValueData(t, test.measurement.Measure().Name(), 3) // The value is still the last one of shouldReportCases
+		checkLastValueData(t, test.measurement.Measure().Name(), 4) // The value is still the last one of shouldReportCases
 	}
 }
 


### PR DESCRIPTION
`metrics.Record` adds a layer around `stats.Record` to guide what metrics can be record based on package level config.

Expected:
If the config is not set, do record. User should make sure the config is set before using `metrics.Record` otherwise it just proxies to `stats.Record` based the assumption that users expect the metrics to be recorded when they call this function.

Actual:
If the config is not set, don't record.