### PR TITLE
Retry DNS errors in spoof client.

### DIFF
--- a/test/spoof/error_checks.go
+++ b/test/spoof/error_checks.go
@@ -1,0 +1,36 @@
+package spoof
+
+import (
+	"net"
+	"net/url"
+	"strings"
+)
+
+func isTCPTimeout(err error) bool {
+	if err, ok := err.(net.Error); ok && err.Timeout() {
+		return true
+	}
+	return false
+}
+
+func isDNSError(err error) bool {
+	if err, ok := err.(*url.Error); err != nil && ok {
+		if err, ok := err.Err.(*net.OpError); err != nil && ok {
+			if err, ok := err.Err.(*net.DNSError); err != nil && ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isTCPConnectRefuse(err error) bool {
+	// The alternative for the string check is:
+	// 	errNo := (((err.(*url.Error)).Err.(*net.OpError)).Err.(*os.SyscallError).Err).(syscall.Errno)
+	// if errNo == syscall.Errno(0x6f) {...}
+	// But with assertions, of course.
+	if strings.Contains(err.Error(), "connect: connection refused") {
+		return true
+	}
+	return false
+}

--- a/test/spoof/error_checks.go
+++ b/test/spoof/error_checks.go
@@ -6,11 +6,9 @@ import (
 	"strings"
 )
 
-func isTCPTimeout(err error) bool {
-	if err, ok := err.(net.Error); ok && err.Timeout() {
-		return true
-	}
-	return false
+func isTCPTimeout(e error) bool {
+	err, ok := e.(net.Error)
+	return err != nil && ok && err.Timeout()
 }
 
 func isDNSError(err error) bool {
@@ -29,7 +27,7 @@ func isTCPConnectRefuse(err error) bool {
 	// 	errNo := (((err.(*url.Error)).Err.(*net.OpError)).Err.(*os.SyscallError).Err).(syscall.Errno)
 	// if errNo == syscall.Errno(0x6f) {...}
 	// But with assertions, of course.
-	if strings.Contains(err.Error(), "connect: connection refused") {
+	if err != nil && strings.Contains(err.Error(), "connect: connection refused") {
 		return true
 	}
 	return false

--- a/test/spoof/error_checks.go
+++ b/test/spoof/error_checks.go
@@ -1,3 +1,21 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// spoof contains logic to make polling HTTP requests against an endpoint with optional host spoofing.
+
 package spoof
 
 import (

--- a/test/spoof/error_checks_test.go
+++ b/test/spoof/error_checks_test.go
@@ -1,0 +1,36 @@
+package spoof
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestDNSError(t *testing.T) {
+	client := &http.Client{}
+
+	for _, tt := range []struct {
+		name     string
+		url      string
+		dnsError bool
+	}{{
+		name:     "url does not exist",
+		url:      "http://this.url.does.not.exist",
+		dnsError: true,
+	}, {
+		name:     "ip address",
+		url:      "http://127.0.0.1",
+		dnsError: false,
+	}, {
+		name:     "localhost",
+		url:      "http://localhost:8080",
+		dnsError: false,
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", tt.url, nil)
+			_, err := client.Do(req)
+			if dnsError := isDNSError(err); tt.dnsError != dnsError {
+				t.Errorf("Expected dnsError=%v, got %v", tt.dnsError, dnsError)
+			}
+		})
+	}
+}

--- a/test/spoof/error_checks_test.go
+++ b/test/spoof/error_checks_test.go
@@ -24,12 +24,77 @@ func TestDNSError(t *testing.T) {
 		name:     "localhost",
 		url:      "http://localhost:8080",
 		dnsError: false,
+	}, {
+		name:     "no error",
+		url:      "http://google.com",
+		dnsError: false,
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest("GET", tt.url, nil)
 			_, err := client.Do(req)
 			if dnsError := isDNSError(err); tt.dnsError != dnsError {
 				t.Errorf("Expected dnsError=%v, got %v", tt.dnsError, dnsError)
+			}
+		})
+	}
+}
+
+func TestTCPConnectRefuse(t *testing.T) {
+	client := &http.Client{}
+
+	for _, tt := range []struct {
+		name      string
+		url       string
+		tcpRefuse bool
+	}{{
+		name:      "nothing listening",
+		url:       "http://localhost:60001",
+		tcpRefuse: true,
+	}, {
+		name:      "dns error",
+		url:       "http://this.url.does.not.exist",
+		tcpRefuse: false,
+	}, {
+		name:      "google.com",
+		url:       "https://google.com",
+		tcpRefuse: false,
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", tt.url, nil)
+			_, err := client.Do(req)
+			if tcpRefuse := isTCPConnectRefuse(err); tt.tcpRefuse != tcpRefuse {
+				t.Errorf("Expected tcpRefuse=%v, got %v", tt.tcpRefuse, tcpRefuse)
+			}
+		})
+	}
+}
+
+func TestTCPTimeout(t *testing.T) {
+	client := &http.Client{}
+
+	// We have no postive test for TCP timeout, but we do have a few negative tests.
+	for _, tt := range []struct {
+		name       string
+		url        string
+		tcpTimeout bool
+	}{{
+		name:       "nothing listening",
+		url:        "http://localhost:60001",
+		tcpTimeout: false,
+	}, {
+		name:       "dns error",
+		url:        "http://this.url.does.not.exist",
+		tcpTimeout: false,
+	}, {
+		name:       "google.com",
+		url:        "https://google.com",
+		tcpTimeout: false,
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", tt.url, nil)
+			_, err := client.Do(req)
+			if tcpTimeout := isTCPTimeout(err); tt.tcpTimeout != tcpTimeout {
+				t.Errorf("Expected tcpTimeout=%v, got %v", tt.tcpTimeout, tcpTimeout)
 			}
 		})
 	}

--- a/test/spoof/error_checks_test.go
+++ b/test/spoof/error_checks_test.go
@@ -72,7 +72,7 @@ func TestTCPConnectRefuse(t *testing.T) {
 func TestTCPTimeout(t *testing.T) {
 	client := &http.Client{}
 
-	// We have no postive test for TCP timeout, but we do have a few negative tests.
+	// We have no positive test for TCP timeout, but we do have a few negative tests.
 	for _, tt := range []struct {
 		name       string
 		url        string

--- a/test/spoof/error_checks_test.go
+++ b/test/spoof/error_checks_test.go
@@ -1,3 +1,21 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// spoof contains logic to make polling HTTP requests against an endpoint with optional host spoofing.
+
 package spoof
 
 import (

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -197,7 +197,12 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker) (*Res
 				sc.logf("Retrying %s for TCP timeout %v", req.URL.String(), err)
 				return false, nil
 			}
-
+			// Retry DNS errors -- as tests may be using .xip.io or .nip.io domains
+			// which may be flaky sometimes.
+			if err, ok := err.(*net.DNSError); ok {
+				sc.logf("Retrying %s for DNS error %v", req.URL.String(), err)
+				return false, nil
+			}
 			// Repeat the poll on `connection refused` errors, which are usually transient Istio errors.
 			// The alternative for the string check is:
 			// 	errNo := (((err.(*url.Error)).Err.(*net.OpError)).Err.(*os.SyscallError).Err).(syscall.Errno)

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -23,9 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
-	"strings"
 	"time"
 
 	ingress "github.com/knative/pkg/test/ingress"
@@ -193,22 +191,17 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker) (*Res
 		req.Header.Add(pollReqHeader, "True")
 		resp, err = sc.Do(req)
 		if err != nil {
-			if err, ok := err.(net.Error); ok && err.Timeout() {
+			if isTCPTimeout(err) {
 				sc.logf("Retrying %s for TCP timeout %v", req.URL.String(), err)
 				return false, nil
 			}
-			// Retry DNS errors -- as tests may be using .xip.io or .nip.io domains
-			// which may be flaky sometimes.
-			if err, ok := err.(*net.DNSError); ok {
+			// Retrying on DNS error, since we may be using xip.io or nip.io in tests.
+			if isDNSError(err) {
 				sc.logf("Retrying %s for DNS error %v", req.URL.String(), err)
 				return false, nil
 			}
 			// Repeat the poll on `connection refused` errors, which are usually transient Istio errors.
-			// The alternative for the string check is:
-			// 	errNo := (((err.(*url.Error)).Err.(*net.OpError)).Err.(*os.SyscallError).Err).(syscall.Errno)
-			// if errNo == syscall.Errno(0x6f) {...}
-			// But with assertions, of course.
-			if strings.Contains(err.Error(), "connect: connection refused") {
+			if isTCPConnectRefuse(err) {
 				sc.logf("Retrying %s for connection refused %v", req.URL.String(), err)
 				return false, nil
 			}


### PR DESCRIPTION
Adding retries for DNS error to prepare for using `.xip.io` or `.nip.io` in our tests.
