### PR TITLE
Dont use istio-system namespace as default for monitoring components

### DIFF
--- a/test/monitoring/monitoring.go
+++ b/test/monitoring/monitoring.go
@@ -29,10 +29,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const (
-	namespace = "istio-system"
-)
-
 // CheckPortAvailability checks to see if the port is available on the machine.
 func CheckPortAvailability(port int) error {
 	server, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
@@ -47,7 +43,7 @@ func CheckPortAvailability(port int) error {
 
 // GetPods retrieves the current existing podlist for the app in monitoring namespace
 // This uses app=<app> as labelselector for selecting pods
-func GetPods(kubeClientset *kubernetes.Clientset, app string) (*v1.PodList, error) {
+func GetPods(kubeClientset *kubernetes.Clientset, app, namespace string) (*v1.PodList, error) {
 	pods, err := kubeClientset.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", app)})
 	if err == nil && len(pods.Items) == 0 {
 		err = fmt.Errorf("No %s Pod found on the cluster. Ensure monitoring is switched on for your Knative Setup", app)
@@ -63,7 +59,7 @@ func Cleanup(pid int) error {
 }
 
 // PortForward sets up local port forward to the pod specified by the "app" label in the given namespace
-func PortForward(logf logging.FormatLogger, podList *v1.PodList, localPort, remotePort int) (int, error) {
+func PortForward(logf logging.FormatLogger, podList *v1.PodList, localPort, remotePort int, namespace string) (int, error) {
 	podName := podList.Items[0].Name
 	portFwdCmd := fmt.Sprintf("kubectl port-forward %s %d:%d -n %s", podName, localPort, remotePort, namespace)
 	portFwdProcess, err := executeCmdBackground(logf, portFwdCmd)

--- a/test/zipkin/util.go
+++ b/test/zipkin/util.go
@@ -41,6 +41,9 @@ const (
 	// App is the name of this component.
 	// This will be used as a label selector
 	app = "zipkin"
+
+	// Namespace we are using for istio components
+	istioNs = "istio-system"
 )
 
 var (
@@ -67,13 +70,13 @@ func SetupZipkinTracing(kubeClientset *kubernetes.Clientset, logf logging.Format
 			return
 		}
 
-		zipkinPods, err := monitoring.GetPods(kubeClientset, app)
+		zipkinPods, err := monitoring.GetPods(kubeClientset, app, istioNs)
 		if err != nil {
 			logf("Error retrieving Zipkin pod details: %v", err)
 			return
 		}
 
-		zipkinPortForwardPID, err = monitoring.PortForward(logf, zipkinPods, ZipkinPort, ZipkinPort)
+		zipkinPortForwardPID, err = monitoring.PortForward(logf, zipkinPods, ZipkinPort, ZipkinPort, istioNs)
 		if err != nil {
 			logf("Error starting kubectl port-forward command: %v", err)
 			return


### PR DESCRIPTION
Some monitoring components are in knative-monitoring namespace, namely pronetheus while a few like zipkin are in istio namespace. Make this generic so that each component can define this.