### PR TITLE
 Add SetupFakeContextWithCancel so that context can be canceled. 

### DIFF
--- a/reconciler/testing/context.go
+++ b/reconciler/testing/context.go
@@ -28,8 +28,17 @@ import (
 	logtesting "knative.dev/pkg/logging/testing"
 )
 
+// SetupFakeContext sets up the the Context and the fake informers for the tests.
 func SetupFakeContext(t *testing.T) (context.Context, []controller.Informer) {
-	ctx := logtesting.TestContextWithLogger(t)
+	c, _, is := SetupFakeContextWithCancel(t)
+	return c, is
+}
+
+// SetupFakeContextWithCancel sets up the the Context and the fake informers for the tests
+// The provided context can be canceled using provided callback.
+func SetupFakeContextWithCancel(t *testing.T) (context.Context, context.CancelFunc, []controller.Informer) {
+	ctx, c := context.WithCancel(logtesting.TestContextWithLogger(t))
 	ctx = controller.WithEventRecorder(ctx, record.NewFakeRecorder(1000))
-	return injection.Fake.SetupInformers(ctx, &rest.Config{})
+	ctx, is := injection.Fake.SetupInformers(ctx, &rest.Config{})
+	return ctx, c, is
 }


### PR DESCRIPTION
This will help tests to terminate their informer loops.
Otherwise they don't and that's no good, since we get panics and race conditions.

/assign mattmoor