### PR TITLE
Defaulting watcher

### DIFF
--- a/configmap/informed_watcher.go
+++ b/configmap/informed_watcher.go
@@ -43,6 +43,7 @@ func NewInformedWatcherFromFactory(sif informers.SharedInformerFactory, namespac
 		ManualWatcher: ManualWatcher{
 			Namespace: namespace,
 		},
+		defaults: make(map[string]*corev1.ConfigMap),
 	}
 }
 
@@ -79,9 +80,6 @@ var _ DefaultingWatcher = (*InformedWatcher)(nil)
 
 // WatchWithDefault implements DefaultingWatcher.
 func (i *InformedWatcher) WatchWithDefault(cm corev1.ConfigMap, o Observer) {
-	if i.defaults == nil {
-		i.defaults = map[string]*corev1.ConfigMap{}
-	}
 	i.defaults[cm.Name] = &cm
 
 	i.m.Lock()

--- a/configmap/informed_watcher.go
+++ b/configmap/informed_watcher.go
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
-istributed under the License is istributed on an "AS IS" BASIS,
+distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	informers "k8s.io/client-go/informers"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -34,7 +35,7 @@ func NewDefaultWatcher(kc kubernetes.Interface, namespace string) *InformedWatch
 	return NewInformedWatcher(kc, namespace)
 }
 
