### PR TITLE
Remove glog from test/logging

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1280,7 +1280,6 @@
     "github.com/davecgh/go-spew/spew",
     "github.com/evanphx/json-patch",
     "github.com/ghodss/yaml",
-    "github.com/golang/glog",
     "github.com/golang/protobuf/jsonpb",
     "github.com/golang/protobuf/proto",
     "github.com/google/go-cmp/cmp",

--- a/test/logging/logging.go
+++ b/test/logging/logging.go
@@ -21,13 +21,11 @@ package logging
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/golang/glog"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
@@ -35,9 +33,6 @@ import (
 )
 
 const (
-	// VerboseLogLevel defines verbose log level as 10
-	VerboseLogLevel glog.Level = 10
-
 	// 1 second was chosen arbitrarily
 	metricViewReportingPeriod = 1 * time.Second
 
@@ -134,11 +129,6 @@ func InitializeMetricExporter(context string) {
 func InitializeLogger(logVerbose bool) {
 	logLevel := "info"
 	if logVerbose {
-		// Both gLog and "go test" use -v flag. The code below is a work around so that we can still set v value for gLog
-		flag.StringVar(&logLevel, "logLevel", fmt.Sprint(VerboseLogLevel), "verbose log level")
-		flag.Lookup("v").Value.Set(logLevel)
-		glog.Infof("Logging set to verbose mode with logLevel %d", VerboseLogLevel)
-
 		logLevel = "debug"
 	}
 


### PR DESCRIPTION
As described in https://github.com/knative/pkg/issues/766, `glog` will cause some issues and is not suggested to be used, and all Knative projects are using either zipkin logger or simple `log`.

This PR remove `glog` from test/logging/logging.go.

/cc @grantr 
/cc @adrcunha 