### PR TITLE
Return when we have error

### DIFF
--- a/test/mako/alerter/slack/config.go
+++ b/test/mako/alerter/slack/config.go
@@ -51,6 +51,7 @@ func init() {
 	contents, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		log.Printf("Failed to load the config file: %v", err)
+		return
 	}
 	config := &config{}
 	if err = yaml.Unmarshal(contents, &config); err != nil {


### PR DESCRIPTION
This prevents unmarshalling json when we have errors reading the config