### PR TITLE
clustermanager: move common helpers and add more helpers

### DIFF
--- a/testutils/clustermanager/gke.go
+++ b/testutils/clustermanager/gke.go
@@ -37,8 +37,6 @@ type GKECluster struct {
 	NeedCleanup bool
 	// TODO: evaluate returning "google.golang.org/api/container/v1.Cluster" when implementing the creation logic
 	Cluster *string
-	// Exec is the function used for execute standard shell functions, return stdout and stderr
-	Exec func(string, ...string) ([]byte, error)
 }
 
 // Setup sets up a GKECluster client.
@@ -47,9 +45,7 @@ type GKECluster struct {
 // region: default to regional cluster if not provided, and use default backup regions
 // zone: default is none, must be provided together with region
 func (gs *GKEClient) Setup(numNodes *int, nodeType *string, region *string, zone *string, project *string) (ClusterOperations, error) {
-	gc := &GKECluster{
-		Exec: standardExec,
-	}
+	gc := &GKECluster{}
 	// check for local run
 	if nil != project { // if project is supplied, use it and create cluster
 		gc.Project = project
@@ -102,7 +98,7 @@ func (gc *GKECluster) Delete() error {
 // if project can be derived from gcloud, sets it up as well
 func (gc *GKECluster) checkEnvironment() error {
 	// if kubeconfig is configured, use it
-	output, err := gc.Exec("kubectl", "config", "current-context")
+	output, err := common.Exec("kubectl", "config", "current-context")
 	if nil == err {
 		// output should be in the form of gke_PROJECT_REGION_CLUSTER
 		parts := strings.Split(string(output), "_")
@@ -119,7 +115,7 @@ func (gc *GKECluster) checkEnvironment() error {
 	}
 
 	// if gcloud is pointing to a project, use it
-	output, err = gc.Exec("gcloud", "config", "get-value", "project")
+	output, err = common.Exec("gcloud", "config", "get-value", "project")
 	if nil != err {
 		return fmt.Errorf("failed getting gcloud project: '%v'", err)
 	}

--- a/testutils/clustermanager/gke.go
+++ b/testutils/clustermanager/gke.go
@@ -98,7 +98,7 @@ func (gc *GKECluster) Delete() error {
 // if project can be derived from gcloud, sets it up as well
 func (gc *GKECluster) checkEnvironment() error {
 	// if kubeconfig is configured, use it
-	output, err := common.Exec("kubectl", "config", "current-context")
+	output, err := common.StandardExec("kubectl", "config", "current-context")
 	if nil == err {
 		// output should be in the form of gke_PROJECT_REGION_CLUSTER
 		parts := strings.Split(string(output), "_")
@@ -115,7 +115,7 @@ func (gc *GKECluster) checkEnvironment() error {
 	}
 
 	// if gcloud is pointing to a project, use it
-	output, err = common.Exec("gcloud", "config", "get-value", "project")
+	output, err = common.StandardExec("gcloud", "config", "get-value", "project")
 	if nil != err {
 		return fmt.Errorf("failed getting gcloud project: '%v'", err)
 	}

--- a/testutils/clustermanager/gke_test.go
+++ b/testutils/clustermanager/gke_test.go
@@ -69,22 +69,23 @@ func TestGKECheckEnvironment(t *testing.T) {
 		},
 	}
 
-	oldFunc := common.Exec
+	oldFunc := common.StandardExec
 	defer func() {
 		// restore
-		common.Exec = oldFunc
+		common.StandardExec = oldFunc
 	}()
 
 	for _, data := range datas {
 		gc := GKECluster{}
 		// mock for testing
-		common.Exec = func(name string, args ...string) ([]byte, error) {
+		common.StandardExec = func(name string, args ...string) ([]byte, error) {
 			var out []byte
 			var err error
-			if "gcloud" == name {
+			switch name {
+			case "gcloud":
 				out = []byte(data.gcloudOut)
 				err = data.gcloudErr
-			} else if "kubectl" == name {
+			case "kubectl":
 				out = []byte(data.kubectlOut)
 				err = data.kubectlErr
 			}

--- a/testutils/common/common.go
+++ b/testutils/common/common.go
@@ -16,8 +16,37 @@ limitations under the License.
 
 package common
 
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+)
+
+var (
+	// GetOSEnv is for easier mocking in unit tests
+	GetOSEnv = os.Getenv
+	// Exec is for easier mocking in unit tests
+	Exec = StandardExec
+)
+
+// StandardExec executes shell command and returns stdout and stderr
+func StandardExec(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
 // IsProw checks if the process is initialized by Prow
 func IsProw() bool {
 	// TODO: Implement
-	return false
+	return true
+}
+
+// GetRepoName gets repo name by the path where the repo cloned to
+func GetRepoName() (string, error) {
+	out, err := Exec("git", "rev-parse", "--show-toplevel")
+	if nil != err {
+		return "", fmt.Errorf("failed git rev-parse --show-toplevel: '%v'", err)
+	}
+	return strings.TrimSpace(path.Base(string(out))), nil
 }

--- a/testutils/common/common.go
+++ b/testutils/common/common.go
@@ -27,24 +27,23 @@ import (
 var (
 	// GetOSEnv is for easier mocking in unit tests
 	GetOSEnv = os.Getenv
-	// Exec is for easier mocking in unit tests
-	Exec = StandardExec
+	// StandardExec is for easier mocking in unit tests
+	StandardExec = standardExec
 )
 
-// StandardExec executes shell command and returns stdout and stderr
-func StandardExec(name string, args ...string) ([]byte, error) {
+// standardExec executes shell command and returns stdout and stderr
+func standardExec(name string, args ...string) ([]byte, error) {
 	return exec.Command(name, args...).Output()
 }
 
 // IsProw checks if the process is initialized by Prow
 func IsProw() bool {
-	// TODO: Implement
-	return true
+	return "" != GetOSEnv("PROW_JOB_ID")
 }
 
 // GetRepoName gets repo name by the path where the repo cloned to
 func GetRepoName() (string, error) {
-	out, err := Exec("git", "rev-parse", "--show-toplevel")
+	out, err := StandardExec("git", "rev-parse", "--show-toplevel")
 	if nil != err {
 		return "", fmt.Errorf("failed git rev-parse --show-toplevel: '%v'", err)
 	}

--- a/testutils/common/common_test.go
+++ b/testutils/common/common_test.go
@@ -63,15 +63,15 @@ func TestGetRepoName(t *testing.T) {
 		},
 	}
 
-	oldFunc := Exec
+	oldFunc := StandardExec
 	defer func() {
 		// restore
-		Exec = oldFunc
+		StandardExec = oldFunc
 	}()
 
 	for _, data := range datas {
 		// mock for testing
-		Exec = func(name string, args ...string) ([]byte, error) {
+		StandardExec = func(name string, args ...string) ([]byte, error) {
 			return []byte(data.out), data.err
 		}
 

--- a/testutils/common/common_test.go
+++ b/testutils/common/common_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestStandardExec(t *testing.T) {
+	datas := []struct {
+		cmd    string
+		args   []string
+		expOut string
+		expErr error
+	}{
+		{"bash", []string{"-c", "echo foo"}, "foo\n", nil},
+		{"cmd_not_exist", []string{"-c", "echo"}, "", fmt.Errorf("exec: \"cmd_not_exist\": executable file not found in $PATH")},
+	}
+
+	for _, data := range datas {
+		data := data
+		out, err := StandardExec(data.cmd, data.args...)
+		if !reflect.DeepEqual(string(out), data.expOut) || (nil == err && nil != data.expErr) || (nil != err && nil == data.expErr) ||
+			(nil != err && nil != data.expErr && err.Error() != data.expErr.Error()) {
+			t.Errorf("running cmd: '%v', args: '%v'\nwant: out - '%v', err - '%v'\n got: out - '%s', err - '%v'",
+				data.cmd, data.args, data.expOut, data.expErr, string(out), err)
+		}
+	}
+}
+
+func TestGetRepoName(t *testing.T) {
+	datas := []struct {
+		out    string
+		err    error
+		expOut string
+		expErr error
+	}{
+		{
+			// Good run
+			"a/b/c", nil, "c", nil,
+		}, {
+			// Good run
+			"a/b/c/", nil, "c", nil,
+		}, {
+			// Git error
+			"", fmt.Errorf("git error"), "", fmt.Errorf("failed git rev-parse --show-toplevel: 'git error'"),
+		},
+	}
+
+	oldFunc := Exec
+	defer func() {
+		// restore
+		Exec = oldFunc
+	}()
+
+	for _, data := range datas {
+		// mock for testing
+		Exec = func(name string, args ...string) ([]byte, error) {
+			return []byte(data.out), data.err
+		}
+
+		out, err := GetRepoName()
+		if string(data.expOut) != out || !reflect.DeepEqual(err, data.expErr) {
+			t.Errorf("testing getting repo name with:\n\tmocked git output: '%s'\n\tmocked git err: '%v'\nwant: out - '%s', err - '%v'\ngot: out - '%s', err - '%v'",
+				data.out, data.err, data.expOut, data.expErr, out, err)
+		}
+	}
+}


### PR DESCRIPTION
Turns out to be `StandardExec` needs to be mocked in more than one place for unit testing, move it out of `GKECluster` struct to make it simpler. Also, add more common functions as well as unit tests

/cc @adrcunha 