### PR TITLE
This upstreams a useful helper from serving.

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -69,6 +69,17 @@ func PassNew(f func(interface{})) func(interface{}, interface{}) {
 	}
 }
 
+// HandleAll wraps the provided handler function into a cache.ResourceEventHandler
+// that sends all events to the given handler.  For Updates, only the new object
+// is forwarded.
+func HandleAll(h func(interface{})) cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    h,
+		UpdateFunc: PassNew(h),
+		DeleteFunc: h,
+	}
+}
+
 // Filter makes it simple to create FilterFunc's for use with
 // cache.FilteringResourceEventHandler that filter based on the
 // schema.GroupVersionKind of the controlling resources.

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -45,6 +45,21 @@ func TestPassNew(t *testing.T) {
 	})(old, new)
 }
 
+func TestHandleAll(t *testing.T) {
+	old := "foo"
+	new := "bar"
+
+	ha := HandleAll(func(got interface{}) {
+		if new != got.(string) {
+			t.Errorf("HandleAll() = %v, wanted %v", got, new)
+		}
+	})
+
+	ha.OnAdd(new)
+	ha.OnUpdate(old, new)
+	ha.OnDelete(new)
+}
+
 var (
 	boolTrue  = true
 	boolFalse = false


### PR DESCRIPTION
In serving we have `reconciler.Handler` that wraps a handler function
(e.g. `Enqueue`) in the `cache.ResourceEventHandlerFuncs`.  This pattern
was becoming pervasive, so this simpler handler dramatically reduced our
boilerplate.
