### PR TITLE
Deprecate apis.Immutable and apis.Annotatable.

### DIFF
--- a/apis/contexts.go
+++ b/apis/contexts.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+import (
+	"context"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+)
+
+// This is attached to contexts passed to webhook interfaces when
+// the receiver being validated is being created.
+type inCreateKey struct{}
+
+// WithinCreate is used to note that the webhook is calling within
+// the context of a Create operation.
+func WithinCreate(ctx context.Context) context.Context {
+	return context.WithValue(ctx, inCreateKey{}, struct{}{})
+}
+
+// IsInCreate checks whether the context is a Create.
+func IsInCreate(ctx context.Context) bool {
+	return ctx.Value(inCreateKey{}) != nil
+}
+
+// This is attached to contexts passed to webhook interfaces when
+// the receiver being validated is being updated.
+type inUpdateKey struct{}
+
+// WithinUpdate is used to note that the webhook is calling within
+// the context of a Update operation.
+func WithinUpdate(ctx context.Context, base interface{}) context.Context {
+	return context.WithValue(ctx, inUpdateKey{}, base)
+}
+
+// IsInUpdate checks whether the context is an Update.
+func IsInUpdate(ctx context.Context) bool {
+	return ctx.Value(inUpdateKey{}) != nil
+}
+
+// GetBaseline returns the baseline of the update, or nil when we
+// are not within an update context.
+func GetBaseline(ctx context.Context) interface{} {
+	return ctx.Value(inUpdateKey{})
+}
+
+// This is attached to contexts passed to webhook interfaces when
+// the receiver being validated is being created.
+type userInfoKey struct{}
+
+// WithUserInfo is used to note that the webhook is calling within
+// the context of a Create operation.
+func WithUserInfo(ctx context.Context, ui *authenticationv1.UserInfo) context.Context {
+	return context.WithValue(ctx, userInfoKey{}, ui)
+}
+
+// GetUserInfo accesses the UserInfo attached to the webhook context.
+func GetUserInfo(ctx context.Context) *authenticationv1.UserInfo {
+	if ui, ok := ctx.Value(userInfoKey{}).(*authenticationv1.UserInfo); ok {
+		return ui
+	}
+	return nil
+}

