### PR TITLE
golang format tools

### DIFF
--- a/logging/config_test.go
+++ b/logging/config_test.go
@@ -220,8 +220,8 @@ func TestEmptyComponent(t *testing.T) {
 			Name:      "config-logging",
 		},
 		Data: map[string]string{
-			"zap-logger-config":   "{\"level\": \"error\",\n\"outputPaths\": [\"stdout\"],\n\"errorOutputPaths\": [\"stderr\"],\n\"encoding\": \"json\"}",
-			"loglevel.": ll.String(),
+			"zap-logger-config": "{\"level\": \"error\",\n\"outputPaths\": [\"stdout\"],\n\"errorOutputPaths\": [\"stderr\"],\n\"encoding\": \"json\"}",
+			"loglevel.":         ll.String(),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
