### PR TITLE
Fix spoof to not always append port

### DIFF
--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -116,10 +116,9 @@ func New(
 	transport := &http.Transport{
 		DialContext: func(ctx context.Context, network, addr string) (conn net.Conn, e error) {
 			spoofed := addr
-			if i := strings.LastIndex(addr, ":"); i != -1 && domain == addr[:i] {
-				// The original hostname:port is spoofed by replacing the hostname by the value
-				// returned by ResolveEndpoint.
-				spoofed = endpoint + ":" + addr[i+1:]
+			i := strings.LastIndex(addr, ":")
+			if (i == -1 && domain == addr) || (i != -1 && domain == addr[:i]) {
+				spoofed = endpoint
 			}
 			return dialContext(ctx, network, spoofed)
 		},


### PR DESCRIPTION
In #630 we changed transport spoofer behavior to always
append a port to our resolved host. A valid use case is to
supply a full l4 dest as the spoof targed (myhost:port). In
this case we now append an extra port resulting in an invalid
dest. Lets keep our original behavior where assume our spoofed
endpoint is a l4 dest, not a hostname.