### PR TITLE
#457 Duck type user annotation logic

### DIFF
--- a/apis/interfaces.go
+++ b/apis/interfaces.go
@@ -70,6 +70,6 @@ type Annotatable interface{}
 // HasSpec indicates that a particular type has a specification information
 // and that information is retrievable.
 type HasSpec interface {
-	// GetSpec returns the spec of the resource.
-	GetSpec() interface{}
+	// GetUntypedSpec returns the spec of the resource.
+	GetUntypedSpec() interface{}
 }

--- a/apis/interfaces.go
+++ b/apis/interfaces.go
@@ -66,3 +66,10 @@ type Listable interface {
 // The webhook functionality for this has been turned down, which is why this
 // interface is empty.
 type Annotatable interface{}
+
+// HasSpec indicates that a particular type has a specification information
+// and that information is retrievable.
+type HasSpec interface {
+	// GetSpec returns the spec of the resource.
+	GetSpec() interface{}
+}

--- a/apis/user_info.go
+++ b/apis/user_info.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+import (
+	"context"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// CreatorAnnotationSuffix is the suffix of the annotation key to describe
+	// the user that created the resource.
+	CreatorAnnotationSuffix = "/creator"
+
+	// UpdaterAnnotationSuffix is the suffix of the annotation key to describe
+	// the user that last updated the resource.
+	UpdaterAnnotationSuffix = "/lastModifier"
+)
+
+// SetUserInfoAnnotations sets creator and updater annotations on a resource.
+func SetUserInfoAnnotations(resource HasSpec, ctx context.Context, groupName string) {
+	if ui := GetUserInfo(ctx); ui != nil {
+		objectMetaAccessor, ok := resource.(metav1.ObjectMetaAccessor)
+		if !ok {
+			return
+		}
+
+		annotations := objectMetaAccessor.GetObjectMeta().GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+			defer objectMetaAccessor.GetObjectMeta().SetAnnotations(annotations)
+		}
+
+		if IsInUpdate(ctx) {
+			old := GetBaseline(ctx).(HasSpec)
+			if equality.Semantic.DeepEqual(old.GetSpec(), resource.GetSpec()) {
+				return
+			}
+			annotations[groupName+UpdaterAnnotationSuffix] = ui.Username
+		} else {
+			annotations[groupName+CreatorAnnotationSuffix] = ui.Username
+			annotations[groupName+UpdaterAnnotationSuffix] = ui.Username
+		}
+	}
+}

--- a/testing/resource.go
+++ b/testing/resource.go
@@ -21,9 +21,6 @@ import (
 	"fmt"
 
 	"github.com/knative/pkg/apis"
-	"github.com/knative/pkg/kmp"
-
-	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -37,13 +34,6 @@ type Resource struct {
 
 	Spec ResourceSpec `json:"spec,omitempty"`
 }
-
-const (
-	// CreatorAnnotation is the annotation that denotes the user that created the resource.
-	CreatorAnnotation = "testing.knative.dev/creator"
-	// UpdaterAnnotation is the annotation that denotes the user that last updated the resource.
-	UpdaterAnnotation = "testing.knative.dev/updater"
-)
 
 // Check that Resource may be validated and defaulted.
 var _ apis.Validatable = (*Resource)(nil)
@@ -60,47 +50,14 @@ type ResourceSpec struct {
 	FieldThatsImmutableWithDefault string `json:"fieldThatsImmutableWithDefault,omitempty"`
 }
 
+// GetSpec returns the spec of the Resource.
+func (r *Resource) GetSpec() interface{} {
+	return r.Spec
+}
+
 // SetDefaults sets the defaults on the object.
 func (c *Resource) SetDefaults(ctx context.Context) {
 	c.Spec.SetDefaults(ctx)
-
-	if apis.IsInUpdate(ctx) {
-		old := apis.GetBaseline(ctx).(*Resource)
-		c.AnnotateUserInfo(ctx, old, apis.GetUserInfo(ctx))
-	} else {
-		c.AnnotateUserInfo(ctx, nil, apis.GetUserInfo(ctx))
-	}
-}
-
-// AnnotateUserInfo satisfies the Annotatable interface.
-func (c *Resource) AnnotateUserInfo(ctx context.Context, prev *Resource, ui *authenticationv1.UserInfo) {
-	a := c.ObjectMeta.GetAnnotations()
-	if a == nil {
-		a = map[string]string{}
-	}
-	userName := ui.Username
-
-	// If previous is nil (i.e. this is `Create` operation),
-	// then we set both fields.
-	// Otherwise copy creator from the previous state.
-	if prev == nil {
-		a[CreatorAnnotation] = userName
-	} else {
-		// No spec update ==> bail out.
-		if ok, _ := kmp.SafeEqual(prev.Spec, c.Spec); ok {
-			if prev.ObjectMeta.GetAnnotations() != nil {
-				a[CreatorAnnotation] = prev.ObjectMeta.GetAnnotations()[CreatorAnnotation]
-				userName = prev.ObjectMeta.GetAnnotations()[UpdaterAnnotation]
-			}
-		} else {
-			if prev.ObjectMeta.GetAnnotations() != nil {
-				a[CreatorAnnotation] = prev.ObjectMeta.GetAnnotations()[CreatorAnnotation]
-			}
-		}
-	}
-	// Regardless of `old` set the updater.
-	a[UpdaterAnnotation] = userName
-	c.ObjectMeta.SetAnnotations(a)
 }
 
 func (c *Resource) Validate(ctx context.Context) *apis.FieldError {

--- a/testing/resource.go
+++ b/testing/resource.go
@@ -50,8 +50,8 @@ type ResourceSpec struct {
 	FieldThatsImmutableWithDefault string `json:"fieldThatsImmutableWithDefault,omitempty"`
 }
 
-// GetSpec returns the spec of the Resource.
-func (r *Resource) GetSpec() interface{} {
+// GetUntypedSpec returns the spec of the resource.
+func (r *Resource) GetUntypedSpec() interface{} {
 	return r.Spec
 }
 

--- a/webhook/helper_test.go
+++ b/webhook/helper_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	. "github.com/knative/pkg/logging/testing"
+	. "github.com/knative/pkg/testing"
 )
 
 func waitForServerAvailable(t *testing.T, serverURL string, timeout time.Duration) error {
@@ -116,4 +117,16 @@ func createSecureTLSClient(t *testing.T, kubeClient kubernetes.Interface, acOpts
 			TLSClientConfig: tlsClientConfig,
 		},
 	}, nil
+}
+
+func createResource(name string) *Resource {
+	return &Resource{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      name,
+		},
+		Spec: ResourceSpec{
+			FieldWithValidation: "magic value",
+		},
+	}
 }

