### PR TITLE
Cluster management lib: create cluster with addon

### DIFF
--- a/testutils/clustermanager/doc.go
+++ b/testutils/clustermanager/doc.go
@@ -22,9 +22,12 @@ usage example:
 func acquireCluster() {
     clusterOps := GKEClient{}.Setup(2, "n1-standard-8", "us-east1", "a", "myproject")
     // Cast to GKEOperation
-    GKEOps := clusterOps.(GKECluster)
-    if err = GKEOps.Acquire(); err != nil {
-        log.Fatalf("Failed acquire cluster: '%v'", err)
+    GKEOps := clusterOps.(*GKECluster)
+    if err := GKEOps.Initialize(); err != nil {
+		log.Fatalf("failed initializing GKE Client: '%v'", err)
+	}
+    if err := GKEOps.Acquire(); err != nil {
+        log.Fatalf("failed acquire cluster: '%v'", err)
     }
     log.Printf("GKE project is: %s", GKEOps.Project)
     log.Printf("GKE cluster is: %v", GKEOps.Cluster)

--- a/testutils/clustermanager/doc.go
+++ b/testutils/clustermanager/doc.go
@@ -18,19 +18,5 @@ limitations under the License.
 Package clustermanager provides support for managing clusters for e2e tests,
 responsible for creating/deleting cluster, and cluster life cycle management if
 running in Prow
-usage example:
-func acquireCluster() {
-    clusterOps := GKEClient{}.Setup(2, "n1-standard-8", "us-east1", "a", "myproject")
-    // Cast to GKEOperation
-    GKEOps := clusterOps.(*GKECluster)
-    if err := GKEOps.Initialize(); err != nil {
-		log.Fatalf("failed initializing GKE Client: '%v'", err)
-	}
-    if err := GKEOps.Acquire(); err != nil {
-        log.Fatalf("failed acquire cluster: '%v'", err)
-    }
-    log.Printf("GKE project is: %s", GKEOps.Project)
-    log.Printf("GKE cluster is: %v", GKEOps.Cluster)
-}
 */
 package clustermanager

--- a/testutils/clustermanager/example_test.go
+++ b/testutils/clustermanager/example_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustermanager
+
+import "log"
+
+// This is not a real test, it's for documenting purpose, showcasing the usage
+// of entire clustermanager package
+// Important: DO NOT add `// Output` comment inside this function as it will
+// cause `go test` execute this function. See here: https://blog.golang.org/examples
+func Example() {
+	var (
+		numNodes int64 = 2
+		nodeType       = "n1-standard-8"
+		region         = "us-east1"
+		zone           = "a"
+		project        = "myGKEproject"
+		addons         = []string{"istio"}
+	)
+	gkeClient := GKEClient{}
+	clusterOps := gkeClient.Setup(&numNodes, &nodeType, &region, &zone, &project, addons)
+	// Cast to GKEOperation
+	gkeOps := clusterOps.(*GKECluster)
+	if err := gkeOps.Initialize(); err != nil {
+		log.Fatalf("failed initializing GKE Client: '%v'", err)
+	}
+	if err := gkeOps.Acquire(); err != nil {
+		log.Fatalf("failed acquire cluster: '%v'", err)
+	}
+	log.Printf("GKE project is: %s", *gkeOps.Project)
+	log.Printf("GKE cluster is: %v", gkeOps.Cluster)
+}

--- a/testutils/clustermanager/gke.go
+++ b/testutils/clustermanager/gke.go
@@ -23,12 +23,12 @@ import (
 	"strings"
 	"time"
 
+	container "google.golang.org/api/container/v1beta1"
 	"knative.dev/pkg/testutils/clustermanager/boskos"
 	"knative.dev/pkg/testutils/common"
 
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
-	container "google.golang.org/api/container/v1beta1"
 )
 
 const (
@@ -60,6 +60,7 @@ type GKERequest struct {
 	Region        string
 	Zone          string
 	BackupRegions []string
+	Addons        []string
 }
 
 // GKECluster implements ClusterOperations
@@ -114,14 +115,18 @@ func (gsc *GKESDKClient) getOperation(project, location, opName string) (*contai
 // nodeType: default to n1-standard-4 if not provided
 // region: default to regional cluster if not provided, and use default backup regions
 // zone: default is none, must be provided together with region
-func (gs *GKEClient) Setup(numNodes *int64, nodeType *string, region *string, zone *string, project *string) ClusterOperations {
+// project: no default
+// addons: cluster addons to be added to cluster
+func (gs *GKEClient) Setup(numNodes *int64, nodeType *string, region *string, zone *string, project *string, addons []string) ClusterOperations {
 	gc := &GKECluster{
 		Request: &GKERequest{
 			NumNodes:      DefaultGKENumNodes,
 			NodeType:      DefaultGKENodeType,
 			Region:        DefaultGKERegion,
 			Zone:          DefaultGKEZone,
-			BackupRegions: DefaultGKEBackupRegions},
+			BackupRegions: DefaultGKEBackupRegions,
+			Addons:        addons,
+		},
 	}
 
 	if nil != project { // use provided project and create cluster
@@ -236,7 +241,11 @@ func (gc *GKECluster) Acquire() error {
 		err = nil
 		rb := &container.CreateClusterRequest{
 			Cluster: &container.Cluster{
-				Name:             clusterName,
+				Name: clusterName,
+				// Installing addons after cluster creation takes at least 5
+				// minutes, so install addons as part of cluster creation, which
+				// doesn't seem to add much time on top of cluster creation
+				AddonsConfig:     gc.getAddonsConfig(),
 				InitialNodeCount: gc.Request.NumNodes,
 				NodeConfig: &container.NodeConfig{
 					MachineType: gc.Request.NodeType,
@@ -319,6 +328,27 @@ func (gc *GKECluster) Delete() error {
 		return fmt.Errorf("failed deleting cluster: '%v'", err)
 	}
 	return nil
+}
+
+// getAddonsConfig gets AddonsConfig from Request, contains the logic of
+// converting string argument to typed AddonsConfig, for example `IstioConfig`.
+// Currently supports istio
+func (gc *GKECluster) getAddonsConfig() *container.AddonsConfig {
+	const (
+		// Define all supported addons here
+		istio = "istio"
+	)
+	ac := &container.AddonsConfig{}
+	for _, name := range gc.Request.Addons {
+		switch strings.ToLower(name) {
+		case istio:
+			ac.IstioConfig = &container.IstioConfig{Disabled: false}
+		default:
+			panic(fmt.Sprintf("addon type %q not supported. Has to be one of: %q", name, istio))
+		}
+	}
+
+	return ac
 }
 
 // wait depends on unique opName(operation ID created by cloud), and waits until

--- a/testutils/clustermanager/gke_test.go
+++ b/testutils/clustermanager/gke_test.go
@@ -298,8 +298,8 @@ func TestSetup(t *testing.T) {
 		}
 		c := GKEClient{}
 		co := c.Setup(data.numNodes, data.nodeType, data.region, data.zone, data.project, data.addons)
-		errMsg := fmt.Sprintf("testing setup with:\n\tnumNodes: %v\n\tnodeType: %v\n\tregion: %v\n\tone: %v\n\tproject: %v\n\tregionEnv: %v\n\tbackupRegionEnv: %v",
-			data.numNodes, data.nodeType, data.region, data.zone, data.project, data.regionEnv, data.backupRegionEnv)
+		errMsg := fmt.Sprintf("testing setup with:\n\tnumNodes: %v\n\tnodeType: %v\n\tregion: %v\n\tzone: %v\n\tproject: %v\n\taddons: %v\n\tregionEnv: %v\n\tbackupRegionEnv: %v",
+			data.numNodes, data.nodeType, data.region, data.zone, data.project, data.addons, data.regionEnv, data.backupRegionEnv)
 		gotCo := co.(*GKECluster)
 		// mock for easier comparison
 		gotCo.operations = nil
@@ -820,7 +820,6 @@ func TestDelete(t *testing.T) {
 		if !reflect.DeepEqual(err, data.expErr) {
 			t.Errorf("%s\nerror want: '%v'\nerror got: '%v'", errMsg, err, data.expErr)
 		}
-		// if !reflect.DeepEqual(data.expCluster, gotCluster) {
 		if dif := cmp.Diff(data.expCluster, gotCluster); dif != "" {
 			t.Errorf("%s\nCluster got(+) is different from wanted(-)\n%v", errMsg, dif)
 		}


### PR DESCRIPTION
Initially planned to have `SetAddon` as an exported function to be used as an option, which didn't work as it took far more than 5 minutes to get `Istio` addon installed on an existing cluster. And when installed as part of cluster creation it doesn't seem to add much time on top of cluster creation time, so switch to have addons as a param to cluster creation.

This PR also does:
- Update doc
- Consolidate unit tests
- Prettify unit test error message with cmp.Diff

/cc @adrcunha 