### PR TITLE
Correct a unmarshal error for non pointer members of apis.URL if empty string.

### DIFF
--- a/apis/url.go
+++ b/apis/url.go
@@ -57,11 +57,14 @@ func (u *URL) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &ref); err != nil {
 		return err
 	}
-	r, err := ParseURL(ref)
-	if err != nil {
+	if r, err := ParseURL(ref); err != nil {
 		return err
+	} else if r != nil {
+		*u = *r
+	} else {
+		*u = URL{}
 	}
-	*u = *r
+
 	return nil
 }
 


### PR DESCRIPTION
There was an issue when trying to marshal the addressable struct if the url was an empty string. We do not hit this today because addressable address struct has only one thing and if the url is not set, we omit the outer object. 

