### PR TITLE
Read the logging configmap via API, not from the file system.

### DIFF
--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -72,15 +72,11 @@ func GetConfig(masterURL, kubeconfig string) (*rest.Config, error) {
 // or via reading a configMap from the API.
 // The context is expected to be initialized with injection.
 func GetLoggingConfig(ctx context.Context) (*logging.Config, error) {
-	loggingConfigData, err := configmap.Load("/etc/config-logging")
-	if err == nil {
-		return logging.NewConfigFromMap(loggingConfigData)
-	}
 	loggingConfigMap, err := kubeclient.Get(ctx).CoreV1().ConfigMaps(system.Namespace()).Get(logging.ConfigMapName(), metav1.GetOptions{})
-	if err == nil {
-		return logging.NewConfigFromConfigMap(loggingConfigMap)
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+	return logging.NewConfigFromConfigMap(loggingConfigMap)
 }
 
 func Main(component string, ctors ...injection.ControllerConstructor) {

--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -113,7 +113,6 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 	cfg.Burst = len(ctors) * rest.DefaultBurst
 
 	ctx, informers := injection.Default.SetupInformers(ctx, cfg)
-	kubeClient := kubeclient.Get(ctx)
 
 	// Set up our logger.
 	loggingConfig, err := GetLoggingConfig(ctx)
@@ -125,7 +124,7 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 	ctx = logging.WithLogger(ctx, logger)
 
 	// TODO(mattmoor): This should itself take a context and be injection-based.
-	cmw := configmap.NewInformedWatcher(kubeClient, system.Namespace())
+	cmw := configmap.NewInformedWatcher(kubeclient.Get(ctx), system.Namespace())
 
 	// Based on the reconcilers we have linked, build up the set of controllers to run.
 	controllers := make([]*controller.Impl, 0, len(ctors))

--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -105,7 +105,7 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 	if err != nil {
 		log.Fatal("Error loading logging configuration:", err)
 	}
-	loggingConfig, err := logging.NewConfigFromMap(loggingConfigMap.Data)
+	loggingConfig, err := logging.NewConfigFromConfigMap(loggingConfigMap)
 	if err != nil {
 		log.Fatal("Error parsing logging configuration:", err)
 	}


### PR DESCRIPTION
This makes it possible to run our controllers locally which can be super handy for quick development cycles.