-// NewInformedWatcherFromFactory watchers a Kubernetes namespace for configmap changs
+// NewInformedWatcherFromFactory watches a Kubernetes namespace for configmap changes.
 func NewInformedWatcherFromFactory(sif informers.SharedInformerFactory, namespace string) *InformedWatcher {
 	return &InformedWatcher{
 		sif:      sif,
@@ -45,7 +46,7 @@ func NewInformedWatcherFromFactory(sif informers.SharedInformerFactory, namespac
 	}
 }
 
-// NewInformedWatcher watchers a Kubernetes namespace for configmap changs
+// NewInformedWatcher watches a Kubernetes namespace for configmap changes.
 func NewInformedWatcher(kc kubernetes.Interface, namespace string) *InformedWatcher {
 	return NewInformedWatcherFromFactory(informers.NewSharedInformerFactoryWithOptions(
 		kc,
@@ -61,24 +62,48 @@ type InformedWatcher struct {
 	informer corev1informers.ConfigMapInformer
 	started  bool
 
+	// cfgs are the default ConfigMaps to use if the real ones do not exist or are deleted.
+	cfgs map[string]*corev1.ConfigMap
+
 	// Embedding this struct allows us to reuse the logic
 	// of registering and notifying observers. This simplifies the
-	// InformedWatcher to just setting up the Kubernetes informer
+	// InformedWatcher to just setting up the Kubernetes informer.
 	ManualWatcher
 }
 
 // Asserts that InformedWatcher implements Watcher.
 var _ Watcher = (*InformedWatcher)(nil)
 
-// Start implements Watcher
+// Asserts that InformedWatcher implements DefaultingWatcher.
+var _ DefaultingWatcher = (*InformedWatcher)(nil)
+
+// WatchWithDefault implements DefaultingWatcher.
+func (i *InformedWatcher) WatchWithDefault(cmName string, def *corev1.ConfigMap, o Observer) {
+	if i.cfgs == nil {
+		i.cfgs = map[string]*corev1.ConfigMap{}
+	}
+	i.cfgs[def.Name] = def
+	i.Watch(def.Name, o)
+}
+
+// Start implements Watcher.
 func (i *InformedWatcher) Start(stopCh <-chan struct{}) error {
+	// Pretend that all the defaulted ConfigMaps were just created. This is done before we start
+	// the informer to ensure that if a defaulted ConfigMap does exist, then the real value is
+	// processed after the default one.
+	for k := range i.observers {
+		if cfg, ok := i.cfgs[k]; ok {
+			i.addConfigMapEvent(cfg)
+		}
+	}
+
 	if err := i.registerCallbackAndStartInformer(stopCh); err != nil {
 		return err
 	}
 
 	// Wait until it has been synced (WITHOUT holing the mutex, so callbacks happen)
 	if ok := cache.WaitForCacheSync(stopCh, i.informer.Informer().HasSynced); !ok {
-		return errors.New("Error waiting for ConfigMap informer to sync.")
+		return errors.New("error waiting for ConfigMap informer to sync")
 	}
 
 	return i.checkObservedResourcesExist()
@@ -88,16 +113,17 @@ func (i *InformedWatcher) registerCallbackAndStartInformer(stopCh <-chan struct{
 	i.m.Lock()
 	defer i.m.Unlock()
 	if i.started {
-		return errors.New("Watcher already started!")
+		return errors.New("watcher already started")
 	}
 	i.started = true
 
 	i.informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    i.addConfigMapEvent,
 		UpdateFunc: i.updateConfigMapEvent,
+		DeleteFunc: i.deleteConfigMapEvent,
 	})
 
-	// Start the shared informer factory (non-blocking)
+	// Start the shared informer factory (non-blocking).
 	i.sif.Start(stopCh)
 	return nil
 }
@@ -109,6 +135,12 @@ func (i *InformedWatcher) checkObservedResourcesExist() error {
 	for k := range i.observers {
 		_, err := i.informer.Lister().ConfigMaps(i.Namespace).Get(k)
 		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				if _, ok := i.cfgs[k]; ok {
+					// It is defaulted, so it is OK that it doesn't exist.
+					continue
+				}
+			}
 			return err
 		}
 	}
@@ -123,4 +155,12 @@ func (i *InformedWatcher) addConfigMapEvent(obj interface{}) {
 func (i *InformedWatcher) updateConfigMapEvent(old, new interface{}) {
 	configMap := new.(*corev1.ConfigMap)
 	i.OnChange(configMap)
+}
+
+func (i *InformedWatcher) deleteConfigMapEvent(obj interface{}) {
+	configMap := obj.(*corev1.ConfigMap)
+	if def, ok := i.cfgs[configMap.Name]; ok {
+		i.OnChange(def)
+	}
+	// If there is no default value, then don't do anything.
 }

--- a/configmap/informed_watcher.go
+++ b/configmap/informed_watcher.go
@@ -78,12 +78,12 @@ var _ Watcher = (*InformedWatcher)(nil)
 var _ DefaultingWatcher = (*InformedWatcher)(nil)
 
 // WatchWithDefault implements DefaultingWatcher.
-func (i *InformedWatcher) WatchWithDefault(cmName string, def *corev1.ConfigMap, o Observer) {
+func (i *InformedWatcher) WatchWithDefault(cm corev1.ConfigMap, o Observer) {
 	if i.cfgs == nil {
 		i.cfgs = map[string]*corev1.ConfigMap{}
 	}
-	i.cfgs[def.Name] = def
-	i.Watch(def.Name, o)
+	i.cfgs[cm.Name] = &cm
+	i.Watch(cm.Name, o)
 }
 
 // Start implements Watcher.

--- a/configmap/informed_watcher.go
+++ b/configmap/informed_watcher.go
@@ -83,6 +83,19 @@ func (i *InformedWatcher) WatchWithDefault(cm corev1.ConfigMap, o Observer) {
 		i.cfgs = map[string]*corev1.ConfigMap{}
 	}
 	i.cfgs[cm.Name] = &cm
+
+	i.m.Lock()
+	started := i.started
+	i.m.Unlock()
+	if started {
+		// TODO make both Watch and WatchWithDefault work after the InformedWatcher has started.
+		// This likely entails changing this to `o(&cm)` and having Watch check started, if it has
+		// started, then ensuring i.informer.Lister().ConfigMaps(i.Namespace).Get(cmName) exists and
+		// calling this observer on it. It may require changing Watch and WatchWithDefault to return
+		// an error.
+		panic(errors.New("cannot WatchWithDefault after the InformedWatcher has started"))
+	}
+
 	i.Watch(cm.Name, o)
 }
 

--- a/configmap/informed_watcher.go
+++ b/configmap/informed_watcher.go
@@ -91,7 +91,7 @@ func (i *InformedWatcher) WatchWithDefault(cm corev1.ConfigMap, o Observer) {
 		// started, then ensuring i.informer.Lister().ConfigMaps(i.Namespace).Get(cmName) exists and
 		// calling this observer on it. It may require changing Watch and WatchWithDefault to return
 		// an error.
-		panic(errors.New("cannot WatchWithDefault after the InformedWatcher has started"))
+		panic("cannot WatchWithDefault after the InformedWatcher has started")
 	}
 
 	i.Watch(cm.Name, o)

--- a/configmap/informed_watcher_test.go
+++ b/configmap/informed_watcher_test.go
@@ -175,7 +175,7 @@ func TestWatchMissingOKWithDefaultOnStart(t *testing.T) {
 	cm := NewInformedWatcher(kc, "default")
 
 	foo1 := &counter{name: "foo1"}
-	cm.WatchWithDefault("foo", fooCM, foo1.callback)
+	cm.WatchWithDefault(*fooCM, foo1.callback)
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -242,7 +242,7 @@ func TestDefaultObserved(t *testing.T) {
 	cm := NewInformedWatcher(kc, "default")
 
 	foo1 := &counter{name: "foo1"}
-	cm.WatchWithDefault("foo", defaultFooCM, foo1.callback)
+	cm.WatchWithDefault(*defaultFooCM, foo1.callback)
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -288,7 +288,7 @@ func TestDefaultConfigMapDeleted(t *testing.T) {
 	cm := NewInformedWatcher(kc, "default")
 
 	foo1 := &counter{name: "foo1"}
-	cm.WatchWithDefault("foo", defaultFooCM, foo1.callback)
+	cm.WatchWithDefault(*defaultFooCM, foo1.callback)
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)

--- a/configmap/manual_watcher.go
+++ b/configmap/manual_watcher.go
@@ -29,7 +29,6 @@ type ManualWatcher struct {
 	// Guards mutations to defaultImpl fields
 	m sync.Mutex
 
-	started   bool
 	observers map[string][]Observer
 }
 

--- a/configmap/manual_watcher_test.go
+++ b/configmap/manual_watcher_test.go
@@ -47,8 +47,8 @@ func TestCallbackInvoked(t *testing.T) {
 		},
 	})
 
-	if observer.count == 0 {
-		t.Errorf("Expected callback to be invoked - got invocations %v", observer.count)
+	if observer.count() == 0 {
+		t.Errorf("Expected callback to be invoked - got invocations %v", observer.count())
 	}
 }
 
@@ -67,8 +67,8 @@ func TestDifferentNamespace(t *testing.T) {
 		},
 	})
 
-	if observer.count != 0 {
-		t.Errorf("Expected callback to be not be invoked - got invocations %v", observer.count)
+	if observer.count() != 0 {
+		t.Errorf("Expected callback to be not be invoked - got invocations %v", observer.count())
 	}
 }
 
@@ -88,8 +88,8 @@ func TestLateRegistration(t *testing.T) {
 
 	watcher.Watch("foo", observer.callback)
 
-	if observer.count != 0 {
-		t.Errorf("Expected callback to be not be invoked - got invocations %v", observer.count)
+	if observer.count() != 0 {
+		t.Errorf("Expected callback to be not be invoked - got invocations %v", observer.count())
 	}
 }
 
@@ -109,7 +109,7 @@ func TestDifferentConfigName(t *testing.T) {
 
 	watcher.Watch("bar", observer.callback)
 
-	if observer.count != 0 {
-		t.Errorf("Expected callback to be not be invoked - got invocations %v", observer.count)
+	if observer.count() != 0 {
+		t.Errorf("Expected callback to be not be invoked - got invocations %v", observer.count())
 	}
 }

--- a/configmap/static_watcher_test.go
+++ b/configmap/static_watcher_test.go
@@ -54,7 +54,7 @@ func TestStaticWatcher(t *testing.T) {
 	// When Start returns the callbacks should have been called with the
 	// version of the objects that is available.
 	for _, obj := range []*counter{foo1, foo2, bar} {
-		if got, want := obj.count, 1; got != want {
+		if got, want := obj.count(), 1; got != want {
 			t.Errorf("%v.count = %v, want %v", obj, got, want)
 		}
 	}

--- a/configmap/store.go
+++ b/configmap/store.go
@@ -44,7 +44,7 @@ type Constructors map[string]interface{}
 // An UntypedStore is a responsible for storing and
 // constructing configs from Kubernetes ConfigMaps
 //
-// WatchConfigs should be used with a configmap,Watcher
+// WatchConfigs should be used with a configmap.Watcher
 // in order for this store to remain up to date
 type UntypedStore struct {
 	name   string

--- a/configmap/watcher.go
+++ b/configmap/watcher.go
@@ -26,7 +26,7 @@ import (
 // contents).
 type Observer func(*corev1.ConfigMap)
 
-// Watcher defined the interface that a configmap implementation must implement.
+// Watcher defines the interface that a configmap implementation must implement.
 type Watcher interface {
 	// Watch is called to register a callback to be notified when a named ConfigMap changes.
 	Watch(string, Observer)
@@ -35,4 +35,15 @@ type Watcher interface {
 	// stop watching.  When Start returns, all registered Observers will be called with the
 	// initial state of the ConfigMaps they are watching.
 	Start(<-chan struct{}) error
+}
+
+// DefaultingWatcher is similar to Watcher, but if a ConfigMap is absent, then a code provided
+// default may be used instead.
+type DefaultingWatcher interface {
+	Watcher
+
+	// WatchWithDefault is called to register a callback to be notified when a named
+	// ConfigMap changes. If no ConfigMap with that name exists or is deleted, then
+	// the default value is used.
+	WatchWithDefault(cmName string, def *corev1.ConfigMap, o Observer)
 }

--- a/configmap/watcher.go
+++ b/configmap/watcher.go
@@ -38,12 +38,12 @@ type Watcher interface {
 }
 
 // DefaultingWatcher is similar to Watcher, but if a ConfigMap is absent, then a code provided
-// default may be used instead.
+// default will be used.
 type DefaultingWatcher interface {
 	Watcher
 
-	// WatchWithDefault is called to register a callback to be notified when a named
-	// ConfigMap changes. If no ConfigMap with that name exists or is deleted, then
-	// the default value is used.
-	WatchWithDefault(cmName string, def *corev1.ConfigMap, o Observer)
+	// WatchWithDefault is called to register a callback to be notified when a named ConfigMap
+	// changes. The provided default value is always observed before any real ConfigMap with that
+	// name is. If the real ConfigMap with that name is deleted, then the default value is observed.
+	WatchWithDefault(cm corev1.ConfigMap, o Observer)
 }


### PR DESCRIPTION
<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:

Fixes: <LINK TO ISSUE>
-->

Fixes: #412 

## Proposed Changes

- Extend the existing `configmap.InformedWatcher` to use code provided defaults if the real ConfigMap does not exist.
    - Existing usage will not require any changes. All new functionality is strictly opt-in.