### PR TITLE
golang format tools

### DIFF
--- a/codegen/cmd/injection-gen/generators/client.go
+++ b/codegen/cmd/injection-gen/generators/client.go
@@ -18,6 +18,7 @@ package generators
 
 import (
 	"io"
+
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"

--- a/codegen/cmd/injection-gen/generators/factory.go
+++ b/codegen/cmd/injection-gen/generators/factory.go
@@ -18,6 +18,7 @@ package generators
 
 import (
 	"io"
+
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"

--- a/codegen/cmd/injection-gen/generators/fakeclient.go
+++ b/codegen/cmd/injection-gen/generators/fakeclient.go
@@ -18,6 +18,7 @@ package generators
 
 import (
 	"io"
+
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"

--- a/codegen/cmd/injection-gen/generators/fakefactory.go
+++ b/codegen/cmd/injection-gen/generators/fakefactory.go
@@ -18,6 +18,7 @@ package generators
 
 import (
 	"io"
+
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"

--- a/codegen/cmd/injection-gen/generators/fakeinformer.go
+++ b/codegen/cmd/injection-gen/generators/fakeinformer.go
@@ -18,6 +18,7 @@ package generators
 
 import (
 	"io"
+
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"

--- a/codegen/cmd/injection-gen/generators/informer.go
+++ b/codegen/cmd/injection-gen/generators/informer.go
@@ -18,6 +18,7 @@ package generators
 
 import (
 	"io"
+
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
