### PR TITLE
Expose the EnqueueKeyAfter function on the controller

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -212,6 +212,12 @@ func (c *Impl) EnqueueKey(key string) {
 	c.WorkQueue.Add(key)
 }
 
+// EnqueueKeyAfter takes a namespace/name string and schedules its execution in
+// the work queue after given delay.
+func (c *Impl) EnqueueKeyAfter(key string, delay time.Duration) {
+	c.WorkQueue.AddAfter(key, delay)
+}
+
 // Run starts the controller's worker threads, the number of which is threadiness.
 // It then blocks until stopCh is closed, at which point it shuts down its internal
 // work queue and waits for workers to finish processing their current work items.

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -418,6 +418,26 @@ func TestEnqueues(t *testing.T) {
 	}
 }
 
+func TestEnqeueAfter(t *testing.T) {
+	impl := NewImpl(&NopReconciler{}, TestLogger(t), "Testing", &FakeStatsReporter{})
+	impl.EnqueueKeyAfter("waiting/for", time.Second)
+	impl.EnqueueKeyAfter("the/waterfall", time.Second>>1)
+	impl.EnqueueKeyAfter("to/fall", time.Second<<1)
+	time.Sleep(50 * time.Millisecond)
+	if got, want := impl.WorkQueue.Len(), 0; got != want {
+		t.Errorf("|Queue| = %d, want: %d", got, want)
+	}
+	// Sleep the remaining time.
+	time.Sleep(time.Second - 50*time.Millisecond)
+	if got, want := impl.WorkQueue.Len(), 2; got != want {
+		t.Errorf("|Queue| = %d, want: %d", got, want)
+	}
+	impl.WorkQueue.ShutDown()
+	if got, want := drainWorkQueue(impl.WorkQueue), []string{"the/waterfall", "waiting/for"}; !cmp.Equal(got, want) {
+		t.Errorf("Queue = %v, want: %v, diff: %s", got, want, cmp.Diff(got, want))
+	}
+}
+
 type CountingReconciler struct {
 	m     sync.Mutex
 	Count int


### PR DESCRIPTION
This is needed for the positive handoff, so that we can enqueue
the KPA after we received the positive answer from the activator
but still want to have buffer time to make sure the network
changes propagate everywhere.

/cc @mattmoor 