### PR TITLE
Add ReconcileVirtualService function to pkg

### DIFF
--- a/reconciler/resources/istio/virtualservice.go
+++ b/reconciler/resources/istio/virtualservice.go
@@ -1,0 +1,59 @@
+package istio
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"knative.dev/pkg/apis/istio/v1alpha3"
+	sharedclientset "knative.dev/pkg/client/clientset/versioned"
+	istiolisters "knative.dev/pkg/client/listers/istio/v1alpha3"
+	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/logging"
+)
+
+// VirtualServiceAccessor is an accessor to get/write VirtualService.
+type VirtualServiceAccessor struct {
+	SharedClientSet      sharedclientset.Interface
+	VirtualServiceLister istiolisters.VirtualServiceLister
+}
+
+// ReconcileVirtualService reconciles VirtualService to the desired states.
+func (v *VirtualServiceAccessor) ReconcileVirtualService(ctx context.Context, owner kmeta.Accessor, desired *v1alpha3.VirtualService, recorder record.EventRecorder) (*v1alpha3.VirtualService, error) {
+	logger := logging.FromContext(ctx)
+	ns := desired.Namespace
+	name := desired.Name
+
+	vs, err := v.VirtualServiceLister.VirtualServices(ns).Get(name)
+	if apierrs.IsNotFound(err) {
+		_, err = v.SharedClientSet.NetworkingV1alpha3().VirtualServices(ns).Create(desired)
+		if err != nil {
+			logger.Errorw("Failed to create VirtualService", zap.Error(err))
+			recorder.Eventf(owner, corev1.EventTypeWarning, "CreationFailed",
+				"Failed to create VirtualService %q/%q: %v", ns, name, err)
+			return nil, err
+		}
+		recorder.Eventf(owner, corev1.EventTypeNormal, "Created", "Created VirtualService %q", desired.Name)
+	} else if err != nil {
+		return nil, err
+	} else if !metav1.IsControlledBy(vs, owner) {
+		// Surface an error in the ClusterIngress's status, and return an error.
+		return nil, fmt.Errorf("ingress: %q does not own VirtualService: %q", owner.GetName(), name)
+	} else if !equality.Semantic.DeepEqual(vs.Spec, desired.Spec) {
+		// Don't modify the informers copy
+		existing := vs.DeepCopy()
+		existing.Spec = desired.Spec
+		vs, err = v.SharedClientSet.NetworkingV1alpha3().VirtualServices(ns).Update(existing)
+		if err != nil {
+			logger.Errorw("Failed to update VirtualService", zap.Error(err))
+			return nil, err
+		}
+		recorder.Eventf(owner, corev1.EventTypeNormal, "Updated", "Updated status for VirtualService %q/%q", ns, name)
+	}
+	return vs, nil
+}

