### PR TITLE
Support listing all clusters under a project'

### DIFF
--- a/testutils/gke/client.go
+++ b/testutils/gke/client.go
@@ -96,8 +96,8 @@ func (gsc *sdkClient) DeleteClusterAsync(project, region, zone, clusterName stri
 	if zone != "" {
 		return gsc.Projects.Zones.Clusters.Delete(project, location, clusterName).Context(context.Background()).Do()
 	}
-	opsFullPath := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, clusterName)
-	return gsc.Projects.Locations.Clusters.Delete(opsFullPath).Context(context.Background()).Do()
+	clusterFullPath := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, clusterName)
+	return gsc.Projects.Locations.Clusters.Delete(clusterFullPath).Context(context.Background()).Do()
 }
 
 // GetCluster gets the GKE cluster with the given cluster name.
@@ -106,15 +106,15 @@ func (gsc *sdkClient) GetCluster(project, region, zone, clusterName string) (*co
 	if zone != "" {
 		return gsc.Projects.Zones.Clusters.Get(project, location, clusterName).Context(context.Background()).Do()
 	}
-	opsFullPath := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, clusterName)
-	return gsc.Projects.Locations.Clusters.Get(opsFullPath).Context(context.Background()).Do()
+	clusterFullPath := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, clusterName)
+	return gsc.Projects.Locations.Clusters.Get(clusterFullPath).Context(context.Background()).Do()
 }
 
 // ListClustersInProject lists all the GKE clusters created in the given project.
 func (gsc *sdkClient) ListClustersInProject(project string) ([]*container.Cluster, error) {
 	var clusters []*container.Cluster
-	projectPath := fmt.Sprintf("projects/%s/locations/-", project)
-	resp, err := gsc.Projects.Locations.Clusters.List(projectPath).Do()
+	projectFullPath := fmt.Sprintf("projects/%s/locations/-", project)
+	resp, err := gsc.Projects.Locations.Clusters.List(projectFullPath).Do()
 	if err != nil {
 		return clusters, fmt.Errorf("failed to list clusters under project %s: %v", project, err)
 	}

--- a/testutils/gke/client.go
+++ b/testutils/gke/client.go
@@ -33,6 +33,7 @@ type SDKOperations interface {
 	DeleteClusterAsync(string, string, string, string) (*container.Operation, error)
 	GetCluster(string, string, string, string) (*container.Cluster, error)
 	GetOperation(string, string, string, string) (*container.Operation, error)
+	ListClustersInProject(string) ([]*container.Cluster, error)
 }
 
 // sdkClient Implement SDKOperations
@@ -95,8 +96,8 @@ func (gsc *sdkClient) DeleteClusterAsync(project, region, zone, clusterName stri
 	if zone != "" {
 		return gsc.Projects.Zones.Clusters.Delete(project, location, clusterName).Context(context.Background()).Do()
 	}
-	parent := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, clusterName)
-	return gsc.Projects.Locations.Clusters.Delete(parent).Context(context.Background()).Do()
+	clusterFullPath := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, clusterName)
+	return gsc.Projects.Locations.Clusters.Delete(clusterFullPath).Context(context.Background()).Do()
 }
 
 // GetCluster gets the GKE cluster with the given cluster name.
@@ -109,12 +110,23 @@ func (gsc *sdkClient) GetCluster(project, region, zone, clusterName string) (*co
 	return gsc.Projects.Locations.Clusters.Get(clusterFullPath).Context(context.Background()).Do()
 }
 
+// ListClustersInProject lists all the GKE clusters created in the given project.
+func (gsc *sdkClient) ListClustersInProject(project string) ([]*container.Cluster, error) {
+	var clusters []*container.Cluster
+	projectPath := fmt.Sprintf("projects/%s", project)
+	resp, err := gsc.Projects.Locations.Clusters.List(projectPath).Do()
+	if err != nil {
+		return clusters, fmt.Errorf("failed to list clusters under project %s: %v", project, err)
+	}
+	return resp.Clusters, nil
+}
+
 // GetOperation gets the operation ref with the given operation name.
 func (gsc *sdkClient) GetOperation(project, region, zone, opName string) (*container.Operation, error) {
 	location := GetClusterLocation(region, zone)
 	if zone != "" {
 		return gsc.Service.Projects.Zones.Operations.Get(project, location, opName).Do()
 	}
-	name := fmt.Sprintf("projects/%s/locations/%s/operations/%s", project, location, opName)
-	return gsc.Service.Projects.Locations.Operations.Get(name).Do()
+	clusterFullPath := fmt.Sprintf("projects/%s/locations/%s/operations/%s", project, location, opName)
+	return gsc.Service.Projects.Locations.Operations.Get(clusterFullPath).Do()
 }

