### PR TITLE
Add cluster creation logic for local users

### DIFF
--- a/testutils/clustermanager/client.go
+++ b/testutils/clustermanager/client.go
@@ -18,7 +18,7 @@ package clustermanager
 
 // Client is the entrypoint
 type Client interface {
-	Setup(...interface{}) ClusterOperations
+	Setup(...interface{}) (ClusterOperations, error)
 }
 
 // ClusterOperations contains all provider specific logics

--- a/testutils/clustermanager/gke_test.go
+++ b/testutils/clustermanager/gke_test.go
@@ -56,10 +56,13 @@ func TestGKECheckEnvironment(t *testing.T) {
 			// kubeconfig correctly set
 			"a_b_c_d", nil, "", nil, &fakeProj, &fakeCluster, nil,
 		}, {
+			// kubeconfig not set and gcloud failed
 			"", fmt.Errorf("kubectl not set"), "", fmt.Errorf("gcloud failed"), nil, nil, fmt.Errorf("failed getting gcloud project: 'gcloud failed'"),
 		}, {
+			// kubeconfig not set and gcloud not set
 			"", fmt.Errorf("kubectl not set"), "", nil, nil, nil, nil,
 		}, {
+			// kubeconfig not set and gcloud set
 			"", fmt.Errorf("kubectl not set"), "b", nil, &fakeProj, nil, nil,
 		},
 	}

--- a/testutils/clustermanager/gke_test.go
+++ b/testutils/clustermanager/gke_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustermanager
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+var (
+	fakeProj    = "b"
+	fakeCluster = "d"
+)
+
+func TestGKECheckEnvironment(t *testing.T) {
+	datas := []struct {
+		kubectlOut string
+		kubectlErr error
+		gcloudOut  string
+		gcloudErr  error
+		expProj    *string
+		expCluster *string
+		expErr     error
+	}{
+		{
+			// Base condition, kubectl shouldn't return empty string if there is no error
+			"", nil, "", nil, nil, nil, fmt.Errorf("kubectl current-context is malformed: ''"),
+		}, {
+			// kubeconfig not set and gcloud not set
+			"", fmt.Errorf("kubectl not set"), "", nil, nil, nil, nil,
+		}, {
+			// kubeconfig failed
+			"failed", fmt.Errorf("kubectl other err"), "", nil, nil, nil, fmt.Errorf("failed running kubectl config current-context: 'failed'"),
+		}, {
+			// kubeconfig returned something other than "gke_PROJECT_REGION_CLUSTER"
+			"a_b_c", nil, "", nil, nil, nil, fmt.Errorf("kubectl current-context is malformed: 'a_b_c'"),
+		}, {
+			// kubeconfig returned something other than "gke_PROJECT_REGION_CLUSTER"
+			"a_b_c_d_e", nil, "", nil, nil, nil, fmt.Errorf("kubectl current-context is malformed: 'a_b_c_d_e'"),
+		}, {
+			// kubeconfig correctly set
+			"a_b_c_d", nil, "", nil, &fakeProj, &fakeCluster, nil,
+		}, {
+			"", fmt.Errorf("kubectl not set"), "", fmt.Errorf("gcloud failed"), nil, nil, fmt.Errorf("failed getting gcloud project: 'gcloud failed'"),
+		}, {
+			"", fmt.Errorf("kubectl not set"), "", nil, nil, nil, nil,
+		}, {
+			"", fmt.Errorf("kubectl not set"), "b", nil, &fakeProj, nil, nil,
+		},
+	}
+
+	for _, data := range datas {
+		gc := GKECluster{
+			Exec: func(name string, args ...string) ([]byte, error) {
+				var out []byte
+				var err error
+				if "gcloud" == name {
+					out = []byte(data.gcloudOut)
+					err = data.gcloudErr
+				} else if "kubectl" == name {
+					out = []byte(data.kubectlOut)
+					err = data.kubectlErr
+				}
+				return out, err
+			},
+		}
+		if err := gc.checkEnvironment(); !reflect.DeepEqual(err, data.expErr) || !reflect.DeepEqual(gc.Project, data.expProj) || !reflect.DeepEqual(gc.Cluster, data.expCluster) {
+			t.Errorf("check environment with:\n\tkubectl output: '%s'\n\t\terror: '%v'\n\tgcloud output: '%s'\n\t\t"+
+				"error: '%v'\nwant: project - '%v', cluster - '%v', err - '%v'\ngot: project - '%v', cluster - '%v', err - '%v'",
+				data.kubectlOut, data.kubectlErr, data.gcloudOut, data.gcloudErr, data.expProj, data.expCluster, data.expErr, gc.Project, gc.Cluster, err)
+		}
+	}
+}

--- a/testutils/clustermanager/util.go
+++ b/testutils/clustermanager/util.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustermanager
+
+import (
+	"os/exec"
+)
+
+// standardExec executes shell command and returns stdout and stderr
+func standardExec(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}

--- a/testutils/clustermanager/util_test.go
+++ b/testutils/clustermanager/util_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustermanager
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestStandardExec(t *testing.T) {
+	datas := []struct {
+		cmd    string
+		args   []string
+		expOut string
+		expErr error
+	}{
+		{"bash", []string{"-c", "echo foo"}, "foo\n", nil},
+		{"cmd_not_exist", []string{"-c", "echo"}, "", fmt.Errorf("exec: \"cmd_not_exist\": executable file not found in $PATH")},
+	}
+
+	for _, data := range datas {
+		data := data
+		out, err := standardExec(data.cmd, data.args...)
+		if !reflect.DeepEqual(string(out), data.expOut) || (nil == err && nil != data.expErr) || (nil != err && nil == data.expErr) ||
+			(nil != err && nil != data.expErr && err.Error() != data.expErr.Error()) {
+			t.Errorf("running cmd: '%v', args: '%v'\nwant: out - '%v', err - '%v'\n got: out - '%s', err - '%v'",
+				data.cmd, data.args, data.expOut, data.expErr, string(out), err)
+		}
+	}
+}


### PR DESCRIPTION
Add logic of checking for local environment, i.e. uses existing cluster if kubeconfig is set, uses existing gcp project if gcloud is set.

Part of: https://github.com/knative/test-infra/issues/1186

/cc @adrcunha 