### PR TITLE
Add exportTo field to Istio CRDs

### DIFF
--- a/apis/istio/v1alpha3/destinationrule_types.go
+++ b/apis/istio/v1alpha3/destinationrule_types.go
@@ -125,6 +125,25 @@ type DestinationRuleSpec struct {
 	// One or more named sets that represent individual versions of a
 	// service. Traffic policies can be overridden at subset level.
 	Subsets []Subset `json:"subsets,omitempty"`
+
+	// A list of namespaces to which this destination rule is exported.
+	// The resolution of a destination rule to apply to a service occurs in the
+	// context of a hierarchy of namespaces. Exporting a destination rule allows
+	// it to be included in the resolution hierarchy for services in
+	// other namespaces. This feature provides a mechanism for service owners
+	// and mesh administrators to control the visibility of destination rules
+	// across namespace boundaries.
+	//
+	// If no namespaces are specified then the destination rule is exported to all
+	// namespaces by default.
+	//
+	// The value "." is reserved and defines an export to the same namespace that
+	// the destination rule is declared in. Similarly, the value "*" is reserved and
+	// defines an export to all namespaces.
+	//
+	// NOTE: in the current release, the `exportTo` value is restricted to
+	// "." or "*" (i.e., the current namespace or all namespaces).
+	ExportTo []string `json:"exportTo,omitempty"`
 }
 
 // Traffic policies to apply for a specific destination, across all

--- a/apis/istio/v1alpha3/virtualservice_types.go
+++ b/apis/istio/v1alpha3/virtualservice_types.go
@@ -141,6 +141,25 @@ type VirtualServiceSpec struct {
 	TCP []TCPRoute `json:"tcp,omitempty"`
 
 	TLS []TLSRoute `json:"tls,omitempty"`
+
+	// A list of namespaces to which this destination rule is exported.
+	// The resolution of a destination rule to apply to a service occurs in the
+	// context of a hierarchy of namespaces. Exporting a destination rule allows
+	// it to be included in the resolution hierarchy for services in
+	// other namespaces. This feature provides a mechanism for service owners
+	// and mesh administrators to control the visibility of destination rules
+	// across namespace boundaries.
+	//
+	// If no namespaces are specified then the destination rule is exported to all
+	// namespaces by default.
+	//
+	// The value "." is reserved and defines an export to the same namespace that
+	// the destination rule is declared in. Similarly, the value "*" is reserved and
+	// defines an export to all namespaces.
+	//
+	// NOTE: in the current release, the `exportTo` value is restricted to
+	// "." or "*" (i.e., the current namespace or all namespaces).
+	ExportTo []string `json:"exportTo,omitempty"`
 }
 
 // Describes match conditions and actions for routing HTTP/1.1, HTTP2, and

--- a/apis/istio/v1alpha3/zz_generated.deepcopy.go
+++ b/apis/istio/v1alpha3/zz_generated.deepcopy.go
@@ -200,6 +200,11 @@ func (in *DestinationRuleSpec) DeepCopyInto(out *DestinationRuleSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ExportTo != nil {
+		in, out := &in.ExportTo, &out.ExportTo
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -1144,6 +1149,11 @@ func (in *VirtualServiceSpec) DeepCopyInto(out *VirtualServiceSpec) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.ExportTo != nil {
+		in, out := &in.ExportTo, &out.ExportTo
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }


### PR DESCRIPTION
Istio's [VirtualService](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#VirtualService) and [DestinationRule](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#DestinationRule) CRDs have a field called `exportTo`. These field are also defined in the Istio API [here](https://github.com/istio/api/blob/master/networking/v1alpha3/destination_rule.pb.go#L261) and [here](https://github.com/istio/api/blob/master/networking/v1alpha3/virtual_service.pb.go#L194).

I realized that these fields are missing from this repo's GO translations so in this PR I'm proposing to add them.

_Disclaimer: There could be other fields besides `exportTo` which have not been translated yet to this repo from: https://github.com/istio/api/tree/master/networking/v1alpha3. I haven't checked the other fields, I only needed `exportTo` which was not translated so far._