### PR TITLE
Explictly set GKE cluster version to 'latest'

### DIFF
--- a/testutils/clustermanager/gke.go
+++ b/testutils/clustermanager/gke.go
@@ -39,6 +39,7 @@ const (
 	DefaultGKEZone     = ""
 	regionEnv          = "E2E_CLUSTER_REGION"
 	backupRegionEnv    = "E2E_CLUSTER_BACKUP_REGIONS"
+	defaultGKEVersion  = "latest"
 )
 
 var (
@@ -282,6 +283,9 @@ func (gc *GKECluster) Acquire() error {
 		rb := &container.CreateClusterRequest{
 			Cluster: &container.Cluster{
 				Name: clusterName,
+				// The default cluster version is not latest, has to explicitly
+				// set it as "latest"
+				InitialClusterVersion: defaultGKEVersion,
 				// Installing addons after cluster creation takes at least 5
 				// minutes, so install addons as part of cluster creation, which
 				// doesn't seem to add much time on top of cluster creation


### PR DESCRIPTION
GKE SDK creates cluster with "stable" version by default instead of "latest": https://cloud.google.com/kubernetes-engine/docs/release-notes, explicitly set "latest" to get latest cluster version

/cc @adrcunha 