### PR TITLE
Print target name when failed to ping

### DIFF
--- a/websocket/connection.go
+++ b/websocket/connection.go
@@ -155,7 +155,7 @@ func NewDurableConnection(target string, messageChan chan []byte, logger *zap.Su
 			select {
 			case <-ticker.C:
 				if err := c.write(websocket.PingMessage, []byte{}); err != nil {
-					logger.Errorw(fmt.Sprintf("Failed to send ping message to %q", target), zap.Error(err))
+					logger.Errorw("Failed to send ping message to "+target, zap.Error(err))
 				}
 			case <-c.closeChan:
 				return

--- a/websocket/connection.go
+++ b/websocket/connection.go
@@ -155,7 +155,7 @@ func NewDurableConnection(target string, messageChan chan []byte, logger *zap.Su
 			select {
 			case <-ticker.C:
 				if err := c.write(websocket.PingMessage, []byte{}); err != nil {
-					logger.Errorw("Failed to send ping message", zap.Error(err))
+					logger.Errorw(fmt.Sprintf("Failed to send ping message to %q", target), zap.Error(err))
 				}
 			case <-c.closeChan:
 				return


### PR DESCRIPTION
For example, when serving activator fails to ping autoscaler, it fails
with `Failed to send ping message` message. However, it does not print
target peer's name so it is difficult to debug.

This patch changes to print the target name.

BEFORE:
```
{"level":"error","ts":"2019-09-04T06:13:07.543Z","logger":"activator","caller":"websocket/connection.go:158","msg":"Failed to send ping message","commit":"c2b0a5e","knative.dev/controller":"activator","error":"connection has not yet been established","stacktrace":"knative.dev/serving/vendor/knative.dev/pkg/websocket.NewDurableConnection.func3\n\t/home/knakayam/.go/src/knative.dev/serving/vendor/knative.dev/pkg/websocket/connection.go:158"}
```


AFTER:
```
{"level":"error","ts":"2019-09-04T06:23:13.689Z","logger":"activator","caller":"websocket/connection.go:158","msg":"Failed to send ping message to \"ws://autoscaler.knative-serving.svc.cluster.local:8080\"","commit":"c2b0a5e","knative.dev/controller":"activator","error":"connection has not yet been established","stacktrace":"knative.dev/serving/vendor/knative.dev/pkg/websocket.NewDurableConnection.func3\n\t/home/knakayam/.go/src/knative.dev/serving/vendor/knative.dev/pkg/websocket/connection.go:158"}
```