### PR TITLE
Fix the panics in the naming functions.

### DIFF
--- a/kmeta/names.go
+++ b/kmeta/names.go
@@ -26,15 +26,35 @@ import (
 const (
 	longest = 63
 	md5Len  = 32
-	head    = longest - md5Len
+	head    = longest - md5Len // How much to truncate to fit the hash.
 )
 
 // ChildName generates a name for the resource based upon the parent resource and suffix.
 // If the concatenated name is longer than K8s permits the name is hashed and truncated to permit
 // construction of the resource, but still keeps it unique.
+// If the suffix itself is longer than 31 characters, then the whole string will be hashed
+// and `parent|hash|suffix` will be returned, where parent and suffix will be trimmed to
+// fit (prefix of parent at most of length 31, and prefix of suffix at most length 30).
 func ChildName(parent, suffix string) string {
 	n := parent
 	if len(parent) > (longest - len(suffix)) {
+		// If the suffix is longer than the longest allowed suffix, then
+		// we hash the whole combined string and use that as the suffix.
+		if head-len(suffix) <= 0 {
+			h := md5.Sum([]byte(parent + suffix))
+			// 1. trim parent, if needed
+			if head < len(parent) {
+				parent = parent[:head]
+			}
+			// Format the return string, if it's shorter than longest: pad with
+			// beginning of the suffix. This happens, for example, when parent is
+			// short, but the suffix is very long.
+			ret := parent + fmt.Sprintf("%x", h)
+			if d := longest - len(ret); d > 0 {
+				ret += suffix[:d]
+			}
+			return ret
+		}
 		n = fmt.Sprintf("%s%x", parent[:head-len(suffix)], md5.Sum([]byte(parent)))
 	}
 	return n + suffix

--- a/kmeta/names_test.go
+++ b/kmeta/names_test.go
@@ -40,11 +40,25 @@ func TestChildName(t *testing.T) {
 		parent: strings.Repeat("f", 63),
 		suffix: "-deploy",
 		want:   "ffffffffffffffffffffffff105d7597f637e83cc711605ac3ea4957-deploy",
+	}, {
+		parent: strings.Repeat("f", 63),
+		suffix: strings.Repeat("f", 63),
+		want:   "fffffffffffffffffffffffffffffff0502661254f13c89973cb3a83e0cbec0",
+	}, {
+		parent: "a",
+		suffix: strings.Repeat("f", 63),
+		want:   "ab5cfd486935decbc0d305799f4ce4414ffffffffffffffffffffffffffffff",
+	}, {
+		parent: strings.Repeat("b", 32),
+		suffix: strings.Repeat("f", 32),
+		want:   "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb329c7c81b9ab3ba71aa139066aa5625d",
 	}}
 
 	for _, test := range tests {
-		if got, want := ChildName(test.parent, test.suffix), test.want; got != want {
-			t.Errorf("%s-%s: got: %63s want: %63s\ndiff:%s", test.parent, test.suffix, got, want, cmp.Diff(got, want))
-		}
+		t.Run(test.parent+"-"+test.suffix, func(t *testing.T) {
+			if got, want := ChildName(test.parent, test.suffix), test.want; got != want {
+				t.Errorf("%s-%s: got: %63s want: %63s\ndiff:%s", test.parent, test.suffix, got, want, cmp.Diff(want, got))
+			}
+		})
 	}
 }


### PR DESCRIPTION
currently if the suffix is longer than 31 characters the function would panic.
This fixes that by adding additional checks and trimming. Plus in this case
it will hash the whole string, to ensure uniqueness.

/assign @mattmoor