### PR TITLE
This creates a way for clients of the webhook to decorate the request context.

### DIFF
--- a/testing/resource.go
+++ b/testing/resource.go
@@ -55,6 +55,7 @@ var _ apis.Listable = (*Resource)(nil)
 // ResourceSpec represents test resource spec.
 type ResourceSpec struct {
 	FieldWithDefault               string `json:"fieldWithDefault,omitempty"`
+	FieldWithContextDefault        string `json:"fieldWithContextDefault,omitempty"`
 	FieldWithValidation            string `json:"fieldWithValidation,omitempty"`
 	FieldThatsImmutable            string `json:"fieldThatsImmutable,omitempty"`
 	FieldThatsImmutableWithDefault string `json:"fieldThatsImmutableWithDefault,omitempty"`
@@ -65,10 +66,28 @@ func (c *Resource) SetDefaults(ctx context.Context) {
 	c.Spec.SetDefaults(ctx)
 }
 
+type onContextKey struct{}
+
+// WithValue returns a WithContext for attaching an OnContext with the given value.
+func WithValue(ctx context.Context, val string) context.Context {
+	return context.WithValue(ctx, onContextKey{}, &OnContext{Value: val})
+}
+
+// OnContext is a struct for holding a value attached to a context.
+type OnContext struct {
+	Value string
+}
+
 // SetDefaults sets the defaults on the spec.
 func (cs *ResourceSpec) SetDefaults(ctx context.Context) {
 	if cs.FieldWithDefault == "" {
 		cs.FieldWithDefault = "I'm a default."
+	}
+	if cs.FieldWithContextDefault == "" {
+		oc, ok := ctx.Value(onContextKey{}).(*OnContext)
+		if ok {
+			cs.FieldWithContextDefault = oc.Value
+		}
 	}
 	if cs.FieldThatsImmutableWithDefault == "" {
 		cs.FieldThatsImmutableWithDefault = "this is another default value"

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -179,17 +179,41 @@ func TestValidCreateResourceSucceedsWithDefaultPatch(t *testing.T) {
 	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
 	resp := ac.admit(TestContextWithLogger(t), createCreateResource(r))
 	expectAllowed(t, resp)
-	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{
-		{
-			Operation: "add",
-			Path:      "/spec/fieldThatsImmutableWithDefault",
-			Value:     "this is another default value",
-		}, {
-			Operation: "add",
-			Path:      "/spec/fieldWithDefault",
-			Value:     "I'm a default.",
-		},
-		setUserAnnotation(user1, user1),
+	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{{
+		Operation: "add",
+		Path:      "/spec/fieldThatsImmutableWithDefault",
+		Value:     "this is another default value",
+	}, {
+		Operation: "add",
+		Path:      "/spec/fieldWithDefault",
+		Value:     "I'm a default.",
+	}, setUserAnnotation(user1, user1),
+	})
+}
+
+func TestValidCreateResourceSucceedsWithDefaultPatchWithContext(t *testing.T) {
+	r := createResource("a name")
+	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
+	ctx := TestContextWithLogger(t)
+
+	contextDefault := "I came from context y'all"
+	ctx = WithValue(ctx, contextDefault)
+
+	resp := ac.admit(ctx, createCreateResource(r))
+	expectAllowed(t, resp)
+	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{{
+		Operation: "add",
+		Path:      "/spec/fieldThatsImmutableWithDefault",
+		Value:     "this is another default value",
+	}, {
+		Operation: "add",
+		Path:      "/spec/fieldWithDefault",
+		Value:     "I'm a default.",
+	}, {
+		Operation: "add",
+		Path:      "/spec/fieldWithContextDefault",
+		Value:     contextDefault,
+	}, setUserAnnotation(user1, user1),
 	})
 }
 


### PR DESCRIPTION
Clients of webhook can now decorate the request context with additional metadata via:
```
  ac := &AdmissionController{
    ... // As before
    WithContext: func(ctx context.Context) context.Context {
      // logic to attach stuff to ctx
    }
  }
```

This metadata can then be accessed off of the context in methods like
`SetDefaults` and `Validate` on types registered as webhook handlers.

Fixes: https://github.com/knative/pkg/issues/306

