### PR TITLE
Add pkg stackdriver/config for Stackdriver metadata

### DIFF
--- a/stackdriver/config/config.go
+++ b/stackdriver/config/config.go
@@ -30,6 +30,9 @@ import (
 
 var (
 	mtx sync.RWMutex
+
+	// kubeclient is the in-cluster Kubernetes kubeclient.
+	kubeclient *kubernetes.Clientset
 )
 
 const (
@@ -43,15 +46,15 @@ const (
 	// service account key to use.
 	secretDataFieldKey = "key.json"
 
-	// ProjectIDKey is the name of the ConfigMap field for ProjectID.
+	// ProjectIDKey is the map key for Config.ProjectID.
 	ProjectIDKey = "project-id"
-	// GcpLocationKey is name of the ConfigMap field for GcpLocation.
+	// GcpLocationKey is the map key for Config.GCPLocation.
 	GcpLocationKey = "gcp-location"
-	// ClusterNameKey is the name of the ConfigMap field for ClusterName.
+	// ClusterNameKey is the map key for Config.ClusterName.
 	ClusterNameKey = "cluster-name"
-	// GcpSecretNameKey is the name of the ConfigMap field for GcpSecretName.
+	// GcpSecretNameKey is the map key for GCPSecretName.
 	GcpSecretNameKey = "gcp-secret-name"
-	// GcpSecretNamespaceKey is the name of the ConfigMap field for GcpSecretNamespace.
+	// GcpSecretNamespaceKey is the map key for GCPSecretNamespace.
 	GcpSecretNamespaceKey = "gcp-secret-namespace"
 )
 
@@ -61,21 +64,21 @@ type Config struct {
 	// This is not necessarily the GCP project ID where the Kubernetes cluster is hosted.
 	// Required when the Kubernetes cluster is not hosted on GCE.
 	ProjectID string
-	// GcpLocation is the GCP region or zone to which data is uploaded.
+	// GCPLocation is the GCP region or zone to which data is uploaded.
 	// This is not necessarily the GCP project ID where the Kubernetes cluster is hosted.
 	// Required when the Kubernetes cluster is not hosted on GCE.
-	GcpLocation string
+	GCPLocation string
 	// ClusterName is the cluster name with which the data will be associated in Stackdriver.
 	// Required when the Kubernetes cluster is not hosted on GCE.
 	ClusterName string
-	// GcpSecretName is the optional GCP service account key which will be used to
+	// GCPSecretName is the optional GCP service account key which will be used to
 	// authenticate with Stackdriver. If not provided, Google Application Default Credentials
 	// will be used (https://cloud.google.com/docs/authentication/production).
-	GcpSecretName string
-	// GcpSecretNamespace is the Kubernetes namespace where GcpSecretName is located.
+	GCPSecretName string
+	// GCPSecretNamespace is the Kubernetes namespace where GcpSecretName is located.
 	// The Kubernetes ServiceAccount used by the pod that is exporting data to
 	// Stackdriver should have access to Secrets in this namespace.
-	GcpSecretNamespace string
+	GCPSecretNamespace string
 }
 
 // NewStackdriverConfigFromConfigMap returns a Config for the given configmap
@@ -95,7 +98,7 @@ func NewStackdriverConfigFromMap(config map[string]string) (*Config, error) {
 	}
 
 	if gl, ok := config[GcpLocationKey]; ok {
-		sc.GcpLocation = gl
+		sc.GCPLocation = gl
 	}
 
 	if cn, ok := config[ClusterNameKey]; ok {
@@ -103,30 +106,25 @@ func NewStackdriverConfigFromMap(config map[string]string) (*Config, error) {
 	}
 
 	if gsn, ok := config[GcpSecretNameKey]; ok {
-		sc.GcpSecretName = gsn
+		sc.GCPSecretName = gsn
 	}
 
 	if gsns, ok := config[GcpSecretNamespaceKey]; ok {
-		sc.GcpSecretNamespace = gsns
+		sc.GCPSecretNamespace = gsns
 	}
 
 	return sc, nil
 }
 
-var (
-	// kubeclient is the in-cluster Kubernetes kubeclient.
-	kubeclient *kubernetes.Clientset
-)
-
 // GetStackdriverSecret returns the Kubernetes Secret specified in the given config.
 func GetStackdriverSecret(config *Config) (*v1.Secret, error) {
 	ensureKubeclient()
 	ns := secretNamespaceDefault
-	if config.GcpSecretNamespace != "" {
-		ns = config.GcpSecretNamespace
+	if config.GCPSecretNamespace != "" {
+		ns = config.GCPSecretNamespace
 	}
 
-	return kubeclient.CoreV1().Secrets(ns).Get(config.GcpSecretName, metav1.GetOptions{})
+	return kubeclient.CoreV1().Secrets(ns).Get(config.GCPSecretName, metav1.GetOptions{})
 }
 
 // ConvertSecretToExporterOption converts a Kubernetes Secret to an OpenCensus Stackdriver Exporter Option.

--- a/stackdriver/config/config.go
+++ b/stackdriver/config/config.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"sync"
+
+	"google.golang.org/api/option"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+var (
+	mtx sync.RWMutex
+)
+
+const (
+	// ConfigMapNameEnv is the name of the environment variable that contains the name of
+	// the ConfigMap for stackdriver configuration.
+	ConfigMapNameEnv = "CONFIG_STACKDRIVER_NAME"
+	// secretNamespace is the namespace in which secrets for authenticating with Stackdriver
+	// should be stored.
+	secretNamespace = "knative-serving"
+	// secretDataFieldKey is key of the Kubernetes Secret Data field that contains the GCP
+	// service account key to use.
+	secretDataFieldKey = "key.json"
+
+	// ProjectIDKey is the name of the ConfigMap field for ProjectID.
+	ProjectIDKey = "project-id"
+	// GcpLocationKey is name of the ConfigMap field for GcpLocation.
+	GcpLocationKey = "gcp-location"
+	// ClusterNameKey is the name of the ConfigMap field for ClusterName.
+	ClusterNameKey = "cluster-name"
+	// GcpSecretNameKey is the name of the ConfigMap field for GcpSecretName.
+	GcpSecretNameKey = "gcp-secret-name"
+)
+
+// Config encapsulates the metadata required to configure a Stackdriver client.
+type Config struct {
+	// ProjectID is the stackdriver project ID to which data is uploaded.
+	// This is not necessarily the GCP project ID where the Kubernetes cluster is hosted.
+	// Required when the Kubernetes cluster is not hosted on GCE.
+	ProjectID string
+	// GcpLocation is the GCP region or zone to which data is uploaded.
+	// This is not necessarily the GCP project ID where the Kubernetes cluster is hosted.
+	// Required when the Kubernetes cluster is not hosted on GCE.
+	GcpLocation string
+	// ClusterName is the cluster name with which the data will be associated in Stackdriver.
+	// Required when the Kubernetes cluster is not hosted on GCE.
+	ClusterName string
+	// GcpSecretName is the optional GCP service account key which will be used to
+	// authenticate with Stackdriver. If not provided, Google Application Default Credentials
+	// will be used (https://cloud.google.com/docs/authentication/production).
+	GcpSecretName string
+}
+
+// NewStackdriverConfigFromConfigMap returns a Config for the given configmap
+func NewStackdriverConfigFromConfigMap(config *corev1.ConfigMap) (*Config, error) {
+	if config == nil {
+		return &Config{}, nil
+	}
+	return NewStackdriverConfigFromMap(config.Data)
+}
+
+// NewStackdriverConfigFromMap returns a Config for the given map
+func NewStackdriverConfigFromMap(config map[string]string) (*Config, error) {
+	sc := &Config{}
+
+	if pi, ok := config[ProjectIDKey]; ok {
+		sc.ProjectID = pi
+	}
+
+	if gl, ok := config[GcpLocationKey]; ok {
+		sc.GcpLocation = gl
+	}
+
+	if cn, ok := config[ClusterNameKey]; ok {
+		sc.ClusterName = cn
+	}
+
+	if gsn, ok := config[GcpSecretNameKey]; ok {
+		sc.GcpSecretName = gsn
+	}
+
+	return sc, nil
+}
+
+var (
+	// kubeclient is the in-cluster Kubernetes kubeclient.
+	kubeclient *kubernetes.Clientset
+)
+
+// GetStackdriverSecret returns the Kubernetes Secret specified in the given config.
+func GetStackdriverSecret(config *Config) (*v1.Secret, error) {
+	ensureKubeclient()
+	return kubeclient.CoreV1().Secrets(secretNamespace).Get(config.GcpSecretName, metav1.GetOptions{})
+}
+
+// ConvertSecretToExporterOption converts a Kubernetes Secret to an OpenCensus Stackdriver Exporter Option.
+func ConvertSecretToExporterOption(secret *v1.Secret) option.ClientOption {
+	return option.WithCredentialsJSON(secret.Data[secretDataFieldKey])
+}
+
+func isKubeclientInitialized() bool {
+	mtx.RLock()
+	defer mtx.Unlock()
+
+	return kubeclient != nil
+}
+
+func ensureKubeclient() {
+	if isKubeclientInitialized() {
+		return
+	}
+
+	mtx.Lock()
+	defer mtx.Unlock()
+
+	if kubeclient != nil {
+		return
+	}
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		panic(err.Error())
+	}
+
+	cs, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
+	kubeclient = cs
+}

--- a/stackdriver/config/config.go
+++ b/stackdriver/config/config.go
@@ -65,7 +65,7 @@ type Config struct {
 	// Required when the Kubernetes cluster is not hosted on GCE.
 	ProjectID string
 	// GCPLocation is the GCP region or zone to which data is uploaded.
-	// This is not necessarily the GCP project ID where the Kubernetes cluster is hosted.
+	// This is not necessarily the GCP location where the Kubernetes cluster is hosted.
 	// Required when the Kubernetes cluster is not hosted on GCE.
 	GCPLocation string
 	// ClusterName is the cluster name with which the data will be associated in Stackdriver.

--- a/stackdriver/config/config.go
+++ b/stackdriver/config/config.go
@@ -132,6 +132,8 @@ func ConvertSecretToExporterOption(secret *v1.Secret) option.ClientOption {
 	return option.WithCredentialsJSON(secret.Data[secretDataFieldKey])
 }
 
+// isKubeclientInitialized is a thread-safe check to see if the kubeclient is initialzed.
+// A reader-lock is used to make the check as efficient as possible.
 func isKubeclientInitialized() bool {
 	mtx.RLock()
 	defer mtx.RUnlock()
@@ -147,6 +149,8 @@ func ensureKubeclient() {
 	mtx.Lock()
 	defer mtx.Unlock()
 
+	// Multiple readers can read the kubeclient as nil before reaching
+	// the writer lock, so double check the value is not nil.
 	if kubeclient != nil {
 		return
 	}

--- a/stackdriver/config/config.go
+++ b/stackdriver/config/config.go
@@ -106,6 +106,10 @@ func NewStackdriverConfigFromMap(config map[string]string) (*Config, error) {
 		sc.GcpSecretName = gsn
 	}
 
+	if gsns, ok := config[GcpSecretNamespaceKey]; ok {
+		sc.GcpSecretNamespace = gsns
+	}
+
 	return sc, nil
 }
 

--- a/stackdriver/config/config.go
+++ b/stackdriver/config/config.go
@@ -134,7 +134,7 @@ func ConvertSecretToExporterOption(secret *v1.Secret) option.ClientOption {
 
 func isKubeclientInitialized() bool {
 	mtx.RLock()
-	defer mtx.Unlock()
+	defer mtx.RUnlock()
 
 	return kubeclient != nil
 }

--- a/stackdriver/config/config_test.go
+++ b/stackdriver/config/config_test.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"testing"
+)
+
+func TestNewStackdriverConfigFromConfigMap(t *testing.T) {
+	tests := []struct {
+		name           string
+		configMap      *corev1.ConfigMap
+		expectedConfig Config
+	}{
+		{
+			name: "fullSdConfig",
+			configMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"project-id":      "project",
+					"gcp-location":    "us-west1",
+					"cluster-name":    "cluster",
+					"gcp-secret-name": "secret",
+				},
+			},
+			expectedConfig: Config{
+				ProjectID:     "project",
+				GcpLocation:   "us-west1",
+				ClusterName:   "cluster",
+				GcpSecretName: "secret",
+			},
+		},
+		{
+			name:           "emptySdConfig",
+			configMap:      &corev1.ConfigMap{},
+			expectedConfig: Config{},
+		},
+		{
+			name: "partialSdConfig",
+			configMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"project-id":   "project",
+					"gcp-location": "us-west1",
+					"cluster-name": "cluster",
+				},
+			},
+			expectedConfig: Config{
+				ProjectID:   "project",
+				GcpLocation: "us-west1",
+				ClusterName: "cluster",
+			},
+		},
+		{
+			name: "invalidGcpLocation",
+			configMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"gcp-location": "narnia",
+				},
+			},
+			expectedConfig: Config{
+				GcpLocation: "narnia",
+			},
+		},
+		{
+			name:           "nil",
+			configMap:      nil,
+			expectedConfig: Config{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c, err := NewStackdriverConfigFromConfigMap(test.configMap)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if test.expectedConfig != *c {
+				t.Errorf("Incorrect stackdriver config. Expected: [%v], Got: [%v]", test.expectedConfig, *c)
+			}
+		})
+	}
+}
+
+// This test ensures that ensureKubeClient completes. Errors are expected, but ok.
+func TestEnsureKubeClientNoDeadlock(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		go testKubeclient(t)
+	}
+}
+
+func testKubeclient(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("Expected ensureKubeclient to panic due to not being in a Kubernetes cluster. Did the function run?.")
+		}
+	}()
+
+	ensureKubeclient()
+}

