### PR TITLE
Test for FieldError.Also(nil)

### DIFF
--- a/apis/field_error_test.go
+++ b/apis/field_error_test.go
@@ -599,6 +599,18 @@ not without this: bar.C`,
 	}
 }
 
+func TestAlsoNil(t *testing.T) {
+	errs := &FieldError{
+		Message: "original",
+		Paths:   []string{"foo"},
+	}
+	errs = errs.Also(nil)
+
+	if got, want := errs.Error(), "original: foo"; got != want {
+		t.Errorf("TestAlsoNil: Also(nil).Error() = %v, wanted %v", got, want)
+	}
+}
+
 func TestMergeFieldErrors(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Adding a nil error to a FieldError should be a NOP and there was no test for it. The implementation is already correct; this just adds a test for it.