### PR TITLE
tracing.HTTPSpanMiddlewareIgnoringPaths

### DIFF
--- a/tracing/http.go
+++ b/tracing/http.go
@@ -32,16 +32,15 @@ var (
 	// underlyingSampling uses the underlying sampling configuration (normally via the ConfigMap
 	// config-tracing).
 	underlyingSampling = trace.StartOptions{}
+
+	// HTTPSpanMiddleware is an http.Handler middleware to create spans for the HTTP endpoint.
+	HTTPSpanMiddleware = HTTPSpanIgnoringPaths()
 )
 
-// HTTPSpanMiddleware is a http.Handler middleware to create spans for the HTTP endpoint
-func HTTPSpanMiddleware(next http.Handler) http.Handler {
-	return &ochttp.Handler{Handler: next}
-}
 
-// HTTPSpanMiddlewareIgnoringPaths is an http.Handler middleware to create spans for the HTTP
+// HTTPSpanIgnoringPaths is an http.Handler middleware to create spans for the HTTP
 // endpoint, not sampling any request whose path is in pathsToIgnore.
-func HTTPSpanMiddlewareIgnoringPaths(pathsToIgnore ...string) func(http.Handler) http.Handler {
+func HTTPSpanIgnoringPaths(pathsToIgnore ...string) func(http.Handler) http.Handler {
 	pathsToIgnoreSet := sets.NewString(pathsToIgnore...)
 	return func(next http.Handler) http.Handler {
 		return &ochttp.Handler{

--- a/tracing/http.go
+++ b/tracing/http.go
@@ -20,9 +20,38 @@ import (
 	"net/http"
 
 	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/trace"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var (
+	// neverSample forcibly turns off sampling.
+	neverSample = trace.StartOptions{
+		Sampler: trace.NeverSample(),
+	}
+	// underlyingSampling uses the underlying sampling configuration (normally via the ConfigMap
+	// config-tracing).
+	underlyingSampling = trace.StartOptions{}
 )
 
 // HTTPSpanMiddleware is a http.Handler middleware to create spans for the HTTP endpoint
 func HTTPSpanMiddleware(next http.Handler) http.Handler {
 	return &ochttp.Handler{Handler: next}
+}
+
+// HTTPSpanMiddlewareIgnoringPaths is an http.Handler middleware to create spans for the HTTP
+// endpoint, not sampling any request whose path is in pathsToIgnore.
+func HTTPSpanMiddlewareIgnoringPaths(pathsToIgnore ...string) func(http.Handler) http.Handler {
+	pathsToIgnoreSet := sets.NewString(pathsToIgnore...)
+	return func(next http.Handler) http.Handler {
+		return &ochttp.Handler{
+			Handler: next,
+			GetStartOptions: func(r *http.Request) trace.StartOptions {
+				if pathsToIgnoreSet.Has(r.URL.Path) {
+					return neverSample
+				}
+				return underlyingSampling
+			},
+		}
+	}
 }

--- a/tracing/http_test.go
+++ b/tracing/http_test.go
@@ -96,7 +96,7 @@ func TestHTTPSpanMiddleware(t *testing.T) {
 	}
 }
 
-func TestHTTPSpanMiddlewareIgnoringPaths(t *testing.T) {
+func TestHTTPSpanIgnoringPaths(t *testing.T) {
 	cfg := config.Config{
 		Backend: config.Zipkin,
 		Debug:   true,
@@ -113,7 +113,7 @@ func TestHTTPSpanMiddlewareIgnoringPaths(t *testing.T) {
 	}
 
 	paths := []string{"/readyz"}
-	middleware := HTTPSpanMiddlewareIgnoringPaths(paths...)(&testHandler{})
+	middleware := HTTPSpanIgnoringPaths(paths...)(&testHandler{})
 
 	testCases := map[string]struct {
 		path   string

--- a/tracing/http_test.go
+++ b/tracing/http_test.go
@@ -18,6 +18,7 @@ package tracing_test
 
 import (
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -92,5 +93,79 @@ func TestHTTPSpanMiddleware(t *testing.T) {
 	}
 	if got := spans[0].TraceID.String(); got != traceID {
 		t.Errorf("spans[0].TraceID = %s, want %s", got, traceID)
+	}
+}
+
+func TestHTTPSpanMiddlewareIgnoringPaths(t *testing.T) {
+	cfg := config.Config{
+		Backend: config.Zipkin,
+		Debug:   true,
+	}
+
+	// Create tracer with reporter recorder
+	reporter, co := FakeZipkinExporter()
+	defer reporter.Close()
+	oct := NewOpenCensusTracer(co)
+	defer oct.Finish()
+
+	if err := oct.ApplyConfig(&cfg); err != nil {
+		t.Errorf("Failed to apply tracer config: %v", err)
+	}
+
+	paths := []string{"/readyz"}
+	middleware := HTTPSpanMiddlewareIgnoringPaths(paths...)(&testHandler{})
+
+	testCases := map[string]struct {
+		path   string
+		traced bool
+	}{
+		"traced": {
+			path:   "/",
+			traced: true,
+		},
+		"ignored": {
+			path:   paths[0],
+			traced: false,
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			var lastWrite []byte
+			fw := fakeWriter{lastWrite: &lastWrite}
+
+			url := url.URL{
+				Scheme: "http",
+				Host:   "test.example.com",
+				Path:   tc.path,
+			}
+			req, err := http.NewRequest("GET", url.String(), nil)
+			if err != nil {
+				t.Errorf("Failed to make fake request: %v", err)
+			}
+			traceID := "821e0d50d931235a5ba3fa42eddddd8f"
+			req.Header["X-B3-Traceid"] = []string{traceID}
+			req.Header["X-B3-Spanid"] = []string{"b3bd5e1c4318c78a"}
+
+			middleware.ServeHTTP(fw, req)
+
+			// Assert our next handler was called
+			if diff := cmp.Diff([]byte("fake"), lastWrite); diff != "" {
+				t.Errorf("Got http response (-want, +got) = %v", diff)
+			}
+
+			spans := reporter.Flush()
+			if tc.traced {
+				if len(spans) != 1 {
+					t.Errorf("Got %d spans, expected 1: spans = %v", len(spans), spans)
+				}
+				if got := spans[0].TraceID.String(); got != traceID {
+					t.Errorf("spans[0].TraceID = %s, want %s", got, traceID)
+				}
+			} else {
+				if len(spans) != 0 {
+					t.Errorf("Got %d spans, expected 0: spans = %v", len(spans), spans)
+				}
+			}
+		})
 	}
 }

--- a/tracing/http_test.go
+++ b/tracing/http_test.go
@@ -133,18 +133,18 @@ func TestHTTPSpanMiddlewareIgnoringPaths(t *testing.T) {
 			var lastWrite []byte
 			fw := fakeWriter{lastWrite: &lastWrite}
 
-			url := url.URL{
+			u := &url.URL{
 				Scheme: "http",
 				Host:   "test.example.com",
 				Path:   tc.path,
 			}
-			req, err := http.NewRequest("GET", url.String(), nil)
+			req, err := http.NewRequest("GET", u.String(), nil)
 			if err != nil {
 				t.Errorf("Failed to make fake request: %v", err)
 			}
 			traceID := "821e0d50d931235a5ba3fa42eddddd8f"
-			req.Header["X-B3-Traceid"] = []string{traceID}
-			req.Header["X-B3-Spanid"] = []string{"b3bd5e1c4318c78a"}
+			req.Header.Set("X-B3-Traceid", traceID)
+			req.Header.Set("X-B3-Spanid", "b3bd5e1c4318c78a")
 
 			middleware.ServeHTTP(fw, req)
 


### PR DESCRIPTION
Add tracing.HTTPSpanMiddlewareIgnoringPaths which will turn off tracing for the specified paths.

This is intended to allow us to ignore automated requests, such as liveness and readiness checks.