### PR TITLE
test/webhook-apicoverage: Webhook port fix

### DIFF
--- a/test/webhook-apicoverage/webhook/apicoverage_recorder.go
+++ b/test/webhook-apicoverage/webhook/apicoverage_recorder.go
@@ -162,7 +162,7 @@ func (a *APICoverageRecorder) GetResourceCoverage(w http.ResponseWriter, r *http
 	var ignoredFields coveragecalculator.IgnoredFields
 	ignoredFieldsFilePath := os.Getenv("KO_DATA_PATH") + "/ignoredfields.yaml"
 	if err := ignoredFields.ReadFromFile(ignoredFieldsFilePath); err != nil {
-		fmt.Fprintf(w, "Error reading file: %s", ignoredFieldsFilePath)
+		a.Logger.Errorf("Error reading file %s: %v", ignoredFieldsFilePath, err)
 	}
 
 	tree := a.ResourceForest.TopLevelTrees[resource]
@@ -184,7 +184,7 @@ func (a *APICoverageRecorder) GetTotalCoverage(w http.ResponseWriter, r *http.Re
 
 	ignoredFieldsFilePath := os.Getenv("KO_DATA_PATH") + "/ignoredfields.yaml"
 	if err = ignoredFields.ReadFromFile(ignoredFieldsFilePath); err != nil {
-		fmt.Fprintf(w, "error reading file: %s error: %v", ignoredFieldsFilePath, err)
+		a.Logger.Errorf("Error reading file %s: %v", ignoredFieldsFilePath, err)
 	}
 
 	totalCoverage := coveragecalculator.CoverageValues{}
@@ -200,6 +200,7 @@ func (a *APICoverageRecorder) GetTotalCoverage(w http.ResponseWriter, r *http.Re
 	var body []byte
 	if body, err = json.Marshal(totalCoverage); err != nil {
 		fmt.Fprintf(w, "error marshalling total coverage response: %v", err)
+		return
 	}
 
 	if _, err = w.Write(body); err != nil {

--- a/test/webhook-apicoverage/webhook/webhook.go
+++ b/test/webhook-apicoverage/webhook/webhook.go
@@ -237,7 +237,7 @@ func BuildWebhookConfiguration(componentCommonName string, webhookName string, n
 		FailurePolicy:     admissionregistrationv1beta1.Fail,
 		ClientAuth:        tls.NoClientCert,
 		RegistrationDelay: time.Second * 2,
-		Port:              443,
+		Port:              8443, // Using port greater than 1024 as webhook runs as non-root user.
 		Namespace:         namespace,
 		DeploymentName:    componentCommonName,
 		ServiceName:       componentCommonName,


### PR DESCRIPTION
Deployments cannot use 443 as the target port as its blocked. This change fixes the issue in test/webhook-apicoverage tool.