### PR TITLE
test/webhook-apicoverage: Changing html display to use go templates

### DIFF
--- a/test/webhook-apicoverage/coveragecalculator/calculator.go
+++ b/test/webhook-apicoverage/coveragecalculator/calculator.go
@@ -21,6 +21,14 @@ type CoverageValues struct {
 	TotalFields   int
 	CoveredFields int
 	IgnoredFields int
+
+	PercentCoverage float64
+}
+
+func (c *CoverageValues) CalculatePercentageValue() {
+	if c.TotalFields > 0 {
+		c.PercentCoverage = (float64(c.CoveredFields) / float64(c.TotalFields-c.IgnoredFields)) * 100
+	}
 }
 
 // CalculateTypeCoverage calculates aggregate coverage values based on provided []TypeCoverage

--- a/test/webhook-apicoverage/coveragecalculator/coveragedata.go
+++ b/test/webhook-apicoverage/coveragecalculator/coveragedata.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package coveragecalculator
 
-import "k8s.io/apimachinery/pkg/util/sets"
+import (
+	"strings"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
 
 // FieldCoverage represents coverage data for a field.
 type FieldCoverage struct {
@@ -41,6 +44,11 @@ func (f *FieldCoverage) GetValues() []string {
 		values = append(values, key)
 	}
 	return values
+}
+
+// GetValuesForDisplay returns value strings as comma separated string.
+func (f *FieldCoverage) GetValuesForDisplay() string {
+	return strings.Join(f.GetValues(), ",")
 }
 
 // TypeCoverage encapsulates type information and field coverage.

--- a/test/webhook-apicoverage/tools/tools.go
+++ b/test/webhook-apicoverage/tools/tools.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"os/user"
 	"path"
-	"strings"
 
 	"knative.dev/pkg/test/webhook-apicoverage/coveragecalculator"
 	"knative.dev/pkg/test/webhook-apicoverage/view"
@@ -177,13 +176,12 @@ func GetAndWriteTotalCoverage(webhookIP string, outputFile string) error {
 		return err
 	}
 
-	var buffer strings.Builder
-	buffer.WriteString(view.HTMLHeader)
-	totalCoverageDisplay := view.GetHTMLCoverageValuesDisplay(totalCoverage)
-	buffer.WriteString(totalCoverageDisplay)
-	buffer.WriteString(view.HTMLFooter)
-	if err = ioutil.WriteFile(outputFile, []byte(buffer.String()), 0400); err != nil {
-		return fmt.Errorf("error writing total coverage to output file: %s, error: %v coverage: %s", outputFile, err, totalCoverageDisplay)
+	if htmlData, err := view.GetHTMLCoverageValuesDisplay(totalCoverage); err != nil {
+		return fmt.Errorf("error building html file from total coverage. error: %v", err)
+	} else {
+		if err = ioutil.WriteFile(outputFile, []byte(htmlData), 0400); err != nil {
+			return fmt.Errorf("error writing total coverage to output file: %s, error: %v", outputFile, err)
+		}
 	}
 
 	return nil

--- a/test/webhook-apicoverage/view/aggregate_coverage.html
+++ b/test/webhook-apicoverage/view/aggregate_coverage.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<style type="text/css">
+  <!--
+
+  .tab { margin-left: 50px; }
+
+  .styleheader {color: white; size: A4}
+
+  .values {color: yellow; size: A3}
+
+  table, th, td { border: 1px solid white; text-align: center}
+
+  .braces {color: white; size: A3}
+  -->
+</style>
+<body style="background-color:rgb(0,0,0); font-family: Arial">
+<table style="width: 30%">
+  <tr class="styleheader"><td>Total Fields</td><td>{{ .TotalFields }}</td></tr>
+  <tr class="styleheader"><td>Covered Fields</td><td>{{ .CoveredFields }}</td></tr>
+  <tr class="styleheader"><td>Ignored Fields</td><td>{{ .IgnoredFields }}</td></tr>
+  <tr class="styleheader"><td>Coverage Percentage</td><td>{{ .PercentCoverage }}</td></tr>
+</table>
+</body>
+</html>

--- a/test/webhook-apicoverage/view/html_display.go
+++ b/test/webhook-apicoverage/view/html_display.go
@@ -17,115 +17,53 @@ limitations under the License.
 package view
 
 import (
-	"fmt"
 	"strings"
+	"html/template"
 
 	"knative.dev/pkg/test/webhook-apicoverage/coveragecalculator"
 )
 
-// HTMLHeader sets up an HTML page with the right style format
-var HTMLHeader = fmt.Sprintf(`
-<!DOCTYPE html>
-<html>
-<style type="text/css">
-<!--
-
-.tab { margin-left: 50px; }
-
-.styleheader {color: white; size: A4}
-
-.covered {color: green; size: A3}
-
-.notcovered {color: red; size: A3}
-
-.ignored {color: white; size: A4}
-
-.values {color: yellow; size: A3}
-
-table, th, td { border: 1px solid white; text-align: center}
-
-.braces {color: white; size: A3}
--->
-</style>
-<body style="background-color:rgb(0,0,0); font-family: Arial">
-`)
-
-// HTMLFooter closes the tags for the HTML page.
-var HTMLFooter = fmt.Sprintf(`
-    </body>
-  </html>
-`)
+type HtmlDisplayData struct {
+	TypeCoverages []coveragecalculator.TypeCoverage
+	CoverageNumbers *coveragecalculator.CoverageValues
+}
 
 // GetHTMLDisplay is a helper method to display API Coverage details in json-like format inside a HTML page.
-func GetHTMLDisplay(coverageData []coveragecalculator.TypeCoverage, displayRules DisplayRules) string {
-	var buffer strings.Builder
-	buffer.WriteString(HTMLHeader)
-	for _, typeCoverage := range coverageData {
-		packageName := typeCoverage.Package
-		if displayRules.PackageNameRule != nil {
-			packageName = displayRules.PackageNameRule(packageName)
-		}
+func GetHTMLDisplay(coverageData []coveragecalculator.TypeCoverage, coverageValues *coveragecalculator.CoverageValues) (string, error) {
 
-		typeName := typeCoverage.Type
-		if displayRules.TypeNameRule != nil {
-			typeName = displayRules.TypeNameRule(typeName)
-		}
-		buffer.WriteString(fmt.Sprint(`<div class="styleheader">`))
-		buffer.WriteString(fmt.Sprintf(`<br>Package: %s`, packageName))
-		buffer.WriteString(fmt.Sprintf(`<br>Type: %s`, typeName))
-		buffer.WriteString(fmt.Sprint(`<br></div>`))
-		buffer.WriteString(fmt.Sprint(`<div class="braces"><br>{</div>`))
-		for _, fieldCoverage := range typeCoverage.Fields {
-			var fieldDisplay string
-			if displayRules.FieldRule != nil {
-				fieldDisplay = displayRules.FieldRule(fieldCoverage)
-			} else {
-				fieldDisplay = defaultHTMLTypeDisplay(fieldCoverage)
-			}
-			buffer.WriteString(fieldDisplay)
-		}
-
-		buffer.WriteString(fmt.Sprint(`<div class="braces">}</div>`))
-		buffer.WriteString(fmt.Sprint(`<br>`))
-
+	htmlData := HtmlDisplayData{
+		TypeCoverages: coverageData,
+		CoverageNumbers: coverageValues,
 	}
 
-	buffer.WriteString(HTMLFooter)
-	return buffer.String()
+	tmpl, err := template.ParseFiles("type_coverage.html")
+	if err != nil {
+		return "", err
+	}
+
+	var buffer strings.Builder
+	err = tmpl.Execute(&buffer, htmlData)
+	if err != nil {
+		return "", err
+	}
+
+	return buffer.String(), nil
 }
 
-func defaultHTMLTypeDisplay(field *coveragecalculator.FieldCoverage) string {
-	var buffer strings.Builder
-	if field.Ignored {
-		buffer.WriteString(fmt.Sprintf(`<div class="ignored tab">%s</div>`, field.Field))
-	} else if field.Coverage {
-		buffer.WriteString(fmt.Sprintf(`<div class="covered tab">%s`, field.Field))
-		if len(field.Values) > 0 && !strings.Contains(strings.ToLower(field.Field), "uid") {
-			buffer.WriteString(fmt.Sprintf(`&emsp; &emsp; <span class="values">Values: [%s]</span>`, strings.Join(field.GetValues(), ", ")))
-		}
-		buffer.WriteString(fmt.Sprint(`</div>`))
-	} else {
-		buffer.WriteString(fmt.Sprintf(`<div class="notcovered tab">%s</div>`, field.Field))
-	}
-	return buffer.String()
-}
 
 // GetHTMLCoverageValuesDisplay is a helper method to display coverage values inside a HTML table.
-func GetHTMLCoverageValuesDisplay(coverageValues *coveragecalculator.CoverageValues) string {
-	var buffer strings.Builder
-	buffer.WriteString(fmt.Sprint(`<br>`))
-	buffer.WriteString(fmt.Sprint(`<div class="styleheader">Coverage Values</div>`))
-	buffer.WriteString(fmt.Sprint(`<br>`))
-	buffer.WriteString(fmt.Sprint(`  <table style="width: 30%">`))
-	buffer.WriteString(fmt.Sprintf(`<tr class="styleheader"><td>Total Fields</td><td>%d</td></tr>`, coverageValues.TotalFields))
-	buffer.WriteString(fmt.Sprintf(`<tr class="styleheader"><td>Covered Fields</td><td>%d</td></tr>`, coverageValues.CoveredFields))
-	buffer.WriteString(fmt.Sprintf(`<tr class="styleheader"><td>Ignored Fields</td><td>%d</td></tr>`, coverageValues.IgnoredFields))
+func GetHTMLCoverageValuesDisplay(coverageValues *coveragecalculator.CoverageValues) (string, error) {
 
-	percentCoverage := 0.0
-	if coverageValues.TotalFields > 0 {
-		percentCoverage = (float64(coverageValues.CoveredFields) / float64(coverageValues.TotalFields-coverageValues.IgnoredFields)) * 100
+	tmpl, err := template.ParseFiles("aggregate_coverage.html")
+	if err != nil {
+		return "", err
 	}
-	buffer.WriteString(fmt.Sprintf(`<tr class="styleheader"><td>Coverage Percentage</td><td>%f</td></tr>`, percentCoverage))
-	buffer.WriteString(fmt.Sprint(`</table>`))
-	return buffer.String()
+
+	var buffer strings.Builder
+	err = tmpl.Execute(&buffer, coverageValues)
+	if err != nil {
+		return "", err
+	}
+
+	return buffer.String(), nil
 }

--- a/test/webhook-apicoverage/view/type_coverage.html
+++ b/test/webhook-apicoverage/view/type_coverage.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<style type="text/css">
+  <!--
+
+  .tab { margin-left: 50px; }
+
+  .styleheader {color: white; size: A4}
+
+  .covered {color: green; size: A3}
+
+  .notcovered {color: red; size: A3}
+
+  .ignored {color: white; size: A4}
+
+  .values {color: yellow; size: A3}
+
+  table, th, td { border: 1px solid white; text-align: center}
+
+  .braces {color: white; size: A3}
+  -->
+</style>
+<body style="background-color:rgb(0,0,0); font-family: Arial">
+{{ range $coverageType := .TypeCoverages }}
+  <div class="styleheader">
+    <br>Package: {{ $coverageType.Package }}
+    <br>Type: {{ $coverageType.Type }}
+    <br>
+    <div class="braces">
+      <br>{
+    </div>
+    {{ range $key, $value := $coverageType.Fields }}
+      {{if $value.Ignored }}
+        <div class="ignored tab">{{ $value.Field }}</div>
+      {{else if $value.Coverage}}
+        <div class="covered tab">{{ $value.Field }}
+          {{ $valueLen := len $value.Values }}
+          {{if gt $valueLen 0 }}
+            &emsp; &emsp; <span class="values">Values: [{{$value.GetValuesForDisplay}}]</span>
+          {{end}}
+        </div>
+      {{else}}
+        <div class="notcovered tab">{{ $value.Field }}</div>
+      {{end}}
+    {{end}}
+    <div class="braces">}</div>
+  </div>
+{{end}}
+
+<br>
+<br>
+<div class="styleheader">Coverage Values</div>
+<br>
+<table style="width: 30%">
+  <tr class="styleheader"><td>Total Fields</td><td>{{ .CoverageNumbers.TotalFields }}</td></tr>
+  <tr class="styleheader"><td>Covered Fields</td><td>{{ .CoverageNumbers.CoveredFields }}</td></tr>
+  <tr class="styleheader"><td>Ignored Fields</td><td>{{ .CoverageNumbers.IgnoredFields }}</td></tr>
+  <tr class="styleheader"><td>Coverage Percentage</td><td>{{ .CoverageNumbers.PercentCoverage }}</td></tr>
+</table>
+</body>
+</html>

--- a/test/webhook-apicoverage/webhook/apicoverage_recorder.go
+++ b/test/webhook-apicoverage/webhook/apicoverage_recorder.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"os"
 	"reflect"
-	"strings"
 
 	"go.uber.org/zap"
 	"k8s.io/api/admission/v1beta1"
@@ -168,11 +167,13 @@ func (a *APICoverageRecorder) GetResourceCoverage(w http.ResponseWriter, r *http
 	tree := a.ResourceForest.TopLevelTrees[resource]
 	typeCoverage := tree.BuildCoverageData(a.NodeRules, a.FieldRules, ignoredFields)
 	coverageValues := coveragecalculator.CalculateTypeCoverage(typeCoverage)
+	coverageValues.CalculatePercentageValue()
 
-	var buffer strings.Builder
-	buffer.WriteString(view.GetHTMLDisplay(typeCoverage, a.DisplayRules))
-	buffer.WriteString(view.GetHTMLCoverageValuesDisplay(coverageValues))
-	fmt.Fprint(w, buffer.String())
+	if htmlData, err := view.GetHTMLDisplay(typeCoverage, coverageValues); err != nil {
+		fmt.Fprintf(w, "Error generating html file %v", err)
+	} else {
+		fmt.Fprint(w, htmlData)
+	}
 }
 
 // GetTotalCoverage goes over all the resources setup for the apicoverage tool and returns total coverage values.
@@ -197,6 +198,7 @@ func (a *APICoverageRecorder) GetTotalCoverage(w http.ResponseWriter, r *http.Re
 		totalCoverage.IgnoredFields += coverageValues.IgnoredFields
 	}
 
+	totalCoverage.CalculatePercentageValue()
 	var body []byte
 	if body, err = json.Marshal(totalCoverage); err != nil {
 		fmt.Fprintf(w, "error marshalling total coverage response: %v", err)


### PR DESCRIPTION
This change changes webhook apicoverage HTML display to use to templates
moving away from current approach of using string buffers

This change does not take display-rules into account as its not being
used at the moment. When there is a use-case the template hanlding needs
to be modified accordingly.