### PR TITLE
add openapi-gen=true for some structs

### DIFF
--- a/apis/condition_types.go
+++ b/apis/condition_types.go
@@ -55,6 +55,7 @@ const (
 // Conditions defines a readiness condition for a Knative resource.
 // See: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties
 // +k8s:deepcopy-gen=true
+// +k8s:openapi-gen=true
 type Condition struct {
 	// Type of condition.
 	// +required

--- a/apis/duck/v1beta1/status_types.go
+++ b/apis/duck/v1beta1/status_types.go
@@ -36,6 +36,7 @@ var _ duck.Implementable = (*Conditions)(nil)
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +k8s:openapi-gen=true
 
 // KResource is a skeleton type wrapping Conditions in the manner we expect
 // resource writers defining compatible resources to embed it.  We will

--- a/apis/volatile_time.go
+++ b/apis/volatile_time.go
@@ -22,6 +22,7 @@ import (
 )
 
 // VolatileTime wraps metav1.Time
+// +k8s:openapi-gen=true
 type VolatileTime struct {
 	Inner metav1.Time
 }


### PR DESCRIPTION
Since we want to create openapi spec for [Kubeflow KFServing](https://github.com/kubeflow/kfserving/pull/218) that depends on knative, but no "+k8s:openapi-gen=true" comments in the knative structs so that the openapi-gen will not load the knative structs. 

The PR is going to add "// +k8s:openapi-gen=true" comments for some knative structs. Thanks.