--- a/reconciler/resources/istio/virtualservice_test.go
+++ b/reconciler/resources/istio/virtualservice_test.go
@@ -1,0 +1,147 @@
+package istio
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis/istio/v1alpha3"
+	sharedclientset "knative.dev/pkg/client/clientset/versioned"
+	sharedfake "knative.dev/pkg/client/clientset/versioned/fake"
+	informers "knative.dev/pkg/client/informers/externalversions"
+	fakesharedclient "knative.dev/pkg/client/injection/client/fake"
+	"knative.dev/pkg/controller"
+	logtesting "knative.dev/pkg/logging/testing"
+
+	. "knative.dev/pkg/reconciler/testing"
+)
+
+var ownerObj = &corev1.Service{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "ownerObj",
+		Namespace: "default",
+		UID:       "abcd",
+	},
+}
+var isControl = true
+var ownerRef = metav1.OwnerReference{
+	Kind:       ownerObj.Kind,
+	Name:       ownerObj.Name,
+	UID:        ownerObj.UID,
+	Controller: &isControl,
+}
+
+var origin = &v1alpha3.VirtualService{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:            "vs",
+		Namespace:       "default",
+		OwnerReferences: []metav1.OwnerReference{ownerRef},
+	},
+	Spec: v1alpha3.VirtualServiceSpec{
+		Hosts: []string{"origin.example.com"},
+	},
+}
+
+var desired = &v1alpha3.VirtualService{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:            "vs",
+		Namespace:       "default",
+		OwnerReferences: []metav1.OwnerReference{ownerRef},
+	},
+	Spec: v1alpha3.VirtualServiceSpec{
+		Hosts: []string{"desired.example.com"},
+	},
+}
+
+func TestReconcileVirtualService_Create(t *testing.T) {
+	defer logtesting.ClearAll()
+	ctx, _ := SetupFakeContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	grp := errgroup.Group{}
+	defer func() {
+		cancel()
+		if err := grp.Wait(); err != nil {
+			t.Errorf("Wait() = %v", err)
+		}
+	}()
+
+	sharedClient := fakesharedclient.Get(ctx)
+
+	h := NewHooks()
+	h.OnCreate(&sharedClient.Fake, "virtualservices", func(obj runtime.Object) HookResult {
+		got := obj.(*v1alpha3.VirtualService)
+		if diff := cmp.Diff(got, desired); diff != "" {
+			t.Logf("Unexpected Gateway (-want, +got): %v", diff)
+			return HookIncomplete
+		}
+		return HookComplete
+	})
+
+	accessor := setup(ctx, []*v1alpha3.VirtualService{}, sharedClient, t)
+	recorder := controller.GetEventRecorder(ctx)
+	accessor.ReconcileVirtualService(ctx, ownerObj, desired, recorder)
+
+	if err := h.WaitForHooks(3 * time.Second); err != nil {
+		t.Errorf("Failed to Reconcile VirtualService: %v", err)
+	}
+}
+
+func TestReconcileVirtualService_Update(t *testing.T) {
+	defer logtesting.ClearAll()
+	ctx, _ := SetupFakeContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	grp := errgroup.Group{}
+	defer func() {
+		cancel()
+		if err := grp.Wait(); err != nil {
+			t.Errorf("Wait() = %v", err)
+		}
+	}()
+
+	sharedClient := fakesharedclient.Get(ctx)
+	accessor := setup(ctx, []*v1alpha3.VirtualService{origin}, sharedClient, t)
+
+	h := NewHooks()
+	h.OnUpdate(&sharedClient.Fake, "virtualservices", func(obj runtime.Object) HookResult {
+		got := obj.(*v1alpha3.VirtualService)
+		if diff := cmp.Diff(got, desired); diff != "" {
+			t.Logf("Unexpected Gateway (-want, +got): %v", diff)
+			return HookIncomplete
+		}
+		return HookComplete
+	})
+
+	recorder := controller.GetEventRecorder(ctx)
+	accessor.ReconcileVirtualService(ctx, ownerObj, desired, recorder)
+
+	if err := h.WaitForHooks(3 * time.Second); err != nil {
+		t.Errorf("Failed to Reconcile VirtualService: %v", err)
+	}
+}
+
+func setup(ctx context.Context, vses []*v1alpha3.VirtualService,
+	sharedClient sharedclientset.Interface, t *testing.T) *VirtualServiceAccessor {
+
+	fake := sharedfake.NewSimpleClientset()
+	informer := informers.NewSharedInformerFactory(fake, 0)
+	vsInformer := informer.Networking().V1alpha3().VirtualServices()
+
+	for _, vs := range vses {
+		fake.NetworkingV1alpha3().VirtualServices(vs.Namespace).Create(vs)
+		vsInformer.Informer().GetIndexer().Add(vs)
+	}
+
+	if err := controller.StartInformers(ctx.Done(), vsInformer.Informer()); err != nil {
+		t.Fatalf("failed to start virtualservice informer: %v", err)
+	}
+
+	return &VirtualServiceAccessor{
+		SharedClientSet:      sharedClient,
+		VirtualServiceLister: vsInformer.Lister(),
+	}
+}


### PR DESCRIPTION
The `ReconcileVirtualService` is copied from https://github.com/knative/serving/blob/9599eb48d62f4ac0884b046969e5bc85760fb41b/pkg/reconciler/ingress/ingress.go#L356.

And I will use `ReconcileVirtualService` to replace it once we check in this PR.