### PR TITLE
Fix the flag parsing for integration tests in go 1.13

### DIFF
--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/user"
 	"path"
+	"testing"
 )
 
 // Flags holds the command line flags or defaults for settings in the user's environment.
@@ -44,6 +45,7 @@ type EnvironmentFlags struct {
 }
 
 func initializeFlags() *EnvironmentFlags {
+	testing.Init()
 	var f EnvironmentFlags
 	flag.StringVar(&f.Cluster, "cluster", "",
 		"Provide the cluster to test against. Defaults to the current cluster in kubeconfig.")

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"os/user"
 	"path"
-	"testing"
 )
 
 // Flags holds the command line flags or defaults for settings in the user's environment.
@@ -45,7 +44,7 @@ type EnvironmentFlags struct {
 }
 
 func initializeFlags() *EnvironmentFlags {
-	testing.Init()
+	initTesting()
 	var f EnvironmentFlags
 	flag.StringVar(&f.Cluster, "cluster", "",
 		"Provide the cluster to test against. Defaults to the current cluster in kubeconfig.")

--- a/test/inittesting112.go
+++ b/test/inittesting112.go
@@ -1,0 +1,23 @@
+// +build !go1.13
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+// initTesting is a no-op for 1.12 and below.
+func initTesting() {
+}

--- a/test/inittesting113.go
+++ b/test/inittesting113.go
@@ -1,0 +1,26 @@
+// +build go1.13
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import "testing"
+
+// initTesting inits testing flags for go1.13 and above.
+func initTesting() {
+	testing.Init()
+}


### PR DESCRIPTION
This fixes the errors when running e2e tests.

/cc mattmoor @chaodaiG @adrcunha 
/hold 
we need 1.13 on prow and what now, before this can go in,
but if you patch your vendor/pkg/test/e2e... with this you'll be able to run tests again.