### PR TITLE
Move common helper functions to pkg test

### DIFF
--- a/test/helpers/data.go
+++ b/test/helpers/data.go
@@ -26,7 +26,7 @@ import (
 const (
 	letterBytes   = "abcdefghijklmnopqrstuvwxyz"
 	randSuffixLen = 8
-	sep           = "-"
+	sep           = '-'
 )
 
 func init() {
@@ -46,13 +46,12 @@ func AppendRandomString(prefix string) string {
 		suffix[i] = letterBytes[rand.Intn(len(letterBytes))]
 	}
 
-	return strings.Join([]string{prefix, string(suffix)}, sep)
+	return strings.Join([]string{prefix, string(suffix)}, string(sep))
 }
 
 // MakeK8sNamePrefix converts each chunk of non-alphanumeric character into a single dash
 // and also convert camelcase tokens into dash-delimited lowercase tokens.
 func MakeK8sNamePrefix(s string) string {
-	const dash = '-'
 	var sb strings.Builder
 	newToken := false
 	for _, c := range s {
@@ -61,7 +60,7 @@ func MakeK8sNamePrefix(s string) string {
 			continue
 		}
 		if sb.Len() > 0 && (newToken || unicode.IsUpper(c)) {
-			sb.WriteRune(dash)
+			sb.WriteRune(sep)
 		}
 		sb.WriteRune(unicode.ToLower(c))
 		newToken = false

--- a/test/helpers/data.go
+++ b/test/helpers/data.go
@@ -52,6 +52,7 @@ func AppendRandomString(prefix string) string {
 // MakeK8sNamePrefix converts each chunk of non-alphanumeric character into a single dash
 // and also convert camelcase tokens into dash-delimited lowercase tokens.
 func MakeK8sNamePrefix(s string) string {
+	const dash = '-'
 	var sb strings.Builder
 	newToken := false
 	for _, c := range s {
@@ -60,7 +61,7 @@ func MakeK8sNamePrefix(s string) string {
 			continue
 		}
 		if sb.Len() > 0 && (newToken || unicode.IsUpper(c)) {
-			sb.WriteRune('-')
+			sb.WriteRune(dash)
 		}
 		sb.WriteRune(unicode.ToLower(c))
 		newToken = false

--- a/test/helpers/data.go
+++ b/test/helpers/data.go
@@ -20,6 +20,7 @@ import (
 	"math/rand"
 	"strings"
 	"time"
+	"unicode"
 )
 
 const (
@@ -46,4 +47,31 @@ func AppendRandomString(prefix string) string {
 	}
 
 	return strings.Join([]string{prefix, string(suffix)}, sep)
+}
+
+// MakeK8sNamePrefix converts each chunk of non-alphanumeric character into a single dash
+// and also convert camelcase tokens into dash-delimited lowercase tokens.
+func MakeK8sNamePrefix(s string) string {
+	var sb strings.Builder
+	newToken := false
+	for _, c := range s {
+		if !(unicode.IsLetter(c) || unicode.IsNumber(c)) {
+			newToken = true
+			continue
+		}
+		if sb.Len() > 0 && (newToken || unicode.IsUpper(c)) {
+			sb.WriteRune('-')
+		}
+		sb.WriteRune(unicode.ToLower(c))
+		newToken = false
+	}
+	return sb.String()
+}
+
+// GetBaseFuncName returns the baseFuncName parsed from the fullFuncName.
+// eg. test/e2e.TestMain will return TestMain.
+func GetBaseFuncName(fullFuncName string) string {
+	baseFuncName := fullFuncName[strings.LastIndex(fullFuncName, "/")+1:]
+	baseFuncName = baseFuncName[strings.LastIndex(baseFuncName, ".")+1:]
+	return baseFuncName
 }

--- a/test/helpers/data_test.go
+++ b/test/helpers/data_test.go
@@ -17,16 +17,49 @@ limitations under the License.
 package helpers
 
 import (
-	"fmt"
 	"regexp"
+	"testing"
 )
 
 var matcher = regexp.MustCompile("abcd-[a-z]{8}")
 
-func ExampleAppendRandomString() {
+func TestAppendRandomString(tst *testing.T) {
 	const s = "abcd"
 	t := AppendRandomString(s)
 	o := AppendRandomString(s)
-	fmt.Println(matcher.MatchString(t), matcher.MatchString(o), o != t)
-	// Output: true true true
+	if !matcher.MatchString(t) || !matcher.MatchString(o) || o == t {
+		tst.Fatal()
+	}
+}
+
+func TestMakeK8sNamePrefix(tst *testing.T) {
+	testCases := map[string]string{
+		"abcd123":  "abcd123",
+		"AbCdef":   "ab-cdef",
+		"ABCD":     "a-b-c-d",
+		"aBc*ef&d": "a-bc-ef-d",
+	}
+	for k := range testCases {
+		expected := testCases[k]
+		actual := MakeK8sNamePrefix(k)
+		if expected != actual {
+			tst.Fatalf("Expect %q but actual is %q", expected, actual)
+		}
+	}
+}
+
+func TestGetBaseFuncName(tst *testing.T) {
+	testCases := map[string]string{
+		"test/e2e.TestMain": "TestMain",
+		"e2e.TestMain":      "TestMain",
+		"test/TestMain":     "TestMain",
+		"TestMain":          "TestMain",
+	}
+	for k := range testCases {
+		expected := testCases[k]
+		actual := GetBaseFuncName(k)
+		if expected != actual {
+			tst.Fatalf("Expect %q but actual is %q", expected, actual)
+		}
+	}
 }

--- a/test/helpers/data_test.go
+++ b/test/helpers/data_test.go
@@ -23,43 +23,47 @@ import (
 
 var matcher = regexp.MustCompile("abcd-[a-z]{8}")
 
-func TestAppendRandomString(tst *testing.T) {
+func TestAppendRandomString(t *testing.T) {
 	const s = "abcd"
-	t := AppendRandomString(s)
+	w := AppendRandomString(s)
 	o := AppendRandomString(s)
-	if !matcher.MatchString(t) || !matcher.MatchString(o) || o == t {
-		tst.Fatal()
+	if !matcher.MatchString(w) || !matcher.MatchString(o) || o == w {
+		t.Fatalf("Generated string(s) are incorrect: %q, %q", w, o)
 	}
 }
 
-func TestMakeK8sNamePrefix(tst *testing.T) {
-	testCases := map[string]string{
-		"abcd123":  "abcd123",
-		"AbCdef":   "ab-cdef",
-		"ABCD":     "a-b-c-d",
-		"aBc*ef&d": "a-bc-ef-d",
+func TestMakeK8sNamePrefix(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"abcd123", "abcd123"},
+		{"AbCdef", "ab-cdef"},
+		{"ABCD", "a-b-c-d"},
+		{"aBc*ef&d", "a-bc-ef-d"},
 	}
-	for k := range testCases {
-		expected := testCases[k]
-		actual := MakeK8sNamePrefix(k)
-		if expected != actual {
-			tst.Fatalf("Expect %q but actual is %q", expected, actual)
+	for _, v := range testCases {
+		actual := MakeK8sNamePrefix(v.input)
+		if v.expected != actual {
+			t.Fatalf("Expect %q but actual is %q", v.expected, actual)
 		}
 	}
 }
 
-func TestGetBaseFuncName(tst *testing.T) {
-	testCases := map[string]string{
-		"test/e2e.TestMain": "TestMain",
-		"e2e.TestMain":      "TestMain",
-		"test/TestMain":     "TestMain",
-		"TestMain":          "TestMain",
+func TestGetBaseFuncName(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"test/e2e.TestMain", "TestMain"},
+		{"e2e.TestMain", "TestMain"},
+		{"test/TestMain", "TestMain"},
+		{"TestMain", "TestMain"},
 	}
-	for k := range testCases {
-		expected := testCases[k]
-		actual := GetBaseFuncName(k)
-		if expected != actual {
-			tst.Fatalf("Expect %q but actual is %q", expected, actual)
+	for _, v := range testCases {
+		actual := GetBaseFuncName(v.input)
+		if v.expected != actual {
+			t.Fatalf("Expect %q but actual is %q", v.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
These two functions `MakeK8sNamePrefix` and `GetBaseFuncName` can be used for both `Serving` and `Eventing` E2E test, so move them here for sharing and simplicity.