### PR TITLE
Change how we test the generateName reactor.

### DIFF
--- a/reconciler/testing/generate_name_reactor.go
+++ b/reconciler/testing/generate_name_reactor.go
@@ -46,13 +46,11 @@ type GenerateNameReactor struct {
 // mocking
 func (r *GenerateNameReactor) Handles(action clientgotesting.Action) bool {
 	create, ok := action.(clientgotesting.CreateAction)
-
 	if !ok {
 		return false
 	}
 
 	objMeta, err := meta.Accessor(create.GetObject())
-
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
The 1.14 K8s test libs introduce changes that broke how we were testing this, but it still works in the cases we care about, so this adjusts the test to more accurately test the reactor in the way we actually care about.