### PR TITLE
Add validation for creator and lastModifier annotation

### DIFF
--- a/apis/metadata_validation.go
+++ b/apis/metadata_validation.go
@@ -19,8 +19,19 @@ package apis
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// CreatorAnnotationSuffix is the suffix of the annotation key to describe
+	// the user that created the resource.
+	CreatorAnnotationSuffix = "/creator"
+
+	// UpdaterAnnotationSuffix is the suffix of the annotation key to describe
+	// the user who last modified the resource.
+	UpdaterAnnotationSuffix = "/lastModifier"
 )
 
 // ValidateObjectMetadata validates that `metadata` stanza of the
@@ -59,4 +70,19 @@ func ValidateObjectMetadata(meta metav1.Object) *FieldError {
 	}
 
 	return nil
+}
+
+// ValidateCreatorAndModifier validates `metadata.annotation`
+func ValidateCreatorAndModifier(oldSpec, newSpec interface{}, oldAnnotation, newAnnotation map[string]string, groupName string) *FieldError {
+	var errs *FieldError
+	if oldAnnotation[groupName+CreatorAnnotationSuffix] != newAnnotation[groupName+CreatorAnnotationSuffix] {
+		errs = errs.Also(&FieldError{
+			Message: "annotation value is immutable",
+			Paths:   []string{groupName + CreatorAnnotationSuffix},
+		})
+	}
+	if equality.Semantic.DeepEqual(oldSpec, newSpec) && oldAnnotation[groupName+UpdaterAnnotationSuffix] != newAnnotation[groupName+UpdaterAnnotationSuffix] {
+		errs = errs.Also(ErrInvalidValue(newAnnotation[groupName+UpdaterAnnotationSuffix], groupName+UpdaterAnnotationSuffix))
+	}
+	return errs
 }

--- a/apis/metadata_validation.go
+++ b/apis/metadata_validation.go
@@ -81,6 +81,7 @@ func ValidateCreatorAndModifier(oldSpec, newSpec interface{}, oldAnnotation, new
 			Paths:   []string{groupName + CreatorAnnotationSuffix},
 		})
 	}
+
 	if equality.Semantic.DeepEqual(oldSpec, newSpec) && oldAnnotation[groupName+UpdaterAnnotationSuffix] != newAnnotation[groupName+UpdaterAnnotationSuffix] {
 		errs = errs.Also(ErrInvalidValue(newAnnotation[groupName+UpdaterAnnotationSuffix], groupName+UpdaterAnnotationSuffix))
 	}

--- a/webhook/user_info.go
+++ b/webhook/user_info.go
@@ -24,16 +24,6 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-const (
-	// CreatorAnnotationSuffix is the suffix of the annotation key to describe
-	// the user that created the resource.
-	CreatorAnnotationSuffix = "/creator"
-
-	// UpdaterAnnotationSuffix is the suffix of the annotation key to describe
-	// the user who last modified the resource.
-	UpdaterAnnotationSuffix = "/lastModifier"
-)
-
 // SetUserInfoAnnotations sets creator and updater annotations on a resource.
 func SetUserInfoAnnotations(resource apis.HasSpec, ctx context.Context, groupName string) {
 	if ui := apis.GetUserInfo(ctx); ui != nil {
@@ -53,10 +43,10 @@ func SetUserInfoAnnotations(resource apis.HasSpec, ctx context.Context, groupNam
 			if equality.Semantic.DeepEqual(old.GetUntypedSpec(), resource.GetUntypedSpec()) {
 				return
 			}
-			annotations[groupName+UpdaterAnnotationSuffix] = ui.Username
+			annotations[groupName+apis.UpdaterAnnotationSuffix] = ui.Username
 		} else {
-			annotations[groupName+CreatorAnnotationSuffix] = ui.Username
-			annotations[groupName+UpdaterAnnotationSuffix] = ui.Username
+			annotations[groupName+apis.CreatorAnnotationSuffix] = ui.Username
+			annotations[groupName+apis.UpdaterAnnotationSuffix] = ui.Username
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/4648

`ValidateCreatorAndModifier` function will be used by all the CRD's which will be created by user like
Service, Configuration, Route to validate `/creator` and `/lastModifier` annotation

/assign @markusthoemmes @dgerd 