### PR TITLE
Use *url.URL instead of string in request.go

### DIFF
--- a/apis/url.go
+++ b/apis/url.go
@@ -76,3 +76,9 @@ func (u *URL) String() string {
 	uu := url.URL(*u)
 	return uu.String()
 }
+
+// URL returns the URL as a url.URL.
+func (u *URL) URL() *url.URL {
+	url := url.URL(*u)
+	return &url
+}


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/5419 - Part I

See corresponding `knative.dev/serving` change: https://github.com/knative/serving/pull/5503

/hold