### PR TITLE
Add injection for rbacv1.role

### DIFF
--- a/injection/informers/kubeinformers/rbacv1/role/fake/fake.go
+++ b/injection/informers/kubeinformers/rbacv1/role/fake/fake.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/injection"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory/fake"
+	"github.com/knative/pkg/injection/informers/kubeinformers/rbacv1/role"
+)
+
+var Get = role.Get
+
+func init() {
+	injection.Fake.RegisterInformer(withInformer)
+}
+
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := fake.Get(ctx)
+	inf := f.Rbac().V1().Roles()
+	return context.WithValue(ctx, role.Key{}, inf), inf.Informer()
+}

--- a/injection/informers/kubeinformers/rbacv1/role/fake/fake_test.go
+++ b/injection/informers/kubeinformers/rbacv1/role/fake/fake_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/injection"
+)
+
+func TestGetPanic(t *testing.T) {
+	ctx := context.Background()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Get() should have panicked")
+		}
+	}()
+
+	// Get before registration
+	if empty := Get(ctx); empty != nil {
+		t.Errorf("Unexpected informer: %v", empty)
+	}
+}
+
+func TestRegistration(t *testing.T) {
+	ctx := context.Background()
+
+	// Check how many informers have registered.
+	inffs := injection.Fake.GetInformers()
+	if want, got := 1, len(inffs); want != got {
+		t.Errorf("GetInformers() = %d, wanted %d", want, got)
+	}
+
+	// Setup the informers.
+	var infs []controller.Informer
+	ctx, infs = injection.Fake.SetupInformers(ctx, &rest.Config{})
+
+	// We should see that a single informer was set up.
+	if want, got := 1, len(infs); want != got {
+		t.Errorf("SetupInformers() = %d, wanted %d", want, got)
+	}
+
+	// Get our informer from the context.
+	if inf := Get(ctx); inf == nil {
+		t.Error("Get() = nil, wanted non-nil")
+	}
+}

--- a/injection/informers/kubeinformers/rbacv1/role/role.go
+++ b/injection/informers/kubeinformers/rbacv1/role/role.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package role
+
+import (
+	"context"
+
+	rbacv1 "k8s.io/client-go/informers/rbac/v1"
+
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/injection"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
+	"github.com/knative/pkg/logging"
+)
+
+func init() {
+	injection.Default.RegisterInformer(withInformer)
+}
+
+// Key is used as the key for associating information
+// with a context.Context.
+type Key struct{}
+
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := factory.Get(ctx)
+	inf := f.Rbac().V1().Roles()
+	return context.WithValue(ctx, Key{}, inf), inf.Informer()
+}
+
+// Get extracts the Kubernetes Role Binding informer from the context.
+func Get(ctx context.Context) rbacv1.RoleInformer {
+	untyped := ctx.Value(Key{})
+	if untyped == nil {
+		logging.FromContext(ctx).Panicf(
+			"Unable to fetch %T from context.", (rbacv1.RoleInformer)(nil))
+	}
+	return untyped.(rbacv1.RoleInformer)
+}

--- a/injection/informers/kubeinformers/rbacv1/role/role_test.go
+++ b/injection/informers/kubeinformers/rbacv1/role/role_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package role
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/injection"
+)
+
+func TestGetPanic(t *testing.T) {
+	ctx := context.Background()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Get() should have panicked")
+		}
+	}()
+
+	// Get before registration
+	if empty := Get(ctx); empty != nil {
+		t.Errorf("Unexpected informer: %v", empty)
+	}
+}
+
+func TestRegistration(t *testing.T) {
+	ctx := context.Background()
+
+	// Check how many informers have registered.
+	inffs := injection.Default.GetInformers()
+	if want, got := 1, len(inffs); want != got {
+		t.Errorf("GetInformers() = %d, wanted %d", want, got)
+	}
+
+	// Setup the informers.
+	var infs []controller.Informer
+	ctx, infs = injection.Default.SetupInformers(ctx, &rest.Config{})
+
+	// We should see that a single informer was set up.
+	if want, got := 1, len(infs); want != got {
+		t.Errorf("SetupInformers() = %d, wanted %d", want, got)
+	}
+
+	// Get our informer from the context.
+	if inf := Get(ctx); inf == nil {
+		t.Error("Get() = nil, wanted non-nil")
+	}
+}


### PR DESCRIPTION
Adds injection for rbacv1.role; code adapted from rolebinding which was pre-existing.