### PR TITLE
Cluster operations wait for *Operation object directly

### DIFF
--- a/testutils/clustermanager/client.go
+++ b/testutils/clustermanager/client.go
@@ -24,6 +24,6 @@ type Client interface {
 // ClusterOperations contains all provider specific logics
 type ClusterOperations interface {
 	Provider() string
+	Initialize() error
 	Acquire() error
-	Delete() error
 }

--- a/testutils/clustermanager/gke.go
+++ b/testutils/clustermanager/gke.go
@@ -41,7 +41,9 @@ const (
 
 var (
 	DefaultGKEBackupRegions = []string{"us-west1", "us-east1"}
-	// This is an arbitrary number determined based on past experience
+	protectedProjects       = []string{"knative-tests"}
+	protectedClusters       = []string{"knative-prow"}
+	// These are arbitrary numbers determined based on past experience
 	creationTimeout = 20 * time.Minute
 )
 
@@ -74,6 +76,7 @@ type GKECluster struct {
 type GKESDKOperations interface {
 	create(string, string, *container.CreateClusterRequest) (*container.Operation, error)
 	get(string, string, string) (*container.Cluster, error)
+	getOperation(string, string, string) (*container.Operation, error)
 }
 
 // GKESDKClient Implement GKESDKOperations
@@ -89,6 +92,11 @@ func (gsc *GKESDKClient) create(project, location string, rb *container.CreateCl
 func (gsc *GKESDKClient) get(project, location, cluster string) (*container.Cluster, error) {
 	clusterFullPath := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, cluster)
 	return gsc.Projects.Locations.Clusters.Get(clusterFullPath).Context(context.Background()).Do()
+}
+
+func (gsc *GKESDKClient) getOperation(project, location, opName string) (*container.Operation, error) {
+	name := fmt.Sprintf("projects/%s/locations/%s/operations/%s", project, location, opName)
+	return gsc.Service.Projects.Locations.Operations.Get(name).Do()
 }
 
 // Setup sets up a GKECluster client.
@@ -168,6 +176,9 @@ func (gc *GKECluster) Initialize() error {
 	if nil == gc.Project || "" == *gc.Project {
 		return fmt.Errorf("gcp project must be set")
 	}
+	if !common.IsProw() && nil == gc.Cluster {
+		gc.NeedCleanup = true
+	}
 	log.Printf("use project '%s' for running test", *gc.Project)
 	return nil
 }
@@ -182,6 +193,7 @@ func (gc *GKECluster) Provider() string {
 // in us-central1, and default BackupRegions are us-west1 and us-east1. If
 // Region or Zone is provided then there is no retries
 func (gc *GKECluster) Acquire() error {
+	gc.ensureProtected()
 	var err error
 	// Check if using existing cluster
 	if nil != gc.Cluster {
@@ -217,41 +229,30 @@ func (gc *GKECluster) Acquire() error {
 			},
 			ProjectId: *gc.Project,
 		}
-		log.Printf("Creating cluster in %s", getClusterLocation(region, gc.Request.Zone))
-		_, err = gc.operations.create(*gc.Project, getClusterLocation(region, gc.Request.Zone), rb)
+
+		clusterLoc := getClusterLocation(region, gc.Request.Zone)
+		// TODO(chaodaiG): add deleting logic once cluster deletion logic is done
+
+		log.Printf("Creating cluster '%s' in '%s'", clusterName, clusterLoc)
+		var createOp *container.Operation
+		createOp, err = gc.operations.create(*gc.Project, clusterLoc, rb)
 		if nil == err {
-			// The process above doesn't seem to wait, wait for it
-			log.Printf("Waiting for cluster creation")
-			timeout := time.After(creationTimeout)
-			tick := time.Tick(50 * time.Millisecond)
-			for {
-				select {
-				// Got a timeout! fail with a timeout error
-				case <-timeout:
-					err = fmt.Errorf("timed out waiting for cluster creation")
-					break
-				case <-tick:
-					cluster, err = gc.operations.get(*gc.Project, getClusterLocation(region, gc.Request.Zone), clusterName)
-				}
-				if err != nil || cluster.Status == "RUNNING" {
-					break
-				}
-				if cluster.Status != "PROVISIONING" {
-					err = fmt.Errorf("cluster in bad state: '%s'", cluster.Status)
-					break
-				}
+			if err = gc.wait(clusterLoc, createOp.Name, creationTimeout); nil == err {
+				cluster, err = gc.operations.get(*gc.Project, clusterLoc, rb.Cluster.Name)
 			}
 		}
-
 		if nil != err {
 			errMsg := fmt.Sprintf("error creating cluster: '%v'", err)
+			if gc.NeedCleanup { // Delete half created cluster if it's user created
+				// TODO(chaodaiG): add this part when deletion logic is done
+			}
 			// TODO(chaodaiG): catch specific errors as we know what the error look like for stockout etc.
 			if len(regions) != i+1 {
 				errMsg = fmt.Sprintf("%s. Retry another region '%s' for cluster creation", errMsg, regions[i+1])
 			}
 			log.Printf(errMsg)
 		} else {
-			log.Printf("cluster creation succeeded")
+			log.Printf("cluster creation completed")
 			gc.Cluster = cluster
 			break
 		}
@@ -260,13 +261,70 @@ func (gc *GKECluster) Acquire() error {
 	return err
 }
 
-// Delete deletes a GKE cluster
-func (gc *GKECluster) Delete() error {
-	if !gc.NeedCleanup {
-		return nil
+// wait depends on unique opName(operation ID created by cloud), and waits until
+// it's done
+func (gc *GKECluster) wait(location, opName string, wait time.Duration) error {
+	validStatuses := []string{"PENDING", "RUNNING", "DONE"}
+	doneStatus := "DONE"
+	var op *container.Operation
+	var err error
+
+	timeout := time.After(wait)
+	tick := time.Tick(500 * time.Millisecond)
+	for {
+		select {
+		// Got a timeout! fail with a timeout error
+		case <-timeout:
+			return fmt.Errorf("timed out waiting")
+		case <-tick:
+			// Retry 3 times in case of weird network error, or rate limiting
+			r := 0
+			for w := 50 * time.Microsecond; r < 3; w *= 2 {
+				r++
+				op, err = gc.operations.getOperation(*gc.Project, location, opName)
+				if nil == err {
+					valid := false
+					for _, validStatus := range validStatuses {
+						if op.Status == validStatus {
+							valid = true
+						}
+					}
+					if !valid {
+						err = fmt.Errorf("unexpected operation status: '%s'", op.Status)
+					} else if op.Status == doneStatus {
+						return nil
+					} else { // valid operation, no need to retry
+						break
+					}
+				}
+				time.Sleep(w)
+			}
+			// If err still persist after retries, exit
+			if nil != err {
+				return err
+			}
+		}
 	}
-	// TODO: Perform GKE specific cluster deletion logics
-	return nil
+
+	return err
+}
+
+// ensureProtected ensures not operating on protected project/cluster
+func (gc *GKECluster) ensureProtected() {
+	if nil != gc.Project {
+		for _, pp := range protectedProjects {
+			if *gc.Project == pp {
+				log.Fatalf("project '%s' is protected", *gc.Project)
+			}
+		}
+	}
+	if nil != gc.Cluster {
+		for _, pc := range protectedClusters {
+			if gc.Cluster.Name == pc {
+				log.Fatalf("cluster '%s' is protected", gc.Cluster.Name)
+			}
+		}
+	}
 }
 
 // checks for existing cluster by looking at kubeconfig,

--- a/testutils/clustermanager/gke_test.go
+++ b/testutils/clustermanager/gke_test.go
@@ -43,15 +43,39 @@ func setupFakeGKECluster() GKECluster {
 
 type FakeGKESDKClient struct {
 	// map of parent: clusters slice
-	clusters     map[string][]*container.Cluster
-	regionStatus map[string]string
+	clusters map[string][]*container.Cluster
+	// map of operationID: operation
+	ops map[string]*container.Operation
+
+	// An incremental number for new ops
+	opNumber int
+	// A lookup table for determining ops statuses
+	opStatus map[string]string
 }
 
 func newFakeGKESDKClient() *FakeGKESDKClient {
 	return &FakeGKESDKClient{
-		clusters:     make(map[string][]*container.Cluster),
-		regionStatus: make(map[string]string),
+		clusters: make(map[string][]*container.Cluster),
+		ops:      make(map[string]*container.Operation),
+		opStatus: make(map[string]string),
 	}
+}
+
+// automatically registers new ops, and mark it "DONE" by default. Update
+// fgsc.opStatus by fgsc.opStatus[string(fgsc.opNumber+1)]="PENDING" to make the
+// next operation pending
+func (fgsc *FakeGKESDKClient) newOp() *container.Operation {
+	opName := string(fgsc.opNumber)
+	op := &container.Operation{
+		Name:   opName,
+		Status: "DONE",
+	}
+	if status, ok := fgsc.opStatus[opName]; ok {
+		op.Status = status
+	}
+	fgsc.opNumber++
+	fgsc.ops[opName] = op
+	return op
 }
 
 // fake create cluster, fail if cluster already exists
@@ -72,12 +96,9 @@ func (fgsc *FakeGKESDKClient) create(project, location string, rb *container.Cre
 		Location: location,
 		Status:   "RUNNING",
 	}
-	if status, ok := fgsc.regionStatus[location]; ok {
-		cluster.Status = status
-	}
 
 	fgsc.clusters[parent] = append(fgsc.clusters[parent], cluster)
-	return nil, nil
+	return fgsc.newOp(), nil
 }
 
 func (fgsc *FakeGKESDKClient) get(project, location, cluster string) (*container.Cluster, error) {
@@ -90,6 +111,13 @@ func (fgsc *FakeGKESDKClient) get(project, location, cluster string) (*container
 		}
 	}
 	return nil, fmt.Errorf("cluster not found")
+}
+
+func (fgsc *FakeGKESDKClient) getOperation(project, location, opName string) (*container.Operation, error) {
+	if op, ok := fgsc.ops[opName]; ok {
+		return op, nil
+	}
+	return nil, fmt.Errorf("op not found")
 }
 
 func TestSetup(t *testing.T) {
@@ -425,7 +453,7 @@ func TestAcquire(t *testing.T) {
 	fakeBuildID := "1234"
 	datas := []struct {
 		existCluster       *container.Cluster
-		regionStates       map[string]string
+		nextOpStatus       []string
 		expClusterName     string
 		expClusterLocation string
 		expErr             error
@@ -435,20 +463,20 @@ func TestAcquire(t *testing.T) {
 			&container.Cluster{
 				Name:     "customcluster",
 				Location: "us-central1",
-			}, map[string]string{}, "customcluster", "us-central1", nil,
+			}, []string{}, "customcluster", "us-central1", nil,
 		}, {
 			// cluster creation succeeded
-			nil, map[string]string{}, fakeClusterName, "us-central1", nil,
+			nil, []string{}, fakeClusterName, "us-central1", nil,
 		}, {
 			// cluster creation succeeded retry
-			nil, map[string]string{"us-central1": "PROVISIONING"}, fakeClusterName, "us-west1", nil,
+			nil, []string{"PENDING"}, fakeClusterName, "us-west1", nil,
 		}, {
 			// cluster creation failed all retry
-			nil, map[string]string{"us-central1": "PROVISIONING", "us-west1": "PROVISIONING", "us-east1": "PROVISIONING"},
-			"", "", fmt.Errorf("timed out waiting for cluster creation"),
+			nil, []string{"PENDING", "PENDING", "PENDING"},
+			"", "", fmt.Errorf("timed out waiting"),
 		}, {
 			// cluster creation went bad state
-			nil, map[string]string{"us-central1": "BAD", "us-west1": "BAD", "us-east1": "BAD"}, "", "", fmt.Errorf("cluster in bad state: 'BAD'"),
+			nil, []string{"BAD", "BAD", "BAD"}, "", "", fmt.Errorf("unexpected operation status: 'BAD'"),
 		},
 	}
 
@@ -456,7 +484,8 @@ func TestAcquire(t *testing.T) {
 	oldFunc := common.GetOSEnv
 	// mock timeout so it doesn't run forever
 	oldTimeout := creationTimeout
-	creationTimeout = 100 * time.Millisecond
+	// wait function polls every 500ms, give it 1000 to avoid random timeout
+	creationTimeout = 1000 * time.Millisecond
 	defer func() {
 		// restore
 		common.GetOSEnv = oldFunc
@@ -478,7 +507,9 @@ func TestAcquire(t *testing.T) {
 			fgc.Cluster = data.existCluster
 		}
 		fgc.Project = &fakeProj
-		fgc.operations.(*FakeGKESDKClient).regionStatus = data.regionStates
+		for i, status := range data.nextOpStatus {
+			fgc.operations.(*FakeGKESDKClient).opStatus[string(i)] = status
+		}
 
 		fgc.Request = &GKERequest{
 			NumNodes:      DefaultGKENumNodes,
@@ -494,8 +525,8 @@ func TestAcquire(t *testing.T) {
 			gotLocation = fgc.Cluster.Location
 		}
 		if !reflect.DeepEqual(err, data.expErr) || data.expClusterName != gotName || data.expClusterLocation != gotLocation {
-			t.Errorf("testing acquiring cluster, with:\n\texisting cluster: '%v'\n\tbad regions: '%v'\nwant: cluster name - '%s', location - '%s', err - '%v'\ngot: cluster name - '%s', location - '%s', err - '%v'",
-				data.existCluster, data.regionStates, data.expClusterName, data.expClusterLocation, data.expErr, gotName, gotLocation, err)
+			t.Errorf("testing acquiring cluster, with:\n\texisting cluster: '%v'\n\tnext operations outcomes: '%v'\nwant: cluster name - '%s', location - '%s', err - '%v'\ngot: cluster name - '%s', location - '%s', err - '%v'",
+				data.existCluster, data.nextOpStatus, data.expClusterName, data.expClusterLocation, data.expErr, gotName, gotLocation, err)
 		}
 	}
 }

--- a/testutils/clustermanager/gke_test.go
+++ b/testutils/clustermanager/gke_test.go
@@ -441,7 +441,7 @@ func TestGKECheckEnvironment(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(err, data.expErr) || !reflect.DeepEqual(fgc.Project, data.expProj) || !reflect.DeepEqual(clusterGot, data.expCluster) {
-			t.Errorf("check environment with:\n\tkubectl output: '%s'\n\t\terror: '%v'\n\tgcloud output: '%s'\n\t\t"+
+			t.Errorf("check environment with:\n\tkubectl output: %q\n\t\terror: '%v'\n\tgcloud output: %q\n\t\t"+
 				"error: '%v'\nwant: project - '%v', cluster - '%v', err - '%v'\ngot: project - '%v', cluster - '%v', err - '%v'",
 				data.kubectlOut, data.kubectlErr, data.gcloudOut, data.gcloudErr, data.expProj, data.expCluster, data.expErr, fgc.Project, fgc.Cluster, err)
 		}
@@ -476,7 +476,7 @@ func TestAcquire(t *testing.T) {
 			"", "", fmt.Errorf("timed out waiting"),
 		}, {
 			// cluster creation went bad state
-			nil, []string{"BAD", "BAD", "BAD"}, "", "", fmt.Errorf("unexpected operation status: 'BAD'"),
+			nil, []string{"BAD", "BAD", "BAD"}, "", "", fmt.Errorf("unexpected operation status: %q", "BAD"),
 		},
 	}
 
@@ -525,7 +525,7 @@ func TestAcquire(t *testing.T) {
 			gotLocation = fgc.Cluster.Location
 		}
 		if !reflect.DeepEqual(err, data.expErr) || data.expClusterName != gotName || data.expClusterLocation != gotLocation {
-			t.Errorf("testing acquiring cluster, with:\n\texisting cluster: '%v'\n\tnext operations outcomes: '%v'\nwant: cluster name - '%s', location - '%s', err - '%v'\ngot: cluster name - '%s', location - '%s', err - '%v'",
+			t.Errorf("testing acquiring cluster, with:\n\texisting cluster: '%v'\n\tnext operations outcomes: '%v'\nwant: cluster name - %q, location - %q, err - '%v'\ngot: cluster name - %q, location - %q, err - '%v'",
 				data.existCluster, data.nextOpStatus, data.expClusterName, data.expClusterLocation, data.expErr, gotName, gotLocation, err)
 		}
 	}


### PR DESCRIPTION
Previous implementation waits on cluster creation operations indirectly by querying cluster status, which might not work all the time. Switch to wait on `*container.Operation` returned by cluster creation method instead, this should be much more reliable. Also, the same wait mechanism can be reused by `delete` and any other future operations.

By the way introduce protection for protected projects and cluster as currently supported

/cc @adrcunha 