### PR TITLE
Rework how we GlobalResync.

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -359,14 +359,14 @@ func (c *Impl) handleErr(err error, key string) {
 	c.WorkQueue.Forget(key)
 }
 
-// GlobalResync enqueues all objects from the passed SharedInformer
+// GlobalResync enqueues (with a delay) all objects from the passed SharedInformer
 func (c *Impl) GlobalResync(si cache.SharedInformer) {
 	alwaysTrue := func(interface{}) bool { return true }
 	c.FilteredGlobalResync(alwaysTrue, si)
 }
 
-// FilteredGlobalResync enqueues all objects from the SharedInformer
-// that pass the filter function
+// FilteredGlobalResync enqueues (with a delay) all objects from the
+// SharedInformer that pass the filter function
 func (c *Impl) FilteredGlobalResync(f func(interface{}) bool, si cache.SharedInformer) {
 	list := si.GetStore().List()
 	count := float64(len(list))

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -255,12 +256,14 @@ func (c *Impl) EnqueueLabelOfClusterScopedResource(nameLabel string) func(obj in
 // EnqueueKey takes a namespace/name string and puts it onto the work queue.
 func (c *Impl) EnqueueKey(key string) {
 	c.WorkQueue.Add(key)
+	c.logger.Debugf("Adding to queue %s (depth: %d)", key, c.WorkQueue.Len())
 }
 
 // EnqueueKeyAfter takes a namespace/name string and schedules its execution in
 // the work queue after given delay.
 func (c *Impl) EnqueueKeyAfter(key string, delay time.Duration) {
 	c.WorkQueue.AddAfter(key, delay)
+	c.logger.Debugf("Adding to queue %s (delay: %v, depth: %d)", key, delay, c.WorkQueue.Len())
 }
 
 // Run starts the controller's worker threads, the number of which is threadiness.
@@ -299,6 +302,8 @@ func (c *Impl) processNextWorkItem() bool {
 		return false
 	}
 	key := obj.(string)
+
+	c.logger.Debugf("Processing from queue %s (depth: %d)", key, c.WorkQueue.Len())
 
 	startTime := time.Now()
 	// Send the metrics for the current queue depth
@@ -347,6 +352,7 @@ func (c *Impl) handleErr(err error, key string) {
 	// Re-queue the key if it's an transient error.
 	if !IsPermanentError(err) {
 		c.WorkQueue.AddRateLimited(key)
+		c.logger.Debugf("Requeuing key %s due to non-permanent error (depth: %d)", key, c.WorkQueue.Len())
 		return
 	}
 
@@ -355,8 +361,19 @@ func (c *Impl) handleErr(err error, key string) {
 
 // GlobalResync enqueues all objects from the passed SharedInformer
 func (c *Impl) GlobalResync(si cache.SharedInformer) {
-	for _, key := range si.GetStore().ListKeys() {
-		c.EnqueueKey(key)
+	alwaysTrue := func(interface{}) bool { return true }
+	c.FilteredGlobalResync(alwaysTrue, si)
+}
+
+// FilteredGlobalResync enqueues all objects from the SharedInformer
+// that pass the filter function
+func (c *Impl) FilteredGlobalResync(f func(interface{}) bool, si cache.SharedInformer) {
+	list := si.GetStore().List()
+	count := float64(len(list))
+	for _, obj := range list {
+		if f(obj) {
+			c.EnqueueAfter(obj, wait.Jitter(time.Second, count))
+		}
 	}
 }
 

--- a/controller/helper.go
+++ b/controller/helper.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/cache"
 
 	"knative.dev/pkg/kmeta"
 )
@@ -49,19 +48,5 @@ func EnsureTypeMeta(f Callback, gvk schema.GroupVersionKind) Callback {
 
 		// Pass in the mutated copy (accessor is not just a type cast)
 		f(copy)
-	}
-}
-
-// SendGlobalUpdates triggers an update event for all objects from the
-// passed SharedInformer.
-//
-// Since this is triggered not by a real update of these objects
-// themselves, we have no way of knowing the change to these objects
-// if any, so we call handler.OnUpdate(obj, obj) for all of them
-// regardless if they have changes or not.
-func SendGlobalUpdates(si cache.SharedInformer, handler cache.ResourceEventHandler) {
-	store := si.GetStore()
-	for _, obj := range store.List() {
-		handler.OnUpdate(obj, obj)
 	}
 }

--- a/controller/helper_test.go
+++ b/controller/helper_test.go
@@ -28,24 +28,6 @@ import (
 	. "knative.dev/pkg/testing"
 )
 
-func TestSendGlobalUpdate(t *testing.T) {
-	called := make(map[interface{}]bool)
-	handler := cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(old, new interface{}) {
-			called[new] = true
-		},
-	}
-	SendGlobalUpdates(&dummyInformer{}, handler)
-	for _, obj := range dummyObjs {
-		if updated := called[obj]; !updated {
-			t.Errorf("Expected obj %v to be updated but wasn't", obj)
-		}
-	}
-	if len(dummyObjs) != len(called) {
-		t.Errorf("Expected to see %d updates, saw %d", len(dummyObjs), len(called))
-	}
-}
-
 func TestEnsureTypeMeta(t *testing.T) {
 	gvk := schema.GroupVersionKind{
 		Group:   "foo.bar.com",


### PR DESCRIPTION
This consolidates the logic for how we do GlobalResyncs in a few ways:
1. Remove SendGlobalUpdates and replace it with FilteredGlobalResync.
2. Have GlobalResync go through the FilteredGlobalResync with a tautological predicate.
3. Change the way we enqueue things during a global resync to avoid flooding the system
   by using EnqueueAfter and wait.Jitter to stagger how things are queued.

The background for this is that when I started to benchmark reconciliation of a large
number of resources we'd see random large stalls like [this](https://mako.dev/run?run_key=4882560844824576&~dl=1&~cl=1&~rl=1&~rvl=1&~il=1&~sksl=1&~pal=1)
fairly consistently.  Looking at the logs, these stalls coincide with incredibly deep
work queues due to global resyncs triggers by configmap notifications. When I disabled
global resyncs the spikes [went away](https://mako.dev/run?run_key=4975897060835328&~dl=1&~cl=1&~rl=1&~rvl=1&~il=1&~sksl=1&~pal=1).

To mitigate the huge pile-up due to the global resync we use `wait.Jitter` to stagger how
things are enqueued with a `maxFactor` of the length of the store.  This also seems to
[keep things flowing](https://mako.dev/run?run_key=5701802099998720&~dl=1&~cl=1&~rl=1&~rvl=1&~il=1&~sksl=1&~pal=1),
although we will possibly need to tune things further.