### PR TITLE
Remove openapi-gen annotations

### DIFF
--- a/apis/condition_types.go
+++ b/apis/condition_types.go
@@ -55,7 +55,6 @@ const (
 // Conditions defines a readiness condition for a Knative resource.
 // See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 // +k8s:deepcopy-gen=true
-// +k8s:openapi-gen=true
 type Condition struct {
 	// Type of condition.
 	// +required

--- a/apis/duck/v1/status_types.go
+++ b/apis/duck/v1/status_types.go
@@ -36,7 +36,6 @@ var _ duck.Implementable = (*Conditions)(nil)
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +k8s:openapi-gen=true
 
 // KResource is a skeleton type wrapping Conditions in the manner we expect
 // resource writers defining compatible resources to embed it.  We will

--- a/apis/duck/v1beta1/status_types.go
+++ b/apis/duck/v1beta1/status_types.go
@@ -36,7 +36,6 @@ var _ duck.Implementable = (*Conditions)(nil)
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +k8s:openapi-gen=true
 
 // KResource is a skeleton type wrapping Conditions in the manner we expect
 // resource writers defining compatible resources to embed it.  We will

--- a/apis/volatile_time.go
+++ b/apis/volatile_time.go
@@ -22,7 +22,6 @@ import (
 )
 
 // VolatileTime wraps metav1.Time
-// +k8s:openapi-gen=true
 type VolatileTime struct {
 	Inner metav1.Time
 }


### PR DESCRIPTION
`openapi-gen` is not used anymore in Knative.