### PR TITLE
Increase maxRecvMsgSize in grpc server of mako-stub

### DIFF
--- a/test/mako/stub-sidecar/main.go
+++ b/test/mako/stub-sidecar/main.go
@@ -32,7 +32,8 @@ import (
 )
 
 const (
-	port = ":9813"
+	port                               = ":9813"
+	defaultServerMaxReceiveMessageSize = 1024 * 1024 * 100
 )
 
 type server struct {
@@ -105,7 +106,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
-	s := grpc.NewServer()
+	s := grpc.NewServer(grpc.MaxRecvMsgSize(defaultServerMaxReceiveMessageSize))
 	stopCh := make(chan struct{})
 	go func() {
 		qspb.RegisterQuickstoreServer(s, &server{stopCh: stopCh})

--- a/test/mako/stub-sidecar/main.go
+++ b/test/mako/stub-sidecar/main.go
@@ -32,7 +32,8 @@ import (
 )
 
 const (
-	port                               = ":9813"
+	port = ":9813"
+	// A 10 minutes run at 1000 rps of eventing perf tests is usually ~= 70 MBi, so 100MBi is reasonable
 	defaultServerMaxReceiveMessageSize = 1024 * 1024 * 100
 )
 


### PR DESCRIPTION
This should mitigate the #694

/assign grantr
/area test-and-release