### PR TITLE
Share the configmap name logic for Logging and Metrics.

### DIFF
--- a/logging/config.go
+++ b/logging/config.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -28,6 +29,8 @@ import (
 	"github.com/knative/pkg/changeset"
 	"github.com/knative/pkg/logging/logkey"
 )
+
+const ConfigMapNameEnv = "CONFIG_LOGGING_NAME"
 
 // NewLogger creates a logger with the supplied configuration.
 // In addition to the logger, it returns AtomicLevel that can
@@ -184,4 +187,13 @@ func UpdateLevelFromConfigMap(logger *zap.SugaredLogger, atomicLevel zap.AtomicL
 			}
 		}
 	}
+}
+
+// ConfigMapName gets the name of the logging ConfigMap
+func ConfigMapName() string {
+	cm := os.Getenv(ConfigMapNameEnv)
+	if cm == "" {
+		return "config-logging"
+	}
+	return cm
 }

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -29,6 +29,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	DomainEnv        = "METRICS_DOMAIN"
+	ConfigMapNameEnv = "CONFIG_OBSERVABILITY_NAME"
+)
+
 // metricsBackend specifies the backend to use for metrics
 type metricsBackend string
 
@@ -201,8 +206,8 @@ func getMetricsConfig(ops ExporterOptions, logger *zap.SugaredLogger) (*metricsC
 
 // UpdateExporterFromConfigMap returns a helper func that can be used to update the exporter
 // when a config map is updated.
-// DEPRECATED. Use UpdateExporter instead.
-func UpdateExporterFromConfigMap(domain string, component string, logger *zap.SugaredLogger) func(configMap *corev1.ConfigMap) {
+func UpdateExporterFromConfigMap(component string, logger *zap.SugaredLogger) func(configMap *corev1.ConfigMap) {
+	domain := Domain()
 	return func(configMap *corev1.ConfigMap) {
 		UpdateExporter(ExporterOptions{
 			Domain:    domain,
@@ -253,4 +258,30 @@ func isNewExporterRequired(newConfig *metricsConfig) bool {
 	}
 
 	return false
+}
+
+// ConfigMapName gets the name of the metrics ConfigMap
+func ConfigMapName() string {
+	cm := os.Getenv(ConfigMapNameEnv)
+	if cm == "" {
+		return "config-observability"
+	}
+	return cm
+}
+
+// Domain holds the metrics domain to use for surfacing metrics.
+func Domain() string {
+	if domain := os.Getenv(DomainEnv); domain != "" {
+		return domain
+	}
+
+	panic(fmt.Sprintf(`The environment variable %q is not set
+
+If this is a process running on Kubernetes, then it should be specifying
+this via:
+
+  env:
+  - name: %s
+    value: knative.dev/some-repository
+`, DomainEnv, DomainEnv))
 }


### PR DESCRIPTION
This also adds a way to fetch the metrics "domain" following a similar pattern to `system.Namespace()`.

