### PR TITLE
Use cluster-location GCP metadata as the location value

### DIFF
--- a/metrics/gcp_metadata.go
+++ b/metrics/gcp_metadata.go
@@ -28,7 +28,7 @@ func retrieveGCPMetadata() *gcpMetadata {
 	if err == nil && project != "" {
 		gm.project = project
 	}
-	location, err := metadata.Zone()
+	location, err := metadata.InstanceAttributeValue("cluster-location")
 	if err == nil && location != "" {
 		gm.location = location
 	}


### PR DESCRIPTION
Use cluster-location GCP metadata as the location value so that `location` will be region for regional clusters and zone for zonal clusters.