### PR TITLE
Adjust tracker to take structured keys as well.

### DIFF
--- a/resolver/addressable_resolver.go
+++ b/resolver/addressable_resolver.go
@@ -24,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/pkg/apis"
 	pkgapisduck "knative.dev/pkg/apis/duck"
@@ -43,7 +44,7 @@ type URIResolver struct {
 }
 
 // NewURIResolver constructs a new URIResolver with context and a callback passed to the URIResolver's tracker.
-func NewURIResolver(ctx context.Context, callback func(string)) *URIResolver {
+func NewURIResolver(ctx context.Context, callback func(types.NamespacedName)) *URIResolver {
 	ret := &URIResolver{}
 
 	ret.tracker = tracker.New(callback, controller.GetTrackerLease(ctx))

--- a/resolver/addressable_resolver_test.go
+++ b/resolver/addressable_resolver_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"knative.dev/pkg/apis"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
@@ -160,7 +161,7 @@ func TestGetURI_ObjectReference(t *testing.T) {
 	for n, tc := range tests {
 		t.Run(n, func(t *testing.T) {
 			ctx, _ := fakedynamicclient.With(context.Background(), scheme.Scheme, tc.objects...)
-			r := resolver.NewURIResolver(ctx, func(string) {})
+			r := resolver.NewURIResolver(ctx, func(types.NamespacedName) {})
 
 			// Run it twice since this should be idempotent. URI Resolver should
 			// not modify the cache's copy.

--- a/tracker/enqueue.go
+++ b/tracker/enqueue.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/client-go/tools/cache"
 
 	"knative.dev/pkg/kmeta"
 )
@@ -38,7 +38,7 @@ import (
 // When OnChanged is called by the informer for a particular
 // GroupVersionKind, the provided callback is called with the "key"
 // of each object actively watching the changed object.
-func New(callback func(string), lease time.Duration) Interface {
+func New(callback func(types.NamespacedName), lease time.Duration) Interface {
 	return &impl{
 		leaseDuration: lease,
 		cb:            callback,
@@ -55,14 +55,14 @@ type impl struct {
 	// before having to renew the lease.
 	leaseDuration time.Duration
 
-	cb func(string)
+	cb func(types.NamespacedName)
 }
 
 // Check that impl implements Interface.
 var _ Interface = (*impl)(nil)
 
 // set is a map from keys to expirations
-type set map[string]time.Time
+type set map[types.NamespacedName]time.Time
 
 // Track implements Interface.
 func (i *impl) Track(ref corev1.ObjectReference, obj interface{}) error {
@@ -83,10 +83,12 @@ func (i *impl) Track(ref corev1.ObjectReference, obj interface{}) error {
 		return fmt.Errorf("invalid ObjectReference:\n%s", strings.Join(fieldErrors, "\n"))
 	}
 
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	object, err := kmeta.DeletionHandlingAccessor(obj)
 	if err != nil {
 		return err
 	}
+
+	key := types.NamespacedName{Namespace: object.GetNamespace(), Name: object.GetName()}
 
 	i.m.Lock()
 	defer i.m.Unlock()

--- a/tracker/enqueue_test.go
+++ b/tracker/enqueue_test.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
 	. "knative.dev/pkg/testing"
@@ -30,7 +31,7 @@ import (
 
 func TestHappyPaths(t *testing.T) {
 	calls := 0
-	f := func(key string) {
+	f := func(key types.NamespacedName) {
 		calls = calls + 1
 	}
 
@@ -165,7 +166,7 @@ func TestHappyPaths(t *testing.T) {
 }
 
 func TestAllowedObjectReferences(t *testing.T) {
-	trk := New(func(key string) {}, 10*time.Millisecond)
+	trk := New(func(key types.NamespacedName) {}, 10*time.Millisecond)
 	thing1 := &Resource{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "ref.knative.dev/v1alpha1",
@@ -231,7 +232,7 @@ func TestAllowedObjectReferences(t *testing.T) {
 }
 
 func TestBadObjectReferences(t *testing.T) {
-	trk := New(func(key string) {}, 10*time.Millisecond)
+	trk := New(func(key types.NamespacedName) {}, 10*time.Millisecond)
 	thing1 := &Resource{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "ref.knative.dev/v1alpha1",


### PR DESCRIPTION
This is a followup for #703. We didn't actually keep current behavior correctly so this is fixing forward what I broke.

Related to https://github.com/knative/serving/pull/5620 and https://github.com/knative/eventing/pull/1942