### PR TITLE
Preserve the original port if it is specified

### DIFF
--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -135,7 +135,12 @@ func (sc *SpoofingClient) Do(req *http.Request) (*Response, error) {
 
 	// Controls the actual resolution.
 	if sc.endpoint != "" {
-		req.URL.Host = sc.endpoint
+		// Preserve the original port if it is specified
+		if req.URL.Port() != "" {
+			req.URL.Host = fmt.Sprintf("%s:%s", sc.endpoint, req.URL.Port())
+		} else {
+			req.URL.Host = sc.endpoint
+		}
 	}
 
 	// Starting span to capture zipkin trace.


### PR DESCRIPTION
The SpoofingClient replaces the entire `URL.Host`, which is actually the URL `authority`, so it replaces the `port` as well. We need to preserve the port. This will enable advanced E2E testing on non-standard ports.