### PR TITLE
Add OWNERS to the websocket which was missing before.

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -46,6 +46,11 @@ aliases:
   - mdemirhan
   - yanweiguo
 
+  network-approvers:
+  - markusthoemmes
+  - tcnghia
+  - vagababov
+
   productivity-approvers:
   - adrcunha
   - chaodaiG

--- a/websocket/OWNERS
+++ b/websocket/OWNERS
@@ -1,0 +1,4 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- controller-approvers

--- a/websocket/OWNERS
+++ b/websocket/OWNERS
@@ -1,4 +1,4 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- controller-approvers
+- network-approvers


### PR DESCRIPTION
Alias it to the controller approvers which seem more or less reasonable

/assign @mattmoor @vaikas-google 