### PR TITLE
jsonTrace errors are retried until the timeout.

### DIFF
--- a/test/zipkin/util.go
+++ b/test/zipkin/util.go
@@ -20,6 +20,7 @@ package zipkin
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"sync"
@@ -134,26 +135,29 @@ func JSONTrace(traceID string, expected int, timeout time.Duration) (trace []mod
 	for len(trace) != expected {
 		select {
 		case <-t:
-			return trace, &TimeoutError{}
+			return trace, &TimeoutError{
+				lastErr: err,
+			}
 		default:
 			trace, err = jsonTrace(traceID)
-			if err != nil {
-				return trace, err
-			}
 		}
 	}
-	return trace, nil
+	return trace, err
 }
 
 // TimeoutError is an error returned by JSONTrace if it times out before getting the expected number
 // of traces.
-type TimeoutError struct{}
-
-func (*TimeoutError) Error() string {
-	return "timeout getting JSONTrace"
+type TimeoutError struct{
+	lastErr error
 }
 
-// jsonTrace gets a trace from Zipkin and returns it.
+func (t *TimeoutError) Error() string {
+	return fmt.Sprintf("timeout getting JSONTrace, most recent error: %v", t.lastErr)
+}
+
+// jsonTrace gets a trace from Zipkin and returns it. Errors returned from this function should be
+// retried, as they are likely caused by random problems communicating with Zipkin, or Zipkin
+// communicating with its data store.
 func jsonTrace(traceID string) ([]model.SpanModel, error) {
 	var empty []model.SpanModel
 
@@ -171,7 +175,7 @@ func jsonTrace(traceID string) ([]model.SpanModel, error) {
 	var models []model.SpanModel
 	err = json.Unmarshal(body, &models)
 	if err != nil {
-		return empty, err
+		return empty, fmt.Errorf("unmarshalling JSON, %q: %v", body, err)
 	}
 	return models, nil
 }

--- a/test/zipkin/util.go
+++ b/test/zipkin/util.go
@@ -175,7 +175,7 @@ func jsonTrace(traceID string) ([]model.SpanModel, error) {
 	var models []model.SpanModel
 	err = json.Unmarshal(body, &models)
 	if err != nil {
-		return empty, fmt.Errorf("unmarshalling JSON, %q: %v", body, err)
+		return empty, fmt.Errorf("got an error in unmarshalling JSON %q: %v", body, err)
 	}
 	return models, nil
 }


### PR DESCRIPTION
Helps with knative/eventing#2040.

Changes:
* jsonTrace errors are retried until the timeout.
* jsonTrace json.Unmarshal errors include the string being unmarshaled. 