### PR TITLE
Drop error return type from controller.StartAll.

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -221,7 +221,7 @@ func (c *Impl) EnqueueKeyAfter(key string, delay time.Duration) {
 // Run starts the controller's worker threads, the number of which is threadiness.
 // It then blocks until stopCh is closed, at which point it shuts down its internal
 // work queue and waits for workers to finish processing their current work items.
-func (c *Impl) Run(threadiness int, stopCh <-chan struct{}) error {
+func (c *Impl) Run(threadiness int, stopCh <-chan struct{}) {
 	defer runtime.HandleCrash()
 	sg := sync.WaitGroup{}
 	defer sg.Wait()
@@ -242,8 +242,6 @@ func (c *Impl) Run(threadiness int, stopCh <-chan struct{}) error {
 	logger.Info("Started workers")
 	<-stopCh
 	logger.Info("Shutting down workers")
-
-	return nil
 }
 
 // processNextWorkItem will read a single work item off the workqueue and


### PR DESCRIPTION
This confused me in terms of the error modes available here. Went down a rabbithole propagating errors from here through StartAll only to notice this can never return an error in the first place.