### PR TITLE
Make repository optional in config-mako

### DIFF
--- a/test/mako/alerter/alerter.go
+++ b/test/mako/alerter/alerter.go
@@ -17,6 +17,8 @@ limitations under the License.
 package alerter
 
 import (
+	"log"
+
 	qpb "github.com/google/mako/proto/quickstore/quickstore_go_proto"
 	"knative.dev/pkg/test/helpers"
 	"knative.dev/pkg/test/mako/alerter/github"
@@ -31,23 +33,21 @@ type Alerter struct {
 }
 
 // SetupGitHub will setup SetupGitHub for the alerter.
-func (alerter *Alerter) SetupGitHub(org, repo, githubTokenPath string) error {
+func (alerter *Alerter) SetupGitHub(org, repo, githubTokenPath string) {
 	issueHandler, err := github.Setup(org, repo, githubTokenPath, false)
 	if err != nil {
-		return err
+		log.Printf("Error happens in setup '%v', Github alerter will not be enabled", err)
 	}
 	alerter.githubIssueHandler = issueHandler
-	return nil
 }
 
 // SetupSlack will setup Slack for the alerter.
-func (alerter *Alerter) SetupSlack(userName, readTokenPath, writeTokenPath string, channels []config.Channel) error {
+func (alerter *Alerter) SetupSlack(userName, readTokenPath, writeTokenPath string, channels []config.Channel) {
 	messageHandler, err := slack.Setup(userName, readTokenPath, writeTokenPath, channels, false)
 	if err != nil {
-		return err
+		log.Printf("Error happens in setup '%v', Slack alerter will not be enabled", err)
 	}
 	alerter.slackMessageHandler = messageHandler
-	return nil
 }
 
 // HandleBenchmarkResult will handle the benchmark result which returns from `q.Store()`

--- a/test/mako/alerter/github/issue.go
+++ b/test/mako/alerter/github/issue.go
@@ -17,6 +17,7 @@ limitations under the License.
 package github
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -69,6 +70,12 @@ type config struct {
 
 // Setup creates the necessary setup to make calls to work with github issues
 func Setup(org, repo, githubTokenPath string, dryrun bool) (*IssueHandler, error) {
+	if org == "" {
+		return nil, errors.New("org cannot be empty")
+	}
+	if repo == "" {
+		return nil, errors.New("repo cannot be empty")
+	}
 	ghc, err := ghutil.NewGithubClient(githubTokenPath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot authenticate to github: %v", err)

--- a/test/mako/config/configmap.go
+++ b/test/mako/config/configmap.go
@@ -31,6 +31,9 @@ const (
 
 // Config defines the mako configuration options.
 type Config struct {
+	// Organization holds the name of the organization for the current repository.
+	Organization string
+
 	// Repository holds the name of the repository that runs the benchmarks.
 	Repository string
 
@@ -53,6 +56,9 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		AdditionalTags: []string{},
 	}
 
+	if raw, ok := data["organization"]; ok {
+		lc.Organization = raw
+	}
 	if raw, ok := data["repository"]; ok {
 		lc.Repository = raw
 	}

--- a/test/mako/config/environment.go
+++ b/test/mako/config/environment.go
@@ -22,6 +22,21 @@ import (
 
 // TODO: perhaps cache the loaded CM.
 
+const defaultOrg = "knative"
+
+// GetOrganization returns the organization from the configmap.
+// It will return the defaultOrg if any error happens or it's empty.
+func GetOrganization() string {
+	cfg, err := loadConfig()
+	if err != nil {
+		return defaultOrg
+	}
+	if cfg.Organization == "" {
+		return defaultOrg
+	}
+	return cfg.Organization
+}
+
 // GetRepository returns the repository from the configmap.
 // It will return an empty string if any error happens.
 func GetRepository() string {

--- a/test/mako/config/environment.go
+++ b/test/mako/config/environment.go
@@ -22,14 +22,12 @@ import (
 
 // TODO: perhaps cache the loaded CM.
 
-// MustGetRepository returns the repository from the configmap, or dies.
-func MustGetRepository() string {
+// GetRepository returns the repository from the configmap.
+// It will return an empty string if any error happens.
+func GetRepository() string {
 	cfg, err := loadConfig()
 	if err != nil {
-		log.Fatalf("unable to load config from the configmap: %v", err)
-	}
-	if cfg.Repository == "" {
-		log.Fatal("unable to get repository from the configmap")
+		return ""
 	}
 	return cfg.Repository
 }

--- a/test/mako/sidecar.go
+++ b/test/mako/sidecar.go
@@ -143,7 +143,7 @@ func Setup(ctx context.Context, extraTags ...string) (*Client, error) {
 	alerter := &alerter.Alerter{}
 	alerter.SetupGitHub(
 		org,
-		config.MustGetRepository(),
+		config.GetRepository(),
 		tokenPath("github-token"),
 	)
 	alerter.SetupSlack(


### PR DESCRIPTION
Make `repository` to be optional in `config-mako` configmap, since it's only required for Github operations. This PR is unblocking `eventing` since they don't want setting up alert for now.

/cc @adrcunha 
/cc @chaodaiG 
/cc @grantr 