### PR TITLE
Format markdown

### DIFF
--- a/injection/README.md
+++ b/injection/README.md
@@ -147,7 +147,7 @@ func TestFoo(t *testing.T) {
 ## Starting controllers
 
 All we do is import the controller packages and pass their constructors along
-with a component name to our shared main.  Then our shared main method sets it
+with a component name to our shared main. Then our shared main method sets it
 all up and runs our controllers.
 
 ```go


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`