### PR TITLE
Reducing the log level for github commit to info

### DIFF
--- a/logging/config.go
+++ b/logging/config.go
@@ -66,7 +66,7 @@ func enrichLoggerWithCommitID(logger *zap.SugaredLogger) *zap.SugaredLogger {
 		return logger.With(zap.String(logkey.GitHubCommitID, commmitID))
 	}
 
-	logger.Warnf("Fetch GitHub commit ID from kodata failed: %v", err)
+	logger.Infof("Fetch GitHub commit ID from kodata failed: %v", err)
 	return logger
 }
 


### PR DESCRIPTION
The logger by default attempts to fetch the commit id from kodata.
When that fails log a message with info rather than warning, to
avoid creating spurious warning message when starting applications.

Fixes #505

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>