### PR TITLE
Add dprotaso to the configmap-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -23,6 +23,7 @@ aliases:
   configmap-approvers:
   - mattmoor
   - mdemirhan
+  - dprotaso
 
   controller-approvers:
   - mattmoor


### PR DESCRIPTION
Authored the store thing here https://github.com/knative/serving/pull/2009
Previous clean up of the watchers https://github.com/knative/pkg/pull/59