### PR TITLE
Improve kmp.ShortDiff when one object is invalid

### DIFF
--- a/kmp/reporters.go
+++ b/kmp/reporters.go
@@ -111,12 +111,24 @@ func (r *ShortDiffReporter) Report(rs cmp.Result) {
 	t := cur.Type()
 	var diff string
 	// Prefix struct values with the types to add clarity in output
-	if !vx.IsValid() || !vy.IsValid() {
-		r.err = fmt.Errorf("Unable to diff %+v and %+v on path %#v", vx, vy, r.path)
+	if !vx.IsValid() && !vy.IsValid() {
+		r.err = fmt.Errorf("Both are invalid on path %#v", r.path)
 	} else if t.Kind() == reflect.Struct {
-		diff = fmt.Sprintf("%#v:\n\t-: %+v: \"%+v\"\n\t+: %+v: \"%+v\"\n", r.path, t, vx, t, vy)
+		diff = fmt.Sprintf("%#v:\n", r.path)
+		if vx.IsValid() {
+			diff += fmt.Sprintf("\t-: %+v: \"%+v\"\n", t, vx)
+		}
+		if vy.IsValid() {
+			diff += fmt.Sprintf("\t+: %+v: \"%+v\"\n", t, vy)
+		}
 	} else {
-		diff = fmt.Sprintf("%#v:\n\t-: \"%+v\"\n\t+: \"%+v\"\n", r.path, vx, vy)
+		diff = fmt.Sprintf("%#v:\n", r.path)
+		if vx.IsValid() {
+			diff += fmt.Sprintf("\t-: \"%+v\"\n", vx)
+		}
+		if vy.IsValid() {
+			diff += fmt.Sprintf("\t+: \"%+v\"\n", vy)
+		}
 	}
 	r.diffs = append(r.diffs, diff)
 }

--- a/kmp/reporters.go
+++ b/kmp/reporters.go
@@ -112,25 +112,27 @@ func (r *ShortDiffReporter) Report(rs cmp.Result) {
 	var diff string
 	// Prefix struct values with the types to add clarity in output
 	if !vx.IsValid() && !vy.IsValid() {
-		r.err = fmt.Errorf("Both are invalid on path %#v", r.path)
-	} else if t.Kind() == reflect.Struct {
-		diff = fmt.Sprintf("%#v:\n", r.path)
-		if vx.IsValid() {
-			diff += fmt.Sprintf("\t-: %+v: \"%+v\"\n", t, vx)
-		}
-		if vy.IsValid() {
-			diff += fmt.Sprintf("\t+: %+v: \"%+v\"\n", t, vy)
-		}
+		r.err = fmt.Errorf("Unable to diff %+v and %+v on path %#v", vx, vy, r.path)
 	} else {
 		diff = fmt.Sprintf("%#v:\n", r.path)
 		if vx.IsValid() {
-			diff += fmt.Sprintf("\t-: \"%+v\"\n", vx)
+			diff += r.diffString("-", t, vx)
 		}
 		if vy.IsValid() {
-			diff += fmt.Sprintf("\t+: \"%+v\"\n", vy)
+			diff += r.diffString("+", t, vy)
 		}
 	}
 	r.diffs = append(r.diffs, diff)
+}
+
+func (r *ShortDiffReporter) diffString(diffType string, t reflect.Type, v reflect.Value) string {
+	var diff string
+	if t.Kind() == reflect.Struct {
+		diff = fmt.Sprintf("\t%s: %+v: \"%+v\"\n", diffType, t, v)
+	} else {
+		diff = fmt.Sprintf("\t%s: \"%+v\"\n", diffType, v)
+	}
+	return diff
 }
 
 // PopStep implements the cmp.Reporter.

--- a/kmp/reporters.go
+++ b/kmp/reporters.go
@@ -126,13 +126,11 @@ func (r *ShortDiffReporter) Report(rs cmp.Result) {
 }
 
 func (r *ShortDiffReporter) diffString(diffType string, t reflect.Type, v reflect.Value) string {
-	var diff string
 	if t.Kind() == reflect.Struct {
-		diff = fmt.Sprintf("\t%s: %+v: \"%+v\"\n", diffType, t, v)
+		return fmt.Sprintf("\t%s: %+v: \"%+v\"\n", diffType, t, v)
 	} else {
-		diff = fmt.Sprintf("\t%s: \"%+v\"\n", diffType, v)
+		return fmt.Sprintf("\t%s: \"%+v\"\n", diffType, v)
 	}
-	return diff
 }
 
 // PopStep implements the cmp.Reporter.

--- a/kmp/reporters_test.go
+++ b/kmp/reporters_test.go
@@ -329,6 +329,15 @@ func TestImmutableReporter(t *testing.T) {
 		want: `{map[string]string}["Foo"]:
 	-: "Bar"
 `,
+	}, {
+		name: "Map add a key",
+		x:    map[string]string{},
+		y: map[string]string{
+			"Foo": "Bar",
+		},
+		want: `{map[string]string}["Foo"]:
+	+: "Bar"
+`,
 	}}
 
 	for _, test := range tests {

--- a/kmp/reporters_test.go
+++ b/kmp/reporters_test.go
@@ -217,7 +217,9 @@ func TestImmutableReporter(t *testing.T) {
 		x: testStruct{
 			StringField: "foo",
 		},
-		expectErr: true,
+		want: `root:
+	-: "{A: StringField:foo IntField:0 StructField:{ChildString: ChildInt:0} Omit: Ignore: Dash: MultiComma:}"
+`,
 	}, {
 		name: "Single character field name",
 		x: testStruct{

--- a/kmp/reporters_test.go
+++ b/kmp/reporters_test.go
@@ -320,6 +320,15 @@ func TestImmutableReporter(t *testing.T) {
 		},
 		want: "",
 		opts: []cmp.Option{cmpopts.IgnoreUnexported(privateStruct{})},
+	}, {
+		name: "Map with a missing key",
+		x: map[string]string{
+			"Foo": "Bar",
+		},
+		y: map[string]string{},
+		want: `{map[string]string}["Foo"]:
+	-: "Bar"
+`,
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixed knative/serving#4655

* Both are invalid throw an error

* If x is invalid and y is valid, add '+' prefix and no '-'

* If x is valid and y is invalid, add '-' prefix and not '+'
