### PR TITLE
Spoof at the Resolver layer, not the Request layer

### DIFF
--- a/test/clients.go
+++ b/test/clients.go
@@ -20,6 +20,7 @@ package test
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -38,8 +39,8 @@ type KubeClient struct {
 }
 
 // NewSpoofingClient returns a spoofing client to make requests
-func NewSpoofingClient(client *KubeClient, logf logging.FormatLogger, domain string, resolvable bool) (*spoof.SpoofingClient, error) {
-	return spoof.New(client.Kube, logf, domain, resolvable, Flags.IngressEndpoint)
+func NewSpoofingClient(client *KubeClient, transport *http.Transport, logf logging.FormatLogger, domain string, resolvable bool) (*spoof.SpoofingClient, error) {
+	return spoof.New(client.Kube, transport, logf, domain, resolvable, Flags.IngressEndpoint)
 }
 
 // NewKubeClient instantiates and returns several clientsets required for making request to the

--- a/test/request.go
+++ b/test/request.go
@@ -134,8 +134,15 @@ func MatchesAllOf(checkers ...spoof.ResponseChecker) spoof.ResponseChecker {
 // the domain in the request headers, otherwise it will make the request directly to domain.
 // desc will be used to name the metric that is emitted to track how long it took for the
 // domain to get into the state checked by inState.  Commas in `desc` must be escaped.
-func WaitForEndpointState(kubeClient *KubeClient, logf logging.FormatLogger, theURL string, inState spoof.ResponseChecker, desc string, resolvable bool, opts ...RequestOption) (*spoof.Response, error) {
-	return WaitForEndpointStateWithTimeout(kubeClient, logf, theURL, inState, desc, resolvable, spoof.RequestTimeout, opts...)
+func WaitForEndpointState(
+	kubeClient *KubeClient,
+	logf logging.FormatLogger,
+	theURL string,
+	inState spoof.ResponseChecker,
+	desc string,
+	resolvable bool,
+	opts ...RequestOption) (*spoof.Response, error) {
+	return WaitForEndpointStateWithTimeout(kubeClient, http.DefaultTransport.(*http.Transport), logf, theURL, inState, desc, resolvable, spoof.RequestTimeout, opts...)
 }
 
 // WaitForEndpointStateWithTimeout will poll an endpoint until inState indicates the state is achieved
@@ -145,8 +152,15 @@ func WaitForEndpointState(kubeClient *KubeClient, logf logging.FormatLogger, the
 // desc will be used to name the metric that is emitted to track how long it took for the
 // domain to get into the state checked by inState.  Commas in `desc` must be escaped.
 func WaitForEndpointStateWithTimeout(
-	kubeClient *KubeClient, logf logging.FormatLogger, theURL string, inState spoof.ResponseChecker,
-	desc string, resolvable bool, timeout time.Duration, opts ...RequestOption) (*spoof.Response, error) {
+	kubeClient *KubeClient,
+	transport *http.Transport,
+	logf logging.FormatLogger,
+	theURL string,
+	inState spoof.ResponseChecker,
+	desc string,
+	resolvable bool,
+	timeout time.Duration,
+	opts ...RequestOption) (*spoof.Response, error) {
 	defer logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForEndpointState/%s", desc)).End()
 
 	// Try parsing the "theURL" with and without a scheme.
@@ -167,7 +181,7 @@ func WaitForEndpointStateWithTimeout(
 		opt(req)
 	}
 
-	client, err := NewSpoofingClient(kubeClient, logf, asURL.Hostname(), resolvable)
+	client, err := NewSpoofingClient(kubeClient, transport, logf, asURL.Hostname(), resolvable)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #621.

Currently, Spoofing is done at the request layer, meaning `http.Request.Host` and `http.Request.URL.Host` are modified. This doesn't work with HTTPS because `http.Request.URL.Host` must match the TLS certificate Common Name or Subject Alternative Names, and therefore cannot be tempered. The solution is to spoof at the DNS resolution.

This also contains a minor change to accept a custom http.Transport that will be used in HTTPS E2E tests.