### PR TITLE
Add CredentialName into Gateway

### DIFF
--- a/apis/istio/v1alpha3/gateway_types.go
+++ b/apis/istio/v1alpha3/gateway_types.go
@@ -259,6 +259,24 @@ type TLSOptions struct {
 	// client side certificate.
 	CaCertificates string `json:"caCertificates"`
 
+	// The credentialName stands for a unique identifier that can be used
+	// to identify the serverCertificate and the privateKey. The
+	// credentialName appended with suffix "-cacert" is used to identify
+	// the CaCertificates associated with this server. Gateway workloads
+	// capable of fetching credentials from a remote credential store such
+	// as Kubernetes secrets, will be configured to retrieve the
+	// serverCertificate and the privateKey using credentialName, instead
+	// of using the file system paths specified above. If using mutual TLS,
+	// gateway workload instances will retrieve the CaCertificates using
+	// credentialName-cacert. The semantics of the name are platform
+	// dependent.  In Kubernetes, the default Istio supplied credential
+	// server expects the credentialName to match the name of the
+	// Kubernetes secret that holds the server certificate, the private
+	// key, and the CA certificate (if using mutual TLS). Set the
+	// `ISTIO_META_USER_SDS` metadata variable in the gateway's proxy to
+	// enable the dynamic credential fetching feature.
+	CredentialName string `json:"credentialName,omitempty"`
+
 	// A list of alternate names to verify the subject identity in the
 	// certificate presented by the client.
 	SubjectAltNames []string `json:"subjectAltNames"`


### PR DESCRIPTION
Add `CredentialName` into `Gateway` for TLS configuration.
Note that this feature depends on Istio 1.1. So don't check it in until Istio 1.1 is landed within Knative.
