### PR TITLE
update links

### DIFF
--- a/apis/condition_types.go
+++ b/apis/condition_types.go
@@ -53,7 +53,7 @@ const (
 )
 
 // Conditions defines a readiness condition for a Knative resource.
-// See: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties
+// See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 // +k8s:deepcopy-gen=true
 // +k8s:openapi-gen=true
 type Condition struct {

--- a/apis/duck/v1alpha1/conditions_types.go
+++ b/apis/duck/v1alpha1/conditions_types.go
@@ -60,7 +60,7 @@ const (
 )
 
 // Conditions defines a readiness condition for a Knative resource.
-// See: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties
+// See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 // +k8s:deepcopy-gen=true
 type Condition struct {
 	// Type of condition.


### PR DESCRIPTION
https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties is moved to https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties