### PR TITLE
added limitrange and resourcequota informers

### DIFF
--- a/injection/informers/kubeinformers/corev1/limitrange/fake/fake.go
+++ b/injection/informers/kubeinformers/corev1/limitrange/fake/fake.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/injection/informers/kubeinformers/corev1/limitrange"
+	"knative.dev/pkg/injection/informers/kubeinformers/factory/fake"
+)
+
+var Get = limitrange.Get
+
+func init() {
+	injection.Fake.RegisterInformer(withInformer)
+}
+
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := fake.Get(ctx)
+	inf := f.Core().V1().LimitRanges()
+	return context.WithValue(ctx, limitrange.Key{}, inf), inf.Informer()
+}

--- a/injection/informers/kubeinformers/corev1/limitrange/fake/fake_test.go
+++ b/injection/informers/kubeinformers/corev1/limitrange/fake/fake_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/client-go/rest"
+
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+)
+
+func TestGetPanic(t *testing.T) {
+	ctx := context.Background()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Get() should have panicked")
+		}
+	}()
+
+	// Get before registration
+	if empty := Get(ctx); empty != nil {
+		t.Errorf("Unexpected informer: %v", empty)
+	}
+}
+
+func TestRegistration(t *testing.T) {
+	ctx := context.Background()
+
+	// Check how many informers have registered.
+	inffs := injection.Fake.GetInformers()
+	if want, got := 1, len(inffs); want != got {
+		t.Errorf("GetInformers() = %d, wanted %d", want, got)
+	}
+
+	// Setup the informers.
+	var infs []controller.Informer
+	ctx, infs = injection.Fake.SetupInformers(ctx, &rest.Config{})
+
+	// We should see that a single informer was set up.
+	if want, got := 1, len(infs); want != got {
+		t.Errorf("SetupInformers() = %d, wanted %d", want, got)
+	}
+
+	// Get our informer from the context.
+	if inf := Get(ctx); inf == nil {
+		t.Error("Get() = nil, wanted non-nil")
+	}
+}

--- a/injection/informers/kubeinformers/corev1/limitrange/limitrange.go
+++ b/injection/informers/kubeinformers/corev1/limitrange/limitrange.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package limitrange
+
+import (
+	"context"
+
+	corev1 "k8s.io/client-go/informers/core/v1"
+
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/injection/informers/kubeinformers/factory"
+	"knative.dev/pkg/logging"
+)
+
+func init() {
+	injection.Default.RegisterInformer(withInformer)
+}
+
+// Key is used as the key for associating information
+// with a context.Context.
+type Key struct{}
+
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := factory.Get(ctx)
+	inf := f.Core().V1().LimitRanges()
+	return context.WithValue(ctx, Key{}, inf), inf.Informer()
+}
+
+// Get extracts the Kubernetes ConfigMap informer from the context.
+func Get(ctx context.Context) corev1.LimitRangeInformer {
+	untyped := ctx.Value(Key{})
+	if untyped == nil {
+		logging.FromContext(ctx).Panicf(
+			"Unable to fetch %T from context.", (corev1.LimitRangeInformer)(nil))
+	}
+	return untyped.(corev1.LimitRangeInformer)
+}

--- a/injection/informers/kubeinformers/corev1/limitrange/limitrange_test.go
+++ b/injection/informers/kubeinformers/corev1/limitrange/limitrange_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package limitrange
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/client-go/rest"
+
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+)
+
+func TestGetPanic(t *testing.T) {
+	ctx := context.Background()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Get() should have panicked")
+		}
+	}()
+
+	// Get before registration
+	if empty := Get(ctx); empty != nil {
+		t.Errorf("Unexpected informer: %v", empty)
+	}
+}
+
+func TestRegistration(t *testing.T) {
+	ctx := context.Background()
+
+	// Check how many informers have registered.
+	inffs := injection.Default.GetInformers()
+	if want, got := 1, len(inffs); want != got {
+		t.Errorf("GetInformers() = %d, wanted %d", want, got)
+	}
+
+	// Setup the informers.
+	var infs []controller.Informer
+	ctx, infs = injection.Default.SetupInformers(ctx, &rest.Config{})
+
+	// We should see that a single informer was set up.
+	if want, got := 1, len(infs); want != got {
+		t.Errorf("SetupInformers() = %d, wanted %d", want, got)
+	}
+
+	// Get our informer from the context.
+	if inf := Get(ctx); inf == nil {
+		t.Error("Get() = nil, wanted non-nil")
+	}
+}

--- a/injection/informers/kubeinformers/corev1/resourcequota/fake/fake.go
+++ b/injection/informers/kubeinformers/corev1/resourcequota/fake/fake.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/injection/informers/kubeinformers/corev1/resourcequota"
+	"knative.dev/pkg/injection/informers/kubeinformers/factory/fake"
+)
+
+var Get = resourcequota.Get
+
+func init() {
+	injection.Fake.RegisterInformer(withInformer)
+}
+
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := fake.Get(ctx)
+	inf := f.Core().V1().ResourceQuotas()
+	return context.WithValue(ctx, resourcequota.Key{}, inf), inf.Informer()
+}

--- a/injection/informers/kubeinformers/corev1/resourcequota/fake/fake_test.go
+++ b/injection/informers/kubeinformers/corev1/resourcequota/fake/fake_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/client-go/rest"
+
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+)
+
+func TestGetPanic(t *testing.T) {
+	ctx := context.Background()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Get() should have panicked")
+		}
+	}()
+
+	// Get before registration
+	if empty := Get(ctx); empty != nil {
+		t.Errorf("Unexpected informer: %v", empty)
+	}
+}
+
+func TestRegistration(t *testing.T) {
+	ctx := context.Background()
+
+	// Check how many informers have registered.
+	inffs := injection.Fake.GetInformers()
+	if want, got := 1, len(inffs); want != got {
+		t.Errorf("GetInformers() = %d, wanted %d", want, got)
+	}
+
+	// Setup the informers.
+	var infs []controller.Informer
+	ctx, infs = injection.Fake.SetupInformers(ctx, &rest.Config{})
+
+	// We should see that a single informer was set up.
+	if want, got := 1, len(infs); want != got {
+		t.Errorf("SetupInformers() = %d, wanted %d", want, got)
+	}
+
+	// Get our informer from the context.
+	if inf := Get(ctx); inf == nil {
+		t.Error("Get() = nil, wanted non-nil")
+	}
+}

--- a/injection/informers/kubeinformers/corev1/resourcequota/resourcequota.go
+++ b/injection/informers/kubeinformers/corev1/resourcequota/resourcequota.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcequota
+
+import (
+	"context"
+
+	corev1 "k8s.io/client-go/informers/core/v1"
+
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/injection/informers/kubeinformers/factory"
+	"knative.dev/pkg/logging"
+)
+
+func init() {
+	injection.Default.RegisterInformer(withInformer)
+}
+
+// Key is used as the key for associating information
+// with a context.Context.
+type Key struct{}
+
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := factory.Get(ctx)
+	inf := f.Core().V1().ResourceQuotas()
+	return context.WithValue(ctx, Key{}, inf), inf.Informer()
+}
+
+// Get extracts the Kubernetes ResourceQuota informer from the context.
+func Get(ctx context.Context) corev1.ResourceQuotaInformer {
+	untyped := ctx.Value(Key{})
+	if untyped == nil {
+		logging.FromContext(ctx).Panicf(
+			"Unable to fetch %T from context.", (corev1.ResourceQuotaInformer)(nil))
+	}
+	return untyped.(corev1.ResourceQuotaInformer)
+}

--- a/injection/informers/kubeinformers/corev1/resourcequota/resourcequota_test.go
+++ b/injection/informers/kubeinformers/corev1/resourcequota/resourcequota_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcequota
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/client-go/rest"
+
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+)
+
+func TestGetPanic(t *testing.T) {
+	ctx := context.Background()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Get() should have panicked")
+		}
+	}()
+
+	// Get before registration
+	if empty := Get(ctx); empty != nil {
+		t.Errorf("Unexpected informer: %v", empty)
+	}
+}
+
+func TestRegistration(t *testing.T) {
+	ctx := context.Background()
+
+	// Check how many informers have registered.
+	inffs := injection.Default.GetInformers()
+	if want, got := 1, len(inffs); want != got {
+		t.Errorf("GetInformers() = %d, wanted %d", want, got)
+	}
+
+	// Setup the informers.
+	var infs []controller.Informer
+	ctx, infs = injection.Default.SetupInformers(ctx, &rest.Config{})
+
+	// We should see that a single informer was set up.
+	if want, got := 1, len(infs); want != got {
+		t.Errorf("SetupInformers() = %d, wanted %d", want, got)
+	}
+
+	// Get our informer from the context.
+	if inf := Get(ctx); inf == nil {
+		t.Error("Get() = nil, wanted non-nil")
+	}
+}


### PR DESCRIPTION
These informers are missing from the builtin set and are necessary from some of the controllers we're building for `kf`. Since they're native to K8s we'd like to contribute them upstream so the set becomes more complete.