### PR TITLE
Do not hard code namespace when checking pod logs

### DIFF
--- a/test/clients.go
+++ b/test/clients.go
@@ -95,9 +95,9 @@ func (client *KubeClient) CreatePod(pod *corev1.Pod) (*corev1.Pod, error) {
 	return pods.Create(pod)
 }
 
-// PodLogs returns Pod logs for given Pod and Container
-func (client *KubeClient) PodLogs(podName, containerName string) ([]byte, error) {
-	pods := client.Kube.CoreV1().Pods(Flags.Namespace)
+// PodLogs returns Pod logs for given Pod and Container in the namespace
+func (client *KubeClient) PodLogs(podName, containerName, namespace string) ([]byte, error) {
+	pods := client.Kube.CoreV1().Pods(namespace)
 	podList, err := pods.List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err

--- a/test/kube_checks.go
+++ b/test/kube_checks.go
@@ -89,9 +89,9 @@ func DeploymentScaledToZeroFunc() func(d *appsv1.Deployment) (bool, error) {
 
 // WaitForLogContent waits until logs for given Pod/Container include the given content.
 // If the content is not present within timeout it returns error.
-func WaitForLogContent(client *KubeClient, podName, containerName, content string) error {
+func WaitForLogContent(client *KubeClient, podName, containerName, namespace, content string) error {
 	return wait.PollImmediate(interval, logTimeout, func() (bool, error) {
-		logs, err := client.PodLogs(podName, containerName)
+		logs, err := client.PodLogs(podName, containerName, namespace)
 		if err != nil {
 			return true, err
 		}


### PR DESCRIPTION
I think it's better to let user specify the `namespace`, rather than hard code it with the one passed as a flag, since it's not mandatory for the user to pass the `namespace` flag. 

Other functions in the `kube_checks.go` file are actually either allowing passing `namespace` or directly using the `pod` or `deployment` reference.