### PR TITLE
Add RPS constants

### DIFF
--- a/metrics/metricskey/constants.go
+++ b/metrics/metricskey/constants.go
@@ -71,6 +71,8 @@ var (
 		"knative.dev/serving/autoscaler/actual_pods",
 		"knative.dev/serving/autoscaler/stable_request_concurrency",
 		"knative.dev/serving/autoscaler/panic_request_concurrency",
+		"knative.dev/serving/autoscaler/stable_requests_per_second",
+		"knative.dev/serving/autoscaler/panic_requests_per_second",
 		"knative.dev/serving/autoscaler/target_concurrency_per_pod",
 		"knative.dev/serving/autoscaler/panic_mode",
 		"knative.dev/serving/revision/request_count",


### PR DESCRIPTION
Part of https://github.com/knative/serving/issues/5228

Adding RPS constants to metrics keys.
/cc @yanweiguo 