### PR TITLE
Report the status text in addition to the code on failure.

### DIFF
--- a/test/request.go
+++ b/test/request.go
@@ -74,7 +74,7 @@ func IsOneOfStatusCodes(codes ...int) spoof.ResponseChecker {
 			}
 		}
 
-		return true, fmt.Errorf("status = %d, want one of: %v", resp.StatusCode, codes)
+		return true, fmt.Errorf("status = %d %s, want one of: %v", resp.StatusCode, resp.Status, codes)
 	}
 }
 


### PR DESCRIPTION
This should surface better info from the 502s we've been seeing (I hope).