### PR TITLE
Add support for new addons for GKE cluster

### DIFF
--- a/testutils/gke/addon.go
+++ b/testutils/gke/addon.go
@@ -26,9 +26,9 @@ import (
 const (
 	// Define all supported addons here
 	istio    = "istio"
-	hpa      = "horizontalPodAutoscaling"
-	hlb      = "httpLoadBalancing"
-	cloudRun = "cloudRun"
+	hpa      = "horizontalpodautoscaling"
+	hlb      = "httploadbalancing"
+	cloudRun = "cloudrun"
 )
 
 // GetAddonsConfig gets AddonsConfig from a slice of addon names, contains the logic of

--- a/testutils/gke/addon.go
+++ b/testutils/gke/addon.go
@@ -33,7 +33,7 @@ const (
 
 // GetAddonsConfig gets AddonsConfig from a slice of addon names, contains the logic of
 // converting string argument to typed AddonsConfig, for example `IstioConfig`.
-// Currently supports istio, HorizontalPodAutoscaling and HttpLoadBalancing
+// Currently supports Istio, HorizontalPodAutoscaling, HttpLoadBalancing and CloudRun.
 func GetAddonsConfig(addons []string) *container.AddonsConfig {
 	ac := &container.AddonsConfig{}
 	for _, name := range addons {

--- a/testutils/gke/addon.go
+++ b/testutils/gke/addon.go
@@ -25,20 +25,29 @@ import (
 
 const (
 	// Define all supported addons here
-	istio = "istio"
+	istio    = "istio"
+	hpa      = "horizontalPodAutoscaling"
+	hlb      = "httpLoadBalancing"
+	cloudRun = "cloudRun"
 )
 
 // GetAddonsConfig gets AddonsConfig from a slice of addon names, contains the logic of
 // converting string argument to typed AddonsConfig, for example `IstioConfig`.
-// Currently supports istio
+// Currently supports istio, HorizontalPodAutoscaling and HttpLoadBalancing
 func GetAddonsConfig(addons []string) *container.AddonsConfig {
 	ac := &container.AddonsConfig{}
 	for _, name := range addons {
 		switch strings.ToLower(name) {
 		case istio:
 			ac.IstioConfig = &container.IstioConfig{Disabled: false}
+		case hpa:
+			ac.HorizontalPodAutoscaling = &container.HorizontalPodAutoscaling{Disabled: false}
+		case hlb:
+			ac.HttpLoadBalancing = &container.HttpLoadBalancing{Disabled: false}
+		case cloudRun:
+			ac.CloudRunConfig = &container.CloudRunConfig{Disabled: false}
 		default:
-			panic(fmt.Sprintf("addon type %q not supported. Has to be one of: %q", name, istio))
+			panic(fmt.Sprintf("addon type %q not supported. Has to be one of: %q", name, []string{istio, hpa, hlb, cloudRun}))
 		}
 	}
 

--- a/testutils/gke/request_test.go
+++ b/testutils/gke/request_test.go
@@ -29,7 +29,7 @@ func TestNewCreateClusterRequest(t *testing.T) {
 			MinNodes:    1,
 			MaxNodes:    1,
 			NodeType:    "n1-standard-4",
-			Addons:      []string{"istio"},
+			Addons:      []string{"Istio"},
 		},
 		errorExpected: false,
 	}, {
@@ -39,7 +39,7 @@ func TestNewCreateClusterRequest(t *testing.T) {
 			MinNodes:    10,
 			MaxNodes:    10,
 			NodeType:    "n1-standard-8",
-			Addons:      []string{"horizontalPodAutoscaling", "httpLoadBalancing", "cloudRun"},
+			Addons:      []string{"HorizontalPodAutoscaling", "HttpLoadBalancing", "CloudRun"},
 		},
 		errorExpected: false,
 	}, {

--- a/testutils/gke/request_test.go
+++ b/testutils/gke/request_test.go
@@ -24,12 +24,22 @@ func TestNewCreateClusterRequest(t *testing.T) {
 		errorExpected bool
 	}{{
 		req: &Request{
-			Project:     "project-b",
-			ClusterName: "name-b",
+			Project:     "project-a",
+			ClusterName: "name-a",
 			MinNodes:    1,
 			MaxNodes:    1,
 			NodeType:    "n1-standard-4",
 			Addons:      []string{"istio"},
+		},
+		errorExpected: false,
+	}, {
+		req: &Request{
+			Project:     "project-b",
+			ClusterName: "name-b",
+			MinNodes:    10,
+			MaxNodes:    10,
+			NodeType:    "n1-standard-8",
+			Addons:      []string{"horizontalPodAutoscaling", "httpLoadBalancing", "cloudRun"},
 		},
 		errorExpected: false,
 	}, {


### PR DESCRIPTION
Support adding `HorizontalPodAutoscaling`, `HttpLoadBalancing` and `CloudRun` addons for GKE clusters in the gke lib.

/cc @chaodaiG 