--- a/webhook/user_info.go
+++ b/webhook/user_info.go
@@ -28,12 +28,12 @@ const (
 	// the user that created the resource.
 	CreatorAnnotationSuffix = "/creator"
 
-	// LastModifierAnnotationSuffix is the suffix of the annotation key to describe
+	// UpdaterAnnotationSuffix is the suffix of the annotation key to describe
 	// the user who last modified the resource.
-	LastModifierAnnotationSuffix = "/lastModifier"
+	UpdaterAnnotationSuffix = "/updater"
 )
 
-// SetUserInfoAnnotations sets creator and lastModifier annotations on a resource.
+// SetUserInfoAnnotations sets creator and updater annotations on a resource.
 func SetUserInfoAnnotations(resource apis.HasSpec, ctx context.Context, groupName string) {
 	if ui := apis.GetUserInfo(ctx); ui != nil {
 		objectMetaAccessor, ok := resource.(metav1.ObjectMetaAccessor)
@@ -52,10 +52,10 @@ func SetUserInfoAnnotations(resource apis.HasSpec, ctx context.Context, groupNam
 			if equality.Semantic.DeepEqual(old.GetSpec(), resource.GetSpec()) {
 				return
 			}
-			annotations[groupName+LastModifierAnnotationSuffix] = ui.Username
+			annotations[groupName+UpdaterAnnotationSuffix] = ui.Username
 		} else {
 			annotations[groupName+CreatorAnnotationSuffix] = ui.Username
-			annotations[groupName+LastModifierAnnotationSuffix] = ui.Username
+			annotations[groupName+UpdaterAnnotationSuffix] = ui.Username
 		}
 	}
 }

