### PR TITLE
Replace string pointer with plain string

### DIFF
--- a/test/ingress/ingress.go
+++ b/test/ingress/ingress.go
@@ -31,8 +31,8 @@ const (
 	istioIngressName      = "istio-ingressgateway"
 )
 
-// GetIngressEndpoint gets the endpoint IP or hostname to use for the service.
-func GetIngressEndpoint(kubeClientset *kubernetes.Clientset) (*string, error) {
+// GetIngressEndpoint gets the ingress public IP or hostname.
+func GetIngressEndpoint(kubeClientset *kubernetes.Clientset) (string, error) {
 	ingressName := istioIngressName
 	if gatewayOverride := os.Getenv("GATEWAY_OVERRIDE"); gatewayOverride != "" {
 		ingressName = gatewayOverride
@@ -44,13 +44,13 @@ func GetIngressEndpoint(kubeClientset *kubernetes.Clientset) (*string, error) {
 
 	ingress, err := kubeClientset.CoreV1().Services(ingressNamespace).Get(ingressName, metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	endpoint, err := EndpointFromService(ingress)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return &endpoint, nil
+	return endpoint, nil
 }
 
 // EndpointFromService extracts the endpoint from the service's ingress.

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -119,7 +119,7 @@ func ResolveEndpoint(kubeClientset *kubernetes.Clientset, domain string, resolva
 	// If the domain is resolvable, we can use it directly when we make requests.
 	endpoint := domain
 	if !resolvable {
-		e := &endpointOverride
+		e := endpointOverride
 		if endpointOverride == "" {
 			var err error
 			// If the domain that the Route controller is configured to assign to Route.Status.Domain
@@ -129,7 +129,7 @@ func ResolveEndpoint(kubeClientset *kubernetes.Clientset, domain string, resolva
 				return "", err
 			}
 		}
-		endpoint = *e
+		endpoint = e
 	}
 	return endpoint, nil
 }


### PR DESCRIPTION
There is no reason to use a string pointer here.
It makes the calling code weird since string pointers are pretty much never used in Go.