### PR TITLE
Add support to flush the metrics exporter

### DIFF
--- a/metrics/config.go
+++ b/metrics/config.go
@@ -226,6 +226,8 @@ func UpdateExporter(ops ExporterOptions, logger *zap.SugaredLogger) error {
 	}
 
 	if isNewExporterRequired(newConfig) {
+		logger.Info("Flushing the existing exporter before setting up the new exporter.")
+		FlushExporter()
 		e, err := newMetricsExporter(newConfig, logger)
 		if err != nil {
 			logger.Errorf("Failed to update a new metrics exporter based on metric config %v. error: %v", newConfig, err)

--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -90,18 +90,16 @@ func setCurMetricsConfig(c *metricsConfig) {
 }
 
 // FlushExporter waits for exported data to be uploaded.
-// This is useful when the process is shutting down and
-// you do not want to lose recent data.
-// Return value indicates whether the exporter wrote the
-// contents or not.
+// This should be called before the process shuts down or exporter is replaced.
+// Return value indicates whether the exporter is flushable or not.
 func FlushExporter() bool {
 	e := getCurMetricsExporter()
 	if e == nil {
 		return false
 	}
 
-	if sdEx, ok := e.(flushable); ok {
-		sdEx.Flush()
+	if f, ok := e.(flushable); ok {
+		f.Flush()
 		return true
 	}
 	return false

--- a/metrics/stackdriver_exporter_test.go
+++ b/metrics/stackdriver_exporter_test.go
@@ -78,6 +78,7 @@ func fakeGcpMetadataFun() *gcpMetadata {
 type fakeExporter struct{}
 
 func (fe *fakeExporter) ExportView(vd *view.Data) {}
+func (fe *fakeExporter) Flush()                   {}
 
 func newFakeExporter(o stackdriver.Options) (view.Exporter, error) {
 	return &fakeExporter{}, nil


### PR DESCRIPTION
We need to flush metrics before replacing the exporters and also before shutting down the processes. This PR adds a public func FlushExporter and calls it when replacing exporters. This func will also be called in serving repo when the processed are shutting down.