--- a/webhook/user_info.go
+++ b/webhook/user_info.go
@@ -49,7 +49,7 @@ func SetUserInfoAnnotations(resource apis.HasSpec, ctx context.Context, groupNam
 
 		if apis.IsInUpdate(ctx) {
 			old := apis.GetBaseline(ctx).(apis.HasSpec)
-			if equality.Semantic.DeepEqual(old.GetSpec(), resource.GetSpec()) {
+			if equality.Semantic.DeepEqual(old.GetUntypedSpec(), resource.GetUntypedSpec()) {
 				return
 			}
 			annotations[groupName+UpdaterAnnotationSuffix] = ui.Username

--- a/webhook/user_info_test.go
+++ b/webhook/user_info_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/knative/pkg/apis"
+	. "github.com/knative/pkg/logging/testing"
+	. "github.com/knative/pkg/testing"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"reflect"
+	"testing"
+)
+
+const (
+	creatorAnnotation      = "testing.knative.dev/creator"
+	lastModifierAnnotation = "testing.knative.dev/lastModifier"
+)
+
+func TestSetUserInfoAnnotationsWhenWithinCreate(t *testing.T) {
+	tests := []struct {
+		name                string
+		configureContext    func(context.Context) context.Context
+		setup               func(context.Context, *Resource)
+		expectedAnnotations map[string]string
+	}{
+		{
+			name: "test create",
+			configureContext: func(ctx context.Context) context.Context {
+				return apis.WithinCreate(apis.WithUserInfo(ctx, &authenticationv1.UserInfo{Username: user1}))
+			},
+			setup: func(ctx context.Context, r *Resource) {
+				r.Annotations = map[string]string{}
+			},
+			expectedAnnotations: map[string]string{
+				creatorAnnotation:      user1,
+				lastModifierAnnotation: user1,
+			},
+		},
+		{
+			name: "test create (should override user info annotations when they are present)",
+			configureContext: func(ctx context.Context) context.Context {
+				return apis.WithinCreate(apis.WithUserInfo(ctx, &authenticationv1.UserInfo{Username: user1}))
+			},
+			setup: func(ctx context.Context, r *Resource) {
+				r.Annotations = map[string]string{
+					creatorAnnotation:      user2,
+					lastModifierAnnotation: user2,
+				}
+			},
+			expectedAnnotations: map[string]string{
+				creatorAnnotation:      user1,
+				lastModifierAnnotation: user1,
+			},
+		},
+		{
+			name: "test create (should not touch annotations when no user info available)",
+			configureContext: func(ctx context.Context) context.Context {
+				return apis.WithinCreate(ctx)
+			},
+			setup: func(ctx context.Context, r *Resource) {
+			},
+			expectedAnnotations: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := createResource("a name")
+
+			ctx := tc.configureContext(TestContextWithLogger(t))
+
+			tc.setup(ctx, r)
+
+			SetUserInfoAnnotations(r, ctx, "testing.knative.dev")
+
+			if !reflect.DeepEqual(r.Annotations, tc.expectedAnnotations) {
+				t.Logf("Got :  %#v", r.Annotations)
+				t.Logf("Want: %#v", tc.expectedAnnotations)
+				if diff := cmp.Diff(tc.expectedAnnotations, r.Annotations, cmpopts.EquateEmpty()); diff != "" {
+					t.Logf("diff: %v", diff)
+				}
+				t.Fatalf("Annotations don't match")
+			}
+
+		})
+	}
+}
+
+func TestSetUserInfoAnnotationsWhenWithinUpdate(t *testing.T) {
+	tests := []struct {
+		name                string
+		configureContext    func(context.Context, *Resource) context.Context
+		setup               func(context.Context, *Resource)
+		expectedAnnotations map[string]string
+	}{
+		{
+			name: "test update (should add lastModifier annotation when it is not present)",
+			configureContext: func(ctx context.Context, r *Resource) context.Context {
+				return apis.WithinUpdate(apis.WithUserInfo(ctx, &authenticationv1.UserInfo{Username: user1}), r)
+			},
+			setup: func(ctx context.Context, r *Resource) {
+				r.Annotations = map[string]string{
+					creatorAnnotation: user2,
+				}
+				r.Spec.FieldWithDefault = "changing this field"
+			},
+			expectedAnnotations: map[string]string{
+				creatorAnnotation:      user2,
+				lastModifierAnnotation: user1,
+			},
+		},
+		{
+			name: "test update (should update lastModifier annotation when it is present)",
+			configureContext: func(ctx context.Context, r *Resource) context.Context {
+				return apis.WithinUpdate(apis.WithUserInfo(ctx, &authenticationv1.UserInfo{Username: user1}), r)
+			},
+			setup: func(ctx context.Context, r *Resource) {
+				r.Annotations = map[string]string{
+					creatorAnnotation:      user2,
+					lastModifierAnnotation: user2,
+				}
+				r.Spec.FieldWithDefault = "changing this field"
+			},
+			expectedAnnotations: map[string]string{
+				// should not change
+				creatorAnnotation:      user2,
+				lastModifierAnnotation: user1,
+			},
+		},
+		{
+			name: "test update (should not touch annotations when no user info available)",
+			configureContext: func(ctx context.Context, r *Resource) context.Context {
+				return apis.WithinUpdate(ctx, r)
+			},
+			setup: func(ctx context.Context, r *Resource) {
+				// this is not necessary, but let's do this in case the execution flow changes
+				r.Spec.FieldWithDefault = "changing this field"
+			},
+			expectedAnnotations: nil,
+		},
+		{
+			name: "test update (should not touch annotations when nothing in spec is changed)",
+			configureContext: func(ctx context.Context, r *Resource) context.Context {
+				return apis.WithinUpdate(apis.WithUserInfo(ctx, &authenticationv1.UserInfo{Username: user1}), r)
+			},
+			setup: func(ctx context.Context, r *Resource) {
+				// change nothing
+			},
+			expectedAnnotations: map[string]string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := createResource("a name")
+
+			ctx := tc.configureContext(TestContextWithLogger(t), r)
+
+			new := r.DeepCopy()
+
+			tc.setup(ctx, new)
+
+			SetUserInfoAnnotations(new, ctx, "testing.knative.dev")
+
+			if !reflect.DeepEqual(new.Annotations, tc.expectedAnnotations) {
+				t.Logf("Got :  %#v", new.Annotations)
+				t.Logf("Want: %#v", tc.expectedAnnotations)
+				if diff := cmp.Diff(tc.expectedAnnotations, new.Annotations, cmpopts.EquateEmpty()); diff != "" {
+					t.Logf("diff: %v", diff)
+				}
+				t.Fatalf("Annotations don't match")
+			}
+
+		})
+	}
+}

