### PR TITLE
Make a small adjustment to hack/update-deps.sh

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+readonly ROOT_DIR=$(dirname $0)/..
+source ${ROOT_DIR}/vendor/github.com/knative/test-infra/scripts/library.sh
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
-source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/library.sh
-
-cd ${REPO_ROOT_DIR}
+cd ${ROOT_DIR}
 
 # Ensure we have everything we need under vendor/
 dep ensure


### PR DESCRIPTION
This form should be more hospitable to running things to auto-update `knative/test-infra`.

I canaried this change in `knative/sample-controller`, and was able to produce: https://github.com/knative/sample-controller/pull/11