### PR TITLE
Remove deprecated NewFixedWatcher

### DIFF
--- a/configmap/static_watcher.go
+++ b/configmap/static_watcher.go
@@ -22,13 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// NewFixedWatcher returns a StaticWatcher that exposes a collection of ConfigMaps.
-//
-// Deprecated: Use NewStaticWatcher
-func NewFixedWatcher(cms ...*corev1.ConfigMap) *StaticWatcher {
-	return NewStaticWatcher(cms...)
-}
-
 // NewStaticWatcher returns an StaticWatcher that exposes a collection of ConfigMaps.
 func NewStaticWatcher(cms ...*corev1.ConfigMap) *StaticWatcher {
 	cmm := make(map[string]*corev1.ConfigMap)


### PR DESCRIPTION
Last user, in `knative.dev` was the eventing repo.

That is cleaned up here:
https://github.com/knative/eventing/pull/1927

/hold