### PR TITLE
Enable coverage for test code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,6 @@
 
 **/zz_generated.*.go linguist-generated=true
 /client/** linguist-generated=true
-/test/** coverage-excluded=true
 /metrics/gcp_metadata.go coverage-excluded=true
 
 *.sh text eol=lf

--- a/test/gke/client.go
+++ b/test/gke/client.go
@@ -27,13 +27,13 @@ import (
 
 // SDKOperations wraps GKE SDK related functions
 type SDKOperations interface {
-	CreateCluster(string, string, string, *container.CreateClusterRequest) error
-	CreateClusterAsync(string, string, string, *container.CreateClusterRequest) (*container.Operation, error)
-	DeleteCluster(string, string, string, string) error
-	DeleteClusterAsync(string, string, string, string) (*container.Operation, error)
-	GetCluster(string, string, string, string) (*container.Cluster, error)
-	GetOperation(string, string, string, string) (*container.Operation, error)
-	ListClustersInProject(string) ([]*container.Cluster, error)
+	CreateCluster(project, region, zone string, req *container.CreateClusterRequest) error
+	CreateClusterAsync(project, region, zone string, req *container.CreateClusterRequest) (*container.Operation, error)
+	DeleteCluster(project, region, zone, clusterName string) error
+	DeleteClusterAsync(project, region, zone, clusterName string) (*container.Operation, error)
+	GetCluster(project, region, zone, clusterName string) (*container.Cluster, error)
+	GetOperation(project, region, zone, opName string) (*container.Operation, error)
+	ListClustersInProject(project string) ([]*container.Cluster, error)
 }
 
 // sdkClient Implement SDKOperations


### PR DESCRIPTION
As we talked in the meeting, now we should enable go test coverage  check for `pkg/test`.

/cc @adrcunha 