### PR TITLE
Revert "Add SIGPIPE signal handler to the signals package (#689)"

### DIFF
--- a/signals/signal_posix.go
+++ b/signals/signal_posix.go
@@ -23,4 +23,4 @@ import (
 	"syscall"
 )
 
-var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGPIPE}
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}


### PR DESCRIPTION
This reverts commit 1fb9a433083f3e74ff9de88a5ff6bd37ab7bd709.

As per the doc (https://golang.org/pkg/os/signal/#hdr-SIGPIPE)

> If the program has not called Notify to receive SIGPIPE signals, then the behavior depends on the file descriptor number. A write to a broken pipe on file descriptors 1 or 2 (standard output or standard error) will cause the program to exit with a SIGPIPE signal. A write to a broken pipe on some other file descriptor will take no action on the SIGPIPE signal, and the write will fail with an EPIPE error. 

> If the program has called Notify to receive SIGPIPE signals, the file descriptor number does not matter. The SIGPIPE signal will be delivered to the Notify channel, and the write will fail with an EPIPE error. 

>  This means that, by default, command line programs will behave like typical Unix command line programs, while other programs will not crash with SIGPIPE when writing to a closed network connection. 

With the SIGPIPE signal in there, we crash when writing to a closed network connection. While that shouldn't happen in general, it's certainly not something we should crash for.