### PR TITLE
Fix the problem in kubelogs when source is not controller.

### DIFF
--- a/test/logstream/kubelogs.go
+++ b/test/logstream/kubelogs.go
@@ -137,11 +137,17 @@ func (k *kubelogs) handleLine(l string) {
 			continue
 		}
 
+		// We also get logs not from controllers (activator, autoscaler).
+		// So replace controller string in them with their callsite.
+		site := line.Controller
+		if site == "" {
+			site = line.Caller
+		}
 		// E 15:04:05.000 [route-controller] [default/testroute-xyz] this is my message
 		msg := fmt.Sprintf("%s %s [%s] [%s] %s",
 			strings.ToUpper(string(line.Level[0])),
 			line.Timestamp.Format(timeFormat),
-			line.Controller,
+			site,
 			line.Key,
 			line.Message)
 


### PR DESCRIPTION
If the source is activator or autoscaler, we'd just print  in the logstream
making it not very useful for searching.

Replace it with call site, if the controller is not set all.

/assign mattmoor