--- a/testutils/gke/client.go
+++ b/testutils/gke/client.go
@@ -96,8 +96,8 @@ func (gsc *sdkClient) DeleteClusterAsync(project, region, zone, clusterName stri
 	if zone != "" {
 		return gsc.Projects.Zones.Clusters.Delete(project, location, clusterName).Context(context.Background()).Do()
 	}
-	clusterFullPath := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, clusterName)
-	return gsc.Projects.Locations.Clusters.Delete(clusterFullPath).Context(context.Background()).Do()
+	opsFullPath := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, clusterName)
+	return gsc.Projects.Locations.Clusters.Delete(opsFullPath).Context(context.Background()).Do()
 }
 
 // GetCluster gets the GKE cluster with the given cluster name.
@@ -106,14 +106,14 @@ func (gsc *sdkClient) GetCluster(project, region, zone, clusterName string) (*co
 	if zone != "" {
 		return gsc.Projects.Zones.Clusters.Get(project, location, clusterName).Context(context.Background()).Do()
 	}
-	clusterFullPath := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, clusterName)
-	return gsc.Projects.Locations.Clusters.Get(clusterFullPath).Context(context.Background()).Do()
+	opsFullPath := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, clusterName)
+	return gsc.Projects.Locations.Clusters.Get(opsFullPath).Context(context.Background()).Do()
 }
 
 // ListClustersInProject lists all the GKE clusters created in the given project.
 func (gsc *sdkClient) ListClustersInProject(project string) ([]*container.Cluster, error) {
 	var clusters []*container.Cluster
-	projectPath := fmt.Sprintf("projects/%s", project)
+	projectPath := fmt.Sprintf("projects/%s/locations/-", project)
 	resp, err := gsc.Projects.Locations.Clusters.List(projectPath).Do()
 	if err != nil {
 		return clusters, fmt.Errorf("failed to list clusters under project %s: %v", project, err)
@@ -127,6 +127,6 @@ func (gsc *sdkClient) GetOperation(project, region, zone, opName string) (*conta
 	if zone != "" {
 		return gsc.Service.Projects.Zones.Operations.Get(project, location, opName).Do()
 	}
-	clusterFullPath := fmt.Sprintf("projects/%s/locations/%s/operations/%s", project, location, opName)
-	return gsc.Service.Projects.Locations.Operations.Get(clusterFullPath).Do()
+	opsFullPath := fmt.Sprintf("projects/%s/locations/%s/operations/%s", project, location, opName)
+	return gsc.Service.Projects.Locations.Operations.Get(opsFullPath).Do()
 }

--- a/testutils/gke/fake/client.go
+++ b/testutils/gke/fake/client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+	"strings"
 
 	container "google.golang.org/api/container/v1beta1"
 	"knative.dev/pkg/testutils/gke"
@@ -170,6 +171,19 @@ func (fgsc *GKESDKClient) GetCluster(project, region, zone, cluster string) (*co
 		}
 	}
 	return nil, fmt.Errorf("cluster not found")
+}
+
+// ListClustersInProject lists all the GKE clusters created in the given project.
+func (fgsc *GKESDKClient) ListClustersInProject(project string) ([]*container.Cluster, error) {
+	allClusters := make([]*container.Cluster, 0)
+	projectPath := fmt.Sprintf("projects/%s", project)
+	for location, cls := range fgsc.clusters {
+		// If the clusters are under this project
+		if strings.HasPrefix(location, projectPath) {
+			allClusters = append(allClusters, cls...)
+		}
+	}
+	return allClusters, nil
 }
 
 // GetOperation gets the operation with the given settings.


### PR DESCRIPTION
For performance test cluster lifecycle management, we need to list all clusters under a project. Add the support in our library.

/cc @chaodaiG 