### PR TITLE
Update OWNER_ALIASES for metrics-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -45,6 +45,7 @@ aliases:
   metrics-approvers:
   - mdemirhan
   - yanweiguo
+  - anniefu
 
   network-approvers:
   - markusthoemmes


### PR DESCRIPTION
Add myself to metrics-approvers for additional PR bandwidth in metrics.