### PR TITLE
Pinning opencensus stackdriver exporter in Gopkg.toml to avoid build breakage

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,7 +56,9 @@ required = [
 
 [[constraint]]
   name = "contrib.go.opencensus.io/exporter/stackdriver"
-  version = "v0.12.2"
+  # The build fails against 0.12.6 and newer because
+  # stackdriver.Options.GetMonitoredResource was removed.
+  version = "<=v0.12.5"
 
 [[constraint]]
   name = "github.com/google/mako"


### PR DESCRIPTION
The build fails against more recent versions of this package because `stackdriver.Options.GetMonitoredResource` was removed. That struct attribute is used in metrics/stackdriver_exporter.go. Relevant [commit](https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/commit/b0cbe77587ebe726c8dc9d4d00101c28c7ac2527). 

I don't have a good sense for what follow-on work should be done to reach compatibility with the lastest opencensus exporter, but would be happy to open an issue if this should be tracked.