### PR TITLE
Add Addressable type converters to v1 Addressable

### DIFF
--- a/apis/duck/v1/addressable_types.go
+++ b/apis/duck/v1/addressable_types.go
@@ -22,6 +22,8 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
+	"knative.dev/pkg/apis/duck/v1alpha1"
+	"knative.dev/pkg/apis/duck/v1beta1"
 )
 
 // Addressable provides a generic mechanism for a custom resource
@@ -66,6 +68,34 @@ var (
 // GetFullType implements duck.Implementable
 func (*Addressable) GetFullType() duck.Populatable {
 	return &AddressableType{}
+}
+
+// ToBeta returns a new v1beta1 Addressable from this v1 Addressable.
+func (a *Addressable) ToBeta() v1beta1.Addressable {
+	return v1beta1.Addressable{
+		URL: a.URL.DeepCopy(),
+	}
+}
+
+// FromBeta returns a new v1 Addressable from a v1beta1 Addressable.
+func FromBeta(a v1beta1.Addressable) Addressable {
+	return Addressable{
+		URL: a.URL.DeepCopy(),
+	}
+}
+
+// ToAlpha returns a new v1alpha1 Addressable from this v1 Addressable.
+func (a *Addressable) ToAlpha() v1alpha1.Addressable {
+	return v1alpha1.Addressable{
+		Addressable: a.ToBeta(),
+	}
+}
+
+// FromAlpha returns a new v1 Addressable from a v1alpha1 Addressable.
+func FromAlpha(a v1alpha1.Addressable) Addressable {
+	return Addressable{
+		URL: a.Addressable.URL.DeepCopy(),
+	}
 }
 
 // Populate implements duck.Populatable

--- a/apis/duck/v1/addressable_types.go
+++ b/apis/duck/v1/addressable_types.go
@@ -17,13 +17,14 @@ limitations under the License.
 package v1
 
 import (
+	"context"
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
-	"knative.dev/pkg/apis/duck/v1alpha1"
-	"knative.dev/pkg/apis/duck/v1beta1"
 )
 
 // Addressable provides a generic mechanism for a custom resource
@@ -36,8 +37,12 @@ type Addressable struct {
 	URL *apis.URL `json:"url,omitempty"`
 }
 
-// Addressable is an Implementable "duck type".
-var _ duck.Implementable = (*Addressable)(nil)
+var (
+	// Addressable is an Implementable "duck type".
+	_ duck.Implementable = (*Addressable)(nil)
+	// Addressable is a Convertible type.
+	_ apis.Convertible = (*Addressable)(nil)
+)
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -70,32 +75,14 @@ func (*Addressable) GetFullType() duck.Populatable {
 	return &AddressableType{}
 }
 
-// ToBeta returns a new v1beta1 Addressable from this v1 Addressable.
-func (a *Addressable) ToBeta() v1beta1.Addressable {
-	return v1beta1.Addressable{
-		URL: a.URL.DeepCopy(),
-	}
+// ConvertUp implements apis.Convertible
+func (a *Addressable) ConvertUp(ctx context.Context, to apis.Convertible) error {
+	return fmt.Errorf("v1 is the highest known version, got: %T", to)
 }
 
-// FromBeta returns a new v1 Addressable from a v1beta1 Addressable.
-func FromBeta(a v1beta1.Addressable) Addressable {
-	return Addressable{
-		URL: a.URL.DeepCopy(),
-	}
-}
-
-// ToAlpha returns a new v1alpha1 Addressable from this v1 Addressable.
-func (a *Addressable) ToAlpha() v1alpha1.Addressable {
-	return v1alpha1.Addressable{
-		Addressable: a.ToBeta(),
-	}
-}
-
-// FromAlpha returns a new v1 Addressable from a v1alpha1 Addressable.
-func FromAlpha(a v1alpha1.Addressable) Addressable {
-	return Addressable{
-		URL: a.Addressable.URL.DeepCopy(),
-	}
+// ConvertDown implements apis.Convertible
+func (a *Addressable) ConvertDown(ctx context.Context, from apis.Convertible) error {
+	return fmt.Errorf("v1 is the highest known version, got: %T", from)
 }
 
 // Populate implements duck.Populatable

--- a/apis/duck/v1/addressable_types_test.go
+++ b/apis/duck/v1/addressable_types_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"testing"
+
+	"knative.dev/pkg/apis"
+)
+
+func TestBetaConversion(t *testing.T) {
+	tests := []struct {
+		name string
+		addr Addressable
+		want apis.URL
+	}{{
+		name: "just url",
+		addr: Addressable{
+			URL: &apis.URL{
+				Scheme: "https",
+				Host:   "bar.com",
+			},
+		},
+		want: apis.URL{
+			Scheme: "https",
+			Host:   "bar.com",
+		},
+	}, {
+		name: "url with path",
+		addr: Addressable{
+			URL: &apis.URL{
+				Scheme: "https",
+				Host:   "bar.com",
+				Path:   "/v1",
+			},
+		},
+		want: apis.URL{
+			Scheme: "https",
+			Host:   "bar.com",
+			Path:   "/v1",
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			beta := test.addr.ToBeta()
+			gotBeta := beta.URL
+			gotRoundtrip := FromBeta(beta).URL
+
+			if test.want.String() != gotBeta.String() {
+				t.Errorf("v1beta1.URL = %v, wanted %v", gotBeta, test.want)
+			}
+			if test.want.String() != gotRoundtrip.String() {
+				t.Errorf("rountrip v1.URL = %v, wanted %v", gotRoundtrip, test.want)
+			}
+		})
+	}
+}
+
+func TestAlphaConversion(t *testing.T) {
+	tests := []struct {
+		name string
+		addr Addressable
+		want apis.URL
+	}{{
+		name: "just url",
+		addr: Addressable{
+			URL: &apis.URL{
+				Scheme: "https",
+				Host:   "bar.com",
+			},
+		},
+		want: apis.URL{
+			Scheme: "https",
+			Host:   "bar.com",
+		},
+	}, {
+		name: "url with path",
+		addr: Addressable{
+			URL: &apis.URL{
+				Scheme: "https",
+				Host:   "bar.com",
+				Path:   "/v1",
+			},
+		},
+		want: apis.URL{
+			Scheme: "https",
+			Host:   "bar.com",
+			Path:   "/v1",
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			alpha := test.addr.ToAlpha()
+			gotAlpha := alpha.GetURL()
+			gotRoundtrip := FromAlpha(alpha).URL
+
+			if test.want.String() != gotAlpha.String() {
+				t.Errorf("v1alpha1.GetURL() = %v, wanted %v", gotAlpha, test.want)
+			}
+			if test.want.String() != gotRoundtrip.String() {
+				t.Errorf("roundtrip v1.GetURL() = %v, wanted %v", gotRoundtrip, test.want)
+			}
+		})
+	}
+}

--- a/apis/duck/v1alpha1/addressable_types.go
+++ b/apis/duck/v1alpha1/addressable_types.go
@@ -87,6 +87,7 @@ func (t *AddressableType) Populate() {
 	}
 }
 
+// GetURL returns the URL type for the Addressable.
 func (a Addressable) GetURL() apis.URL {
 	if a.URL != nil {
 		return *a.URL

--- a/apis/duck/v1alpha1/addressable_types.go
+++ b/apis/duck/v1alpha1/addressable_types.go
@@ -17,11 +17,15 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
+	"knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/apis/duck/v1beta1"
 )
 
@@ -37,8 +41,12 @@ type Addressable struct {
 	Hostname string `json:"hostname,omitempty"`
 }
 
-// Addressable is an Implementable "duck type".
-var _ duck.Implementable = (*Addressable)(nil)
+var (
+	// Addressable is an Implementable "duck type".
+	_ duck.Implementable = (*Addressable)(nil)
+	// Addressable is a Convertible type.
+	_ apis.Convertible = (*Addressable)(nil)
+)
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -69,6 +77,35 @@ var (
 // GetFullType implements duck.Implementable
 func (*Addressable) GetFullType() duck.Populatable {
 	return &AddressableType{}
+}
+
+// ConvertUp implements apis.Convertible
+func (a *Addressable) ConvertUp(ctx context.Context, to apis.Convertible) error {
+	url := a.GetURL()
+	switch sink := to.(type) {
+	case *v1.Addressable:
+		sink.URL = url.DeepCopy()
+		return nil
+	case *v1beta1.Addressable:
+		sink.URL = url.DeepCopy()
+		return nil
+	default:
+		return fmt.Errorf("unknown version, got: %T", to)
+	}
+}
+
+// ConvertDown implements apis.Convertible
+func (a *Addressable) ConvertDown(ctx context.Context, from apis.Convertible) error {
+	switch source := from.(type) {
+	case *v1.Addressable:
+		a.URL = source.URL.DeepCopy()
+		return nil
+	case *v1beta1.Addressable:
+		a.URL = source.URL.DeepCopy()
+		return nil
+	default:
+		return fmt.Errorf("unknown version, got: %T", from)
+	}
 }
 
 // Populate implements duck.Populatable

--- a/apis/duck/v1alpha1/addressable_types_test.go
+++ b/apis/duck/v1alpha1/addressable_types_test.go
@@ -72,7 +72,7 @@ func TestGetURL(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.addr.GetURL()
 			if got.String() != test.want.String() {
-				t.Errorf("GetURL() = %v, wanted %v", test.want, got)
+				t.Errorf("GetURL() = %v, wanted %v", got, test.want)
 			}
 		})
 	}

--- a/apis/duck/v1beta1/addressable_types.go
+++ b/apis/duck/v1beta1/addressable_types.go
@@ -17,11 +17,15 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
+	"knative.dev/pkg/apis/duck/v1"
 )
 
 // Addressable provides a generic mechanism for a custom resource
@@ -34,8 +38,12 @@ type Addressable struct {
 	URL *apis.URL `json:"url,omitempty"`
 }
 
-// Addressable is an Implementable "duck type".
-var _ duck.Implementable = (*Addressable)(nil)
+var (
+	// Addressable is an Implementable "duck type".
+	_ duck.Implementable = (*Addressable)(nil)
+	// Addressable is a Convertible type.
+	_ apis.Convertible = (*Addressable)(nil)
+)
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -66,6 +74,28 @@ var (
 // GetFullType implements duck.Implementable
 func (*Addressable) GetFullType() duck.Populatable {
 	return &AddressableType{}
+}
+
+// ConvertUp implements apis.Convertible
+func (a *Addressable) ConvertUp(ctx context.Context, to apis.Convertible) error {
+	switch sink := to.(type) {
+	case *v1.Addressable:
+		sink.URL = a.URL.DeepCopy()
+		return nil
+	default:
+		return fmt.Errorf("unknown version, got: %T", to)
+	}
+}
+
+// ConvertDown implements apis.Convertible
+func (a *Addressable) ConvertDown(ctx context.Context, from apis.Convertible) error {
+	switch source := from.(type) {
+	case *v1.Addressable:
+		a.URL = source.URL.DeepCopy()
+		return nil
+	default:
+		return fmt.Errorf("unknown version, got: %T", from)
+	}
 }
 
 // Populate implements duck.Populatable

--- a/apis/duck/v1beta1/addressable_types_test.go
+++ b/apis/duck/v1beta1/addressable_types_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package v1beta1
 
 import (
 	"context"
@@ -23,63 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck/v1"
-	"knative.dev/pkg/apis/duck/v1beta1"
 )
-
-func TestGetURL(t *testing.T) {
-	tests := []struct {
-		name string
-		addr Addressable
-		want apis.URL
-	}{{
-		name: "just hostname",
-		addr: Addressable{
-			Hostname: "foo.com",
-		},
-		want: apis.URL{
-			Scheme: "http",
-			Host:   "foo.com",
-		},
-	}, {
-		name: "just url",
-		addr: Addressable{
-			Addressable: v1beta1.Addressable{
-				URL: &apis.URL{
-					Scheme: "https",
-					Host:   "bar.com",
-				},
-			},
-		},
-		want: apis.URL{
-			Scheme: "https",
-			Host:   "bar.com",
-		},
-	}, {
-		name: "both fields",
-		addr: Addressable{
-			Hostname: "foo.bar.svc.cluster.local",
-			Addressable: v1beta1.Addressable{
-				URL: &apis.URL{
-					Scheme: "https",
-					Host:   "baz.com",
-				},
-			},
-		},
-		want: apis.URL{
-			Scheme: "https",
-			Host:   "baz.com",
-		},
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got := test.addr.GetURL()
-			if got.String() != test.want.String() {
-				t.Errorf("GetURL() = %v, wanted %v", got, test.want)
-			}
-		})
-	}
-}
 
 func TestConversion(t *testing.T) {
 	tests := []struct {
@@ -92,11 +36,9 @@ func TestConversion(t *testing.T) {
 	}{{
 		name: "v1",
 		addr: &Addressable{
-			Addressable: v1beta1.Addressable{
-				URL: &apis.URL{
-					Scheme: "https",
-					Host:   "bar.com",
-				},
+			URL: &apis.URL{
+				Scheme: "https",
+				Host:   "bar.com",
 			},
 		},
 		conv:        &v1.Addressable{},
@@ -105,24 +47,9 @@ func TestConversion(t *testing.T) {
 	}, {
 		name: "v1beta1",
 		addr: &Addressable{
-			Addressable: v1beta1.Addressable{
-				URL: &apis.URL{
-					Scheme: "https",
-					Host:   "bar.com",
-				},
-			},
-		},
-		conv:        &v1beta1.Addressable{},
-		wantErrUp:   false,
-		wantErrDown: false,
-	}, {
-		name: "v1alpha1",
-		addr: &Addressable{
-			Addressable: v1beta1.Addressable{
-				URL: &apis.URL{
-					Scheme: "https",
-					Host:   "bar.com",
-				},
+			URL: &apis.URL{
+				Scheme: "https",
+				Host:   "bar.com",
 			},
 		},
 		conv:        &Addressable{},


### PR DESCRIPTION
v1alpha1 embeds v1beta1 which makes them easily convertible. However, we
cannot embed both v1beta1 and v1 into v1alpha1 easily. Updating to just
use v1 in v1alpha1 is breaking so this change implements converters
to enable moving between v1 and v1beta1/v1alpha1 without having to
implement the logic in every client needing to convert.