### PR TITLE
Hook into two other Kubernetes metric subsystems.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1369,6 +1369,7 @@
     "k8s.io/client-go/testing",
     "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/tools/metrics",
     "k8s.io/client-go/tools/record",
     "k8s.io/client-go/util/flowcontrol",
     "k8s.io/client-go/util/workqueue",

--- a/controller/stats_reporter.go
+++ b/controller/stats_reporter.go
@@ -25,6 +25,8 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	"go.uber.org/zap"
+	"k8s.io/client-go/tools/cache"
+	kubemetrics "k8s.io/client-go/tools/metrics"
 	"k8s.io/client-go/util/workqueue"
 	"knative.dev/pkg/metrics"
 )
@@ -49,6 +51,7 @@ var (
 )
 
 func init() {
+	// Register to receive metrics from kubernetes workqueues.
 	wp := &metrics.WorkqueueProvider{
 		Adds: stats.Int64(
 			"workqueue_adds_total",
@@ -78,31 +81,103 @@ func init() {
 	}
 	workqueue.SetProvider(wp)
 
+	// Register to receive metrics from kubernetes reflectors (what powers informers)
+	// NOTE: today these don't actually seem to wire up to anything in Kubernetes.
+	rp := &metrics.ReflectorProvider{
+		ItemsInList: stats.Float64(
+			"reflector_items_in_list",
+			"How many items an API list returns to the reflectors",
+			stats.UnitNone,
+		),
+		// TODO(mattmoor): This is not in the latest version, so it will
+		// be removed in a future version.
+		ItemsInMatch: stats.Float64(
+			"reflector_items_in_match",
+			"",
+			stats.UnitNone,
+		),
+		ItemsInWatch: stats.Float64(
+			"reflector_items_in_watch",
+			"How many items an API watch returns to the reflectors",
+			stats.UnitNone,
+		),
+		LastResourceVersion: stats.Float64(
+			"reflector_last_resource_version",
+			"Last resource version seen for the reflectors",
+			stats.UnitNone,
+		),
+		ListDuration: stats.Float64(
+			"reflector_list_duration_seconds",
+			"How long an API list takes to return and decode for the reflectors",
+			stats.UnitNone,
+		),
+		Lists: stats.Int64(
+			"reflector_lists_total",
+			"Total number of API lists done by the reflectors",
+			stats.UnitNone,
+		),
+		ShortWatches: stats.Int64(
+			"reflector_short_watches_total",
+			"Total number of short API watches done by the reflectors",
+			stats.UnitNone,
+		),
+		WatchDuration: stats.Float64(
+			"reflector_watch_duration_seconds",
+			"How long an API watch takes to return and decode for the reflectors",
+			stats.UnitNone,
+		),
+		Watches: stats.Int64(
+			"reflector_watches_total",
+			"Total number of API watches done by the reflectors",
+			stats.UnitNone,
+		),
+	}
+	cache.SetReflectorMetricsProvider(rp)
+
+	cp := &metrics.ClientProvider{
+		Latency: stats.Float64(
+			"client_latency",
+			"How long Kubernetes API requests take",
+			"s",
+		),
+		Result: stats.Int64(
+			"client_results",
+			"Total number of API requests (broken down by status code)",
+			stats.UnitNone,
+		),
+	}
+	kubemetrics.Register(cp.NewLatencyMetric(), cp.NewResultMetric())
+
+	views := []*view.View{{
+		Description: "Depth of the work queue",
+		Measure:     workQueueDepthStat,
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{reconcilerTagKey},
+	}, {
+		Description: "Number of reconcile operations",
+		Measure:     reconcileCountStat,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{reconcilerTagKey, keyTagKey, successTagKey},
+	}, {
+		Description: "Latency of reconcile operations",
+		Measure:     reconcileLatencyStat,
+		Aggregation: reconcileDistribution,
+		TagKeys:     []tag.Key{reconcilerTagKey, keyTagKey, successTagKey},
+	}}
+	for _, view := range wp.DefaultViews() {
+		views = append(views, view)
+	}
+	for _, view := range rp.DefaultViews() {
+		views = append(views, view)
+	}
+	for _, view := range cp.DefaultViews() {
+		views = append(views, view)
+	}
+
 	// Create views to see our measurements. This can return an error if
 	// a previously-registered view has the same name with a different value.
 	// View name defaults to the measure name if unspecified.
-	err := view.Register(
-		append(wp.DefaultViews(),
-			&view.View{
-				Description: "Depth of the work queue",
-				Measure:     workQueueDepthStat,
-				Aggregation: view.LastValue(),
-				TagKeys:     []tag.Key{reconcilerTagKey},
-			},
-			&view.View{
-				Description: "Number of reconcile operations",
-				Measure:     reconcileCountStat,
-				Aggregation: view.Count(),
-				TagKeys:     []tag.Key{reconcilerTagKey, keyTagKey, successTagKey},
-			},
-			&view.View{
-				Description: "Latency of reconcile operations",
-				Measure:     reconcileLatencyStat,
-				Aggregation: reconcileDistribution,
-				TagKeys:     []tag.Key{reconcilerTagKey, keyTagKey, successTagKey},
-			})...,
-	)
-	if err != nil {
+	if err := view.Register(views...); err != nil {
 		panic(err)
 	}
 }

--- a/metrics/client.go
+++ b/metrics/client.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"k8s.io/client-go/tools/metrics"
+)
+
+// ClientProvider implements the pattern of Kubernetes MetricProvider that may
+// be used to produce suitable metrics for use with metrics.Register()
+type ClientProvider struct {
+	Latency *stats.Float64Measure
+	Result  *stats.Int64Measure
+}
+
+// NewLatencyMetric implements MetricsProvider
+func (cp *ClientProvider) NewLatencyMetric() metrics.LatencyMetric {
+	return latencyMetric{
+		measure: cp.Latency,
+	}
+}
+
+// LatencyView returns a view of the Latency metric.
+func (cp *ClientProvider) LatencyView() *view.View {
+	return measureView(cp.Latency, view.Distribution(BucketsNBy10(0.00001, 8)...))
+}
+
+// NewResultMetric implements MetricsProvider
+func (cp *ClientProvider) NewResultMetric() metrics.ResultMetric {
+	return resultMetric{
+		measure: cp.Result,
+	}
+}
+
+// ResultView returns a view of the Result metric.
+func (cp *ClientProvider) ResultView() *view.View {
+	return measureView(cp.Result, view.Count())
+}
+
+// DefaultViews returns a list of views suitable for passing to view.Register
+func (cp *ClientProvider) DefaultViews() []*view.View {
+	return []*view.View{
+		cp.LatencyView(),
+		cp.ResultView(),
+	}
+}

--- a/metrics/client_test.go
+++ b/metrics/client_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"go.opencensus.io/stats/view"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/metrics"
+
+	"knative.dev/pkg/metrics/metricstest"
+)
+
+// clientFunc lets us implement rest.HTTPClient with a function matching
+// the signature of its Do method.
+type clientFunc struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+var _ rest.HTTPClient = (*clientFunc)(nil)
+
+// Do implements rest.HTTPClient
+func (cf *clientFunc) Do(req *http.Request) (*http.Response, error) {
+	return cf.do(req)
+}
+
+// ClientFunc turns a method matching the signature of rest.HTTPClient's
+// Do() method into an implementation of rest.HTTPClient.
+func ClientFunc(f func(*http.Request) (*http.Response, error)) rest.HTTPClient {
+	return &clientFunc{do: f}
+}
+
+func TestClientMetrics(t *testing.T) {
+	cp := &ClientProvider{
+		Latency: newFloat64("latency"),
+		Result:  newInt64("result"),
+	}
+	metrics.Register(cp.NewLatencyMetric(), cp.NewResultMetric())
+
+	// Reset the metrics configuration to avoid leaked state from other tests.
+	setCurMetricsConfig(nil)
+
+	views := cp.DefaultViews()
+	if got, want := len(views), 2; got != want {
+		t.Errorf("len(DefaultViews()) = %d, want %d", got, want)
+	}
+	if err := view.Register(views...); err != nil {
+		t.Errorf("view.Register() = %v", err)
+	}
+	defer view.Unregister(views...)
+
+	// No stats have been reported yet.
+	metricstest.CheckStatsNotReported(t, "latency", "result")
+
+	base := &url.URL{
+		Scheme: "http",
+		Host:   "api.mattmoor.dev",
+	}
+	config := rest.ContentConfig{
+		ContentType: "application/json",
+		GroupVersion: &schema.GroupVersion{
+			Group:   "testing.knative.dev",
+			Version: "v1alpha1",
+		},
+	}
+	client := ClientFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBufferString("hi")),
+		}, nil
+	})
+
+	// When we send rest requests, we should trigger the metrics setup above.
+	req := rest.NewRequest(client, http.MethodGet, base, "/testing.knative.dev/v1alpha1",
+		config, rest.Serializers{}, nil, nil, 0)
+	result := req.Do()
+	if err := result.Error(); err != nil {
+		t.Errorf("Do() = %v", err)
+	}
+
+	// Now we have stats reported!
+	metricstest.CheckStatsReported(t, "latency", "result")
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -18,11 +18,35 @@ package metrics
 
 import (
 	"context"
+	"net/url"
 	"sync/atomic"
+	"time"
 
 	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/metrics"
 	"k8s.io/client-go/util/workqueue"
+)
+
+var (
+	// tagName is used to associate the provided name with each metric created
+	// through the WorkqueueProvider's methods to implement workqueue.MetricsProvider.
+	// For the kubernetes workqueue implementations this is the queue name provided
+	// to the workqueue constructor.
+	tagName = tag.MustNewKey("name")
+
+	// tagVerb is used to associate the verb of the client action with latency metrics.
+	tagVerb = tag.MustNewKey("verb")
+	// tagCode is used to associate the status code the client gets back from an API call.
+	tagCode = tag.MustNewKey("code")
+	// tagMethod is used to associate the HTTP method the client used for the rest call.
+	tagMethod = tag.MustNewKey("method")
+	// tagHost is used to associate the host to which the HTTP request was made.
+	tagHost = tag.MustNewKey("host")
+	// tagPath is used to associate the path to which the HTTP request as made.
+	tagPath = tag.MustNewKey("path")
 )
 
 type counterMetric struct {
@@ -31,6 +55,7 @@ type counterMetric struct {
 }
 
 var (
+	_ cache.CounterMetric     = (*counterMetric)(nil)
 	_ workqueue.CounterMetric = (*counterMetric)(nil)
 )
 
@@ -68,9 +93,60 @@ type floatMetric struct {
 
 var (
 	_ workqueue.SummaryMetric = (*floatMetric)(nil)
+	_ cache.GaugeMetric       = (*floatMetric)(nil)
 )
 
 // Observe implements SummaryMetric
 func (m floatMetric) Observe(v float64) {
 	Record(context.Background(), m.measure.M(v), stats.WithTags(m.mutators...))
+}
+
+// Set implements GaugeMetric
+func (m floatMetric) Set(v float64) {
+	m.Observe(v)
+}
+
+type latencyMetric struct {
+	measure *stats.Float64Measure
+}
+
+var (
+	_ metrics.LatencyMetric = (*latencyMetric)(nil)
+)
+
+// Observe implements LatencyMetric
+func (m latencyMetric) Observe(verb string, u url.URL, t time.Duration) {
+	Record(context.Background(), m.measure.M(t.Seconds()), stats.WithTags(
+		tag.Insert(tagVerb, verb),
+		tag.Insert(tagHost, u.Host),
+		tag.Insert(tagPath, u.Path),
+	))
+}
+
+type resultMetric struct {
+	measure *stats.Int64Measure
+}
+
+var (
+	_ metrics.ResultMetric = (*resultMetric)(nil)
+)
+
+// Increment implements ResultMetric
+func (m resultMetric) Increment(code, method, host string) {
+	Record(context.Background(), m.measure.M(1), stats.WithTags(
+		tag.Insert(tagCode, code),
+		tag.Insert(tagMethod, method),
+		tag.Insert(tagHost, host),
+	))
+}
+
+// measureView returns a view of the supplied metric.
+func measureView(m stats.Measure, agg *view.Aggregation) *view.View {
+	return &view.View{
+		Name:        m.Name(),
+		Description: m.Description(),
+		Measure:     m,
+		Aggregation: agg,
+		TagKeys:     []tag.Key{tagName},
+	}
 }

--- a/metrics/reflector.go
+++ b/metrics/reflector.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+	"k8s.io/client-go/tools/cache"
+)
+
+// ReflectorProvider implements reflector.MetricsProvider and may be used with
+// reflector.SetProvider to have metrics exported to the provided metrics.
+type ReflectorProvider struct {
+	ItemsInList *stats.Float64Measure
+	// TODO(mattmoor): This is not in the latest version, so it will
+	// be removed in a future version.
+	ItemsInMatch        *stats.Float64Measure
+	ItemsInWatch        *stats.Float64Measure
+	LastResourceVersion *stats.Float64Measure
+	ListDuration        *stats.Float64Measure
+	Lists               *stats.Int64Measure
+	ShortWatches        *stats.Int64Measure
+	WatchDuration       *stats.Float64Measure
+	Watches             *stats.Int64Measure
+}
+
+var (
+	_ cache.MetricsProvider = (*ReflectorProvider)(nil)
+)
+
+// NewItemsInListMetric implements MetricsProvider
+func (rp *ReflectorProvider) NewItemsInListMetric(name string) cache.SummaryMetric {
+	return floatMetric{
+		mutators: []tag.Mutator{tag.Insert(tagName, name)},
+		measure:  rp.ItemsInList,
+	}
+}
+
+// ItemsInListView returns a view of the ItemsInList metric.
+func (rp *ReflectorProvider) ItemsInListView() *view.View {
+	return measureView(rp.ItemsInList, view.Distribution(BucketsNBy10(0.1, 6)...))
+}
+
+// NewItemsInMatchMetric implements MetricsProvider
+func (rp *ReflectorProvider) NewItemsInMatchMetric(name string) cache.SummaryMetric {
+	return floatMetric{
+		mutators: []tag.Mutator{tag.Insert(tagName, name)},
+		measure:  rp.ItemsInMatch,
+	}
+}
+
+// ItemsInMatchView returns a view of the ItemsInMatch metric.
+func (rp *ReflectorProvider) ItemsInMatchView() *view.View {
+	return measureView(rp.ItemsInMatch, view.Distribution(BucketsNBy10(0.1, 6)...))
+}
+
+// NewItemsInWatchMetric implements MetricsProvider
+func (rp *ReflectorProvider) NewItemsInWatchMetric(name string) cache.SummaryMetric {
+	return floatMetric{
+		mutators: []tag.Mutator{tag.Insert(tagName, name)},
+		measure:  rp.ItemsInWatch,
+	}
+}
+
+// ItemsInWatchView returns a view of the ItemsInWatch metric.
+func (rp *ReflectorProvider) ItemsInWatchView() *view.View {
+	return measureView(rp.ItemsInWatch, view.Distribution(BucketsNBy10(0.1, 6)...))
+}
+
+// NewLastResourceVersionMetric implements MetricsProvider
+func (rp *ReflectorProvider) NewLastResourceVersionMetric(name string) cache.GaugeMetric {
+	return floatMetric{
+		mutators: []tag.Mutator{tag.Insert(tagName, name)},
+		measure:  rp.LastResourceVersion,
+	}
+}
+
+// LastResourceVersionView returns a view of the LastResourceVersion metric.
+func (rp *ReflectorProvider) LastResourceVersionView() *view.View {
+	return measureView(rp.LastResourceVersion, view.LastValue())
+}
+
+// NewListDurationMetric implements MetricsProvider
+func (rp *ReflectorProvider) NewListDurationMetric(name string) cache.SummaryMetric {
+	return floatMetric{
+		mutators: []tag.Mutator{tag.Insert(tagName, name)},
+		measure:  rp.ListDuration,
+	}
+}
+
+// ListDurationView returns a view of the ListDuration metric.
+func (rp *ReflectorProvider) ListDurationView() *view.View {
+	return measureView(rp.ListDuration, view.Distribution(BucketsNBy10(0.1, 6)...))
+}
+
+// NewListsMetric implements MetricsProvider
+func (rp *ReflectorProvider) NewListsMetric(name string) cache.CounterMetric {
+	return counterMetric{
+		mutators: []tag.Mutator{tag.Insert(tagName, name)},
+		measure:  rp.Lists,
+	}
+}
+
+// ListsView returns a view of the Lists metric.
+func (rp *ReflectorProvider) ListsView() *view.View {
+	return measureView(rp.Lists, view.Count())
+}
+
+// NewShortWatchesMetric implements MetricsProvider
+func (rp *ReflectorProvider) NewShortWatchesMetric(name string) cache.CounterMetric {
+	return counterMetric{
+		mutators: []tag.Mutator{tag.Insert(tagName, name)},
+		measure:  rp.ShortWatches,
+	}
+}
+
+// ShortWatchesView returns a view of the ShortWatches metric.
+func (rp *ReflectorProvider) ShortWatchesView() *view.View {
+	return measureView(rp.ShortWatches, view.Count())
+}
+
+// NewWatchDurationMetric implements MetricsProvider
+func (rp *ReflectorProvider) NewWatchDurationMetric(name string) cache.SummaryMetric {
+	return floatMetric{
+		mutators: []tag.Mutator{tag.Insert(tagName, name)},
+		measure:  rp.WatchDuration,
+	}
+}
+
+// WatchDurationView returns a view of the WatchDuration metric.
+func (rp *ReflectorProvider) WatchDurationView() *view.View {
+	return measureView(rp.WatchDuration, view.Distribution(BucketsNBy10(0.1, 6)...))
+}
+
+// NewWatchesMetric implements MetricsProvider
+func (rp *ReflectorProvider) NewWatchesMetric(name string) cache.CounterMetric {
+	return counterMetric{
+		mutators: []tag.Mutator{tag.Insert(tagName, name)},
+		measure:  rp.Watches,
+	}
+}
+
+// WatchesView returns a view of the Watches metric.
+func (rp *ReflectorProvider) WatchesView() *view.View {
+	return measureView(rp.Watches, view.Count())
+}
+
+// DefaultViews returns a list of views suitable for passing to view.Register
+func (rp *ReflectorProvider) DefaultViews() []*view.View {
+	return []*view.View{
+		rp.ItemsInListView(),
+		rp.ItemsInMatchView(),
+		rp.ItemsInWatchView(),
+		rp.LastResourceVersionView(),
+		rp.ListDurationView(),
+		rp.ListsView(),
+		rp.ShortWatchesView(),
+		rp.WatchDurationView(),
+		rp.WatchesView(),
+	}
+}

--- a/metrics/reflector_test.go
+++ b/metrics/reflector_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	"go.opencensus.io/stats/view"
+	kubeinformers "k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	"knative.dev/pkg/metrics/metricstest"
+)
+
+func TestReflectorMetrics(t *testing.T) {
+	rp := &ReflectorProvider{
+		ItemsInList:         newFloat64("items_in_list"),
+		ItemsInMatch:        newFloat64("items_in_match"),
+		ItemsInWatch:        newFloat64("items_in_watch"),
+		LastResourceVersion: newFloat64("last_resource_version"),
+		ListDuration:        newFloat64("list_duration"),
+		Lists:               newInt64("lists"),
+		ShortWatches:        newInt64("short_watches"),
+		WatchDuration:       newFloat64("watch_duration"),
+		Watches:             newInt64("watches"),
+	}
+	cache.SetReflectorMetricsProvider(rp)
+
+	// Reset the metrics configuration to avoid leaked state from other tests.
+	setCurMetricsConfig(nil)
+
+	views := rp.DefaultViews()
+	if got, want := len(views), 9; got != want {
+		t.Errorf("len(DefaultViews()) = %d, want %d", got, want)
+	}
+	if err := view.Register(views...); err != nil {
+		t.Errorf("view.Register() = %v", err)
+	}
+	defer view.Unregister(views...)
+
+	metricstest.CheckStatsNotReported(t, "items_in_list", "items_in_match", "items_in_watch",
+		"last_resource_version", "list_duration", "lists", "short_watches", "watch_duration", "watches")
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	fake := kubefake.NewSimpleClientset()
+	factory := kubeinformers.NewSharedInformerFactory(fake, 0)
+	endpoints := factory.Core().V1().Endpoints()
+
+	informer := endpoints.Informer()
+	go informer.Run(stopCh)
+
+	if ok := cache.WaitForCacheSync(stopCh, informer.HasSynced); !ok {
+		t.Error("failed to wait for endpoints cache to sync")
+	}
+
+	// TODO(mattmoor): The reflector metrics don't seem to be hooked up to anything,
+	// so nothing is reported...  (－‸ლ)
+	metricstest.CheckStatsNotReported(t, "items_in_list", "items_in_match", "items_in_watch",
+		"last_resource_version", "list_duration", "lists", "short_watches", "watch_duration", "watches")
+}

--- a/metrics/workqueue.go
+++ b/metrics/workqueue.go
@@ -23,12 +23,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
-// tagName is used to associate the provided name with each metric created
-// through the WorkqueueProvider's methods to implement workqueue.MetricsProvider.
-// For the kubernetes workqueue implementations this is the queue name provided
-// to the workqueue constructor.
-var tagName = tag.MustNewKey("name")
-
 // WorkqueueProvider implements workqueue.MetricsProvider and may be used with
 // workqueue.SetProvider to have metrics exported to the provided metrics.
 type WorkqueueProvider struct {
@@ -116,16 +110,5 @@ func (wp *WorkqueueProvider) DefaultViews() []*view.View {
 		wp.LatencyView(),
 		wp.RetriesView(),
 		wp.WorkDurationView(),
-	}
-}
-
-// measureView returns a view of the supplied metric.
-func measureView(m stats.Measure, agg *view.Aggregation) *view.View {
-	return &view.View{
-		Name:        m.Name(),
-		Description: m.Description(),
-		Measure:     m,
-		Aggregation: agg,
-		TagKeys:     []tag.Key{tagName},
 	}
 }


### PR DESCRIPTION
This adds logic to hook into two other metric systems:
1. `cache.SetReflectorMetricsProvider`, which doesn't seem hooked up in Kubernetes yet, but would theoretically give us metrics about the mechanisms underpinning informers.
2. `metrics.Register`, which hooks us into the rest client infrastructure to give us metrics about low-level API server calls.

Fixes: https://github.com/knative/pkg/issues/679
Fixes: https://github.com/knative/pkg/issues/680

This is WIP until https://github.com/knative/pkg/pull/678 lands.