### PR TITLE
Fix licence to have spaces and comment to match the function

### DIFF
--- a/configmap/testing/configmap.go
+++ b/configmap/testing/configmap.go
@@ -3,7 +3,9 @@ Copyright 2019 The Knative Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +36,7 @@ func ConfigMapFromTestFile(t *testing.T, name string, allowed ...string) *corev1
 	return cm
 }
 
-// configMapsFromTestFile creates two corev1.ConfigMap resources from the config
+// ConfigMapsFromTestFile creates two corev1.ConfigMap resources from the config
 // file read from the testdata directory:
 // 1. The raw configmap read in.
 // 2. A second version of the configmap augmenting `data:` with what's parsed from the value of `_example:`


### PR DESCRIPTION
Subj.


/assign @mattmoor 
