### PR TITLE
Handle and retry 'connection reset by peer' errors

### DIFF
--- a/test/spoof/error_checks.go
+++ b/test/spoof/error_checks.go
@@ -40,13 +40,14 @@ func isDNSError(err error) bool {
 	return strings.Contains(msg, "no such host") || strings.Contains(msg, ":53")
 }
 
-func isTCPConnectRefuse(err error) bool {
+func isConnectionRefused(err error) bool {
 	// The alternative for the string check is:
 	// 	errNo := (((err.(*url.Error)).Err.(*net.OpError)).Err.(*os.SyscallError).Err).(syscall.Errno)
 	// if errNo == syscall.Errno(0x6f) {...}
 	// But with assertions, of course.
-	if err != nil && strings.Contains(err.Error(), "connect: connection refused") {
-		return true
-	}
-	return false
+	return err != nil && strings.Contains(err.Error(), "connect: connection refused")
+}
+
+func isConnectionReset(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "connection reset by peer")
 }


### PR DESCRIPTION
Some E2E are flaky because we do not handle the transient `connection reset by peer` errors.
Examples: [[1]](https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-istio-1.3-mesh/1179951947675865088), [[2]](https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-istio-1.2-mesh/1179919241718009856), [[3]](https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-istio-1.2-mesh/1179979633756475392).

These errors are expected and should simply be retried.