### PR TITLE
Add SIGPIPE signal handler to the signals package

### DIFF
--- a/signals/signal_posix.go
+++ b/signals/signal_posix.go
@@ -23,4 +23,4 @@ import (
 	"syscall"
 )
 
-var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGPIPE}


### PR DESCRIPTION
By default raised SIGPIPE signal will cause the program to exit immediately[1]
and bypass any shutdown logic.

Add syscall.SIGPIPE to the signals we get notified to disable this behavior.

[1] https://golang.org/pkg/os/signal/#hdr-SIGPIPE
