### PR TITLE
Logging config parses all components, rather than just a list passed in.

### DIFF
--- a/logging/config.go
+++ b/logging/config.go
@@ -142,7 +142,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 
 	lc.LoggingLevel = make(map[string]zapcore.Level)
 	for k, v := range data {
-		if component := strings.TrimPrefix(k, "loglevel."); component != k {
+		if component := strings.TrimPrefix(k, "loglevel."); component != k && component != "" {
 			if len(v) > 0 {
 				level, err := levelFromString(v)
 				if err != nil {

--- a/logging/config.go
+++ b/logging/config.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -131,7 +132,7 @@ const defaultZLC = `{
 
 // NewConfigFromMap creates a LoggingConfig from the supplied map,
 // expecting the given list of components.
-func NewConfigFromMap(data map[string]string, components ...string) (*Config, error) {
+func NewConfigFromMap(data map[string]string) (*Config, error) {
 	lc := &Config{}
 	if zlc, ok := data["zap-logger-config"]; ok {
 		lc.LoggingConfig = zlc
@@ -140,16 +141,16 @@ func NewConfigFromMap(data map[string]string, components ...string) (*Config, er
 	}
 
 	lc.LoggingLevel = make(map[string]zapcore.Level)
-	for _, component := range components {
-		if ll := data["loglevel."+component]; len(ll) > 0 {
-			level, err := levelFromString(ll)
-			if err != nil {
-				return nil, err
+	for k, v := range data {
+		if strings.HasPrefix(k, "loglevel.") {
+			component := k[len("loglevel."):]
+			if len(v) > 0 {
+				level, err := levelFromString(v)
+				if err != nil {
+					return nil, err
+				}
+				lc.LoggingLevel[component] = *level
 			}
-			lc.LoggingLevel[component] = *level
-		} else {
-			// We default components to INFO
-			lc.LoggingLevel[component] = zapcore.InfoLevel
 		}
 	}
 	return lc, nil
@@ -157,8 +158,8 @@ func NewConfigFromMap(data map[string]string, components ...string) (*Config, er
 
 // NewConfigFromConfigMap creates a LoggingConfig from the supplied ConfigMap,
 // expecting the given list of components.
-func NewConfigFromConfigMap(configMap *corev1.ConfigMap, components ...string) (*Config, error) {
-	return NewConfigFromMap(configMap.Data, components...)
+func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
+	return NewConfigFromMap(configMap.Data)
 }
 
 func levelFromString(level string) (*zapcore.Level, error) {
@@ -172,19 +173,18 @@ func levelFromString(level string) (*zapcore.Level, error) {
 // UpdateLevelFromConfigMap returns a helper func that can be used to update the logging level
 // when a config map is updated
 func UpdateLevelFromConfigMap(logger *zap.SugaredLogger, atomicLevel zap.AtomicLevel,
-	levelKey string, components ...string) func(configMap *corev1.ConfigMap) {
+	levelKey string) func(configMap *corev1.ConfigMap) {
 	return func(configMap *corev1.ConfigMap) {
-		loggingConfig, err := NewConfigFromConfigMap(configMap, components...)
+		loggingConfig, err := NewConfigFromConfigMap(configMap)
 		if err != nil {
 			logger.Errorw("Failed to parse the logging configmap. Previous config map will be used.", zap.Error(err))
 			return
 		}
 
-		if level, ok := loggingConfig.LoggingLevel[levelKey]; ok {
-			if atomicLevel.Level() != level {
-				logger.Infof("Updating logging level for %v from %v to %v.", levelKey, atomicLevel.Level(), level)
-				atomicLevel.SetLevel(level)
-			}
+		level := loggingConfig.LoggingLevel[levelKey]
+		if atomicLevel.Level() != level {
+			logger.Infof("Updating logging level for %v from %v to %v.", levelKey, atomicLevel.Level(), level)
+			atomicLevel.SetLevel(level)
 		}
 	}
 }

--- a/logging/config.go
+++ b/logging/config.go
@@ -142,8 +142,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 
 	lc.LoggingLevel = make(map[string]zapcore.Level)
 	for k, v := range data {
-		if strings.HasPrefix(k, "loglevel.") {
-			component := k[len("loglevel."):]
+		if component := strings.TrimPrefix(k, "loglevel."); component != k {
 			if len(v) > 0 {
 				level, err := levelFromString(v)
 				if err != nil {

--- a/logging/config_test.go
+++ b/logging/config_test.go
@@ -212,6 +212,28 @@ func TestInvalidLevel(t *testing.T) {
 	}
 }
 
+func TestEmptyComponent(t *testing.T) {
+	ll := zapcore.ErrorLevel
+	c, err := NewConfigFromConfigMap(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "knative-something",
+			Name:      "config-logging",
+		},
+		Data: map[string]string{
+			"zap-logger-config":   "{\"level\": \"error\",\n\"outputPaths\": [\"stdout\"],\n\"errorOutputPaths\": [\"stderr\"],\n\"encoding\": \"json\"}",
+			"loglevel.": ll.String(),
+		},
+	})
+	if err != nil {
+		t.Errorf("Expected no errors. got: %v", err)
+	}
+	// The empty string component should have been ignored, so it should be the default Info, rather
+	// than error as set in the config map.
+	if l := c.LoggingLevel[""]; l != zapcore.InfoLevel {
+		t.Errorf("Expected default Info level for LoggingLevel[\"\"]. got: %v", l)
+	}
+}
+
 func getTestConfig() (*Config, string, string) {
 	wantCfg := "{\"level\": \"error\",\n\"outputPaths\": [\"stdout\"],\n\"errorOutputPaths\": [\"stderr\"],\n\"encoding\": \"json\"}"
 	wantLevel := "debug"


### PR DESCRIPTION
<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:

Fixes: <LINK TO ISSUE>
-->

Logging config parses all components, rather than just a list passed in.

The current API exposed before this change is easy to get wrong. For example, knative/serving's cmd/controller/main.go doesn't pass in the components list, so dynamic updates never occur.