### PR TITLE
Do not override log level if component is undefined in logging config

### DIFF
--- a/logging/config.go
+++ b/logging/config.go
@@ -33,7 +33,12 @@ import (
 
 const ConfigMapNameEnv = "CONFIG_LOGGING_NAME"
 
-var zapLoggerConfig = "zap-logger-config"
+const (
+	loggerConfigKey    = "zap-logger-config"
+	fallbackLoggerName = "fallback-logger"
+)
+
+var emptyLoggerConfigError = errors.New("empty logger configuration")
 
 // NewLogger creates a logger with the supplied configuration.
 // In addition to the logger, it returns AtomicLevel that can
@@ -48,7 +53,7 @@ func NewLogger(configJSON string, levelOverride string, opts ...zap.Option) (*za
 	}
 
 	loggingCfg := zap.NewProductionConfig()
-	if len(levelOverride) > 0 {
+	if levelOverride != "" {
 		if level, err := levelFromString(levelOverride); err == nil {
 			loggingCfg.Level = zap.NewAtomicLevelAt(*level)
 		}
@@ -58,7 +63,7 @@ func NewLogger(configJSON string, levelOverride string, opts ...zap.Option) (*za
 	if err2 != nil {
 		panic(err2)
 	}
-	return enrichLoggerWithCommitID(logger.Named("fallback-logger").Sugar()), loggingCfg.Level
+	return enrichLoggerWithCommitID(logger.Named(fallbackLoggerName).Sugar()), loggingCfg.Level
 }
 
 func enrichLoggerWithCommitID(logger *zap.SugaredLogger) *zap.SugaredLogger {
@@ -74,21 +79,22 @@ func enrichLoggerWithCommitID(logger *zap.SugaredLogger) *zap.SugaredLogger {
 
 // NewLoggerFromConfig creates a logger using the provided Config
 func NewLoggerFromConfig(config *Config, name string, opts ...zap.Option) (*zap.SugaredLogger, zap.AtomicLevel) {
-	logger, level := NewLogger(config.LoggingConfig, config.LoggingLevel[name].String(), opts...)
+	var componentLvl string
+	if lvl, defined := config.LoggingLevel[name]; defined {
+		componentLvl = lvl.String()
+	}
+
+	logger, level := NewLogger(config.LoggingConfig, componentLvl, opts...)
 	return logger.Named(name), level
 }
 
 func newLoggerFromConfig(configJSON string, levelOverride string, opts []zap.Option) (*zap.Logger, zap.AtomicLevel, error) {
-	if len(configJSON) == 0 {
-		return nil, zap.AtomicLevel{}, errors.New("empty logging configuration")
-	}
-
-	var loggingCfg zap.Config
-	if err := json.Unmarshal([]byte(configJSON), &loggingCfg); err != nil {
+	loggingCfg, err := zapConfigFromJSON(configJSON)
+	if err != nil {
 		return nil, zap.AtomicLevel{}, err
 	}
 
-	if len(levelOverride) > 0 {
+	if levelOverride != "" {
 		if level, err := levelFromString(levelOverride); err == nil {
 			loggingCfg.Level = zap.NewAtomicLevelAt(*level)
 		}
@@ -102,6 +108,18 @@ func newLoggerFromConfig(configJSON string, levelOverride string, opts []zap.Opt
 	logger.Info("Successfully created the logger.", zap.String(logkey.JSONConfig, configJSON))
 	logger.Sugar().Infof("Logging level set to %v", loggingCfg.Level)
 	return logger, loggingCfg.Level, nil
+}
+
+func zapConfigFromJSON(configJSON string) (*zap.Config, error) {
+	if configJSON == "" {
+		return nil, emptyLoggerConfigError
+	}
+
+	loggingCfg := &zap.Config{}
+	if err := json.Unmarshal([]byte(configJSON), loggingCfg); err != nil {
+		return nil, err
+	}
+	return loggingCfg, nil
 }
 
 // Config contains the configuration defined in the logging ConfigMap.
@@ -136,7 +154,7 @@ const defaultZLC = `{
 // expecting the given list of components.
 func NewConfigFromMap(data map[string]string) (*Config, error) {
 	lc := &Config{}
-	if zlc, ok := data["zap-logger-config"]; ok {
+	if zlc, ok := data[loggerConfigKey]; ok {
 		lc.LoggingConfig = zlc
 	} else {
 		lc.LoggingConfig = defaultZLC
@@ -157,7 +175,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 	return lc, nil
 }
 
-// NewConfigFromConfigMap creates a LoggingConfig from the supplied ConfigMap,
+// NewConfigFromConfigMap creates a Config from the supplied ConfigMap,
 // expecting the given list of components.
 func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
 	return NewConfigFromMap(configMap.Data)
@@ -175,14 +193,31 @@ func levelFromString(level string) (*zapcore.Level, error) {
 // when a config map is updated
 func UpdateLevelFromConfigMap(logger *zap.SugaredLogger, atomicLevel zap.AtomicLevel,
 	levelKey string) func(configMap *corev1.ConfigMap) {
+
 	return func(configMap *corev1.ConfigMap) {
-		loggingConfig, err := NewConfigFromConfigMap(configMap)
+		config, err := NewConfigFromConfigMap(configMap)
 		if err != nil {
 			logger.Errorw("Failed to parse the logging configmap. Previous config map will be used.", zap.Error(err))
 			return
 		}
 
-		level := loggingConfig.LoggingLevel[levelKey]
+		level, defined := config.LoggingLevel[levelKey]
+		if !defined {
+			// reset to global level
+
+			loggingCfg, err := zapConfigFromJSON(config.LoggingConfig)
+			switch {
+			case err == emptyLoggerConfigError:
+				level = zap.NewAtomicLevel().Level()
+			case err != nil:
+				logger.With(zap.Error(err)).Errorf("Failed to parse logger configuration. "+
+					"Previous log level retained for %v", levelKey)
+				return
+			default:
+				level = loggingCfg.Level.Level()
+			}
+		}
+
 		if atomicLevel.Level() != level {
 			logger.Infof("Updating logging level for %v from %v to %v.", levelKey, atomicLevel.Level(), level)
 			atomicLevel.SetLevel(level)
@@ -228,7 +263,7 @@ func LoggingConfigToJson(cfg *Config) (string, error) {
 	}
 
 	jsonCfg, err := json.Marshal(map[string]string{
-		zapLoggerConfig: cfg.LoggingConfig,
+		loggerConfigKey: cfg.LoggingConfig,
 	})
 	if err != nil {
 		return "", err

--- a/logging/config.go
+++ b/logging/config.go
@@ -204,7 +204,6 @@ func UpdateLevelFromConfigMap(logger *zap.SugaredLogger, atomicLevel zap.AtomicL
 		level, defined := config.LoggingLevel[levelKey]
 		if !defined {
 			// reset to global level
-
 			loggingCfg, err := zapConfigFromJSON(config.LoggingConfig)
 			switch {
 			case err == emptyLoggerConfigError:


### PR DESCRIPTION
### Problem description

Given a ConfigMap named "config-logging" with the following data:
```yaml
data:
  zap-logger-config: { "level": "debug" }
```

The log level of the main component is set to `info` regardless of the value configured in the Zap logger config.

### Reason

`config.LoggingLevel[name]` returns a default value of `int8(0)` if `name` is not in the `config.LoggingLevel` map. This value corresponds to `zapcore.InfoLevel`.

We must ensure that `name` is actually an element of the map before passing the override value to `config.NewLogger()`. Same thing inside `UpdateLevelFromConfigMap()`. 

### Proposed changes

- Set the override value to `""` by default, and use an actual log level _only_ if the user explicitly defined a log level for the given component.
- Ensure the atomic level is reset to the global log level when the component log level is deleted from the ConfigMap.
- (stretch) Polish logging tests

/kind bug