### PR TITLE
Document ParseURL non-conformance with the net/url.Parse api

### DIFF
--- a/apis/url.go
+++ b/apis/url.go
@@ -28,6 +28,8 @@ import (
 type URL url.URL
 
 // ParseURL attempts to parse the given string as a URL.
+// Compatible with net/url.Parse except in the case of an empty string, where
+// the resulting *URL will be nil with no error.
 func ParseURL(u string) (*URL, error) {
 	if u == "" {
 		return nil, nil


### PR DESCRIPTION
## What I expected
If I call `apis.ParseURL(...)` and it returns a nil error, I should be able to use the resulting `apis.URL`.

## What happened
It returns a nil error and a nil URL if passed the empty string, resulting in nil ptr errors.

## Proposed change
I've changed the documentation comment to explain how the API differs from the `net/url.Parse` method so that developers are not surprised by this behavior.

@mattmoor 