### PR TITLE
Add utility methods for api.URL

### DIFF
--- a/apis/url.go
+++ b/apis/url.go
@@ -103,6 +103,9 @@ func (u *URL) String() string {
 
 // URL returns the URL as a url.URL.
 func (u *URL) URL() *url.URL {
+	if u == nil {
+		return &url.URL{}
+	}
 	url := url.URL(*u)
 	return &url
 }

--- a/apis/url.go
+++ b/apis/url.go
@@ -41,6 +41,30 @@ func ParseURL(u string) (*URL, error) {
 	return (*URL)(pu), nil
 }
 
+// HTTP creates an http:// URL pointing to a known domain.
+func HTTP(domain string) *URL {
+	return &URL{
+		Scheme: "http",
+		Host:   domain,
+	}
+}
+
+// HTTPS creates an https:// URL pointing to a known domain.
+func HTTPS(domain string) *URL {
+	return &URL{
+		Scheme: "https",
+		Host:   domain,
+	}
+}
+
+// IsEmpty returns true if the URL is `nil` or represents an empty URL.
+func (u *URL) IsEmpty() bool {
+	if u == nil {
+		return true
+	}
+	return *u == URL{}
+}
+
 // MarshalJSON implements a custom json marshal method used when this type is
 // marshaled using json.Marshal.
 // json.Marshaler impl

--- a/apis/url_test.go
+++ b/apis/url_test.go
@@ -24,48 +24,42 @@ import (
 
 func TestParseURL(t *testing.T) {
 	testCases := map[string]struct {
-		t       string
-		want    *URL
-		nonEmpty bool
-		wantErr bool
+		t         string
+		want      *URL
+		wantEmpty bool
+		wantErr   bool
 	}{
-		"empty": {
-			want: nil,
-		},
 		"empty string": {
-			t:    "",
-			want: nil,
+			want:      nil,
+			wantEmpty: true,
 		},
 		"invalid format": {
-			t:       "💩://error",
-			want:    nil,
-			wantErr: true,
+			t:         "💩://error",
+			want:      nil,
+			wantEmpty: true,
+			wantErr:   true,
 		},
 		"relative": {
 			t: "/path/to/something",
 			want: &URL{
-					Path: "/path/to/something",
-				},
-			nonEmpty: true,
+				Path: "/path/to/something",
+			},
 		},
 		"url": {
 			t: "http://path/to/something",
 			want: &URL{
 				Scheme: "http",
-				Host: "path",
-				Path: "/to/something",
+				Host:   "path",
+				Path:   "/to/something",
 			},
-			nonEmpty: true,
 		},
 		"simplehttp": {
-			t: "http://foo",
+			t:    "http://foo",
 			want: HTTP("foo"),
-			nonEmpty: true,
 		},
 		"simplehttps": {
-			t: "https://foo",
+			t:    "https://foo",
 			want: HTTPS("foo"),
-			nonEmpty: true,
 		},
 	}
 	for n, tc := range testCases {
@@ -81,13 +75,13 @@ func TestParseURL(t *testing.T) {
 				t.Fatalf("ParseURL() = %v, wanted error", got)
 			}
 
-			if tc.nonEmpty {
-				if got.IsEmpty() {
-					t.Errorf("Expected non-empty for %q", tc.t)
-				}
-			} else {
+			if tc.wantEmpty {
 				if !got.IsEmpty() {
 					t.Errorf("Expected empty for %q, got %v", tc.t, got)
+				}
+			} else {
+				if got.IsEmpty() {
+					t.Errorf("Expected non-empty for %q", tc.t)
 				}
 			}
 
@@ -159,8 +153,8 @@ func TestJsonUnmarshalURL(t *testing.T) {
 			b: []byte(`"http://path/to/something"`),
 			want: &URL{
 				Scheme: "http",
-				Host: "path",
-				Path: "/to/something",
+				Host:   "path",
+				Path:   "/to/something",
 			},
 		},
 	}
@@ -207,14 +201,14 @@ func TestJsonMarshalURLAsMember(t *testing.T) {
 			want: []byte(`{"url":""}`),
 		},
 		"relative": {
-			obj: &objectType{URL: URL{Path: "/path/to/something"}},
+			obj:  &objectType{URL: URL{Path: "/path/to/something"}},
 			want: []byte(`{"url":"/path/to/something"}`),
 		},
 		"url": {
-			obj: &objectType {URL: URL{
+			obj: &objectType{URL: URL{
 				Scheme: "http",
-				Host: "path",
-				Path: "/to/something",
+				Host:   "path",
+				Path:   "/to/something",
 			}},
 			want: []byte(`{"url":"http://path/to/something"}`),
 		},
@@ -266,14 +260,14 @@ func TestJsonMarshalURLAsPointerMember(t *testing.T) {
 			want: []byte(`{}`),
 		},
 		"relative": {
-			obj: &objectType{URL: &URL{Path: "/path/to/something"}},
+			obj:  &objectType{URL: &URL{Path: "/path/to/something"}},
 			want: []byte(`{"url":"/path/to/something"}`),
 		},
 		"url": {
 			obj: &objectType{URL: &URL{
 				Scheme: "http",
-				Host: "path",
-				Path: "/to/something",
+				Host:   "path",
+				Path:   "/to/something",
 			}},
 			want: []byte(`{"url":"http://path/to/something"}`),
 		},
@@ -329,15 +323,15 @@ func TestJsonUnmarshalURLAsMember(t *testing.T) {
 			wantErr: `parse %: invalid URL escape "%"`,
 		},
 		"relative": {
-			b: []byte(`{"url":"/path/to/something"}`),
+			b:    []byte(`{"url":"/path/to/something"}`),
 			want: &objectType{URL: URL{Path: "/path/to/something"}},
 		},
 		"url": {
 			b: []byte(`{"url":"http://path/to/something"}`),
-			want: &objectType {URL: URL{
+			want: &objectType{URL: URL{
 				Scheme: "http",
-				Host: "path",
-				Path: "/to/something",
+				Host:   "path",
+				Path:   "/to/something",
 			}},
 		},
 		"empty url": {
@@ -392,15 +386,15 @@ func TestJsonUnmarshalURLAsMemberPointer(t *testing.T) {
 			wantErr: `parse %: invalid URL escape "%"`,
 		},
 		"relative": {
-			b: []byte(`{"url":"/path/to/something"}`),
-			want: &objectType {URL: &URL{Path: "/path/to/something"}},
+			b:    []byte(`{"url":"/path/to/something"}`),
+			want: &objectType{URL: &URL{Path: "/path/to/something"}},
 		},
 		"url": {
 			b: []byte(`{"url":"http://path/to/something"}`),
-			want: &objectType {URL: &URL{
+			want: &objectType{URL: &URL{
 				Scheme: "http",
-				Host: "path",
-				Path: "/to/something",
+				Host:   "path",
+				Path:   "/to/something",
 			}},
 		},
 		"empty url": {

--- a/apis/url_test.go
+++ b/apis/url_test.go
@@ -27,6 +27,7 @@ func TestParseURL(t *testing.T) {
 	testCases := map[string]struct {
 		t       string
 		want    *URL
+		nonEmpty bool
 		wantErr bool
 	}{
 		"empty": {
@@ -43,19 +44,29 @@ func TestParseURL(t *testing.T) {
 		},
 		"relative": {
 			t: "/path/to/something",
-			want: func() *URL {
-				uu, _ := url.Parse("/path/to/something")
-				u := URL(*uu)
-				return &u
-			}(),
+			want: &URL{
+					Path: "/path/to/something",
+				},
+			nonEmpty: true,
 		},
 		"url": {
 			t: "http://path/to/something",
-			want: func() *URL {
-				uu, _ := url.Parse("http://path/to/something")
-				u := URL(*uu)
-				return &u
-			}(),
+			want: &URL{
+				Scheme: "http",
+				Host: "path",
+				Path: "/to/something",
+			},
+			nonEmpty: true,
+		},
+		"simplehttp": {
+			t: "http://foo",
+			want: HTTP("foo"),
+			nonEmpty: true,
+		},
+		"simplehttps": {
+			t: "https://foo",
+			want: HTTPS("foo"),
+			nonEmpty: true,
 		},
 	}
 	for n, tc := range testCases {
@@ -69,6 +80,16 @@ func TestParseURL(t *testing.T) {
 				return
 			} else if tc.wantErr {
 				t.Fatalf("ParseURL() = %v, wanted error", got)
+			}
+
+			if tc.nonEmpty {
+				if got.IsEmpty() {
+					t.Errorf("Expected non-empty for %q", tc.t)
+				}
+			} else {
+				if !got.IsEmpty() {
+					t.Errorf("Expected empty for %q, got %v", tc.t, got)
+				}
 			}
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {

--- a/apis/url_test.go
+++ b/apis/url_test.go
@@ -17,7 +17,6 @@ package apis
 
 import (
 	"encoding/json"
-	"net/url"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -152,19 +151,17 @@ func TestJsonUnmarshalURL(t *testing.T) {
 		},
 		"relative": {
 			b: []byte(`"/path/to/something"`),
-			want: func() *URL {
-				uu, _ := url.Parse("/path/to/something")
-				u := URL(*uu)
-				return &u
-			}(),
+			want: &URL{
+				Path: "/path/to/something",
+			},
 		},
 		"url": {
 			b: []byte(`"http://path/to/something"`),
-			want: func() *URL {
-				uu, _ := url.Parse("http://path/to/something")
-				u := URL(*uu)
-				return &u
-			}(),
+			want: &URL{
+				Scheme: "http",
+				Host: "path",
+				Path: "/to/something",
+			},
 		},
 	}
 	for n, tc := range testCases {
@@ -210,19 +207,15 @@ func TestJsonMarshalURLAsMember(t *testing.T) {
 			want: []byte(`{"url":""}`),
 		},
 		"relative": {
-			obj: func() *objectType {
-				uu, _ := url.Parse("/path/to/something")
-				u := URL(*uu)
-				return &objectType{URL: u}
-			}(),
+			obj: &objectType{URL: URL{Path: "/path/to/something"}},
 			want: []byte(`{"url":"/path/to/something"}`),
 		},
 		"url": {
-			obj: func() *objectType {
-				uu, _ := url.Parse("http://path/to/something")
-				u := URL(*uu)
-				return &objectType{URL: u}
-			}(),
+			obj: &objectType {URL: URL{
+				Scheme: "http",
+				Host: "path",
+				Path: "/to/something",
+			}},
 			want: []byte(`{"url":"http://path/to/something"}`),
 		},
 		"empty url": {
@@ -273,19 +266,15 @@ func TestJsonMarshalURLAsPointerMember(t *testing.T) {
 			want: []byte(`{}`),
 		},
 		"relative": {
-			obj: func() *objectType {
-				uu, _ := url.Parse("/path/to/something")
-				u := URL(*uu)
-				return &objectType{URL: &u}
-			}(),
+			obj: &objectType{URL: &URL{Path: "/path/to/something"}},
 			want: []byte(`{"url":"/path/to/something"}`),
 		},
 		"url": {
-			obj: func() *objectType {
-				uu, _ := url.Parse("http://path/to/something")
-				u := URL(*uu)
-				return &objectType{URL: &u}
-			}(),
+			obj: &objectType{URL: &URL{
+				Scheme: "http",
+				Host: "path",
+				Path: "/to/something",
+			}},
 			want: []byte(`{"url":"http://path/to/something"}`),
 		},
 		"empty url": {
@@ -341,19 +330,15 @@ func TestJsonUnmarshalURLAsMember(t *testing.T) {
 		},
 		"relative": {
 			b: []byte(`{"url":"/path/to/something"}`),
-			want: func() *objectType {
-				uu, _ := url.Parse("/path/to/something")
-				u := URL(*uu)
-				return &objectType{URL: u}
-			}(),
+			want: &objectType{URL: URL{Path: "/path/to/something"}},
 		},
 		"url": {
 			b: []byte(`{"url":"http://path/to/something"}`),
-			want: func() *objectType {
-				uu, _ := url.Parse("http://path/to/something")
-				u := URL(*uu)
-				return &objectType{URL: u}
-			}(),
+			want: &objectType {URL: URL{
+				Scheme: "http",
+				Host: "path",
+				Path: "/to/something",
+			}},
 		},
 		"empty url": {
 			b:    []byte(`{"url":""}`),
@@ -408,19 +393,15 @@ func TestJsonUnmarshalURLAsMemberPointer(t *testing.T) {
 		},
 		"relative": {
 			b: []byte(`{"url":"/path/to/something"}`),
-			want: func() *objectType {
-				uu, _ := url.Parse("/path/to/something")
-				u := URL(*uu)
-				return &objectType{URL: &u}
-			}(),
+			want: &objectType {URL: &URL{Path: "/path/to/something"}},
 		},
 		"url": {
 			b: []byte(`{"url":"http://path/to/something"}`),
-			want: func() *objectType {
-				uu, _ := url.Parse("http://path/to/something")
-				u := URL(*uu)
-				return &objectType{URL: &u}
-			}(),
+			want: &objectType {URL: &URL{
+				Scheme: "http",
+				Host: "path",
+				Path: "/to/something",
+			}},
 		},
 		"empty url": {
 			b:    []byte(`{"url":""}`),


### PR DESCRIPTION
In particular, this adds:

* Two constructors for common cases, one for HTTP and one for HTTPS URLs
* An `IsEmpty` method to automate the `nil`-or-empty checks