### PR TITLE
Define package ingress for ingress.go

### DIFF
--- a/test/ingress/ingress.go
+++ b/test/ingress/ingress.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package test
+package ingress
 
 import (
 	"fmt"


### PR DESCRIPTION
This matches the directory structure, and avoids confusion in some tools that expect/require package names to match the directory they're in.