### PR TITLE
Plumb through a structured key, keep current behavior.

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -155,23 +156,23 @@ func NewImplWithStats(r Reconciler, logger *zap.SugaredLogger, workQueueName str
 // EnqueueAfter takes a resource, converts it into a namespace/name string,
 // and passes it to EnqueueKey.
 func (c *Impl) EnqueueAfter(obj interface{}, after time.Duration) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	object, err := kmeta.DeletionHandlingAccessor(obj)
 	if err != nil {
 		c.logger.Errorw("Enqueue", zap.Error(err))
 		return
 	}
-	c.EnqueueKeyAfter(key, after)
+	c.EnqueueKeyAfter(types.NamespacedName{Namespace: object.GetNamespace(), Name: object.GetName()}, after)
 }
 
 // Enqueue takes a resource, converts it into a namespace/name string,
 // and passes it to EnqueueKey.
 func (c *Impl) Enqueue(obj interface{}) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	object, err := kmeta.DeletionHandlingAccessor(obj)
 	if err != nil {
 		c.logger.Errorw("Enqueue", zap.Error(err))
 		return
 	}
-	c.EnqueueKey(key)
+	c.EnqueueKey(types.NamespacedName{Namespace: object.GetNamespace(), Name: object.GetName()})
 }
 
 // EnqueueControllerOf takes a resource, identifies its controller resource,
@@ -186,7 +187,7 @@ func (c *Impl) EnqueueControllerOf(obj interface{}) {
 	// If we can determine the controller ref of this object, then
 	// add that object to our workqueue.
 	if owner := metav1.GetControllerOf(object); owner != nil {
-		c.EnqueueKey(object.GetNamespace() + "/" + owner.Name)
+		c.EnqueueKey(types.NamespacedName{Namespace: object.GetNamespace(), Name: owner.Name})
 	}
 }
 
@@ -218,14 +219,14 @@ func (c *Impl) EnqueueLabelOfNamespaceScopedResource(namespaceLabel, nameLabel s
 				return
 			}
 
-			c.EnqueueKey(fmt.Sprintf("%s/%s", controllerNamespace, controllerKey))
+			c.EnqueueKey(types.NamespacedName{Namespace: controllerNamespace, Name: controllerKey})
 			return
 		}
 
 		// Pass through namespace of the object itself if no namespace label specified.
 		// This is for the scenario that object and the parent resource are of same namespace,
 		// e.g. to enqueue the revision of an endpoint.
-		c.EnqueueKey(fmt.Sprintf("%s/%s", object.GetNamespace(), controllerKey))
+		c.EnqueueKey(types.NamespacedName{Namespace: object.GetNamespace(), Name: controllerKey})
 	}
 }
 
@@ -249,21 +250,27 @@ func (c *Impl) EnqueueLabelOfClusterScopedResource(nameLabel string) func(obj in
 			return
 		}
 
-		c.EnqueueKey(controllerKey)
+		ns, name, err := cache.SplitMetaNamespaceKey(controllerKey)
+		if err != nil {
+			c.logger.Error(err)
+			return
+		}
+
+		c.EnqueueKey(types.NamespacedName{Namespace: ns, Name: name})
 	}
 }
 
 // EnqueueKey takes a namespace/name string and puts it onto the work queue.
