### PR TITLE
Move duck patch helper function from Knative Serving to pkg

### DIFF
--- a/apis/duck/patch.go
+++ b/apis/duck/patch.go
@@ -37,6 +37,8 @@ func marshallBeforeAfter(before, after interface{}) ([]byte, []byte, error) {
 	return rawBefore, rawAfter, nil
 }
 
+// CreateMergePatch creates a json merge patch as specified in
+// http://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-07
 func CreateMergePatch(before, after interface{}) ([]byte, error) {
 	rawBefore, rawAfter, err := marshallBeforeAfter(before, after)
 	if err != nil {
@@ -45,6 +47,17 @@ func CreateMergePatch(before, after interface{}) ([]byte, error) {
 	return jsonmergepatch.CreateMergePatch(rawBefore, rawAfter)
 }
 
+// CreateBytePatch is a helper function that creates the same content as
+// CreatePatch, but returns in []byte format instead of JSONPatch.
+func CreateBytePatch(before, after interface{}) ([]byte, error) {
+	patch, err := CreatePatch(before, after)
+	if err != nil {
+		return nil, err
+	}
+	return patch.MarshalJSON()
+}
+
+// CreatePatch creates a patch as specified in http://jsonpatch.com/
 func CreatePatch(before, after interface{}) (JSONPatch, error) {
 	rawBefore, rawAfter, err := marshallBeforeAfter(before, after)
 	if err != nil {

--- a/apis/duck/patch_test.go
+++ b/apis/duck/patch_test.go
@@ -204,6 +204,28 @@ func TestCreatePatch(t *testing.T) {
 	}}
 
 	for _, test := range tests {
+		t.Run(test.name+" (CreateBytePatch)", func(t *testing.T) {
+			got, err := CreateBytePatch(test.before, test.after)
+			if err != nil {
+				if !test.wantErr {
+					t.Errorf("CreateBytePatch() = %v", err)
+				}
+				return
+			} else if test.wantErr {
+				t.Errorf("CreateBytePatch() = %v, wanted error", got)
+				return
+			}
+
+			want, err := test.want.MarshalJSON()
+			if err != nil {
+				t.Errorf("Error marshaling 'want' condition. want: %v error: %v", want, err)
+			}
+
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("CreateBytePatch (-want, +got) = %v", diff)
+			}
+
+		})
 		t.Run(test.name, func(t *testing.T) {
 			got, err := CreatePatch(test.before, test.after)
 			if err != nil {


### PR DESCRIPTION
We have been maintaining a copy of this helper function in the Knative
Serving tests. Moving it here and adding tests so it can be used more
generally. The function allows creating a []byte patch without having to
check two levels of error conditions.