### PR TITLE
Retry the connection refused errors.

### DIFF
--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -249,7 +249,7 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker) (*Res
 			// if errNo == syscall.Errno(0x6f) {...}
 			// But with assertions, of course.
 			if strings.Contains(err.Error(), "connect: connection refused") {
-				sc.logf("Retrying %s for TCP timeout %v", req.URL.String(), err)
+				sc.logf("Retrying %s for connection refused %v", req.URL.String(), err)
 				return false, nil
 			}
 			return true, err

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/knative/pkg/test/logging"
@@ -238,6 +239,16 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker) (*Res
 		resp, err = sc.Do(req)
 		if err != nil {
 			if err, ok := err.(net.Error); ok && err.Timeout() {
+				sc.logf("Retrying %s for TCP timeout %v", req.URL.String(), err)
+				return false, nil
+			}
+
+			// Repeat the poll on `connection refused` errors, which are usually transient Istio errors.
+			// The alternative for the string check is:
+			// 	errNo := (((err.(*url.Error)).Err.(*net.OpError)).Err.(*os.SyscallError).Err).(syscall.Errno)
+			// if errNo == syscall.Errno(0x6f) {...}
+			// But with assertions, of course.
+			if strings.Contains(err.Error(), "connect: connection refused") {
 				sc.logf("Retrying %s for TCP timeout %v", req.URL.String(), err)
 				return false, nil
 			}


### PR DESCRIPTION
Some of the integration tests fail after Istio reprogramming
with `connection refused` errors.
They are usually transitive and are happening due to the Istio probes
temporarily failing after reprogramming.
With this change we'll retry those errors, hopefully reducing the
flakes.

/cc @tcnghia @mattmoor 
Should help with https://github.com/knative/serving/issues/3452