### PR TITLE
add addafter method that permits enqueueing the objects themselves

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -117,6 +117,17 @@ func NewImpl(r Reconciler, logger *zap.SugaredLogger, workQueueName string, repo
 	}
 }
 
+// EnqueueAfter takes a resource, converts it into a namespace/name string,
+// and passes it to EnqueueKey.
+func (c *Impl) EnqueueAfter(obj interface{}, after time.Duration) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		c.logger.Errorw("Enqueue", zap.Error(err))
+		return
+	}
+	c.EnqueueKeyAfter(key, after)
+}
+
 // Enqueue takes a resource, converts it into a namespace/name string,
 // and passes it to EnqueueKey.
 func (c *Impl) Enqueue(obj interface{}) {


### PR DESCRIPTION
This will help to hide the key formatting altogether in the reconciler code.

/cc @mattmoor 