### PR TITLE
golang format tools

### DIFF
--- a/apis/duck/v1alpha1/condition_set.go
+++ b/apis/duck/v1alpha1/condition_set.go
@@ -23,9 +23,9 @@ import (
 
 	"fmt"
 
-	"knative.dev/pkg/apis"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
 
 // Conditions is the interface for a Resource that implements the getter and

--- a/apis/duck/v1alpha1/condition_set_impl_test.go
+++ b/apis/duck/v1alpha1/condition_set_impl_test.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"knative.dev/pkg/apis"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
 
 // TestStatus is to validate ConditionAccessor interface works

--- a/apis/duck/v1alpha1/condition_type_test.go
+++ b/apis/duck/v1alpha1/condition_type_test.go
@@ -24,9 +24,9 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"knative.dev/pkg/apis"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
 
 func TestIsTrue(t *testing.T) {

--- a/apis/duck/v1alpha1/register.go
+++ b/apis/duck/v1alpha1/register.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"knative.dev/pkg/apis/duck"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/apis/duck"
 )
 
 // SchemeGroupVersion is group version used to register these objects

--- a/apis/duck/v1beta1/register.go
+++ b/apis/duck/v1beta1/register.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
-	"knative.dev/pkg/apis/duck"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/apis/duck"
 )
 
 // SchemeGroupVersion is group version used to register these objects

--- a/apis/duck/v1beta1/status_types_test.go
+++ b/apis/duck/v1beta1/status_types_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"knative.dev/pkg/apis"
 	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
 )
 
 func TestStatusGetCondition(t *testing.T) {

--- a/apis/istio/authentication/v1alpha1/policy_types.go
+++ b/apis/istio/authentication/v1alpha1/policy_types.go
@@ -17,8 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"knative.dev/pkg/apis/istio/common/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis/istio/common/v1alpha1"
 )
 
 // +genclient

--- a/apis/istio/authentication/v1alpha1/register.go
+++ b/apis/istio/authentication/v1alpha1/register.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"knative.dev/pkg/apis/istio/authentication"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/apis/istio/authentication"
 )
 
 // SchemeGroupVersion is group version used to register these objects

--- a/apis/istio/v1alpha3/register.go
+++ b/apis/istio/v1alpha3/register.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"knative.dev/pkg/apis/istio"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/apis/istio"
 )
 
 // SchemeGroupVersion is group version used to register these objects

--- a/apis/istio/v1alpha3/virtualservice_types.go
+++ b/apis/istio/v1alpha3/virtualservice_types.go
@@ -17,8 +17,8 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"knative.dev/pkg/apis/istio/common/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis/istio/common/v1alpha1"
 )
 
 // +genclient

--- a/apis/testing/conditions.go
+++ b/apis/testing/conditions.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
 	duckv1b1 "knative.dev/pkg/apis/duck/v1beta1"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // CheckCondition checks if condition `c` on `cc` has value `cs`.

--- a/cloudevents/client_test.go
+++ b/cloudevents/client_test.go
@@ -29,8 +29,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"knative.dev/pkg/cloudevents"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/pkg/cloudevents"
 )
 
 var (

--- a/codegen/cmd/injection-gen/main.go
+++ b/codegen/cmd/injection-gen/main.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/gengo/args"
 	"k8s.io/klog"
 
+	"github.com/spf13/pflag"
 	generatorargs "knative.dev/pkg/codegen/cmd/injection-gen/args"
 	"knative.dev/pkg/codegen/cmd/injection-gen/generators"
-	"github.com/spf13/pflag"
 )
 
 func main() {

--- a/configmap/testing/configmap.go
+++ b/configmap/testing/configmap.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 
 	"github.com/ghodss/yaml"
-	"knative.dev/pkg/configmap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/pkg/configmap"
 )
 
 // ConfigMapFromTestFile creates a v1.ConfigMap from a YAML file

