### PR TITLE
Cluster management lib: Add autoscaling to cluster creation

### DIFF
--- a/testutils/clustermanager/boskos/boskos.go
+++ b/testutils/clustermanager/boskos/boskos.go
@@ -47,7 +47,7 @@ type Client struct {
 }
 
 func newClient(host *string) *boskosclient.Client {
-	if nil == host {
+	if host == nil {
 		hostName := common.GetOSEnv("JOB_NAME")
 		host = &hostName
 	}
@@ -61,7 +61,7 @@ func (c *Client) AcquireGKEProject(host *string) (*boskoscommon.Resource, error)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultWaitDuration)
 	defer cancel()
 	p, err := newClient(host).AcquireWait(ctx, GKEProjectResource, boskoscommon.Free, boskoscommon.Busy)
-	if nil != err {
+	if err != nil {
 		return nil, fmt.Errorf("boskos failed to acquire GKE project: %v", err)
 	}
 	if p == nil {
@@ -77,7 +77,7 @@ func (c *Client) AcquireGKEProject(host *string) (*boskoscommon.Resource, error)
 // other processes, regardless of where the other process is running.
 func (c *Client) ReleaseGKEProject(host *string, name string) error {
 	client := newClient(host)
-	if err := client.Release(name, boskoscommon.Dirty); nil != err {
+	if err := client.Release(name, boskoscommon.Dirty); err != nil {
 		return fmt.Errorf("boskos failed to release GKE project '%s': %v", name, err)
 	}
 	return nil

--- a/testutils/clustermanager/boskos/boskos_test.go
+++ b/testutils/clustermanager/boskos/boskos_test.go
@@ -90,10 +90,10 @@ func TestAcquireGKEProject(t *testing.T) {
 		defer ts.Close()
 		boskosURI = ts.URL
 		_, err := client.AcquireGKEProject(data.host)
-		if data.expErr && (nil == err) {
+		if data.expErr && (err == nil) {
 			t.Fatalf("testing acquiring GKE project, want: err, got: no err")
 		}
-		if !data.expErr && (nil != err) {
+		if !data.expErr && (err != nil) {
 			t.Fatalf("testing acquiring GKE project, want: no err, got: err '%v'", err)
 		}
 	}
@@ -143,10 +143,10 @@ func TestReleaseGKEProject(t *testing.T) {
 		defer ts.Close()
 		boskosURI = ts.URL
 		err := client.ReleaseGKEProject(data.host, data.resName)
-		if data.expErr && (nil == err) {
+		if data.expErr && (err == nil) {
 			t.Fatalf("testing acquiring GKE project, want: err, got: no err")
 		}
-		if !data.expErr && (nil != err) {
+		if !data.expErr && (err != nil) {
 			t.Fatalf("testing acquiring GKE project, want: no err, got: err '%v'", err)
 		}
 	}

--- a/testutils/clustermanager/boskos/fake/fake.go
+++ b/testutils/clustermanager/boskos/fake/fake.go
@@ -33,7 +33,7 @@ type FakeBoskosClient struct {
 }
 
 func (c *FakeBoskosClient) getOwner(host *string) string {
-	if nil == host {
+	if host == nil {
 		return fakeOwner
 	}
 	return *host

--- a/testutils/clustermanager/example_test.go
+++ b/testutils/clustermanager/example_test.go
@@ -24,7 +24,8 @@ import "log"
 // cause `go test` execute this function. See here: https://blog.golang.org/examples
 func Example() {
 	var (
-		numNodes int64 = 2
+		minNodes int64 = 1
+		maxNodes int64 = 3
 		nodeType       = "n1-standard-8"
 		region         = "us-east1"
 		zone           = "a"
@@ -32,7 +33,7 @@ func Example() {
 		addons         = []string{"istio"}
 	)
 	gkeClient := GKEClient{}
-	clusterOps := gkeClient.Setup(&numNodes, &nodeType, &region, &zone, &project, addons)
+	clusterOps := gkeClient.Setup(&minNodes, &maxNodes, &nodeType, &region, &zone, &project, addons)
 	// Cast to GKEOperation
 	gkeOps := clusterOps.(*GKECluster)
 	if err := gkeOps.Initialize(); err != nil {

--- a/testutils/clustermanager/gke.go
+++ b/testutils/clustermanager/gke.go
@@ -32,7 +32,8 @@ import (
 )
 
 const (
-	DefaultGKENumNodes = 1
+	DefaultGKEMinNodes = 1
+	DefaultGKEMaxNodes = 3
 	DefaultGKENodeType = "n1-standard-4"
 	DefaultGKERegion   = "us-central1"
 	DefaultGKEZone     = ""
@@ -45,8 +46,9 @@ var (
 	protectedProjects       = []string{"knative-tests"}
 	protectedClusters       = []string{"knative-prow"}
 	// These are arbitrary numbers determined based on past experience
-	creationTimeout = 20 * time.Minute
-	deletionTimeout = 10 * time.Minute
+	creationTimeout    = 20 * time.Minute
+	deletionTimeout    = 10 * time.Minute
+	autoscalingTimeout = time.Minute
 )
 
 // GKEClient implements Client
@@ -55,7 +57,8 @@ type GKEClient struct {
 
 // GKERequest contains all requests collected for cluster creation
 type GKERequest struct {
-	NumNodes      int64
+	MinNodes      int64
+	MaxNodes      int64
 	NodeType      string
 	Region        string
 	Zone          string
@@ -82,6 +85,7 @@ type GKESDKOperations interface {
 	delete(string, string, string) (*container.Operation, error)
 	get(string, string, string) (*container.Cluster, error)
 	getOperation(string, string, string) (*container.Operation, error)
+	setAutoscaling(string, string, string, string, *container.SetNodePoolAutoscalingRequest) (*container.Operation, error)
 }
 
 // GKESDKClient Implement GKESDKOperations
@@ -110,17 +114,28 @@ func (gsc *GKESDKClient) getOperation(project, location, opName string) (*contai
 	return gsc.Service.Projects.Locations.Operations.Get(name).Do()
 }
 
+// setAutoscaling sets up autoscaling for a nodepool. This function is not
+// covered by either `Clusters.Update` or `NodePools.Update`, so can not really
+// make it as generic as the others
+func (gsc *GKESDKClient) setAutoscaling(project, clusterName, location, nodepoolName string,
+	rb *container.SetNodePoolAutoscalingRequest) (*container.Operation, error) {
+	parent := fmt.Sprintf("projects/%s/locations/%s/clusters/%s/nodePools/%s", project, location, clusterName, nodepoolName)
+	return gsc.Service.Projects.Locations.Clusters.NodePools.SetAutoscaling(parent, rb).Do()
+}
+
 // Setup sets up a GKECluster client.
-// numNodes: default to 3 if not provided
+// minNodes: default to 1 if not provided
+// maxNodes: default to 3 if not provided
 // nodeType: default to n1-standard-4 if not provided
 // region: default to regional cluster if not provided, and use default backup regions
 // zone: default is none, must be provided together with region
 // project: no default
 // addons: cluster addons to be added to cluster
-func (gs *GKEClient) Setup(numNodes *int64, nodeType *string, region *string, zone *string, project *string, addons []string) ClusterOperations {
+func (gs *GKEClient) Setup(minNodes *int64, maxNodes *int64, nodeType *string, region *string, zone *string, project *string, addons []string) ClusterOperations {
 	gc := &GKECluster{
 		Request: &GKERequest{
-			NumNodes:      DefaultGKENumNodes,
+			MinNodes:      DefaultGKEMinNodes,
+			MaxNodes:      DefaultGKEMaxNodes,
 			NodeType:      DefaultGKENodeType,
 			Region:        DefaultGKERegion,
 			Zone:          DefaultGKEZone,
@@ -129,39 +144,42 @@ func (gs *GKEClient) Setup(numNodes *int64, nodeType *string, region *string, zo
 		},
 	}
 
-	if nil != project { // use provided project and create cluster
+	if project != nil { // use provided project and create cluster
 		gc.Project = project
 		gc.NeedCleanup = true
 	}
 
-	if nil != numNodes {
-		gc.Request.NumNodes = *numNodes
+	if minNodes != nil {
+		gc.Request.MinNodes = *minNodes
 	}
-	if nil != nodeType {
+	if maxNodes != nil {
+		gc.Request.MaxNodes = *maxNodes
+	}
+	if nodeType != nil {
 		gc.Request.NodeType = *nodeType
 	}
-	if nil != region {
+	if region != nil {
 		gc.Request.Region = *region
 	}
-	if "" != common.GetOSEnv(regionEnv) {
+	if common.GetOSEnv(regionEnv) != "" {
 		gc.Request.Region = common.GetOSEnv(regionEnv)
 	}
-	if "" != common.GetOSEnv(backupRegionEnv) {
+	if common.GetOSEnv(backupRegionEnv) != "" {
 		gc.Request.BackupRegions = strings.Split(common.GetOSEnv(backupRegionEnv), " ")
 	}
-	if nil != zone {
+	if zone != nil {
 		gc.Request.Zone = *zone
 		gc.Request.BackupRegions = make([]string, 0)
 	}
 
 	ctx := context.Background()
 	c, err := google.DefaultClient(ctx, container.CloudPlatformScope)
-	if nil != err {
+	if err != nil {
 		log.Fatalf("failed create google client: '%v'", err)
 	}
 
 	containerService, err := container.New(c)
-	if nil != err {
+	if err != nil {
 		log.Fatalf("failed create container service: '%v'", err)
 	}
 	gc.operations = &GKESDKClient{containerService}
@@ -175,25 +193,25 @@ func (gs *GKEClient) Setup(numNodes *int64, nodeType *string, region *string, zo
 // projects to decide whether use existing cluster/project or creating new ones.
 func (gc *GKECluster) Initialize() error {
 	// Try obtain project name via `kubectl`, `gcloud`
-	if nil == gc.Project {
-		if err := gc.checkEnvironment(); nil != err {
+	if gc.Project == nil {
+		if err := gc.checkEnvironment(); err != nil {
 			return fmt.Errorf("failed checking existing cluster: '%v'", err)
-		} else if nil != gc.Cluster { // return if Cluster was already set by kubeconfig
+		} else if gc.Cluster != nil { // return if Cluster was already set by kubeconfig
 			return nil
 		}
 	}
 	// Get project name from boskos if running in Prow
-	if nil == gc.Project && common.IsProw() {
+	if gc.Project == nil && common.IsProw() {
 		project, err := gc.boskosOps.AcquireGKEProject(nil)
-		if nil != err {
+		if err != nil {
 			return fmt.Errorf("failed acquire boskos project: '%v'", err)
 		}
 		gc.Project = &project.Name
 	}
-	if nil == gc.Project || "" == *gc.Project {
+	if gc.Project == nil || *gc.Project == "" {
 		return errors.New("gcp project must be set")
 	}
-	if !common.IsProw() && nil == gc.Cluster {
+	if !common.IsProw() && gc.Cluster == nil {
 		gc.NeedCleanup = true
 	}
 	log.Printf("Using project %q for running test", *gc.Project)
@@ -213,12 +231,12 @@ func (gc *GKECluster) Acquire() error {
 	gc.ensureProtected()
 	var err error
 	// Check if using existing cluster
-	if nil != gc.Cluster {
+	if gc.Cluster != nil {
 		return nil
 	}
 	// Perform GKE specific cluster creation logics
 	clusterName, err := getResourceName(ClusterResource)
-	if nil != err {
+	if err != nil {
 		return fmt.Errorf("failed getting cluster name: '%v'", err)
 	}
 
@@ -246,7 +264,7 @@ func (gc *GKECluster) Acquire() error {
 				// minutes, so install addons as part of cluster creation, which
 				// doesn't seem to add much time on top of cluster creation
 				AddonsConfig:     gc.getAddonsConfig(),
-				InitialNodeCount: gc.Request.NumNodes,
+				InitialNodeCount: gc.Request.MinNodes,
 				NodeConfig: &container.NodeConfig{
 					MachineType: gc.Request.NodeType,
 				},
@@ -258,24 +276,38 @@ func (gc *GKECluster) Acquire() error {
 
 		// Deleting cluster if it already exists
 		existingCluster, _ := gc.operations.get(*gc.Project, clusterLoc, clusterName)
-		if nil != existingCluster {
+		if existingCluster != nil {
 			log.Printf("Cluster %q already exists in %q. Deleting...", clusterName, clusterLoc)
 			op, err = gc.operations.delete(*gc.Project, clusterName, clusterLoc)
-			if nil == err {
+			if err == nil {
 				err = gc.wait(clusterLoc, op.Name, deletionTimeout)
 			}
 		}
 		// Creating cluster only if previous step succeeded
-		if nil == err {
+		if err == nil {
 			log.Printf("Creating cluster %q in %q", clusterName, clusterLoc)
 			op, err = gc.operations.create(*gc.Project, clusterLoc, rb)
-			if nil == err {
-				if err = gc.wait(clusterLoc, op.Name, creationTimeout); nil == err {
+			if err == nil {
+				if err = gc.wait(clusterLoc, op.Name, creationTimeout); err == nil {
 					cluster, err = gc.operations.get(*gc.Project, clusterLoc, rb.Cluster.Name)
 				}
 			}
+			if err == nil { // Enable autoscaling and set limits
+				arb := &container.SetNodePoolAutoscalingRequest{
+					Autoscaling: &container.NodePoolAutoscaling{
+						Enabled:      true,
+						MinNodeCount: gc.Request.MinNodes,
+						MaxNodeCount: gc.Request.MaxNodes,
+					},
+				}
+
+				op, err = gc.operations.setAutoscaling(*gc.Project, clusterName, clusterLoc, "default-pool", arb)
+				if err == nil {
+					err = gc.wait(clusterLoc, op.Name, autoscalingTimeout)
+				}
+			}
 		}
-		if nil != err {
+		if err != nil {
 			errMsg := fmt.Sprintf("Error during cluster creation: '%v'. ", err)
 			if gc.NeedCleanup { // Delete half created cluster if it's user created
 				errMsg = fmt.Sprintf("%sDeleting cluster %q in %q in background...\n", errMsg, clusterName, clusterLoc)
@@ -315,16 +347,16 @@ func (gc *GKECluster) Delete() error {
 	}
 	// Should only get here if running locally and cluster created by this
 	// client, so at this moment cluster should have been set
-	if nil == gc.Cluster {
+	if gc.Cluster == nil {
 		return fmt.Errorf("cluster doesn't exist")
 	}
 
 	log.Printf("Deleting cluster %q in %q", gc.Cluster.Name, gc.Cluster.Location)
 	op, err := gc.operations.delete(*gc.Project, gc.Cluster.Name, gc.Cluster.Location)
-	if nil == err {
+	if err == nil {
 		err = gc.wait(gc.Cluster.Location, op.Name, deletionTimeout)
 	}
-	if nil != err {
+	if err != nil {
 		return fmt.Errorf("failed deleting cluster: '%v'", err)
 	}
 	return nil
@@ -373,7 +405,7 @@ func (gc *GKECluster) wait(location, opName string, wait time.Duration) error {
 			// Retry 3 times in case of weird network error, or rate limiting
 			for r, w := 0, 50*time.Microsecond; r < 3; r, w = r+1, w*2 {
 				op, err = gc.operations.getOperation(*gc.Project, location, opName)
-				if nil == err {
+				if err == nil {
 					if op.Status == doneStatus {
 						return nil
 					} else if op.Status == pendingStatus || op.Status == runningStatus {
@@ -388,7 +420,7 @@ func (gc *GKECluster) wait(location, opName string, wait time.Duration) error {
 				time.Sleep(w)
 			}
 			// If err still persist after retries, exit
-			if nil != err {
+			if err != nil {
 				return err
 			}
 		}
@@ -399,14 +431,14 @@ func (gc *GKECluster) wait(location, opName string, wait time.Duration) error {
 
 // ensureProtected ensures not operating on protected project/cluster
 func (gc *GKECluster) ensureProtected() {
-	if nil != gc.Project {
+	if gc.Project != nil {
 		for _, pp := range protectedProjects {
 			if *gc.Project == pp {
 				log.Fatalf("project %q is protected", *gc.Project)
 			}
 		}
 	}
-	if nil != gc.Cluster {
+	if gc.Cluster != nil {
 		for _, pc := range protectedClusters {
 			if gc.Cluster.Name == pc {
 				log.Fatalf("cluster %q is protected", gc.Cluster.Name)
@@ -422,7 +454,7 @@ func (gc *GKECluster) checkEnvironment() error {
 	var err error
 	// if kubeconfig is configured, use it
 	output, err := common.StandardExec("kubectl", "config", "current-context")
-	if nil == err {
+	if err == nil {
 		currentContext := strings.TrimSpace(string(output))
 		if strings.HasPrefix(currentContext, "gke_") {
 			// output should be in the form of gke_PROJECT_REGION_CLUSTER
@@ -433,25 +465,25 @@ func (gc *GKECluster) checkEnvironment() error {
 				log.Printf("kubeconfig isn't empty, uses this cluster for running tests: %s", currentContext)
 				gc.Project = &parts[1]
 				gc.Cluster, err = gc.operations.get(*gc.Project, parts[2], parts[3])
-				if nil != err {
+				if err != nil {
 					return fmt.Errorf("couldn't find cluster %s in %s in %s, does it exist? %v", parts[3], parts[1], parts[2], err)
 				}
 				return nil
 			}
 		}
 	}
-	if nil != err && len(output) > 0 {
+	if err != nil && len(output) > 0 {
 		// this is unexpected error, should shout out directly
 		return fmt.Errorf("failed running kubectl config current-context: '%s'", string(output))
 	}
 
 	// if gcloud is pointing to a project, use it
 	output, err = common.StandardExec("gcloud", "config", "get-value", "project")
-	if nil != err {
+	if err != nil {
 		return fmt.Errorf("failed getting gcloud project: '%v'", err)
 	}
 	if string(output) != "" {
-		project := string(output)
+		project := strings.Trim(strings.TrimSpace(string(output)), "\n\r")
 		gc.Project = &project
 	}
 

--- a/testutils/clustermanager/gke.go
+++ b/testutils/clustermanager/gke.go
@@ -48,7 +48,7 @@ var (
 	// These are arbitrary numbers determined based on past experience
 	creationTimeout    = 20 * time.Minute
 	deletionTimeout    = 10 * time.Minute
-	autoscalingTimeout = time.Minute
+	autoscalingTimeout = 1 * time.Minute
 )
 
 // GKEClient implements Client

--- a/testutils/clustermanager/gke_test.go
+++ b/testutils/clustermanager/gke_test.go
@@ -153,7 +153,6 @@ func (fgsc *FakeGKESDKClient) getOperation(project, location, opName string) (*c
 func (fgsc *FakeGKESDKClient) setAutoscaling(project, clusterName, location, nodepoolName string,
 	rb *container.SetNodePoolAutoscalingRequest) (*container.Operation, error) {
 
-	// parent := fmt.Sprintf("projects/%s/locations/%s/clusters/%s/nodePools/%s", project, location, clusterName, nodepoolName)
 	cluster, err := fgsc.get(project, location, clusterName)
 	if err != nil {
 		return nil, err
@@ -163,10 +162,6 @@ func (fgsc *FakeGKESDKClient) setAutoscaling(project, clusterName, location, nod
 			np.Autoscaling = rb.Autoscaling
 		}
 	}
-	// cluster.NodePools = append([]*container.NodePool{&container.NodePool{
-	// 	Autoscaling: rb.Autoscaling,
-	// 	Name:        nodepoolName,
-	// }}, cluster.NodePools...)
 	return fgsc.newOp(), nil
 }
 

--- a/testutils/clustermanager/util.go
+++ b/testutils/clustermanager/util.go
@@ -35,13 +35,13 @@ type ResourceType string
 func getResourceName(rt ResourceType) (string, error) {
 	var resName string
 	repoName, err := common.GetRepoName()
-	if nil != err {
+	if err != nil {
 		return "", fmt.Errorf("failed getting reponame for forming resource name: '%v'", err)
 	}
 	resName = fmt.Sprintf("k%s-%s", repoName, string(rt))
 	if common.IsProw() {
 		buildNumStr := common.GetOSEnv("BUILD_NUMBER")
-		if "" == buildNumStr {
+		if buildNumStr == "" {
 			return "", fmt.Errorf("failed getting BUILD_NUMBER env var")
 		}
 		if len(buildNumStr) > 20 {
@@ -53,7 +53,7 @@ func getResourceName(rt ResourceType) (string, error) {
 }
 
 func getClusterLocation(region, zone string) string {
-	if "" != zone {
+	if zone != "" {
 		region = fmt.Sprintf("%s-%s", region, zone)
 	}
 	return region

--- a/testutils/clustermanager/util_test.go
+++ b/testutils/clustermanager/util_test.go
@@ -52,7 +52,7 @@ func TestGetResourceName(t *testing.T) {
 		}
 
 		out, err := getResourceName(ClusterResource)
-		if nil != err {
+		if err != nil {
 			t.Fatalf("getting resource name for cluster, wanted: 'no error', got: '%v'", err)
 		}
 		if out != data.exp {

--- a/testutils/common/common.go
+++ b/testutils/common/common.go
@@ -38,13 +38,13 @@ func standardExec(name string, args ...string) ([]byte, error) {
 
 // IsProw checks if the process is initialized by Prow
 func IsProw() bool {
-	return "" != GetOSEnv("PROW_JOB_ID")
+	return GetOSEnv("PROW_JOB_ID") != ""
 }
 
 // GetRepoName gets repo name by the path where the repo cloned to
 func GetRepoName() (string, error) {
 	out, err := StandardExec("git", "rev-parse", "--show-toplevel")
-	if nil != err {
+	if err != nil {
 		return "", fmt.Errorf("failed git rev-parse --show-toplevel: '%v'", err)
 	}
 	return strings.TrimSpace(path.Base(string(out))), nil

--- a/testutils/common/common_test.go
+++ b/testutils/common/common_test.go
@@ -26,20 +26,26 @@ func TestStandardExec(t *testing.T) {
 	datas := []struct {
 		cmd    string
 		args   []string
-		expOut string
+		expOut []byte
 		expErr error
 	}{
-		{"bash", []string{"-c", "echo foo"}, "foo\n", nil},
-		{"cmd_not_exist", []string{"-c", "echo"}, "", fmt.Errorf("exec: \"cmd_not_exist\": executable file not found in $PATH")},
+		{"bash", []string{"-c", "echo foo"}, []byte("foo\n"), nil},
+		{"cmd_not_exist", []string{"-c", "echo"}, []byte{}, fmt.Errorf("exec: \"cmd_not_exist\": executable file not found in $PATH")},
 	}
 
 	for _, data := range datas {
 		data := data
 		out, err := StandardExec(data.cmd, data.args...)
-		if !reflect.DeepEqual(string(out), data.expOut) || (err != nil && data.expErr != nil) || (err != nil && data.expErr == nil) ||
-			(err != nil && data.expErr != nil && err.Error() != data.expErr.Error()) {
-			t.Errorf("running cmd: '%v', args: '%v'\nwant: out - '%v', err - '%v'\n got: out - '%s', err - '%v'",
-				data.cmd, data.args, data.expOut, data.expErr, string(out), err)
+		if err != nil {
+			err = fmt.Errorf(err.Error())
+		}
+		errMsg := fmt.Sprintf("running cmd: '%v', args: '%v'", data.cmd, data.args)
+		if !reflect.DeepEqual(data.expErr, err) {
+			t.Errorf("%s\nerror want: '%v'\nerror got: '%v'", errMsg, err, data.expErr)
+		}
+
+		if !reflect.DeepEqual(string(out), string(data.expOut)) {
+			t.Errorf("%s\noutput want: '%v'\noutput got: '%v'", errMsg, string(data.expOut), string(out))
 		}
 	}
 }

--- a/testutils/common/common_test.go
+++ b/testutils/common/common_test.go
@@ -36,8 +36,8 @@ func TestStandardExec(t *testing.T) {
 	for _, data := range datas {
 		data := data
 		out, err := StandardExec(data.cmd, data.args...)
-		if !reflect.DeepEqual(string(out), data.expOut) || (nil == err && nil != data.expErr) || (nil != err && nil == data.expErr) ||
-			(nil != err && nil != data.expErr && err.Error() != data.expErr.Error()) {
+		if !reflect.DeepEqual(string(out), data.expOut) || (err != nil && data.expErr != nil) || (err != nil && data.expErr == nil) ||
+			(err != nil && data.expErr != nil && err.Error() != data.expErr.Error()) {
 			t.Errorf("running cmd: '%v', args: '%v'\nwant: out - '%v', err - '%v'\n got: out - '%s', err - '%v'",
 				data.cmd, data.args, data.expOut, data.expErr, string(out), err)
 		}


### PR DESCRIPTION
Autoscaling is enabled by default for all e2e test in knative, adding this function as default. By the way fixed a bug in existing project set by `gcloud`, as well as some cleanups of switching from `nil ==` style to `== nil` style.

/cc @adrcunha 
Part of: https://github.com/knative/test-infra/issues/1186