### PR TITLE
Test Infra 2.0: Add cluster management lib skeleton

### DIFF
--- a/testutils/OWNERS
+++ b/testutils/OWNERS
@@ -1,0 +1,4 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- productivity-approvers

--- a/testutils/README.md
+++ b/testutils/README.md
@@ -1,0 +1,5 @@
+## THIS IS STILL A WORK IN PROGRESS
+
+## Test Infra 2.0 Supporting Libs
+
+See [high level](https://docs.google.com/document/d/1QHPks3oRKccTpzAOJuU2tgHjyiA0Somm7PwdQVupyk0/edit#heading=h.x9snb54sjlu9) and [low level](https://docs.google.com/document/d/1PQ6DLL8kqMSSmciTSrR9RLaJt8sBgaziLEkwkP9TKec/edit#heading=h.x9snb54sjlu9) designs for more details

--- a/testutils/clustermanager/boskos/boskos.go
+++ b/testutils/clustermanager/boskos/boskos.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package boskos
+
+// AcquireGKEProject acquires GKE Boskos Project
+func AcquireGKEProject() (string, error) {
+	// TODO: implement the logic
+	return "", nil
+}
+
+// ReleaseGKEProject releases project
+func ReleaseGKEProject(name string) error {
+	// TODO: implement the logic
+	return nil
+}

--- a/testutils/clustermanager/client.go
+++ b/testutils/clustermanager/client.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustermanager
+
+// Client is the entrypoint
+type Client interface {
+	Setup(...interface{}) ClusterOperations
+}
+
+// ClusterOperations contains all provider specific logics
+type ClusterOperations interface {
+	Provider() string
+	Acquire() error
+	Delete() error
+}

--- a/testutils/clustermanager/doc.go
+++ b/testutils/clustermanager/doc.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package clustermanager provides support for managing clusters for e2e tests,
+responsible for creating/deleting cluster, and cluster life cycle management if
+running in Prow
+usage example:
+func acquireCluster() {
+    clusterOps := GKEClient{}.Setup(2, "n1-standard-8", "us-east1", "a", "myproject")
+    // Cast to GKEOperation
+    GKEOps := clusterOps.(GKECluster)
+    if err = GKEOps.Acquire(); err != nil {
+        log.Fatalf("Failed acquire cluster: '%v'", err)
+    }
+    log.Printf("GKE project is: %s", GKEOps.Project)
+    log.Printf("GKE cluster is: %v", GKEOps.Cluster)
+}
+*/
+package clustermanager

--- a/testutils/clustermanager/gke.go
+++ b/testutils/clustermanager/gke.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustermanager
+
+import (
+	"fmt"
+
+	"knative.dev/pkg/testutils/clustermanager/boskos"
+	"knative.dev/pkg/testutils/common"
+)
+
+// GKEClient implements Client
+type GKEClient struct {
+}
+
+// GKECluster implements ClusterOperations
+type GKECluster struct {
+	// Project might be GKE specific, so put it here
+	Project *string
+	// NeedCleanup tells whether the cluster needs to be deleted afterwards
+	// This probably should be part of task wrapper's logic
+	NeedCleanup bool
+	// TODO: evaluate returning "google.golang.org/api/container/v1.Cluster" when implementing the creation logic
+	Cluster *string
+}
+
+// Setup sets up a GKECluster client.
+// numNodes: default to 3 if not provided
+// nodeType: default to n1-standard-4 if not provided
+// region: default to regional cluster if not provided, and use default backup regions
+// zone: default is none, must be provided together with region
+func (gs *GKEClient) Setup(numNodes *int, nodeType *string, region *string, zone *string, project *string) (ClusterOperations, error) {
+	var err error
+	gc := &GKECluster{}
+	if nil != project { // use provided project and create cluster
+		gc.Project = project
+		gc.NeedCleanup = true
+	} else if err = gc.checkEnvironment(); nil != err {
+		return nil, fmt.Errorf("failed checking existing cluster: '%v'", err)
+	}
+	if nil != gc.Cluster {
+		return gc, nil
+	}
+	if common.IsProw() {
+		if *gc.Project, err = boskos.AcquireGKEProject(); nil != err {
+			return nil, fmt.Errorf("failed acquire boskos project: '%v'", err)
+		}
+	}
+	return gc, nil
+}
+
+// Provider returns gke
+func (gc *GKECluster) Provider() string {
+	return "gke"
+}
+
+// Acquire gets existing cluster or create a new one
+func (gc *GKECluster) Acquire() error {
+	// Check if using existing cluster
+	if nil != gc.Cluster {
+		return nil
+	}
+	// TODO: Perform GKE specific cluster creation logics
+	return nil
+}
+
+// Delete deletes a GKE cluster
+func (gc *GKECluster) Delete() error {
+	if !gc.NeedCleanup {
+		return nil
+	}
+	// TODO: Perform GKE specific cluster deletion logics
+	return nil
+}
+
+// checks for existing cluster by looking at kubeconfig,
+// and sets up gc.Project and gc.Cluster properly, otherwise fail it.
+// if project can be derived from gcloud, sets it up as well
+func (gc *GKECluster) checkEnvironment() error {
+	// TODO: implement this
+	return nil
+}

--- a/testutils/common/common.go
+++ b/testutils/common/common.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+// IsProw checks if the process is initialized by Prow
+func IsProw() bool {
+	// TODO: Implement
+	return false
+}


### PR DESCRIPTION
This is part of test infra 2.0 work, aiming to provide a lib for managing life cycles of k8s clusters for testing purpose. This PR includes a skeleton lib, once this is merged, all other functionalities(Marked as TODOs) can be implemented and reviewed in parallel.

Part of: https://github.com/knative/test-infra/issues/1186

/cc @adrcunha 
/cc @srinivashegde86 