### PR TITLE
This prints better log when CM is loaded.

### DIFF
--- a/configmap/store.go
+++ b/configmap/store.go
@@ -166,7 +166,7 @@ func (s *UntypedStore) OnConfigChanged(c *corev1.ConfigMap) {
 		return
 	}
 
-	s.logger.Infof("%s config %q config was added or updated: %v", s.name, name, result)
+	s.logger.Infof("%s config %q config was added or updated: %#v", s.name, name, result)
 	storage.Store(result)
 
 	go func() {


### PR DESCRIPTION
Now we just print a struct, which is unparseable.
With this change in hand each field will have a name.

/assign @mattmoor