### PR TITLE
Ignore idempotent updates and other cleanups

### DIFF
--- a/configmap/informed_watcher.go
+++ b/configmap/informed_watcher.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	informers "k8s.io/client-go/informers"
 	corev1informers "k8s.io/client-go/informers/core/v1"
@@ -140,17 +141,14 @@ func (i *InformedWatcher) registerCallbackAndStartInformer(stopCh <-chan struct{
 }
 
 func (i *InformedWatcher) checkObservedResourcesExist() error {
-	i.m.Lock()
-	defer i.m.Unlock()
+	i.m.RLock()
+	defer i.m.RUnlock()
 	// Check that all objects with Observers exist in our informers.
 	for k := range i.observers {
-		_, err := i.informer.Lister().ConfigMaps(i.Namespace).Get(k)
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				if _, ok := i.defaults[k]; ok {
-					// It is defaulted, so it is OK that it doesn't exist.
-					continue
-				}
+		if _, err := i.informer.Lister().ConfigMaps(i.Namespace).Get(k); err != nil {
+			if _, ok := i.defaults[k]; ok && k8serrors.IsNotFound(err) {
+				// It is defaulted, so it is OK that it doesn't exist.
+				continue
 			}
 			return err
 		}
@@ -163,8 +161,13 @@ func (i *InformedWatcher) addConfigMapEvent(obj interface{}) {
 	i.OnChange(configMap)
 }
 
-func (i *InformedWatcher) updateConfigMapEvent(old, new interface{}) {
-	configMap := new.(*corev1.ConfigMap)
+func (i *InformedWatcher) updateConfigMapEvent(o, n interface{}) {
+	// Ignore updates that are idempotent. We are seeing those
+	// periodically.
+	if equality.Semantic.DeepEqual(o, n) {
+		return
+	}
+	configMap := n.(*corev1.ConfigMap)
 	i.OnChange(configMap)
 }
 


### PR DESCRIPTION
This makes sure we don't call the configmap update on the idempotent updates, which we get now and that causes us lots of global resyncs. (┛◉Д◉)┛彡┻━┻.
This should improve our performance under heavier loads.

In addition I went ahead and applied some nitpicking to the code.

/assign mattmoor