### PR TITLE
Add a version of GlobalResync that calls an event handler.

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -618,9 +618,14 @@ func (*dummyInformer) GetStore() cache.Store {
 }
 
 var dummyKeys = []string{"foo/bar", "bar/foo", "fizz/buzz"}
+var dummyObjs = []interface{}{"foo/bar", "bar/foo", "fizz/buzz"}
 
 func (*dummyStore) ListKeys() []string {
 	return dummyKeys
+}
+
+func (*dummyStore) List() []interface{} {
+	return dummyObjs
 }
 
 func TestImplGlobalResync(t *testing.T) {

--- a/controller/helper.go
+++ b/controller/helper.go
@@ -53,7 +53,7 @@ func EnsureTypeMeta(f Callback, gvk schema.GroupVersionKind) Callback {
 }
 
 // SendGlobalUpdates triggers an update event for all objects from the
-// passed ShareInformer.
+// passed SharedInformer.
 //
 // Since this is triggered not by a real update of these objects
 // themselves, we have no way of knowing the change to these objects

--- a/controller/helper.go
+++ b/controller/helper.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/knative/pkg/kmeta"
 )
@@ -48,5 +49,19 @@ func EnsureTypeMeta(f Callback, gvk schema.GroupVersionKind) Callback {
 
 		// Pass in the mutated copy (accessor is not just a type cast)
 		f(copy)
+	}
+}
+
+// SendGlobalUpdates triggers an update event for all objects from the
+// passed ShareInformer.
+//
+// Since this is triggered not by a real update of these objects
+// themselves, we have no way of knowing the change to these objects
+// if any, so we call handler.OnUpdate(obj, obj) for all of them
+// regardless if they have changes or not.
+func SendGlobalUpdates(si cache.SharedInformer, handler cache.ResourceEventHandler) {
+	store := si.GetStore()
+	for _, obj := range store.List() {
+		handler.OnUpdate(obj, obj)
 	}
 }

--- a/controller/helper_test.go
+++ b/controller/helper_test.go
@@ -28,6 +28,24 @@ import (
 	. "github.com/knative/pkg/testing"
 )
 
+func TestSendGlobalUpdate(t *testing.T) {
+	called := make(map[interface{}]bool)
+	handler := cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(old, new interface{}) {
+			called[new] = true
+		},
+	}
+	SendGlobalUpdates(&dummyInformer{}, handler)
+	for _, obj := range dummyObjs {
+		if updated, _ := called[obj]; !updated {
+			t.Errorf("Expected obj %v to be updated but wasn't", obj)
+		}
+	}
+	if len(dummyObjs) != len(called) {
+		t.Errorf("Expected to see %d updates, saw %d", len(dummyObjs), len(called))
+	}
+}
+
 func TestEnsureTypeMeta(t *testing.T) {
 	gvk := schema.GroupVersionKind{
 		Group:   "foo.bar.com",


### PR DESCRIPTION
This allows impl to apply filtering and queuing logic of their own,
instead of calling Enqueue() for everything.

Currently ConfigMap update event triggers GlobalResync which will evade the filtering logic like ClusterIngress class annotation (or KPA class annotation).  Once this is checked in we can switch ConfigMap update to use this version instead.

<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:

Fixes: <LINK TO ISSUE>
-->