--- a/stackdriver/config/config_test.go
+++ b/stackdriver/config/config_test.go
@@ -72,7 +72,7 @@ func TestNewStackdriverConfigFromConfigMap(t *testing.T) {
 }
 
 // This test ensures that ensureKubeClient completes. Errors are expected, but ok.
-func TestEnsureKubeClientNoDeadlock(t *testing.T) {
+func TestEnsureKubeclientNoDeadlock(t *testing.T) {
 	done := make(chan bool)
 	for i := 0; i < 10; i++ {
 		go testKubeclient(t, done)
@@ -87,7 +87,7 @@ func TestEnsureKubeClientNoDeadlock(t *testing.T) {
 func testKubeclient(t *testing.T, doneCh chan bool) {
 	defer func() {
 		if recover() == nil {
-			t.Error("Expected ensureKubeclient to panic due to not being in a Kubernetes cluster. Did the function run?.")
+			t.Error("Expected ensureKubeclient to panic due to not being in a Kubernetes cluster. Did the function run?")
 		}
 
 		doneCh <- true

--- a/stackdriver/config/config_test.go
+++ b/stackdriver/config/config_test.go
@@ -16,17 +16,19 @@ func TestNewStackdriverConfigFromConfigMap(t *testing.T) {
 			name: "fullSdConfig",
 			configMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"project-id":      "project",
-					"gcp-location":    "us-west1",
-					"cluster-name":    "cluster",
-					"gcp-secret-name": "secret",
+					"project-id":           "project",
+					"gcp-location":         "us-west1",
+					"cluster-name":         "cluster",
+					"gcp-secret-name":      "secret",
+					"gcp-secret-namespace": "non-default",
 				},
 			},
 			expectedConfig: Config{
-				ProjectID:     "project",
-				GcpLocation:   "us-west1",
-				ClusterName:   "cluster",
-				GcpSecretName: "secret",
+				ProjectID:          "project",
+				GcpLocation:        "us-west1",
+				ClusterName:        "cluster",
+				GcpSecretName:      "secret",
+				GcpSecretNamespace: "non-default",
 			},
 		},
 		{

--- a/stackdriver/config/config_test.go
+++ b/stackdriver/config/config_test.go
@@ -25,10 +25,10 @@ func TestNewStackdriverConfigFromConfigMap(t *testing.T) {
 			},
 			expectedConfig: Config{
 				ProjectID:          "project",
-				GcpLocation:        "us-west1",
+				GCPLocation:        "us-west1",
 				ClusterName:        "cluster",
-				GcpSecretName:      "secret",
-				GcpSecretNamespace: "non-default",
+				GCPSecretName:      "secret",
+				GCPSecretNamespace: "non-default",
 			},
 		},
 		{
@@ -47,19 +47,8 @@ func TestNewStackdriverConfigFromConfigMap(t *testing.T) {
 			},
 			expectedConfig: Config{
 				ProjectID:   "project",
-				GcpLocation: "us-west1",
+				GCPLocation: "us-west1",
 				ClusterName: "cluster",
-			},
-		},
-		{
-			name: "invalidGcpLocation",
-			configMap: &corev1.ConfigMap{
-				Data: map[string]string{
-					"gcp-location": "narnia",
-				},
-			},
-			expectedConfig: Config{
-				GcpLocation: "narnia",
 			},
 		},
 		{

--- a/stackdriver/config/config_test.go
+++ b/stackdriver/config/config_test.go
@@ -71,26 +71,11 @@ func TestNewStackdriverConfigFromConfigMap(t *testing.T) {
 	}
 }
 
-// This test ensures that ensureKubeClient completes. Errors are expected, but ok.
-func TestEnsureKubeclientNoDeadlock(t *testing.T) {
-	done := make(chan bool)
-	for i := 0; i < 10; i++ {
-		go testKubeclient(t, done)
-	}
-
-	// Wait for 10 responses
-	for i := 0; i < 10; i++ {
-		<-done
-	}
-}
-
-func testKubeclient(t *testing.T, doneCh chan bool) {
+func TestEnsureKubeClient(t *testing.T) {
 	defer func() {
 		if recover() == nil {
 			t.Error("Expected ensureKubeclient to panic due to not being in a Kubernetes cluster. Did the function run?")
 		}
-
-		doneCh <- true
 	}()
 
 	ensureKubeclient()


### PR DESCRIPTION
Add "knative.dev/pkg/stackdriver/config" pkg that encapsulates metadata required to create a Stackdriver client. This metadata is provided by default on Google Compute Engine (GCE) by the GCE metadata server. 

On other compute platforms, adding this config will allow manually specifying Stackdriver metadata so that metrics & traces can still be sent to Stackdriver by user's choice.

Part of knative/serving#5777