### PR TITLE
Change 'updater' to 'lastModifier' in webhook

### DIFF
--- a/webhook/user_info.go
+++ b/webhook/user_info.go
@@ -45,7 +45,7 @@ func SetUserInfoAnnotations(resource apis.HasSpec, ctx context.Context, groupNam
 		annotations := objectMetaAccessor.GetObjectMeta().GetAnnotations()
 		if annotations == nil {
 			annotations = map[string]string{}
-			defer objectMetaAccessor.GetObjectMeta().SetAnnotations(annotations)
+			objectMetaAccessor.GetObjectMeta().SetAnnotations(annotations)
 		}
 
 		if apis.IsInUpdate(ctx) {

--- a/webhook/user_info.go
+++ b/webhook/user_info.go
@@ -31,7 +31,7 @@ const (
 
 	// UpdaterAnnotationSuffix is the suffix of the annotation key to describe
 	// the user who last modified the resource.
-	UpdaterAnnotationSuffix = "/updater"
+	UpdaterAnnotationSuffix = "/lastModifier"
 )
 
 // SetUserInfoAnnotations sets creator and updater annotations on a resource.

--- a/webhook/user_info_test.go
+++ b/webhook/user_info_test.go
@@ -44,8 +44,8 @@ func TestSetUserInfoAnnotationsWhenWithinCreate(t *testing.T) {
 			r.Annotations = map[string]string{}
 		},
 		expectedAnnotations: map[string]string{
-			"pkg.knative.dev/creator": user1,
-			"pkg.knative.dev/updater": user1,
+			"pkg.knative.dev/creator":      user1,
+			"pkg.knative.dev/lastModifier": user1,
 		},
 	}, {
 		name: "test create (should override user info annotations when they are present)",
@@ -54,13 +54,13 @@ func TestSetUserInfoAnnotationsWhenWithinCreate(t *testing.T) {
 		},
 		setup: func(ctx context.Context, r *Resource) {
 			r.Annotations = map[string]string{
-				"pkg.knative.dev/creator": user2,
-				"pkg.knative.dev/updater": user2,
+				"pkg.knative.dev/creator":      user2,
+				"pkg.knative.dev/lastModifier": user2,
 			}
 		},
 		expectedAnnotations: map[string]string{
-			"pkg.knative.dev/creator": user1,
-			"pkg.knative.dev/updater": user1,
+			"pkg.knative.dev/creator":      user1,
+			"pkg.knative.dev/lastModifier": user1,
 		},
 	}, {
 		name: "test create (should not touch annotations when no user info available)",
@@ -113,8 +113,8 @@ func TestSetUserInfoAnnotationsWhenWithinUpdate(t *testing.T) {
 			r.Spec.FieldWithDefault = "changing this field"
 		},
 		expectedAnnotations: map[string]string{
-			"pkg.knative.dev/creator": user2,
-			"pkg.knative.dev/updater": user1,
+			"pkg.knative.dev/creator":      user2,
+			"pkg.knative.dev/lastModifier": user1,
 		},
 	}, {
 		name: "test update (should update updater annotation when it is present)",
@@ -123,15 +123,15 @@ func TestSetUserInfoAnnotationsWhenWithinUpdate(t *testing.T) {
 		},
 		setup: func(ctx context.Context, r *Resource) {
 			r.Annotations = map[string]string{
-				"pkg.knative.dev/creator": user2,
-				"pkg.knative.dev/updater": user2,
+				"pkg.knative.dev/creator":      user2,
+				"pkg.knative.dev/lastModifier": user2,
 			}
 			r.Spec.FieldWithDefault = "changing this field"
 		},
 		expectedAnnotations: map[string]string{
 			// should not change
-			"pkg.knative.dev/creator": user2,
-			"pkg.knative.dev/updater": user1,
+			"pkg.knative.dev/creator":      user2,
+			"pkg.knative.dev/lastModifier": user1,
 		},
 	}, {
 		name: "test update (should not touch annotations when no user info available)",

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -220,7 +220,7 @@ func TestAdmitCreates(t *testing.T) {
 			Value:     user1,
 		}, {
 			Operation: "add",
-			Path:      "/metadata/annotations/pkg.knative.dev~1updater",
+			Path:      "/metadata/annotations/pkg.knative.dev~1lastModifier",
 			Value:     user1,
 		}, {
 			Operation: "add",
@@ -259,7 +259,7 @@ func TestAdmitCreates(t *testing.T) {
 		},
 		patches: []jsonpatch.JsonPatchOperation{{
 			Operation: "replace",
-			Path:      "/metadata/annotations/pkg.knative.dev~1updater",
+			Path:      "/metadata/annotations/pkg.knative.dev~1lastModifier",
 			Value:     user1,
 		}, {
 			Operation: "add",
@@ -346,7 +346,7 @@ func TestAdmitUpdates(t *testing.T) {
 		},
 		patches: []jsonpatch.JsonPatchOperation{{
 			Operation: "replace",
-			Path:      "/metadata/annotations/pkg.knative.dev~1updater",
+			Path:      "/metadata/annotations/pkg.knative.dev~1lastModifier",
 			Value:     user2,
 		}},
 	}, {

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -171,8 +171,8 @@ func TestAdmitCreates(t *testing.T) {
 			r.TypeMeta.APIVersion = "v1alpha1"
 			r.SetDefaults(ctx)
 			r.Annotations = map[string]string{
-				"pkg.knative.dev/creator": user1,
-				"pkg.knative.dev/updater": user1,
+				"pkg.knative.dev/creator":      user1,
+				"pkg.knative.dev/lastModifier": user1,
 			}
 		},
 		patches: []jsonpatch.JsonPatchOperation{},
@@ -182,8 +182,8 @@ func TestAdmitCreates(t *testing.T) {
 			r.TypeMeta.APIVersion = "v1beta1"
 			r.SetDefaults(ctx)
 			r.Annotations = map[string]string{
-				"pkg.knative.dev/creator": user1,
-				"pkg.knative.dev/updater": user1,
+				"pkg.knative.dev/creator":      user1,
+				"pkg.knative.dev/lastModifier": user1,
 			}
 		},
 		patches: []jsonpatch.JsonPatchOperation{},
@@ -195,8 +195,8 @@ func TestAdmitCreates(t *testing.T) {
 			Operation: "add",
 			Path:      "/metadata/annotations",
 			Value: map[string]interface{}{
-				"pkg.knative.dev/creator": user1,
-				"pkg.knative.dev/updater": user1,
+				"pkg.knative.dev/creator":      user1,
+				"pkg.knative.dev/lastModifier": user1,
 			},
 		}, {
 			Operation: "add",
@@ -240,8 +240,8 @@ func TestAdmitCreates(t *testing.T) {
 			Operation: "add",
 			Path:      "/metadata/annotations",
 			Value: map[string]interface{}{
-				"pkg.knative.dev/creator": user1,
-				"pkg.knative.dev/updater": user1,
+				"pkg.knative.dev/creator":      user1,
+				"pkg.knative.dev/lastModifier": user1,
 			},
 		}, {
 			Operation: "add",
@@ -254,7 +254,7 @@ func TestAdmitCreates(t *testing.T) {
 			r.SetDefaults(ctx)
 			// THIS IS NOT WHO IS CREATING IT, IT IS LIES!
 			r.Annotations = map[string]string{
-				"pkg.knative.dev/updater": user2,
+				"pkg.knative.dev/lastModifier": user2,
 			}
 		},
 		patches: []jsonpatch.JsonPatchOperation{{
@@ -399,8 +399,8 @@ func TestAdmitUpdates(t *testing.T) {
 			ctx := TestContextWithLogger(t)
 
 			old.Annotations = map[string]string{
-				"pkg.knative.dev/creator": user1,
-				"pkg.knative.dev/updater": user1,
+				"pkg.knative.dev/creator":      user1,
+				"pkg.knative.dev/lastModifier": user1,
 			}
 
 			tc.setup(ctx, old)
@@ -788,8 +788,8 @@ func setUserAnnotation(userC, userU string) jsonpatch.JsonPatchOperation {
 		Operation: "add",
 		Path:      "/metadata/annotations",
 		Value: map[string]interface{}{
-			"pkg.knative.dev/creator": userC,
-			"pkg.knative.dev/updater": userU,
+			"pkg.knative.dev/creator":      userC,
+			"pkg.knative.dev/lastModifier": userU,
 		},
 	}
 }


### PR DESCRIPTION
Both eventing and serving curretly use lastModifier. Nothing seems to
implement the pkg 'HasSpec' interface yet so this should be a safe
change. This brings the annotation in-line with currentb behavior

Fixes #511