--- a/controller/stats_reporter.go
+++ b/controller/stats_reporter.go
@@ -21,11 +21,11 @@ import (
 	"errors"
 	"time"
 
-	"knative.dev/pkg/metrics"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	"go.uber.org/zap"
+	"knative.dev/pkg/metrics"
 )
 
 var (

--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"go.uber.org/zap"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
@@ -32,7 +33,6 @@ import (
 	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
-	"go.uber.org/zap"
 )
 
 func Main(component string, ctors ...injection.ControllerConstructor) {

--- a/metrics/record.go
+++ b/metrics/record.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"path"
 
-	"knative.dev/pkg/metrics/metricskey"
 	"go.opencensus.io/stats"
+	"knative.dev/pkg/metrics/metricskey"
 )
 
 // Record decides whether to record one measurement via OpenCensus based on the

--- a/metrics/stackdriver_exporter.go
+++ b/metrics/stackdriver_exporter.go
@@ -18,10 +18,10 @@ import (
 
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource"
-	"knative.dev/pkg/metrics/metricskey"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	"go.uber.org/zap"
+	"knative.dev/pkg/metrics/metricskey"
 )
 
 // customMetricTypePrefix is the metric type prefix for unsupported metrics by

--- a/metrics/stackdriver_exporter_test.go
+++ b/metrics/stackdriver_exporter_test.go
@@ -17,11 +17,11 @@ import (
 	"testing"
 
 	"contrib.go.opencensus.io/exporter/stackdriver"
-	. "knative.dev/pkg/logging/testing"
-	"knative.dev/pkg/metrics/metricskey"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+	. "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/metrics/metricskey"
 )
 
 var (

--- a/reconciler/testing/table.go
+++ b/reconciler/testing/table.go
@@ -25,13 +25,13 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"knative.dev/pkg/controller"
-	"knative.dev/pkg/kmeta"
-	_ "knative.dev/pkg/system/testing" // Setup system.Namespace()
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/kmeta"
+	_ "knative.dev/pkg/system/testing" // Setup system.Namespace()
 )
 
 // TableRow holds a single row of our table test.

--- a/test/clients.go
+++ b/test/clients.go
@@ -22,14 +22,14 @@ import (
 	"fmt"
 	"strings"
 
-	"knative.dev/pkg/test/logging"
-	"knative.dev/pkg/test/spoof"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	k8styped "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"knative.dev/pkg/test/logging"
+	"knative.dev/pkg/test/spoof"
 )
 
 // KubeClient holds instances of interfaces for making requests to kubernetes client.

--- a/test/kube_checks.go
+++ b/test/kube_checks.go
@@ -25,12 +25,12 @@ import (
 	"strings"
 	"time"
 
-	"knative.dev/pkg/test/logging"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8styped "k8s.io/client-go/kubernetes/typed/core/v1"
+	"knative.dev/pkg/test/logging"
 )
 
 const (

--- a/test/logging/logging.go
+++ b/test/logging/logging.go
@@ -28,10 +28,10 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/glog"
-	"knative.dev/pkg/logging"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
 )
 
 const (

--- a/test/monitoring/monitoring.go
+++ b/test/monitoring/monitoring.go
@@ -23,10 +23,10 @@ import (
 	"os/exec"
 	"strings"
 
-	"knative.dev/pkg/test/logging"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/test/logging"
 )
 
 // CheckPortAvailability checks to see if the port is available on the machine.

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -24,12 +24,12 @@ import (
 	"net/http"
 	"time"
 
-	ingress "knative.dev/pkg/test/ingress"
-	"knative.dev/pkg/test/logging"
-	"knative.dev/pkg/test/zipkin"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	ingress "knative.dev/pkg/test/ingress"
+	"knative.dev/pkg/test/logging"
+	"knative.dev/pkg/test/zipkin"
 
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/plugin/ochttp/propagation/b3"

--- a/test/zipkin/util.go
+++ b/test/zipkin/util.go
@@ -25,10 +25,10 @@ import (
 	"net/http"
 	"sync"
 
-	"knative.dev/pkg/test/logging"
-	"knative.dev/pkg/test/monitoring"
 	"go.opencensus.io/trace"
 	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/test/logging"
+	"knative.dev/pkg/test/monitoring"
 )
 
 const (

--- a/testing/inner_default_resource.go
+++ b/testing/inner_default_resource.go
@@ -19,8 +19,8 @@ package testing
 import (
 	"context"
 
-	"knative.dev/pkg/apis"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/testing/resource.go
+++ b/testing/resource.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"fmt"
 
-	"knative.dev/pkg/apis"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/tracing/http_test.go
+++ b/tracing/http_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"knative.dev/pkg/tracing/config"
 	openzipkin "github.com/openzipkin/zipkin-go"
 	zipkinreporter "github.com/openzipkin/zipkin-go/reporter"
 	reporterrecorder "github.com/openzipkin/zipkin-go/reporter/recorder"
+	"knative.dev/pkg/tracing/config"
 )
 
 type fakeWriter struct {

--- a/tracing/opencensus.go
+++ b/tracing/opencensus.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"sync"
 
-	"knative.dev/pkg/tracing/config"
 	zipkinmodel "github.com/openzipkin/zipkin-go/model"
 	zipkinreporter "github.com/openzipkin/zipkin-go/reporter"
 	"go.opencensus.io/exporter/zipkin"
 	"go.opencensus.io/trace"
+	"knative.dev/pkg/tracing/config"
 )
 
 // ConfigOption is the interface for adding additional exporters and configuring opencensus tracing.

--- a/tracing/opencensus_test.go
+++ b/tracing/opencensus_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"knative.dev/pkg/tracing/config"
 	openzipkin "github.com/openzipkin/zipkin-go"
 	zipkinreporter "github.com/openzipkin/zipkin-go/reporter"
 	reporterrecorder "github.com/openzipkin/zipkin-go/reporter/recorder"
 	"go.opencensus.io/trace"
+	"knative.dev/pkg/tracing/config"
 )
 
 func TestOpenCensusTracerGlobalLifecycle(t *testing.T) {

--- a/webhook/user_info_test.go
+++ b/webhook/user_info_test.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	"knative.dev/pkg/apis"
 	. "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/testing"
-	authenticationv1 "k8s.io/api/authentication/v1"
 )
 
 func TestSetUserInfoAnnotationsWhenWithinCreate(t *testing.T) {

--- a/webhook/webhook_deprecated_test.go
+++ b/webhook/webhook_deprecated_test.go
@@ -19,12 +19,12 @@ package webhook
 import (
 	"testing"
 
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	. "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/ptr"
 	. "knative.dev/pkg/testing"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // In strict mode, you are not allowed to set a deprecated filed when doing a Create.

--- a/webhook/webhook_integration_test.go
+++ b/webhook/webhook_integration_test.go
@@ -28,11 +28,11 @@ import (
 	"testing"
 	"time"
 
-	. "knative.dev/pkg/testing"
 	"github.com/mattbaird/jsonpatch"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	. "knative.dev/pkg/testing"
 )
 
 const testTimeout = time.Duration(10 * time.Second)

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"knative.dev/pkg/apis"
 	"github.com/mattbaird/jsonpatch"
 	"go.uber.org/zap"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
@@ -45,6 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	"knative.dev/pkg/apis"
 
 	. "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/testing"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @mattmoor