--- a/apis/contexts_test.go
+++ b/apis/contexts_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+import (
+	"context"
+	"testing"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+)
+
+func TestContexts(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name  string
+		ctx   context.Context
+		check func(context.Context) bool
+		want  bool
+	}{{
+		name:  "is in create",
+		ctx:   WithinCreate(ctx),
+		check: IsInCreate,
+		want:  true,
+	}, {
+		name:  "not in create (bare)",
+		ctx:   ctx,
+		check: IsInCreate,
+		want:  false,
+	}, {
+		name:  "not in create (update)",
+		ctx:   WithinUpdate(ctx, struct{}{}),
+		check: IsInCreate,
+		want:  false,
+	}, {
+		name:  "is in update",
+		ctx:   WithinUpdate(ctx, struct{}{}),
+		check: IsInUpdate,
+		want:  true,
+	}, {
+		name:  "not in update (bare)",
+		ctx:   ctx,
+		check: IsInUpdate,
+		want:  false,
+	}, {
+		name:  "not in update (create)",
+		ctx:   WithinCreate(ctx),
+		check: IsInUpdate,
+		want:  false,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.check(tc.ctx)
+			if tc.want != got {
+				t.Errorf("check() = %v, wanted %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestGetBaseline(t *testing.T) {
+	ctx := context.Background()
+
+	if got := GetBaseline(ctx); got != nil {
+		t.Errorf("GetBaseline() = %v, wanted %v", got, nil)
+	}
+
+	var foo interface{} = "this is the object"
+	ctx = WithinUpdate(ctx, foo)
+
+	if want, got := foo, GetBaseline(ctx); got != want {
+		t.Errorf("GetBaseline() = %v, wanted %v", got, want)
+	}
+}
+
+func TestGetUserInfo(t *testing.T) {
+	ctx := context.Background()
+
+	if got := GetUserInfo(ctx); got != nil {
+		t.Errorf("GetUserInfo() = %v, wanted %v", got, nil)
+	}
+
+	bob := &authenticationv1.UserInfo{Username: "bob"}
+	ctx = WithUserInfo(ctx, bob)
+
+	if want, got := bob, GetUserInfo(ctx); got != want {
+		t.Errorf("GetUserInfo() = %v, wanted %v", got, want)
+	}
+}

--- a/apis/interfaces.go
+++ b/apis/interfaces.go
@@ -19,7 +19,6 @@ package apis
 import (
 	"context"
 
-	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -37,6 +36,7 @@ type Validatable interface {
 
 // Immutable indicates that a particular type has fields that should
 // not change after creation.
+// DEPRECATED: Use WithinUpdate / GetBaseline from within Validatable instead.
 type Immutable interface {
 	// CheckImmutableFields checks that the current instance's immutable
 	// fields haven't changed from the provided original.
@@ -52,6 +52,7 @@ type Listable interface {
 }
 
 // Annotatable indicates that a particular type applies various annotations.
-type Annotatable interface {
-	AnnotateUserInfo(ctx context.Context, previous Annotatable, ui *authenticationv1.UserInfo)
-}
+// DEPRECATED: Use WithUserInfo / GetUserInfo from within SetDefaults instead.
+// The webhook functionality for this has been turned down, which is why this
+// interface is empty.
+type Annotatable interface{}

--- a/testing/inner_default_resource.go
+++ b/testing/inner_default_resource.go
@@ -64,8 +64,3 @@ func (cs *InnerDefaultSpec) SetDefaults(ctx context.Context) {
 func (*InnerDefaultResource) Validate(ctx context.Context) *apis.FieldError {
 	return nil
 }
-
-// AnnotateUserInfo satisfies the Annotatable interface.
-// For this type it is nop.
-func (*InnerDefaultResource) AnnotateUserInfo(ctx context.Context, p apis.Annotatable, userName string) {
-}


### PR DESCRIPTION
Deprecate apis.Immutable and apis.Annotatable.

This deprecates the `apis.Immutable` and `apis.Annotatable` interfaces,
which were both awkward niche extensions of `apis.Validatable` and
`apis.SetDefaults` for specific contexts that the former set didn't
cover well.

With this change, the expectation is that types that want to check
for immutability will instead access the "baseline" object via the
context from within updates.  For example:

```
func (new *Type) Validate(ctx context.Context) *apis.FieldError {
  if apis.IsInUpdate(ctx) {
    old := apis.GetBaseline(ctx).(*Type)
    // Update specific validation based on new and old.
  }
}
```

For applying user annotations, the type writer can write:

```
func (new *Type) SetDefaults(ctx context.Context) {
  if apis.IsInCreate(ctx) {
    ui := apis.GetUserInfo(ctx)
    // Set creator annotation from ui
  }

  if apis.IsInUpdate(ctx) {
    ui := apis.GetUserInfo(ctx)
    old := apis.GetBaseline(ctx).(*Type)
    // Compare old.Spec vs. new.Spec and on changes
    // update the "updater" annotation from ui.
  }
}
```

One of the key motivations for this refactoring was to enable us
to do more powerful validation in `apis.Validate` beyond the niche
of immutability checking (and without introducing yet-another
one-off niche interface).  In the BYO Revision name PoC I abused
`apis.Immutable` to do more arbitrary before/after validation,
which with this can simply be a part of `apis.Validatable`.

See: knative/serving#3562

## BREAKING CHANGES

The general stance on deprecating interfaces such as these will be
to deprecate them in a non-breaking way (via a comment for now). They
will be hollowed out when the functionality is removed from the webhook,
but left in because of diamond dependency problems.  In this change
we remove the `apis.Annotatable` functionality and deprecate the
`apis.Immutable` functionality.