### PR TITLE
Improve the logging situation in table tests

### DIFF
--- a/reconciler/testing/table.go
+++ b/reconciler/testing/table.go
@@ -25,12 +25,17 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"go.uber.org/zap"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/logging/logkey"
 	_ "knative.dev/pkg/system/testing" // Setup system.Namespace()
 )
 
@@ -107,6 +112,12 @@ func (r *TableRow) Test(t *testing.T, factory Factory) {
 	ctx := r.Ctx
 	if ctx == nil {
 		ctx = context.Background()
+	} else {
+		// If we have logger setup on the context, decorate it with the key, so that the logs
+		// look like in prod.
+		l := logging.FromContext(ctx)
+		l = l.With(zap.String(logkey.Key, r.Key))
+		ctx = logging.WithLogger(ctx, l)
 	}
 
 	// Run the Reconcile we're testing.
@@ -122,7 +133,7 @@ func (r *TableRow) Test(t *testing.T, factory Factory) {
 	}
 
 	// Previous state is used to diff resource expected state for update requests that were missed.
-	objPrevState := map[string]runtime.Object{}
+	objPrevState := make(map[string]runtime.Object, len(r.Objects))
 	for _, o := range r.Objects {
 		objPrevState[objKey(o)] = o
 	}
@@ -341,7 +352,7 @@ func (tt TableTest) Test(t *testing.T, factory Factory) {
 	t.Helper()
 	for _, test := range tt {
 		// Record the original objects in table.
-		originObjects := []runtime.Object{}
+		originObjects := make([]runtime.Object, 0, len(test.Objects))
 		for _, obj := range test.Objects {
 			originObjects = append(originObjects, obj.DeepCopyObject())
 		}


### PR DESCRIPTION
Currently the table tests do not annotate the context logger with the key
which means we puts lots of unnecessary logging in the reconcilers to log the key that is being reconciled.
So this fixes that.
Also precreates some containers to the needed size.

/assign mattmoor