### PR TITLE
JSONTrace returns a structured object, not just a string.

### DIFF
--- a/test/zipkin/util.go
+++ b/test/zipkin/util.go
@@ -14,17 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//util has constants and helper methods useful for zipkin tracing support.
+// util has constants and helper methods useful for zipkin tracing support.
 
 package zipkin
 
 import (
-	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"sync"
+	"time"
 
+	"github.com/openzipkin/zipkin-go/model"
 	"go.opencensus.io/trace"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/test/logging"
@@ -32,7 +34,7 @@ import (
 )
 
 const (
-	//ZipkinTraceIDHeader HTTP response header key to be used to store Zipkin Trace ID.
+	// ZipkinTraceIDHeader HTTP response header key to be used to store Zipkin Trace ID.
 	ZipkinTraceIDHeader = "ZIPKIN_TRACE_ID"
 
 	// ZipkinPort is port exposed by the Zipkin Pod
@@ -43,11 +45,11 @@ const (
 	ZipkinTraceEndpoint = "http://localhost:9411/api/v2/trace/"
 
 	// App is the name of this component.
-	// This will be used as a label selector
+	// This will be used as a label selector.
 	app = "zipkin"
 
-	// Namespace we are using for istio components
-	istioNs = "istio-system"
+	// istioNS is the namespace we are using for istio components.
+	istioNS = "istio-system"
 )
 
 var (
@@ -66,21 +68,21 @@ var (
 // SetupZipkinTracing sets up zipkin tracing which involves:
 // 1. Setting up port-forwarding from localhost to zipkin pod on the cluster
 //    (pid of the process doing Port-Forward is stored in a global variable).
-// 2. Enable AlwaysSample config for tracing.
-func SetupZipkinTracing(kubeClientset *kubernetes.Clientset, logf logging.FormatLogger) {
+// 2. Enable AlwaysSample config for tracing for the SpoofingClient.
+func SetupZipkinTracing(kubeClientset *kubernetes.Clientset, logf logging.FormatLogger) bool {
 	setupOnce.Do(func() {
 		if err := monitoring.CheckPortAvailability(ZipkinPort); err != nil {
 			logf("Zipkin port not available on the machine: %v", err)
 			return
 		}
 
-		zipkinPods, err := monitoring.GetPods(kubeClientset, app, istioNs)
+		zipkinPods, err := monitoring.GetPods(kubeClientset, app, istioNS)
 		if err != nil {
 			logf("Error retrieving Zipkin pod details: %v", err)
 			return
 		}
 
-		zipkinPortForwardPID, err = monitoring.PortForward(logf, zipkinPods, ZipkinPort, ZipkinPort, istioNs)
+		zipkinPortForwardPID, err = monitoring.PortForward(logf, zipkinPods, ZipkinPort, ZipkinPort, istioNS)
 		if err != nil {
 			logf("Error starting kubectl port-forward command: %v", err)
 			return
@@ -93,17 +95,33 @@ func SetupZipkinTracing(kubeClientset *kubernetes.Clientset, logf logging.Format
 		logf("Successfully setup SpoofingClient for Zipkin Tracing")
 		ZipkinTracingEnabled = true
 	})
+	return ZipkinTracingEnabled
 }
 
 // CleanupZipkinTracingSetup cleans up the Zipkin tracing setup on the machine. This involves killing the process performing port-forward.
+// This should be called exactly once in TestMain. Likely in the form:
+//
+// func TestMain(m *testing.M) {
+//     os.Exit(wrappedMain(m))
+// }
+//
+// func wrappedMain(m *testing.M) {
+//    // Any setup required for the tests.
+//    defer zipkin.CleanupZipkinTracingSetup(logger)
+//    return m.Run()
+// }
 func CleanupZipkinTracingSetup(logf logging.FormatLogger) {
 	teardownOnce.Do(func() {
+		// Because CleanupZipkinTracingSetup only runs once, make sure that now that it has been
+		// run, SetupZipkinTracing will no longer setup any port forwarding.
+		setupOnce.Do(func() {})
+
 		if !ZipkinTracingEnabled {
 			return
 		}
 
 		if err := monitoring.Cleanup(zipkinPortForwardPID); err != nil {
-			logf("Encountered error killing port-forward process in CleanupZipkingTracingSetup() : %v", err)
+			logf("Encountered error killing port-forward process in CleanupZipkinTracingSetup() : %v", err)
 			return
 		}
 
@@ -117,29 +135,53 @@ func CheckZipkinPortAvailability() error {
 	return monitoring.CheckPortAvailability(ZipkinPort)
 }
 
-// JSONTrace returns a trace for the given traceId in JSON format
-func JSONTrace(traceID string) (string, error) {
+// JSONTrace returns a trace for the given traceId. It will continually try to get the trace. If the
+// trace it gets has the expected number of spans, then it will be returned. If not, it will try
+// again. If it reaches timeout, then it returns everything it has so far with an error.
+func JSONTrace(traceID string, expected int, timeout time.Duration) ([]model.SpanModel, error) {
+	var traceSoFar []model.SpanModel
+	t := time.After(timeout)
+	for {
+		if len(traceSoFar) == expected {
+			return traceSoFar, nil
+		}
+		select {
+		case <-t:
+			return traceSoFar, fmt.Errorf("timeout getting JSONTrace: %+v", traceSoFar)
+		default:
+			var err error
+			traceSoFar, err = jsonTrace(traceID)
+			if err != nil {
+				return traceSoFar, err
+			}
+		}
+	}
+}
+
+// jsonTrace gets a trace from Zipkin and returns it.
+func jsonTrace(traceID string) ([]model.SpanModel, error) {
+	var empty []model.SpanModel
+
 	// Check if zipkin port forwarding is setup correctly
 	if err := CheckZipkinPortAvailability(); err == nil {
-		return "", err
+		return empty, err
 	}
 
 	resp, err := http.Get(ZipkinTraceEndpoint + traceID)
 	if err != nil {
-		return "", err
+		return empty, err
 	}
 	defer resp.Body.Close()
 
-	trace, err := ioutil.ReadAll(resp.Body)
+	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return empty, err
 	}
 
-	var prettyJSON bytes.Buffer
-	err = json.Indent(&prettyJSON, trace, "", "\t")
+	var models []model.SpanModel
+	err = json.Unmarshal(body, &models)
 	if err != nil {
-		return "", err
+		return empty, err
 	}
-
-	return prettyJSON.String(), nil
+	return models, nil
 }


### PR DESCRIPTION
Improve the testing with Zipkin utilities:
- JSONTrace returns a structured object, not just a string.
- JSONTrace no longer sleeps, it retries until a specified timeout.
- Document how CleanupZipkinTracingSetup.