### PR TITLE
golang format tools

### DIFF
--- a/apis/duck/v1alpha1/addressable_types.go
+++ b/apis/duck/v1alpha1/addressable_types.go
@@ -25,7 +25,7 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
-	"knative.dev/pkg/apis/duck/v1"
+	v1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/apis/duck/v1beta1"
 )
 

--- a/apis/duck/v1alpha1/addressable_types_test.go
+++ b/apis/duck/v1alpha1/addressable_types_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/apis"
-	"knative.dev/pkg/apis/duck/v1"
+	v1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/apis/duck/v1beta1"
 )
 

--- a/apis/duck/v1beta1/addressable_types.go
+++ b/apis/duck/v1beta1/addressable_types.go
@@ -25,7 +25,7 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
-	"knative.dev/pkg/apis/duck/v1"
+	v1 "knative.dev/pkg/apis/duck/v1"
 )
 
 // Addressable provides a generic mechanism for a custom resource

--- a/apis/duck/v1beta1/addressable_types_test.go
+++ b/apis/duck/v1beta1/addressable_types_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/apis"
-	"knative.dev/pkg/apis/duck/v1"
+	v1 "knative.dev/pkg/apis/duck/v1"
 )
 
 func TestConversion(t *testing.T) {

--- a/tracing/http.go
+++ b/tracing/http.go
@@ -37,7 +37,6 @@ var (
 	HTTPSpanMiddleware = HTTPSpanIgnoringPaths()
 )
 
-
 // HTTPSpanIgnoringPaths is an http.Handler middleware to create spans for the HTTP
 // endpoint, not sampling any request whose path is in pathsToIgnore.
 func HTTPSpanIgnoringPaths(pathsToIgnore ...string) func(http.Handler) http.Handler {


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign mattmoor
