### PR TITLE
Expand the tracing package to support stackdriver.

### DIFF
--- a/tracing/config/tracing.go
+++ b/tracing/config/tracing.go
@@ -75,7 +75,7 @@ func NewTracingConfigFromMap(cfgMap map[string]string) (*Config, error) {
 
 	if backend, ok := cfgMap[backendKey]; ok {
 		switch bt := BackendType(backend); bt {
-		case Stackdriver, Zipkin:
+		case Stackdriver, Zipkin, None:
 			tc.Backend = bt
 		default:
 			return nil, fmt.Errorf("unsupported tracing backend value %q", backend)

--- a/tracing/config/tracing_test.go
+++ b/tracing/config/tracing_test.go
@@ -36,7 +36,7 @@ func TestEquals(t *testing.T) {
 		expect: true,
 	}, {
 		name:   "Unequal",
-		cmp1:   Config{Enable: true},
+		cmp1:   Config{Backend: Zipkin},
 		cmp2:   Config{},
 		expect: false,
 	}}
@@ -59,10 +59,11 @@ func TestNewConfigFromMap(t *testing.T) {
 		name:  "Empty map",
 		input: map[string]string{},
 		output: Config{
+			Backend:    None,
 			SampleRate: 0.1,
 		},
 	}, {
-		name: "Everything enabled",
+		name: "Everything enabled (legacy)",
 		input: map[string]string{
 			enableKey:         "true",
 			zipkinEndpointKey: "some-endpoint",
@@ -70,10 +71,57 @@ func TestNewConfigFromMap(t *testing.T) {
 			sampleRateKey:     "0.5",
 		},
 		output: Config{
-			Enable:         true,
+			Backend:        Zipkin,
 			Debug:          true,
 			ZipkinEndpoint: "some-endpoint",
 			SampleRate:     0.5,
+		},
+	}, {
+		name: "Everything enabled (zipkin)",
+		input: map[string]string{
+			backendKey:        "zipkin",
+			zipkinEndpointKey: "some-endpoint",
+			debugKey:          "true",
+			sampleRateKey:     "0.5",
+		},
+		output: Config{
+			Backend:        Zipkin,
+			Debug:          true,
+			ZipkinEndpoint: "some-endpoint",
+			SampleRate:     0.5,
+		},
+	}, {
+		name: "Everything enabled (stackdriver)",
+		input: map[string]string{
+			backendKey:              "stackdriver",
+			zipkinEndpointKey:       "some-endpoint",
+			stackdriverProjectIDKey: "my-project",
+			debugKey:                "true",
+			sampleRateKey:           "0.5",
+		},
+		output: Config{
+			Backend:              Stackdriver,
+			Debug:                true,
+			ZipkinEndpoint:       "some-endpoint",
+			StackdriverProjectID: "my-project",
+			SampleRate:           0.5,
+		},
+	}, {
+		name: "Everything enabled (stackdriver, with enabled)",
+		input: map[string]string{
+			enableKey:               "true",
+			backendKey:              "stackdriver",
+			zipkinEndpointKey:       "some-endpoint",
+			stackdriverProjectIDKey: "my-project",
+			debugKey:                "true",
+			sampleRateKey:           "0.5",
+		},
+		output: Config{
+			Backend:              Stackdriver,
+			Debug:                true,
+			ZipkinEndpoint:       "some-endpoint",
+			StackdriverProjectID: "my-project",
+			SampleRate:           0.5,
 		},
 	}}
 

--- a/tracing/opencensus.go
+++ b/tracing/opencensus.go
@@ -5,6 +5,10 @@ import (
 	"io"
 	"sync"
 
+	"contrib.go.opencensus.io/exporter/stackdriver"
+	oczipkin "contrib.go.opencensus.io/exporter/zipkin"
+	zipkin "github.com/openzipkin/zipkin-go"
+	httpreporter "github.com/openzipkin/zipkin-go/reporter/http"
 	"go.opencensus.io/trace"
 
 	"knative.dev/pkg/tracing/config"
@@ -87,7 +91,7 @@ func (oct *OpenCensusTracer) acquireGlobal() error {
 func createOCTConfig(cfg *config.Config) *trace.Config {
 	octCfg := trace.Config{}
 
-	if cfg.Enable {
+	if cfg.Backend != config.None {
 		if cfg.Debug {
 			octCfg.DefaultSampler = trace.AlwaysSample()
 		} else {
@@ -98,4 +102,47 @@ func createOCTConfig(cfg *config.Config) *trace.Config {
 	}
 
 	return &octCfg
+}
+
+func WithExporter(name string) ConfigOption {
+	return func(cfg *config.Config) {
+		var (
+			exporter trace.Exporter
+			closer   io.Closer
+		)
+		switch cfg.Backend {
+		case config.Stackdriver:
+			exp, err := stackdriver.NewExporter(stackdriver.Options{
+				ProjectID: cfg.StackdriverProjectID,
+			})
+			if err != nil {
+				// TODO(mattmoor): log the error
+				return
+			}
+			exporter = exp
+		case config.Zipkin:
+			zipEP, err := zipkin.NewEndpoint(name, ":80")
+			if err != nil {
+				// TODO(mattmoor): log the error
+				return
+			}
+			reporter := httpreporter.NewReporter(cfg.ZipkinEndpoint)
+			exporter = oczipkin.NewExporter(reporter, zipEP)
+			closer = reporter
+		default:
+			// TODO(mattmoor): disable tracing.
+		}
+		if exporter != nil {
+			trace.RegisterExporter(exporter)
+		}
+		if globalOct.exporter != nil {
+			trace.UnregisterExporter(globalOct.exporter)
+		}
+		if globalOct.closer != nil {
+			_ = globalOct.closer.Close()
+		}
+
+		globalOct.exporter = exporter
+		globalOct.closer = closer
+	}
 }

--- a/tracing/opencensus.go
+++ b/tracing/opencensus.go
@@ -138,6 +138,7 @@ func WithExporter(name string, logger *zap.SugaredLogger) ConfigOption {
 		if exporter != nil {
 			trace.RegisterExporter(exporter)
 		}
+		// We know this is set because we are called with acquireGlobal lock held
 		if globalOct.exporter != nil {
 			trace.UnregisterExporter(globalOct.exporter)
 		}

--- a/tracing/opencensus_test.go
+++ b/tracing/opencensus_test.go
@@ -1,28 +1,39 @@
-package tracing
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing_test
 
 import (
-	"crypto/rand"
-	"errors"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	openzipkin "github.com/openzipkin/zipkin-go"
-	zipkinreporter "github.com/openzipkin/zipkin-go/reporter"
-	reporterrecorder "github.com/openzipkin/zipkin-go/reporter/recorder"
-	"go.opencensus.io/trace"
+	. "knative.dev/pkg/tracing"
 	"knative.dev/pkg/tracing/config"
+	. "knative.dev/pkg/tracing/testing"
 )
 
 func TestOpenCensusTracerGlobalLifecycle(t *testing.T) {
-	reporter := reporterrecorder.NewReporter()
+	reporter, co := FakeZipkinExporter()
 	defer reporter.Close()
-	oct := newOCT(reporter)
+	oct := NewOpenCensusTracer(co)
 	// Apply a config to make us the global OCT
 	if err := oct.ApplyConfig(&config.Config{}); err != nil {
 		t.Fatalf("Failed to ApplyConfig on tracer: %v", err)
 	}
 
-	otherOCT := newOCT(reporter)
+	otherOCT := NewOpenCensusTracer(co)
 	if err := otherOCT.ApplyConfig(&config.Config{}); err == nil {
 		t.Fatalf("Expected error when applying config to second OCT.")
 	}
@@ -35,127 +46,4 @@ func TestOpenCensusTracerGlobalLifecycle(t *testing.T) {
 		t.Fatalf("Failed to ApplyConfig on OtherOCT after finishing OCT: %v", err)
 	}
 	otherOCT.Finish()
-}
-
-func TestOpenCensusTracerApplyConfig(t *testing.T) {
-	tcs := []struct {
-		name          string
-		cfg           config.Config
-		expect        *config.Config
-		reporterError bool
-	}{{
-		name: "Disabled config",
-		cfg: config.Config{
-			Enable: false,
-		},
-		expect: nil,
-	}, {
-		name: "Endpoint specified",
-		cfg: config.Config{
-			Enable:         true,
-			ZipkinEndpoint: "test-endpoint:1234",
-		},
-		expect: &config.Config{
-			Enable:         true,
-			ZipkinEndpoint: "test-endpoint:1234",
-		},
-	}}
-
-	endpoint, _ := openzipkin.NewEndpoint("test", "localhost:1234")
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			var gotCfg *config.Config
-			reporter := reporterrecorder.NewReporter()
-			oct := NewOpenCensusTracer(WithZipkinExporter(func(cfg *config.Config) (zipkinreporter.Reporter, error) {
-				gotCfg = cfg
-				if tc.reporterError {
-					return nil, errors.New("Induced reporter factory error")
-				}
-				return reporter, nil
-			}, endpoint))
-
-			if err := oct.ApplyConfig(&tc.cfg); (err == nil) == tc.reporterError {
-				t.Errorf("Failed to apply config: %v", err)
-			}
-			if diff := cmp.Diff(gotCfg, tc.expect); diff != "" {
-				t.Errorf("Got tracer config (-want, +got) = %v", diff)
-			}
-
-			oct.Finish()
-		})
-	}
-}
-
-func TestCreateOCTConfig(t *testing.T) {
-	tcs := []struct {
-		name   string
-		cfg    config.Config
-		expect trace.Config
-	}{{
-		name: "Default",
-		cfg:  config.Config{},
-		expect: trace.Config{
-			DefaultSampler: trace.NeverSample(),
-		},
-	}, {
-		name: "Disabled",
-		cfg: config.Config{
-			Enable: false,
-		},
-		expect: trace.Config{
-			DefaultSampler: trace.NeverSample(),
-		},
-	}, {
-		name: "Debug",
-		cfg: config.Config{
-			Enable: true,
-			Debug:  true,
-		},
-		expect: trace.Config{
-			DefaultSampler: trace.AlwaysSample(),
-		},
-	}, {
-		name: "Debug disabled",
-		cfg: config.Config{
-			Enable: false,
-			Debug:  true,
-		},
-		expect: trace.Config{
-			DefaultSampler: trace.NeverSample(),
-		},
-	}, {
-		name: "percent sampler",
-		cfg: config.Config{
-			Enable:     true,
-			Debug:      false,
-			SampleRate: 0.5,
-		},
-		expect: trace.Config{
-			DefaultSampler: trace.ProbabilitySampler(0.5),
-		},
-	}}
-
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			octCfg := createOCTConfig(&tc.cfg)
-
-			// Create 100 traceIDs and make sure our expected sampler samples the same as what we get
-			for i := 0; i < 100; i++ {
-				spanID := make([]byte, 8)
-				rand.Read(spanID)
-				param := trace.SamplingParameters{}
-				copy(param.SpanID[:], spanID)
-				if tc.expect.DefaultSampler(param).Sample != octCfg.DefaultSampler(param).Sample {
-					t.Errorf("Sampler for config did not match expected sample value for trace.")
-				}
-			}
-		})
-	}
-}
-
-func newOCT(reporter zipkinreporter.Reporter) *OpenCensusTracer {
-	endpoint, _ := openzipkin.NewEndpoint("test", "localhost:1234")
-	return NewOpenCensusTracer(WithZipkinExporter(func(cfg *config.Config) (zipkinreporter.Reporter, error) {
-		return reporter, nil
-	}, endpoint))
 }

--- a/tracing/sampler_test.go
+++ b/tracing/sampler_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"go.opencensus.io/trace"
+	"knative.dev/pkg/tracing/config"
+)
+
+func TestCreateOCTConfig(t *testing.T) {
+	tcs := []struct {
+		name   string
+		cfg    config.Config
+		expect trace.Config
+	}{{
+		name: "Default",
+		cfg:  config.Config{},
+		expect: trace.Config{
+			DefaultSampler: trace.NeverSample(),
+		},
+	}, {
+		name: "Disabled",
+		cfg: config.Config{
+			Backend: config.None,
+		},
+		expect: trace.Config{
+			DefaultSampler: trace.NeverSample(),
+		},
+	}, {
+		name: "Debug",
+		cfg: config.Config{
+			Backend: config.Stackdriver,
+			Debug:   true,
+		},
+		expect: trace.Config{
+			DefaultSampler: trace.AlwaysSample(),
+		},
+	}, {
+		name: "Debug disabled",
+		cfg: config.Config{
+			Backend: config.None,
+			Debug:   true,
+		},
+		expect: trace.Config{
+			DefaultSampler: trace.NeverSample(),
+		},
+	}, {
+		name: "percent sampler",
+		cfg: config.Config{
+			Backend:    config.Zipkin,
+			Debug:      false,
+			SampleRate: 0.5,
+		},
+		expect: trace.Config{
+			DefaultSampler: trace.ProbabilitySampler(0.5),
+		},
+	}}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			octCfg := createOCTConfig(&tc.cfg)
+
+			// Create 100 traceIDs and make sure our expected sampler samples the same as what we get
+			for i := 0; i < 100; i++ {
+				spanID := make([]byte, 8)
+				rand.Read(spanID)
+				param := trace.SamplingParameters{}
+				copy(param.SpanID[:], spanID)
+				if tc.expect.DefaultSampler(param).Sample != octCfg.DefaultSampler(param).Sample {
+					t.Errorf("Sampler for config did not match expected sample value for trace.")
+				}
+			}
+		})
+	}
+}

--- a/tracing/testing/zipkin.go
+++ b/tracing/testing/zipkin.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	openzipkin "github.com/openzipkin/zipkin-go"
+	zipkinreporter "github.com/openzipkin/zipkin-go/reporter"
+	"github.com/openzipkin/zipkin-go/reporter/recorder"
+	"knative.dev/pkg/tracing"
+	"knative.dev/pkg/tracing/config"
+)
+
+func FakeZipkinExporter() (*recorder.ReporterRecorder, tracing.ConfigOption) {
+	// Create tracer with reporter recorder
+	reporter := recorder.NewReporter()
+	endpoint, _ := openzipkin.NewEndpoint("test", "localhost:1234")
+	exp := tracing.WithZipkinExporter(func(cfg *config.Config) (zipkinreporter.Reporter, error) {
+		return reporter, nil
+	}, endpoint)
+
+	return reporter, exp
+}

--- a/tracing/testing/zipkin.go
+++ b/tracing/testing/zipkin.go
@@ -24,6 +24,16 @@ import (
 	"knative.dev/pkg/tracing/config"
 )
 
+// FakeZipkineExporter is intended to capture the testing boilerplate of building
+// up the ConfigOption to pass NewOpenCensusTracer and expose a mechanism for examining
+// the traces it would have reported.  To set it up, use something like:
+//    reporter, co := FakeZipkinExporter()
+//    defer reporter.Close()
+//    oct := NewOpenCensusTracer(co)
+//    defer oct.Close()
+//    // Do stuff.
+//    spans := reporter.Flush()
+//    // Check reported spans.
 func FakeZipkinExporter() (*recorder.ReporterRecorder, tracing.ConfigOption) {
 	// Create tracer with reporter recorder
 	reporter := recorder.NewReporter()

--- a/tracing/zipkin.go
+++ b/tracing/zipkin.go
@@ -20,7 +20,6 @@ import (
 	"contrib.go.opencensus.io/exporter/zipkin"
 	zipkinmodel "github.com/openzipkin/zipkin-go/model"
 	zipkinreporter "github.com/openzipkin/zipkin-go/reporter"
-	httpreporter "github.com/openzipkin/zipkin-go/reporter/http"
 	"go.opencensus.io/trace"
 
 	"knative.dev/pkg/tracing/config"
@@ -29,15 +28,9 @@ import (
 // ZipkinReporterFactory is a factory function which creates a reporter given a config
 type ZipkinReporterFactory func(*config.Config) (zipkinreporter.Reporter, error)
 
-// CreateZipkinReporter returns a zipkin reporter. If EndpointURL is not specified it returns
-// a noop reporter
-func CreateZipkinReporter(cfg *config.Config) (zipkinreporter.Reporter, error) {
-	if cfg.ZipkinEndpoint == "" {
-		return zipkinreporter.NewNoopReporter(), nil
-	}
-	return httpreporter.NewReporter(cfg.ZipkinEndpoint), nil
-}
-
+// DEPRECATED: This function is the legacy entrypoint and should be replaced with one of:
+//  - WithExporter() in production code
+//  - testing/FakeZipkinExporter() in test code.
 func WithZipkinExporter(reporterFact ZipkinReporterFactory, endpoint *zipkinmodel.Endpoint) ConfigOption {
 	return func(cfg *config.Config) {
 		var (
@@ -45,7 +38,7 @@ func WithZipkinExporter(reporterFact ZipkinReporterFactory, endpoint *zipkinmode
 			exporter trace.Exporter
 		)
 
-		if cfg != nil && cfg.Enable {
+		if cfg != nil && cfg.Backend == config.Zipkin {
 			// Initialize our reporter / exporter
 			// do this before cleanup to minimize time where we have duplicate exporters
 			reporter, err := reporterFact(cfg)

--- a/tracing/zipkin_test.go
+++ b/tracing/zipkin_test.go
@@ -14,29 +14,65 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tracing
+package tracing_test
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	openzipkin "github.com/openzipkin/zipkin-go"
+	zipkinreporter "github.com/openzipkin/zipkin-go/reporter"
+	reporterrecorder "github.com/openzipkin/zipkin-go/reporter/recorder"
+	. "knative.dev/pkg/tracing"
 	"knative.dev/pkg/tracing/config"
 )
 
-func TestCreateReporter(t *testing.T) {
-	rep, err := CreateZipkinReporter(&config.Config{
-		ZipkinEndpoint: "http://localhost:8000",
-	})
-	if err != nil {
-		t.Errorf("Failed to create reporter: %v", err)
-	}
+func TestOpenCensusTracerApplyConfig(t *testing.T) {
+	tcs := []struct {
+		name          string
+		cfg           config.Config
+		expect        *config.Config
+		reporterError bool
+	}{{
+		name: "Disabled config",
+		cfg: config.Config{
+			Backend: config.None,
+		},
+		expect: nil,
+	}, {
+		name: "Endpoint specified",
+		cfg: config.Config{
+			Backend:        config.Zipkin,
+			ZipkinEndpoint: "test-endpoint:1234",
+		},
+		expect: &config.Config{
+			Backend:        config.Zipkin,
+			ZipkinEndpoint: "test-endpoint:1234",
+		},
+	}}
 
-	err = rep.Close()
-	if err != nil {
-		t.Errorf("Failed to close reporter: %v", err)
-	}
+	endpoint, _ := openzipkin.NewEndpoint("test", "localhost:1234")
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotCfg *config.Config
+			reporter := reporterrecorder.NewReporter()
+			oct := NewOpenCensusTracer(WithZipkinExporter(func(cfg *config.Config) (zipkinreporter.Reporter, error) {
+				gotCfg = cfg
+				if tc.reporterError {
+					return nil, errors.New("Induced reporter factory error")
+				}
+				return reporter, nil
+			}, endpoint))
 
-	_, err = CreateZipkinReporter(&config.Config{})
-	if err != nil {
-		t.Errorf("Failed to create reporter: %v", err)
+			if err := oct.ApplyConfig(&tc.cfg); (err == nil) == tc.reporterError {
+				t.Errorf("Failed to apply config: %v", err)
+			}
+			if diff := cmp.Diff(gotCfg, tc.expect); diff != "" {
+				t.Errorf("Got tracer config (-want, +got) = %v", diff)
+			}
+
+			oct.Finish()
+		})
 	}
 }


### PR DESCRIPTION
This makes an assortment of changes to support the use of non-Zipkin tracing backends for publishing traces from system components based on config-tracing.

The changes to the config are modeled after config-observability, which already has support for prometheus and stackdriver backends for metrics.

/hold

This is on hold until I can properly stage downstream changes to serving and eventing.