--- a/webhook/user_info_test.go
+++ b/webhook/user_info_test.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	creatorAnnotation      = "testing.knative.dev/creator"
-	lastModifierAnnotation = "testing.knative.dev/lastModifier"
+	creatorAnnotation = "testing.knative.dev/creator"
+	updaterAnnotation = "testing.knative.dev/updater"
 )
 
 func TestSetUserInfoAnnotationsWhenWithinCreate(t *testing.T) {
@@ -49,8 +49,8 @@ func TestSetUserInfoAnnotationsWhenWithinCreate(t *testing.T) {
 				r.Annotations = map[string]string{}
 			},
 			expectedAnnotations: map[string]string{
-				creatorAnnotation:      user1,
-				lastModifierAnnotation: user1,
+				creatorAnnotation: user1,
+				updaterAnnotation: user1,
 			},
 		},
 		{
@@ -60,13 +60,13 @@ func TestSetUserInfoAnnotationsWhenWithinCreate(t *testing.T) {
 			},
 			setup: func(ctx context.Context, r *Resource) {
 				r.Annotations = map[string]string{
-					creatorAnnotation:      user2,
-					lastModifierAnnotation: user2,
+					creatorAnnotation: user2,
+					updaterAnnotation: user2,
 				}
 			},
 			expectedAnnotations: map[string]string{
-				creatorAnnotation:      user1,
-				lastModifierAnnotation: user1,
+				creatorAnnotation: user1,
+				updaterAnnotation: user1,
 			},
 		},
 		{
@@ -111,7 +111,7 @@ func TestSetUserInfoAnnotationsWhenWithinUpdate(t *testing.T) {
 		expectedAnnotations map[string]string
 	}{
 		{
-			name: "test update (should add lastModifier annotation when it is not present)",
+			name: "test update (should add updater annotation when it is not present)",
 			configureContext: func(ctx context.Context, r *Resource) context.Context {
 				return apis.WithinUpdate(apis.WithUserInfo(ctx, &authenticationv1.UserInfo{Username: user1}), r)
 			},
@@ -122,26 +122,26 @@ func TestSetUserInfoAnnotationsWhenWithinUpdate(t *testing.T) {
 				r.Spec.FieldWithDefault = "changing this field"
 			},
 			expectedAnnotations: map[string]string{
-				creatorAnnotation:      user2,
-				lastModifierAnnotation: user1,
+				creatorAnnotation: user2,
+				updaterAnnotation: user1,
 			},
 		},
 		{
-			name: "test update (should update lastModifier annotation when it is present)",
+			name: "test update (should update updater annotation when it is present)",
 			configureContext: func(ctx context.Context, r *Resource) context.Context {
 				return apis.WithinUpdate(apis.WithUserInfo(ctx, &authenticationv1.UserInfo{Username: user1}), r)
 			},
 			setup: func(ctx context.Context, r *Resource) {
 				r.Annotations = map[string]string{
-					creatorAnnotation:      user2,
-					lastModifierAnnotation: user2,
+					creatorAnnotation: user2,
+					updaterAnnotation: user2,
 				}
 				r.Spec.FieldWithDefault = "changing this field"
 			},
 			expectedAnnotations: map[string]string{
 				// should not change
-				creatorAnnotation:      user2,
-				lastModifierAnnotation: user1,
+				creatorAnnotation: user2,
+				updaterAnnotation: user1,
 			},
 		},
 		{

--- a/webhook/user_info_test.go
+++ b/webhook/user_info_test.go
@@ -28,11 +28,6 @@ import (
 	"testing"
 )
 
-const (
-	creatorAnnotation = "testing.knative.dev/creator"
-	updaterAnnotation = "testing.knative.dev/updater"
-)
-
 func TestSetUserInfoAnnotationsWhenWithinCreate(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -48,8 +43,8 @@ func TestSetUserInfoAnnotationsWhenWithinCreate(t *testing.T) {
 			r.Annotations = map[string]string{}
 		},
 		expectedAnnotations: map[string]string{
-			creatorAnnotation: user1,
-			updaterAnnotation: user1,
+			"pkg.knative.dev/creator": user1,
+			"pkg.knative.dev/updater": user1,
 		},
 	}, {
 		name: "test create (should override user info annotations when they are present)",
@@ -58,13 +53,13 @@ func TestSetUserInfoAnnotationsWhenWithinCreate(t *testing.T) {
 		},
 		setup: func(ctx context.Context, r *Resource) {
 			r.Annotations = map[string]string{
-				creatorAnnotation: user2,
-				updaterAnnotation: user2,
+				"pkg.knative.dev/creator": user2,
+				"pkg.knative.dev/updater": user2,
 			}
 		},
 		expectedAnnotations: map[string]string{
-			creatorAnnotation: user1,
-			updaterAnnotation: user1,
+			"pkg.knative.dev/creator": user1,
+			"pkg.knative.dev/updater": user1,
 		},
 	}, {
 		name: "test create (should not touch annotations when no user info available)",
@@ -84,7 +79,7 @@ func TestSetUserInfoAnnotationsWhenWithinCreate(t *testing.T) {
 
 			tc.setup(ctx, r)
 
-			SetUserInfoAnnotations(r, ctx, "testing.knative.dev")
+			SetUserInfoAnnotations(r, ctx, "pkg.knative.dev")
 
 			if !reflect.DeepEqual(r.Annotations, tc.expectedAnnotations) {
 				t.Logf("Got :  %#v", r.Annotations)
@@ -112,13 +107,13 @@ func TestSetUserInfoAnnotationsWhenWithinUpdate(t *testing.T) {
 		},
 		setup: func(ctx context.Context, r *Resource) {
 			r.Annotations = map[string]string{
-				creatorAnnotation: user2,
+				"pkg.knative.dev/creator": user2,
 			}
 			r.Spec.FieldWithDefault = "changing this field"
 		},
 		expectedAnnotations: map[string]string{
-			creatorAnnotation: user2,
-			updaterAnnotation: user1,
+			"pkg.knative.dev/creator": user2,
+			"pkg.knative.dev/updater": user1,
 		},
 	}, {
 		name: "test update (should update updater annotation when it is present)",
@@ -127,15 +122,15 @@ func TestSetUserInfoAnnotationsWhenWithinUpdate(t *testing.T) {
 		},
 		setup: func(ctx context.Context, r *Resource) {
 			r.Annotations = map[string]string{
-				creatorAnnotation: user2,
-				updaterAnnotation: user2,
+				"pkg.knative.dev/creator": user2,
+				"pkg.knative.dev/updater": user2,
 			}
 			r.Spec.FieldWithDefault = "changing this field"
 		},
 		expectedAnnotations: map[string]string{
 			// should not change
-			creatorAnnotation: user2,
-			updaterAnnotation: user1,
+			"pkg.knative.dev/creator": user2,
+			"pkg.knative.dev/updater": user1,
 		},
 	}, {
 		name: "test update (should not touch annotations when no user info available)",
@@ -168,7 +163,7 @@ func TestSetUserInfoAnnotationsWhenWithinUpdate(t *testing.T) {
 
 			tc.setup(ctx, new)
 
-			SetUserInfoAnnotations(new, ctx, "testing.knative.dev")
+			SetUserInfoAnnotations(new, ctx, "pkg.knative.dev")
 
 			if !reflect.DeepEqual(new.Annotations, tc.expectedAnnotations) {
 				t.Logf("Got :  %#v", new.Annotations)

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -555,7 +555,7 @@ func (ac *AdmissionController) mutate(ctx context.Context, req *admissionv1beta1
 
 		s, ok := oldObj.(apis.HasSpec)
 		if ok {
-			apis.SetUserInfoAnnotations(s, ctx, ac.Options.GroupName)
+			SetUserInfoAnnotations(s, ctx, ac.Options.GroupName)
 		}
 
 		if req.SubResource == "" {
@@ -606,7 +606,7 @@ func (ac *AdmissionController) setUserInfoAnnotations(ctx context.Context, patch
 
 	b, a := new.DeepCopyObject().(apis.HasSpec), nh
 
-	apis.SetUserInfoAnnotations(nh, ctx, ac.Options.GroupName)
+	SetUserInfoAnnotations(nh, ctx, ac.Options.GroupName)
 
 	patch, err := duck.CreatePatch(b, a)
 	if err != nil {

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -99,6 +99,9 @@ type ControllerOptions struct {
 	// TLS Client Authentication.
 	// The default value is tls.NoClientCert.
 	ClientAuth tls.ClientAuthType
+
+	// GroupName is the name of the group that is using this webhook.
+	GroupName string
 }
 
 // ResourceCallback defines a signature for resource specific (Route, Configuration, etc.)
@@ -550,6 +553,11 @@ func (ac *AdmissionController) mutate(ctx context.Context, req *admissionv1beta1
 		oldObj = oldObj.DeepCopyObject().(GenericCRD)
 		oldObj.SetDefaults(ctx)
 
+		s, ok := oldObj.(apis.HasSpec)
+		if ok {
+			apis.SetUserInfoAnnotations(s, ctx, ac.Options.GroupName)
+		}
+
 		if req.SubResource == "" {
 			ctx = apis.WithinUpdate(ctx, oldObj)
 		} else {
@@ -568,6 +576,11 @@ func (ac *AdmissionController) mutate(ctx context.Context, req *admissionv1beta1
 		return nil, err
 	}
 
+	if patches, err = ac.setUserInfoAnnotations(ctx, patches, newObj); err != nil {
+		logger.Errorw("Failed the resource user info annotator", zap.Error(err))
+		return nil, err
+	}
+
 	// None of the validators will accept a nil value for newObj.
 	if newObj == nil {
 		return nil, errMissingNewObject
@@ -580,6 +593,26 @@ func (ac *AdmissionController) mutate(ctx context.Context, req *admissionv1beta1
 	}
 
 	return json.Marshal(patches)
+}
+
+func (ac *AdmissionController) setUserInfoAnnotations(ctx context.Context, patches duck.JSONPatch, new GenericCRD) (duck.JSONPatch, error) {
+	if new == nil {
+		return patches, nil
+	}
+	nh, ok := new.(apis.HasSpec)
+	if !ok {
+		return patches, nil
+	}
+
+	b, a := new.DeepCopyObject().(apis.HasSpec), nh
+
+	apis.SetUserInfoAnnotations(nh, ctx, ac.Options.GroupName)
+
+	patch, err := duck.CreatePatch(b, a)
+	if err != nil {
+		return nil, err
+	}
+	return append(patches, patch...), nil
 }
 
 // roundTripPatch generates the JSONPatch that corresponds to round tripping the given bytes through

--- a/webhook/webhook_integration_test.go
+++ b/webhook/webhook_integration_test.go
@@ -179,6 +179,7 @@ func TestValidResponseForResource(t *testing.T) {
 		t.Fatalf("Failed to marshal resource: %s", err)
 	}
 
+	admissionreq.Resource.Group = "pkg.knative.dev"
 	admissionreq.Object.Raw = marshaled
 	rev := &admissionv1beta1.AdmissionReview{
 		Request: admissionreq,
@@ -262,6 +263,7 @@ func TestValidResponseForResourceWithContextDefault(t *testing.T) {
 		t.Fatalf("Failed to marshal resource: %s", err)
 	}
 
+	admissionreq.Resource.Group = "pkg.knative.dev"
 	admissionreq.Object.Raw = marshaled
 	rev := &admissionv1beta1.AdmissionReview{
 		Request: admissionreq,
@@ -362,6 +364,7 @@ func TestInvalidResponseForResource(t *testing.T) {
 		},
 	}
 
+	admissionreq.Resource.Group = "pkg.knative.dev"
 	admissionreq.Object.Raw = marshaled
 
 	rev := &admissionv1beta1.AdmissionReview{

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -172,8 +172,8 @@ func TestAdmitCreates(t *testing.T) {
 			r.TypeMeta.APIVersion = "v1alpha1"
 			r.SetDefaults(ctx)
 			r.Annotations = map[string]string{
-				creatorAnnotation:      user1,
-				lastModifierAnnotation: user1,
+				creatorAnnotation: user1,
+				updaterAnnotation: user1,
 			}
 		},
 		patches: []jsonpatch.JsonPatchOperation{},
@@ -183,8 +183,8 @@ func TestAdmitCreates(t *testing.T) {
 			r.TypeMeta.APIVersion = "v1beta1"
 			r.SetDefaults(ctx)
 			r.Annotations = map[string]string{
-				creatorAnnotation:      user1,
-				lastModifierAnnotation: user1,
+				creatorAnnotation: user1,
+				updaterAnnotation: user1,
 			}
 		},
 		patches: []jsonpatch.JsonPatchOperation{},
@@ -196,8 +196,8 @@ func TestAdmitCreates(t *testing.T) {
 			Operation: "add",
 			Path:      "/metadata/annotations",
 			Value: map[string]interface{}{
-				creatorAnnotation:      user1,
-				lastModifierAnnotation: user1,
+				creatorAnnotation: user1,
+				updaterAnnotation: user1,
 			},
 		}, {
 			Operation: "add",
@@ -221,7 +221,7 @@ func TestAdmitCreates(t *testing.T) {
 			Value:     user1,
 		}, {
 			Operation: "add",
-			Path:      "/metadata/annotations/testing.knative.dev~1lastModifier",
+			Path:      "/metadata/annotations/testing.knative.dev~1updater",
 			Value:     user1,
 		}, {
 			Operation: "add",
@@ -241,8 +241,8 @@ func TestAdmitCreates(t *testing.T) {
 			Operation: "add",
 			Path:      "/metadata/annotations",
 			Value: map[string]interface{}{
-				creatorAnnotation:      user1,
-				lastModifierAnnotation: user1,
+				creatorAnnotation: user1,
+				updaterAnnotation: user1,
 			},
 		}, {
 			Operation: "add",
@@ -264,7 +264,7 @@ func TestAdmitCreates(t *testing.T) {
 			Value:     user1,
 		}, {
 			Operation: "add",
-			Path:      "/metadata/annotations/testing.knative.dev~1lastModifier",
+			Path:      "/metadata/annotations/testing.knative.dev~1updater",
 			Value:     user1,
 		}},
 	}, {
@@ -330,32 +330,32 @@ func TestAdmitUpdates(t *testing.T) {
 			r.SetDefaults(ctx)
 		},
 		mutate: func(ctx context.Context, r *Resource) {
-			// If we don't change anything, the lastModifier
+			// If we don't change anything, the updater
 			// annotation doesn't change.
 		},
 		patches: []jsonpatch.JsonPatchOperation{},
 	}, {
-		name: "test simple update (update lastModifier annotation)",
+		name: "test simple update (update updater annotation)",
 		setup: func(ctx context.Context, r *Resource) {
 			r.SetDefaults(ctx)
 		},
 		mutate: func(ctx context.Context, r *Resource) {
-			// When we change the spec, the lastModifier
+			// When we change the spec, the updater
 			// annotation changes.
 			r.Spec.FieldWithDefault = "not the default"
 		},
 		patches: []jsonpatch.JsonPatchOperation{{
 			Operation: "replace",
-			Path:      "/metadata/annotations/testing.knative.dev~1lastModifier",
+			Path:      "/metadata/annotations/testing.knative.dev~1updater",
 			Value:     user2,
 		}},
 	}, {
-		name: "test simple update (annotation change doesn't change lastModifier)",
+		name: "test simple update (annotation change doesn't change updater)",
 		setup: func(ctx context.Context, r *Resource) {
 			r.SetDefaults(ctx)
 		},
 		mutate: func(ctx context.Context, r *Resource) {
-			// When we change an annotation, the lastModifier doesn't change.
+			// When we change an annotation, the updater doesn't change.
 			r.Annotations["foo"] = "bar"
 		},
 		patches: []jsonpatch.JsonPatchOperation{},
@@ -399,8 +399,8 @@ func TestAdmitUpdates(t *testing.T) {
 			ctx := TestContextWithLogger(t)
 
 			old.Annotations = map[string]string{
-				creatorAnnotation:      user1,
-				lastModifierAnnotation: user1,
+				creatorAnnotation: user1,
+				updaterAnnotation: user1,
 			}
 
 			tc.setup(ctx, old)
@@ -787,8 +787,8 @@ func setUserAnnotation(userC, userU string) jsonpatch.JsonPatchOperation {
 		Operation: "add",
 		Path:      "/metadata/annotations",
 		Value: map[string]interface{}{
-			creatorAnnotation:      userC,
-			lastModifierAnnotation: userU,
+			creatorAnnotation: userC,
+			updaterAnnotation: userU,
 		},
 	}
 }

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -171,8 +171,8 @@ func TestAdmitCreates(t *testing.T) {
 			r.TypeMeta.APIVersion = "v1alpha1"
 			r.SetDefaults(ctx)
 			r.Annotations = map[string]string{
-				creatorAnnotation: user1,
-				updaterAnnotation: user1,
+				"pkg.knative.dev/creator": user1,
+				"pkg.knative.dev/updater": user1,
 			}
 		},
 		patches: []jsonpatch.JsonPatchOperation{},
@@ -182,8 +182,8 @@ func TestAdmitCreates(t *testing.T) {
 			r.TypeMeta.APIVersion = "v1beta1"
 			r.SetDefaults(ctx)
 			r.Annotations = map[string]string{
-				creatorAnnotation: user1,
-				updaterAnnotation: user1,
+				"pkg.knative.dev/creator": user1,
+				"pkg.knative.dev/updater": user1,
 			}
 		},
 		patches: []jsonpatch.JsonPatchOperation{},
@@ -195,8 +195,8 @@ func TestAdmitCreates(t *testing.T) {
 			Operation: "add",
 			Path:      "/metadata/annotations",
 			Value: map[string]interface{}{
-				creatorAnnotation: user1,
-				updaterAnnotation: user1,
+				"pkg.knative.dev/creator": user1,
+				"pkg.knative.dev/updater": user1,
 			},
 		}, {
 			Operation: "add",
@@ -216,11 +216,11 @@ func TestAdmitCreates(t *testing.T) {
 		},
 		patches: []jsonpatch.JsonPatchOperation{{
 			Operation: "add",
-			Path:      "/metadata/annotations/testing.knative.dev~1creator",
+			Path:      "/metadata/annotations/pkg.knative.dev~1creator",
 			Value:     user1,
 		}, {
 			Operation: "add",
-			Path:      "/metadata/annotations/testing.knative.dev~1updater",
+			Path:      "/metadata/annotations/pkg.knative.dev~1updater",
 			Value:     user1,
 		}, {
 			Operation: "add",
@@ -240,8 +240,8 @@ func TestAdmitCreates(t *testing.T) {
 			Operation: "add",
 			Path:      "/metadata/annotations",
 			Value: map[string]interface{}{
-				creatorAnnotation: user1,
-				updaterAnnotation: user1,
+				"pkg.knative.dev/creator": user1,
+				"pkg.knative.dev/updater": user1,
 			},
 		}, {
 			Operation: "add",
@@ -254,16 +254,16 @@ func TestAdmitCreates(t *testing.T) {
 			r.SetDefaults(ctx)
 			// THIS IS NOT WHO IS CREATING IT, IT IS LIES!
 			r.Annotations = map[string]string{
-				creatorAnnotation: user2,
+				"pkg.knative.dev/updater": user2,
 			}
 		},
 		patches: []jsonpatch.JsonPatchOperation{{
 			Operation: "replace",
-			Path:      "/metadata/annotations/testing.knative.dev~1creator",
+			Path:      "/metadata/annotations/pkg.knative.dev~1updater",
 			Value:     user1,
 		}, {
 			Operation: "add",
-			Path:      "/metadata/annotations/testing.knative.dev~1updater",
+			Path:      "/metadata/annotations/pkg.knative.dev~1creator",
 			Value:     user1,
 		}},
 	}, {
@@ -313,7 +313,7 @@ func createCreateResource(ctx context.Context, r *Resource) *admissionv1beta1.Ad
 		panic("failed to marshal resource")
 	}
 	req.Object.Raw = marshaled
-	req.Resource.Group = "testing.knative.dev"
+	req.Resource.Group = "pkg.knative.dev"
 	return req
 }
 
@@ -346,7 +346,7 @@ func TestAdmitUpdates(t *testing.T) {
 		},
 		patches: []jsonpatch.JsonPatchOperation{{
 			Operation: "replace",
-			Path:      "/metadata/annotations/testing.knative.dev~1updater",
+			Path:      "/metadata/annotations/pkg.knative.dev~1updater",
 			Value:     user2,
 		}},
 	}, {
@@ -399,8 +399,8 @@ func TestAdmitUpdates(t *testing.T) {
 			ctx := TestContextWithLogger(t)
 
 			old.Annotations = map[string]string{
-				creatorAnnotation: user1,
-				updaterAnnotation: user1,
+				"pkg.knative.dev/creator": user1,
+				"pkg.knative.dev/updater": user1,
 			}
 
 			tc.setup(ctx, old)
@@ -445,7 +445,7 @@ func createUpdateResource(ctx context.Context, old, new *Resource) *admissionv1b
 		panic("failed to marshal resource")
 	}
 	req.OldObject.Raw = marshaledOld
-	req.Resource.Group = "testing.knative.dev"
+	req.Resource.Group = "pkg.knative.dev"
 	return req
 }
 
@@ -788,8 +788,8 @@ func setUserAnnotation(userC, userU string) jsonpatch.JsonPatchOperation {
 		Operation: "add",
 		Path:      "/metadata/annotations",
 		Value: map[string]interface{}{
-			creatorAnnotation: userC,
-			updaterAnnotation: userU,
+			"pkg.knative.dev/creator": userC,
+			"pkg.knative.dev/updater": userU,
 		},
 	}
 }

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -57,7 +57,6 @@ func newDefaultOptions() ControllerOptions {
 		Port:        443,
 		SecretName:  "webhook-certs",
 		WebhookName: "webhook.knative.dev",
-		GroupName:   "testing.knative.dev",
 	}
 }
 
@@ -314,6 +313,7 @@ func createCreateResource(ctx context.Context, r *Resource) *admissionv1beta1.Ad
 		panic("failed to marshal resource")
 	}
 	req.Object.Raw = marshaled
+	req.Resource.Group = "testing.knative.dev"
 	return req
 }
 
@@ -445,6 +445,7 @@ func createUpdateResource(ctx context.Context, old, new *Resource) *admissionv1b
 		panic("failed to marshal resource")
 	}
 	req.OldObject.Raw = marshaledOld
+	req.Resource.Group = "testing.knative.dev"
 	return req
 }
 


### PR DESCRIPTION
Fixes https://github.com/knative/pkg/issues/457

Moving the user annotation logic done in Knative eventing in https://github.com/knative/eventing/pull/1293 to Knative `pkg`.

Once these changes are merged, the only thing to do at Knative modules is making the resources implement `HasSpec` interface to get them annotated with `abc.knative.dev/creator` and `abc.knative.dev/updater` annotations. See the reason for `HasSpec` interface here: https://github.com/knative/pkg/pull/467#pullrequestreview-250415818

~~I will adapt the tests after I get a quick feedback on the direction.~~
Tests are also adapted.