### PR TITLE
golang format tools

### DIFF
--- a/apis/deprecated_test.go
+++ b/apis/deprecated_test.go
@@ -18,11 +18,12 @@ package apis_test
 
 import (
 	"context"
+	"strings"
+	"testing"
+
 	"github.com/knative/pkg/apis"
 	"github.com/knative/pkg/ptr"
 	. "github.com/knative/pkg/testing"
-	"strings"
-	"testing"
 )
 
 func TestCheckDeprecated(t *testing.T) {

--- a/testing/inner_default_resource.go
+++ b/testing/inner_default_resource.go
@@ -18,6 +18,7 @@ package testing
 
 import (
 	"context"
+
 	"github.com/knative/pkg/apis"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/webhook/webhook_deprecated_test.go
+++ b/webhook/webhook_deprecated_test.go
@@ -17,13 +17,14 @@ limitations under the License.
 package webhook
 
 import (
+	"testing"
+
 	"github.com/knative/pkg/apis"
 	. "github.com/knative/pkg/logging/testing"
 	"github.com/knative/pkg/ptr"
 	. "github.com/knative/pkg/testing"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 // In strict mode, you are not allowed to set a deprecated filed when doing a Create.


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
