### PR TITLE
Extend reconciler and controller owners with engineers mostly working on the reconcilers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -26,13 +26,16 @@ aliases:
   - dprotaso
 
   controller-approvers:
-  - mattmoor
+  - dgerd
   - grantr
+  - mattmoor
   - tcnghia
+  - vagababov
 
   kmeta-approvers:
   - mattmoor
-  - jonjohnsonjr
+  - dgerd
+  - vagababov
 
   logging-approvers:
   - mdemirhan

--- a/reconciler/OWNERS
+++ b/reconciler/OWNERS
@@ -1,0 +1,4 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- controller-approvers


### PR DESCRIPTION
Extend reconciler and controller owners with engineers mostly working on the reconcilers

/assign mattmoor
/cc @dgerd