### PR TITLE
golang format tools

### DIFF
--- a/configmap/informed_watcher_test.go
+++ b/configmap/informed_watcher_test.go
@@ -27,9 +27,9 @@ import (
 )
 
 type counter struct {
-	name  string
-	cfg []*corev1.ConfigMap
-	wg *sync.WaitGroup
+	name string
+	cfg  []*corev1.ConfigMap
+	wg   *sync.WaitGroup
 }
 
 func (c *counter) callback(cm *corev1.ConfigMap) {
@@ -357,14 +357,13 @@ func TestWatchWithDefaultAfterStart(t *testing.T) {
 
 	foo1 := &counter{name: "foo1"}
 
-
 	// Add the WatchWithDefault. This should panic because the InformedWatcher has already started.
 	func() {
 		defer func() {
 			recover()
 		}()
 		cm.WatchWithDefault(*defaultFooCM, foo1.callback)
-			t.Fatal("WatchWithDefault should have panicked")
+		t.Fatal("WatchWithDefault should have panicked")
 	}()
 
 	// We expect nothing.

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -19,9 +19,10 @@ package controller
 import (
 	"context"
 	"fmt"
-	"github.com/google/uuid"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
