### PR TITLE
add openapi-gen=true for istion struct

### DIFF
--- a/apis/istio/v1alpha3/destinationrule_types.go
+++ b/apis/istio/v1alpha3/destinationrule_types.go
@@ -23,6 +23,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // DestinationRule
+// +k8s:openapi-gen=true
 type DestinationRule struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -99,6 +100,7 @@ type DestinationRule struct {
 //       loadBalancer:
 //         simple: ROUND_ROBIN
 //
+// +k8s:openapi-gen=true
 type DestinationRuleSpec struct {
 	// REQUIRED. The name of a service from the service registry. Service
 	// names are looked up from the platform's service registry (e.g.,
@@ -129,6 +131,7 @@ type DestinationRuleSpec struct {
 
 // Traffic policies to apply for a specific destination, across all
 // destination ports. See DestinationRule for examples.
+// +k8s:openapi-gen=true
 type TrafficPolicy struct {
 
 	// Settings controlling the load balancer algorithms.
@@ -152,6 +155,7 @@ type TrafficPolicy struct {
 }
 
 // Traffic policies that apply to specific ports of the service
+// +k8s:openapi-gen=true
 type PortTrafficPolicy struct {
 	// Specifies the port name or number of a port on the destination service
 	// on which this policy is being applied.
@@ -203,6 +207,7 @@ type PortTrafficPolicy struct {
 //
 // **Note:** Policies specified for subsets will not take effect until
 // a route rule explicitly sends traffic to this subset.
+// +k8s:openapi-gen=true
 type Subset struct {
 	// REQUIRED. Name of the subset. The service name and the subset name can
 	// be used for traffic splitting in a route rule.
@@ -253,6 +258,7 @@ type Subset struct {
 //          httpCookie:
 //            name: user
 //            ttl: 0s
+// +k8s:openapi-gen=true
 type LoadBalancerSettings struct {
 	// It is required to specify exactly one of the fields:
 	// Simple or ConsistentHash
@@ -291,6 +297,7 @@ const (
 // connections. The affinity to a particular destination host will be
 // lost when one or more hosts are added/removed from the destination
 // service.
+// +k8s:openapi-gen=true
 type ConsistentHashLB struct {
 
 	// It is required to specify exactly one of the fields as hash key:
@@ -315,6 +322,7 @@ type ConsistentHashLB struct {
 // Describes a HTTP cookie that will be used as the hash key for the
 // Consistent Hash load balancer. If the cookie is not present, it will
 // be generated.
+// +k8s:openapi-gen=true
 type HTTPCookie struct {
 	// REQUIRED. Name of the cookie.
 	Name string `json:"name"`
@@ -346,6 +354,7 @@ type HTTPCookie struct {
 //       tcp:
 //         maxConnections: 100
 //         connectTimeout: 30ms
+// +k8s:openapi-gen=true
 type ConnectionPoolSettings struct {
 
 	// Settings common to both HTTP and TCP upstream connections.
@@ -356,6 +365,7 @@ type ConnectionPoolSettings struct {
 }
 
 // Settings common to both HTTP and TCP upstream connections.
+// +k8s:openapi-gen=true
 type TCPSettings struct {
 	// Maximum number of HTTP1 /TCP connections to a destination host.
 	MaxConnections int32 `json:"maxConnections,omitempty"`
@@ -365,6 +375,7 @@ type TCPSettings struct {
 }
 
 // Settings applicable to HTTP1.1/HTTP2/GRPC connections.
+// +k8s:openapi-gen=true
 type HTTPSettings struct {
 	// Maximum number of pending HTTP requests to a destination. Default 1024.
 	HTTP1MaxPendingRequests int32 `json:"http1MaxPendingRequests,omitempty"`
@@ -414,6 +425,7 @@ type HTTPSettings struct {
 //       consecutiveErrors: 7
 //       interval: 5m
 //       baseEjectionTime: 15m
+// +k8s:openapi-gen=true
 type OutlierDetection struct {
 	// Number of errors before a host is ejected from the connection
 	// pool. Defaults to 5. When the upstream host is accessed over HTTP, a
@@ -483,6 +495,7 @@ type OutlierDetection struct {
 //   trafficPolicy:
 //     tls:
 //       mode: ISTIO_MUTUAL
+// +k8s:openapi-gen=true
 type TLSSettings struct {
 
 	// REQUIRED: Indicates whether connections to this port should be secured
@@ -540,6 +553,7 @@ const (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // DestinationRuleList is a list of DestinationRule resources
+// +k8s:openapi-gen=true
 type DestinationRuleList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/apis/istio/v1alpha3/gateway_types.go
+++ b/apis/istio/v1alpha3/gateway_types.go
@@ -146,6 +146,7 @@ import (
 //         - destination:
 //             name: mongo.prod
 //
+// +k8s:openapi-gen=true
 type Gateway struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -153,6 +154,7 @@ type Gateway struct {
 	Spec GatewaySpec `json:"spec"`
 }
 
+// +k8s:openapi-gen=true
 type GatewaySpec struct {
 	// REQUIRED: A list of server specifications.
 	Servers []Server `json:"servers"`
@@ -214,6 +216,7 @@ type GatewaySpec struct {
 //           serverCertificate: /etc/certs/server.pem
 //           privateKey: /etc/certs/privatekey.pem
 //
+// +k8s:openapi-gen=true
 type Server struct {
 	// REQUIRED: The Port on which the proxy should listen for incoming
 	// connections
@@ -236,6 +239,7 @@ type Server struct {
 	TLS *TLSOptions `json:"tls,omitempty"`
 }
 
+// +k8s:openapi-gen=true
 type TLSOptions struct {
 	// If set to true, the load balancer will send a 302 redirect for all
 	// http connections, asking the clients to use HTTPS.
@@ -302,6 +306,7 @@ const (
 )
 
 // Port describes the properties of a specific port of a service.
+// +k8s:openapi-gen=true
 type Port struct {
 	// REQUIRED: A valid non-negative integer port number.
 	Number int `json:"number"`
@@ -328,6 +333,7 @@ const (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // GatewayList is a list of Gateway resources
+// +k8s:openapi-gen=true
 type GatewayList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/apis/istio/v1alpha3/virtualservice_types.go
+++ b/apis/istio/v1alpha3/virtualservice_types.go
@@ -25,6 +25,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // VirtualService
+// +k8s:openapi-gen=true
 type VirtualService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -96,6 +97,7 @@ type VirtualService struct {
 // A host name can be defined by only one VirtualService. A single
 // VirtualService can be used to describe traffic properties for multiple
 // HTTP and TCP ports.
+// +k8s:openapi-gen=true
 type VirtualServiceSpec struct {
 	// REQUIRED. The destination address for traffic captured by this virtual
 	// service. Could be a DNS name with wildcard prefix or a CIDR
@@ -145,6 +147,7 @@ type VirtualServiceSpec struct {
 
 // Describes match conditions and actions for routing HTTP/1.1, HTTP2, and
 // gRPC traffic. See VirtualService for usage examples.
+// +k8s:openapi-gen=true
 type HTTPRoute struct {
 	// Match conditions to be satisfied for the rule to be
 	// activated. All conditions inside a single match block have AND
@@ -209,6 +212,7 @@ type HTTPRoute struct {
 }
 
 // Headers describes header manipulation rules.
+// +k8s:openapi-gen=true
 type Headers struct {
 	// Header manipulation rules to apply before forwarding a request
 	// to the destination service
@@ -220,6 +224,7 @@ type Headers struct {
 }
 
 // HeaderOperations Describes the header manipulations to apply
+// +k8s:openapi-gen=true
 type HeaderOperations struct {
 	// Overwrite the headers specified by key with the given values
 	Set map[string]string `json:"set,omitempty"`
@@ -257,6 +262,7 @@ type HeaderOperations struct {
 //             host: ratings
 //
 // HTTPMatchRequest CANNOT be empty.
+// +k8s:openapi-gen=true
 type HTTPMatchRequest struct {
 	// URI to match
 	// values are case-sensitive and formatted as follows:
@@ -333,6 +339,7 @@ type HTTPMatchRequest struct {
 	Gateways []string `json:"gateways,omitempty"`
 }
 
+// +k8s:openapi-gen=true
 type HTTPRouteDestination struct {
 	// REQUIRED. Destination uniquely identifies the instances of a service
 	// to which the request/connection should be forwarded to.
@@ -451,6 +458,7 @@ type HTTPRouteDestination struct {
 //         - destination:
 //             host: wikipedia.org
 //
+// +k8s:openapi-gen=true
 type Destination struct {
 	// REQUIRED. The name of a service from the service registry. Service
 	// names are looked up from the platform's service registry (e.g.,
@@ -481,6 +489,7 @@ type Destination struct {
 
 // PortSelector specifies the number of a port to be used for
 // matching or selection for final routing.
+// +k8s:openapi-gen=true
 type PortSelector struct {
 	// Choose one of the fields below.
 
@@ -514,6 +523,7 @@ type PortSelector struct {
 //         port:
 //           number: 5555
 // ```
+// +k8s:openapi-gen=true
 type TCPRoute struct {
 	// Match conditions to be satisfied for the rule to be
 	// activated. All conditions inside a single match block have AND
@@ -556,6 +566,7 @@ type TCPRoute struct {
 //     - destination:
 //         host: reviews.prod.svc.cluster.local
 // ```
+// +k8s:openapi-gen=true
 type TLSRoute struct {
 	// REQUIRED. Match conditions to be satisfied for the rule to be
 	// activated. All conditions inside a single match block have AND
@@ -569,6 +580,7 @@ type TLSRoute struct {
 
 // L4 connection match attributes. Note that L4 connection matching support
 // is incomplete.
+// +k8s:openapi-gen=true
 type L4MatchAttributes struct {
 	// IPv4 or IPv6 ip address of destination with optional subnet.  E.g.,
 	// a.b.c.d/xx form or just a.b.c.d.
@@ -592,6 +604,7 @@ type L4MatchAttributes struct {
 }
 
 // TLS connection match attributes.
+// +k8s:openapi-gen=true
 type TLSMatchAttributes struct {
 	// REQUIRED. SNI (server name indicator) to match on. Wildcard prefixes
 	// can be used in the SNI value, e.g., *.com will match foo.example.com
@@ -642,6 +655,7 @@ type TLSMatchAttributes struct {
 //         authority: bookratings.default.svc.cluster.local
 //       ...
 //
+// +k8s:openapi-gen=true
 type HTTPRedirect struct {
 	// On a redirect, overwrite the Path portion of the URL with this
 	// value. Note that the entire path will be replaced, irrespective of the
@@ -677,6 +691,7 @@ type HTTPRedirect struct {
 //             host: ratings
 //             subset: v1
 //
+// +k8s:openapi-gen=true
 type HTTPRewrite struct {
 	// rewrite the path (or the prefix) portion of the URI with this
 	// value. If the original URI was matched based on prefix, the value
@@ -707,6 +722,7 @@ type HTTPRewrite struct {
 //           attempts: 3
 //           perTryTimeout: 2s
 //
+// +k8s:openapi-gen=true
 type HTTPRetry struct {
 	// REQUIRED. Number of retries for a given request. The interval
 	// between retries will be determined automatically (25ms+). Actual
@@ -749,6 +765,7 @@ type HTTPRetry struct {
 //           - X-Foo-Bar
 //           maxAge: "1d"
 //
+// +k8s:openapi-gen=true
 type CorsPolicy struct {
 	// The list of origins that are allowed to perform CORS requests. The
 	// content will be serialized into the Access-Control-Allow-Origin
@@ -785,6 +802,7 @@ type CorsPolicy struct {
 //
 // *Note:* Delay and abort faults are independent of one another, even if
 // both are specified simultaneously.
+// +k8s:openapi-gen=true
 type HTTPFaultInjection struct {
 	// Delay requests before forwarding, emulating various failures such as
 	// network issues, overloaded upstream service, etc.
@@ -824,6 +842,7 @@ type HTTPFaultInjection struct {
 // seconds. An optional _percent_ field, a value between 0 and 100, can
 // be used to only delay a certain percentage of requests. If left
 // unspecified, all request will be delayed.
+// +k8s:openapi-gen=true
 type InjectDelay struct {
 	// Percentage of requests on which the delay will be injected (0-100).
 	Percent int `json:"percent,omitempty"`
@@ -863,6 +882,7 @@ type InjectDelay struct {
 // return to the caller. The optional _percent_ field, a value between 0
 // and 100, is used to only abort a certain percentage of requests. If
 // not specified, all requests are aborted.
+// +k8s:openapi-gen=true
 type InjectAbort struct {
 	// Percentage of requests to be aborted with the error code provided (0-100).
 	Percent int `json:"percent,omitempty"`
@@ -874,6 +894,7 @@ type InjectAbort struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // VirtualServiceList is a list of VirtualService resources
+// +k8s:openapi-gen=true
 type VirtualServiceList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`


### PR DESCRIPTION
Signed-off-by: runzexia <runzexia@yunify.com>
Our open source project `kubesphere` use the struct of the `istio` part of `knative/pkg`. We are now generating a swagger document for `kubesphere`, but we need to generate `openapi` for this part of the struct.
https://github.com/kubesphere/kubesphere/pull/609
The PR is going to add "// +k8s:openapi-gen=true" comments for some knative structs. Thanks.