### PR TITLE
Stop initializing conditions imperatively.

### DIFF
--- a/apis/duck/v1alpha1/condition_set.go
+++ b/apis/duck/v1alpha1/condition_set.go
@@ -332,13 +332,11 @@ func (r conditionsImpl) InitializeConditions() {
 
 // InitializeCondition updates a Condition to Unknown if not set.
 func (r conditionsImpl) InitializeCondition(t ConditionType) {
-	if c := r.GetCondition(t); c == nil {
-		r.SetCondition(Condition{
-			Type:     t,
-			Status:   corev1.ConditionUnknown,
-			Severity: r.severity(t),
-		})
-	}
+	r.SetCondition(Condition{
+		Type:     t,
+		Status:   corev1.ConditionUnknown,
+		Severity: r.severity(t),
+	})
 }
 
 // NewReflectedConditionsAccessor uses reflection to return a ConditionsAccessor


### PR DESCRIPTION
Reconcilers should consistently produce a set of conditions, so when we initialize we reset the conditions and reconciliation should bring us back to a consistent state.  The status update is already careful about spinning when only timestamps change during this process, so this *should* be safe for all Reconcilers.

Fixes: https://github.com/knative/pkg/issues/357


/hold
Not before 0.5 cuts