### PR TITLE
Simplify the default controller.Impl constructor.

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -123,7 +123,11 @@ type Impl struct {
 
 // NewImpl instantiates an instance of our controller that will feed work to the
 // provided Reconciler as it is enqueued.
-func NewImpl(r Reconciler, logger *zap.SugaredLogger, workQueueName string, reporter StatsReporter) *Impl {
+func NewImpl(r Reconciler, logger *zap.SugaredLogger, workQueueName string) *Impl {
+	return NewImplWithStats(r, logger, workQueueName, MustNewStatsReporter(workQueueName, logger))
+}
+
+func NewImplWithStats(r Reconciler, logger *zap.SugaredLogger, workQueueName string, reporter StatsReporter) *Impl {
 	return &Impl{
 		Reconciler: r,
 		WorkQueue: workqueue.NewNamedRateLimitingQueue(

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -466,7 +466,7 @@ func TestEnqueues(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			impl := NewImpl(&NopReconciler{}, TestLogger(t), "Testing", &FakeStatsReporter{})
+			impl := NewImplWithStats(&NopReconciler{}, TestLogger(t), "Testing", &FakeStatsReporter{})
 			test.work(impl)
 
 			// The rate limit on our queue delays when things are added to the queue.
@@ -482,7 +482,7 @@ func TestEnqueues(t *testing.T) {
 }
 
 func TestEnqeueAfter(t *testing.T) {
-	impl := NewImpl(&NopReconciler{}, TestLogger(t), "Testing", &FakeStatsReporter{})
+	impl := NewImplWithStats(&NopReconciler{}, TestLogger(t), "Testing", &FakeStatsReporter{})
 	impl.EnqueueAfter(&Resource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "for",
@@ -517,7 +517,7 @@ func TestEnqeueAfter(t *testing.T) {
 }
 
 func TestEnqeueKeyAfter(t *testing.T) {
-	impl := NewImpl(&NopReconciler{}, TestLogger(t), "Testing", &FakeStatsReporter{})
+	impl := NewImplWithStats(&NopReconciler{}, TestLogger(t), "Testing", &FakeStatsReporter{})
 	impl.EnqueueKeyAfter("waiting/for", time.Second)
 	impl.EnqueueKeyAfter("the/waterfall", time.Second>>1)
 	impl.EnqueueKeyAfter("to/fall", time.Second<<1)
@@ -550,7 +550,7 @@ func (cr *CountingReconciler) Reconcile(context.Context, string) error {
 
 func TestStartAndShutdown(t *testing.T) {
 	r := &CountingReconciler{}
-	impl := NewImpl(r, TestLogger(t), "Testing", &FakeStatsReporter{})
+	impl := NewImplWithStats(r, TestLogger(t), "Testing", &FakeStatsReporter{})
 
 	stopCh := make(chan struct{})
 	doneCh := make(chan struct{})
@@ -583,7 +583,7 @@ func TestStartAndShutdown(t *testing.T) {
 func TestStartAndShutdownWithWork(t *testing.T) {
 	r := &CountingReconciler{}
 	reporter := &FakeStatsReporter{}
-	impl := NewImpl(r, TestLogger(t), "Testing", reporter)
+	impl := NewImplWithStats(r, TestLogger(t), "Testing", reporter)
 
 	stopCh := make(chan struct{})
 	doneCh := make(chan struct{})
@@ -629,7 +629,7 @@ func (er *ErrorReconciler) Reconcile(context.Context, string) error {
 func TestStartAndShutdownWithErroringWork(t *testing.T) {
 	r := &ErrorReconciler{}
 	reporter := &FakeStatsReporter{}
-	impl := NewImpl(r, TestLogger(t), "Testing", reporter)
+	impl := NewImplWithStats(r, TestLogger(t), "Testing", reporter)
 
 	stopCh := make(chan struct{})
 	doneCh := make(chan struct{})
@@ -677,7 +677,7 @@ func (er *PermanentErrorReconciler) Reconcile(context.Context, string) error {
 func TestStartAndShutdownWithPermanentErroringWork(t *testing.T) {
 	r := &PermanentErrorReconciler{}
 	reporter := &FakeStatsReporter{}
-	impl := NewImpl(r, TestLogger(t), "Testing", reporter)
+	impl := NewImplWithStats(r, TestLogger(t), "Testing", reporter)
 
 	stopCh := make(chan struct{})
 	doneCh := make(chan struct{})
@@ -748,7 +748,7 @@ func (*dummyStore) List() []interface{} {
 
 func TestImplGlobalResync(t *testing.T) {
 	r := &CountingReconciler{}
-	impl := NewImpl(r, TestLogger(t), "Testing", &FakeStatsReporter{})
+	impl := NewImplWithStats(r, TestLogger(t), "Testing", &FakeStatsReporter{})
 
 	stopCh := make(chan struct{})
 	doneCh := make(chan struct{})

--- a/controller/stats_reporter.go
+++ b/controller/stats_reporter.go
@@ -25,6 +25,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+	"go.uber.org/zap"
 )
 
 var (
@@ -101,6 +102,16 @@ func NewStatsReporter(reconciler string) (StatsReporter, error) {
 	}
 
 	return &reporter{reconciler: reconciler, globalCtx: ctx}, nil
+}
+
+// MustNewStatsReporter creates a new instance of StatsReporter.
+// Logs fatally if creation fails.
+func MustNewStatsReporter(reconciler string, logger *zap.SugaredLogger) StatsReporter {
+	stats, err := NewStatsReporter(reconciler)
+	if err != nil {
+		logger.Fatalw("Failed to initialize the stats reporter", zap.Error(err))
+	}
+	return stats
 }
 
 // ReportQueueDepth reports the queue depth metric


### PR DESCRIPTION
A while back we added a "StatsReporter" argument to `controller.NewImpl`,
but in serving every callsite of this is passing:
```
controller.NewImpl(r, logger, "my-string", MustNewStatsReporter("my-string", logger))
```

Where `MustNewStatsReporter` is just a form of knative/pkg's `controller.NewStatsReporter`
that logs fatally when an error is returned.  It is notable that Serving's logic has been
duplicated to both Build and Eventing.

There are a handful of changes here:
1. Move MustNewStatsReporter into knative/pkg
2. Expose the current interface as NewImplWithStats
3. Drop the StatsReporter from NewImpl and default to `MustNewStatsReporter()`

This is a breaking change for downstream repositories, but should make their callsites universally simpler.

/hold

I am going to stage this change on the other repositories, but please voice any objections here in the meantime.