### PR TITLE
Fix the token path for perf tests

### DIFF
--- a/test/mako/sidecar.go
+++ b/test/mako/sidecar.go
@@ -49,6 +49,15 @@ const (
 
 	// slackUserName is the slack user name that is used by Slack client
 	slackUserName = "Knative Testgrid Robot"
+
+	// These token settings are for alerter.
+	// If we want to enable the alerter for a benchmark, we need to mount the
+	// token to the pod, with the same name and path.
+	// See https://github.com/knative/serving/blob/master/test/performance/dataplane-probe/dataplane-probe.yaml
+	tokenFolder     = "/var/secret"
+	githubToken     = "github-token"
+	slackReadToken  = "slack-read-token"
+	slackWriteToken = "slack-write-token"
 )
 
 // Client is a wrapper that wraps all Mako related operations
@@ -144,12 +153,12 @@ func Setup(ctx context.Context, extraTags ...string) (*Client, error) {
 	alerter.SetupGitHub(
 		org,
 		config.GetRepository(),
-		tokenPath("github-token"),
+		tokenPath(githubToken),
 	)
 	alerter.SetupSlack(
 		slackUserName,
-		tokenPath("slack-read-token"),
-		tokenPath("slack-write-token"),
+		tokenPath(slackReadToken),
+		tokenPath(slackWriteToken),
 		config.GetSlackChannels(*benchmarkName),
 	)
 
@@ -165,5 +174,5 @@ func Setup(ctx context.Context, extraTags ...string) (*Client, error) {
 }
 
 func tokenPath(token string) string {
-	return filepath.Join("/var/secrets", token)
+	return filepath.Join(tokenFolder, token)
 }


### PR DESCRIPTION
The secret path should be the same as the `mountPath` in benchmark jobs - https://github.com/knative/serving/blob/e2791cbda767191e089a7a0ca8eae8ec6cd2ecd3/test/performance/dataplane-probe/dataplane-probe.yaml#L283.
This PR changes it to be the correct one - `var/secrets` -> `var/secret`, also make them constants at the top of the file.

/cc @adrcunha 