-func (c *Impl) EnqueueKey(key string) {
+func (c *Impl) EnqueueKey(key types.NamespacedName) {
 	c.WorkQueue.Add(key)
-	c.logger.Debugf("Adding to queue %s (depth: %d)", key, c.WorkQueue.Len())
+	c.logger.Debugf("Adding to queue %s (depth: %d)", key.String(), c.WorkQueue.Len())
 }
 
 // EnqueueKeyAfter takes a namespace/name string and schedules its execution in
 // the work queue after given delay.
-func (c *Impl) EnqueueKeyAfter(key string, delay time.Duration) {
+func (c *Impl) EnqueueKeyAfter(key types.NamespacedName, delay time.Duration) {
 	c.WorkQueue.AddAfter(key, delay)
-	c.logger.Debugf("Adding to queue %s (delay: %v, depth: %d)", key, delay, c.WorkQueue.Len())
+	c.logger.Debugf("Adding to queue %s (delay: %v, depth: %d)", key.String(), delay, c.WorkQueue.Len())
 }
 
 // Run starts the controller's worker threads, the number of which is threadiness.
@@ -306,7 +313,8 @@ func (c *Impl) processNextWorkItem() bool {
 	if shutdown {
 		return false
 	}
-	key := obj.(string)
+	key := obj.(types.NamespacedName)
+	fqdn := key.String()
 
 	c.logger.Debugf("Processing from queue %s (depth: %d)", key, c.WorkQueue.Len())
 
@@ -327,17 +335,17 @@ func (c *Impl) processNextWorkItem() bool {
 		if err != nil {
 			status = falseString
 		}
-		c.statsReporter.ReportReconcile(time.Since(startTime), key, status)
+		c.statsReporter.ReportReconcile(time.Since(startTime), fqdn, status)
 	}()
 
 	// Embed the key into the logger and attach that to the context we pass
 	// to the Reconciler.
-	logger := c.logger.With(zap.String(logkey.TraceId, uuid.New().String()), zap.String(logkey.Key, key))
+	logger := c.logger.With(zap.String(logkey.TraceId, uuid.New().String()), zap.String(logkey.Key, fqdn))
 	ctx := logging.WithLogger(context.TODO(), logger)
 
 	// Run Reconcile, passing it the namespace/name string of the
 	// resource to be synced.
-	if err = c.Reconciler.Reconcile(ctx, key); err != nil {
+	if err = c.Reconciler.Reconcile(ctx, fqdn); err != nil {
 		c.handleErr(err, key)
 		logger.Infof("Reconcile failed. Time taken: %v.", time.Since(startTime))
 		return true
@@ -351,7 +359,7 @@ func (c *Impl) processNextWorkItem() bool {
 	return true
 }
 
-func (c *Impl) handleErr(err error, key string) {
+func (c *Impl) handleErr(err error, key types.NamespacedName) {
 	c.logger.Errorw("Reconcile error", zap.Error(err))
 
 	// Re-queue the key if it's an transient error.
@@ -360,7 +368,7 @@ func (c *Impl) handleErr(err error, key string) {
 	// being processed, queue.Len==0).
 	if !IsPermanentError(err) && !c.WorkQueue.ShuttingDown() {
 		c.WorkQueue.AddRateLimited(key)
-		c.logger.Debugf("Requeuing key %s due to non-permanent error (depth: %d)", key, c.WorkQueue.Len())
+		c.logger.Debugf("Requeuing key %s due to non-permanent error (depth: %d)", key.String(), c.WorkQueue.Len())
 		return
 	}
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -314,7 +314,7 @@ func (c *Impl) processNextWorkItem() bool {
 		return false
 	}
 	key := obj.(types.NamespacedName)
-	fqdn := key.String()
+	keyStr := key.String()
 
 	c.logger.Debugf("Processing from queue %s (depth: %d)", key, c.WorkQueue.Len())
 
@@ -335,17 +335,17 @@ func (c *Impl) processNextWorkItem() bool {
 		if err != nil {
 			status = falseString
 		}
-		c.statsReporter.ReportReconcile(time.Since(startTime), fqdn, status)
+		c.statsReporter.ReportReconcile(time.Since(startTime), keyStr, status)
 	}()
 
 	// Embed the key into the logger and attach that to the context we pass
 	// to the Reconciler.
-	logger := c.logger.With(zap.String(logkey.TraceId, uuid.New().String()), zap.String(logkey.Key, fqdn))
+	logger := c.logger.With(zap.String(logkey.TraceId, uuid.New().String()), zap.String(logkey.Key, keyStr))
 	ctx := logging.WithLogger(context.TODO(), logger)
 
 	// Run Reconcile, passing it the namespace/name string of the
 	// resource to be synced.
-	if err = c.Reconciler.Reconcile(ctx, fqdn); err != nil {
+	if err = c.Reconciler.Reconcile(ctx, keyStr); err != nil {
 		c.handleErr(err, key)
 		logger.Infof("Reconcile failed. Time taken: %v.", time.Since(startTime))
 		return true


### PR DESCRIPTION
As per title, this is an attempt to introduce a structured key to be used by our reconcilers to remove unnecessary boilerplate.