### PR TITLE
Enrich the logs streamed in tests with useful information.

### DIFF
--- a/test/logstream/kubelogs.go
+++ b/test/logstream/kubelogs.go
@@ -48,7 +48,7 @@ type logger func(string, ...interface{})
 var _ streamer = (*kubelogs)(nil)
 
 // timeFormat defines a simple timestamp with millisecond granularity
-const timeFormat = "2006-01-02 15:04:05.000"
+const timeFormat = "15:04:05.000"
 
 func (k *kubelogs) init(t *testing.T) {
 	k.keys = make(map[string]logger)
@@ -135,8 +135,13 @@ func (k *kubelogs) handleLine(l string) {
 		if !strings.Contains(line.Key, name) {
 			continue
 		}
-		// 2006-01-02 15:04:05.000 ERROR [route-controller] [default/testroute-xyz] this is my message
-		logf("%s %s [%s] [%s] %s", line.Timestamp.Format(timeFormat), line.Level, line.Controller, line.Key, line.Message)
+		// E 15:04:05.000 [route-controller] [default/testroute-xyz] this is my message
+		logf("%s %s [%s] [%s] %s",
+			strings.ToUpper(string(line.Level[0])),
+			line.Timestamp.Format(timeFormat),
+			line.Controller,
+			line.Key,
+			line.Message)
 	}
 }
 

--- a/test/logstream/kubelogs.go
+++ b/test/logstream/kubelogs.go
@@ -47,6 +47,9 @@ type logger func(string, ...interface{})
 
 var _ streamer = (*kubelogs)(nil)
 
+// timeFormat defines a simple timestamp with millisecond granularity
+const timeFormat = "2006-01-02 15:04:05.000"
+
 func (k *kubelogs) init(t *testing.T) {
 	k.keys = make(map[string]logger)
 
@@ -132,8 +135,8 @@ func (k *kubelogs) handleLine(l string) {
 		if !strings.Contains(line.Key, name) {
 			continue
 		}
-		// TODO(mattmoor): What information do we want to display?
-		logf("[%s] %s", line.Controller, line.Message)
+		// 2006-01-02 15:04:05.000 ERROR [route-controller] [default/testroute-xyz] this is my message
+		logf("%s %s [%s] [%s] %s", line.Timestamp.Format(timeFormat), line.Level, line.Controller, line.Key, line.Message)
 	}
 }
 


### PR DESCRIPTION
- Level is very useful to spot errors at a glance.
- Time is very helpful to be able to order the statements and notice time gaps.
- Key helps identifying which ressource is being reconciled (could be a child resource).

/assign @mattmoor 

Let's discuss here if this is what we want/need for now. Just printing time without ordering things is not ideal, but maybe a good first step?