### PR TITLE
Increase zipkin wait time before fetching the trace (#318)

### DIFF
--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -274,7 +274,7 @@ func (sc *SpoofingClient) logZipkinTrace(spoofResp *Response) {
 
 	zipkinTraceEndpoint := zipkin.ZipkinTraceEndpoint + traceID
 	// Sleep to ensure all traces are correctly pushed on the backend.
-	time.Sleep(5 * time.Second)
+	time.Sleep(30 * time.Second)
 	resp, err := http.Get(zipkinTraceEndpoint)
 	if err != nil {
 		sc.logf("Error retrieving Zipkin trace: %v", err)


### PR DESCRIPTION
<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:

Increase zipkin wait time before fetching the trace. 

Fixes: #318
-->

Increase zipkin wait time before fetching the trace. 

Fixes: #318
