### PR TITLE
add DeprecatedObjectReference in Destination to support backwards compatibility

### DIFF
--- a/apis/v1alpha1/destination_test.go
+++ b/apis/v1alpha1/destination_test.go
@@ -80,6 +80,42 @@ func TestValidateDestination(t *testing.T) {
 			},
 			want: "missing field(s): ref.kind",
 		},
+		"valid DeprecatedObjectReference": {
+			dest: &Destination{
+				DeprecatedObjectReference:&corev1.ObjectReference{
+					APIVersion: "v1mega1",
+					Name:       "a-name",
+				},
+			},
+			want: "missing field(s): kind",
+		},
+		"invalid DeprecatedObjectReference, missing name": {
+			dest: &Destination{
+				DeprecatedObjectReference: &corev1.ObjectReference{
+					Kind:       "SomeKind",
+					APIVersion: "v1mega1",
+				},
+			},
+			want: "missing field(s): name",
+		},
+		"invalid DeprecatedObjectReference, missing api version": {
+			dest: &Destination{
+				DeprecatedObjectReference: &corev1.ObjectReference{
+					Kind: "SomeKind",
+					Name: "a-name",
+				},
+			},
+			want: "missing field(s): apiVersion",
+		},
+		"invalid DeprecatedObjectReference, missing kind": {
+			dest: &Destination{
+				DeprecatedObjectReference: &corev1.ObjectReference{
+					APIVersion: "v1mega1",
+					Name:       "a-name",
+				},
+			},
+			want: "missing field(s): kind",
+		},
 		"valid uri": {
 			dest: &Destination{
 				URI: &validURL,
@@ -91,7 +127,7 @@ func TestValidateDestination(t *testing.T) {
 					Scheme: "http",
 				},
 			},
-			want: "invalid value: Relative URI is not allowed when Ref is absent: uri",
+			want: "invalid value: Relative URI is not allowed when Ref and [apiVersion, kind, name] is absent: uri",
 		},
 		"invalid, uri is not absolute url": {
 			dest: &Destination{
@@ -99,20 +135,42 @@ func TestValidateDestination(t *testing.T) {
 					Host: "host",
 				},
 			},
-			want: "invalid value: Relative URI is not allowed when Ref is absent: uri",
+			want: "invalid value: Relative URI is not allowed when Ref and [apiVersion, kind, name] is absent: uri",
 
 		},
+		"invalid, both ref and DeprecatedObjectReference are present ": {
+			dest: &Destination{
+					Ref: &corev1.ObjectReference{
+						Kind:       "SomeKind",
+						APIVersion: "v1mega1",
+						Name:       "a-name",
+					},
+				DeprecatedObjectReference: &corev1.ObjectReference{
+					Kind:       "SomeKind",
+					APIVersion: "v1mega1",
+					Name:       "a-name",
+				},
+				},
+			want: "Ref and [apiVersion, kind, name] can't be both present: [apiVersion, kind, name], ref",
+			},
 		"invalid, both uri and ref, uri is absolute URL": {
 			dest: &Destination{
 				URI: &validURL,
 				Ref: &validRef,
 			},
-			want: "Absolute URI is not allowed when Ref is present: ref, uri",
+			want: "Absolute URI is not allowed when Ref or [apiVersion, kind, name] is present: [apiVersion, kind, name], ref, uri",
 		},
-		"invalid, both uri and ref are nil": {
+		"invalid, both uri and [apiVersion, kind, name], uri is absolute URL": {
+			dest: &Destination{
+				URI: &validURL,
+				DeprecatedObjectReference: &validRef,
+			},
+			want: "Absolute URI is not allowed when Ref or [apiVersion, kind, name] is present: [apiVersion, kind, name], ref, uri",
+		},
+		"invalid, both ref, [apiVersion, kind, name] and uri  are nil": {
 			dest: &Destination{
 			},
-			want: "expected at least one, got neither: ref, uri",
+			want: "expected at least one, got none: [apiVersion, kind, name], ref, uri",
 		},
 		"valid, both uri and ref, uri is not a absolute URL": {
 			dest: &Destination{
@@ -120,6 +178,14 @@ func TestValidateDestination(t *testing.T) {
 					Path: "/handler",
 				},
 				Ref: &validRef,
+			},
+		},
+		"valid, both uri and [apiVersion, kind, name], uri is not a absolute URL": {
+			dest: &Destination{
+				URI:  &apis.URL{
+					Path: "/handler",
+				},
+				DeprecatedObjectReference: &validRef,
 			},
 		},
 	}

--- a/apis/v1alpha1/destination_test.go
+++ b/apis/v1alpha1/destination_test.go
@@ -25,13 +25,19 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+const (
+	kind       = "SomeKind"
+	apiVersion = "v1mega1"
+	name       = "a-name"
+)
+
 func TestValidateDestination(t *testing.T) {
 	ctx := context.TODO()
 
 	validRef := corev1.ObjectReference{
-		Kind:       "SomeKind",
-		APIVersion: "v1mega1",
-		Name:       "a-name",
+		Kind:       kind,
+		APIVersion: apiVersion,
+		Name:       name,
 	}
 
 	validURL := apis.URL{
@@ -51,13 +57,13 @@ func TestValidateDestination(t *testing.T) {
 			dest: &Destination{
 				Ref: &validRef,
 			},
-			want:"",
+			want: "",
 		},
 		"invalid ref, missing name": {
 			dest: &Destination{
 				Ref: &corev1.ObjectReference{
-					Kind:       "SomeKind",
-					APIVersion: "v1mega1",
+					Kind:       kind,
+					APIVersion: apiVersion,
 				},
 			},
 			want: "missing field(s): ref.name",
@@ -65,8 +71,8 @@ func TestValidateDestination(t *testing.T) {
 		"invalid ref, missing api version": {
 			dest: &Destination{
 				Ref: &corev1.ObjectReference{
-					Kind: "SomeKind",
-					Name: "a-name",
+					Kind: kind,
+					Name: apiVersion,
 				},
 			},
 			want: "missing field(s): ref.apiVersion",
@@ -74,45 +80,38 @@ func TestValidateDestination(t *testing.T) {
 		"invalid ref, missing kind": {
 			dest: &Destination{
 				Ref: &corev1.ObjectReference{
-					APIVersion: "v1mega1",
-					Name:       "a-name",
+					APIVersion: apiVersion,
+					Name:       name,
 				},
 			},
 			want: "missing field(s): ref.kind",
 		},
-		"valid DeprecatedObjectReference": {
+		"valid [apiVersion, kind, name]": {
 			dest: &Destination{
-				DeprecatedObjectReference:&corev1.ObjectReference{
-					APIVersion: "v1mega1",
-					Name:       "a-name",
-				},
+				DeprecatedKind:       kind,
+				DeprecatedAPIVersion: apiVersion,
+				DeprecatedName:       name,
 			},
-			want: "missing field(s): kind",
+			want: "",
 		},
-		"invalid DeprecatedObjectReference, missing name": {
+		"invalid [apiVersion, kind, name], missing name": {
 			dest: &Destination{
-				DeprecatedObjectReference: &corev1.ObjectReference{
-					Kind:       "SomeKind",
-					APIVersion: "v1mega1",
-				},
+				DeprecatedKind:       kind,
+				DeprecatedAPIVersion: apiVersion,
 			},
 			want: "missing field(s): name",
 		},
-		"invalid DeprecatedObjectReference, missing api version": {
+		"invalid [apiVersion, kind, name], missing api version": {
 			dest: &Destination{
-				DeprecatedObjectReference: &corev1.ObjectReference{
-					Kind: "SomeKind",
-					Name: "a-name",
-				},
+				DeprecatedKind: kind,
+				DeprecatedName: name,
 			},
 			want: "missing field(s): apiVersion",
 		},
-		"invalid DeprecatedObjectReference, missing kind": {
+		"invalid [apiVersion, kind, name], missing kind": {
 			dest: &Destination{
-				DeprecatedObjectReference: &corev1.ObjectReference{
-					APIVersion: "v1mega1",
-					Name:       "a-name",
-				},
+				DeprecatedAPIVersion: apiVersion,
+				DeprecatedName:       name,
 			},
 			want: "missing field(s): kind",
 		},
@@ -136,23 +135,20 @@ func TestValidateDestination(t *testing.T) {
 				},
 			},
 			want: "invalid value: Relative URI is not allowed when Ref and [apiVersion, kind, name] is absent: uri",
-
 		},
-		"invalid, both ref and DeprecatedObjectReference are present ": {
+		"invalid, both ref and [apiVersion, kind, name] are present ": {
 			dest: &Destination{
-					Ref: &corev1.ObjectReference{
-						Kind:       "SomeKind",
-						APIVersion: "v1mega1",
-						Name:       "a-name",
-					},
-				DeprecatedObjectReference: &corev1.ObjectReference{
+				Ref: &corev1.ObjectReference{
 					Kind:       "SomeKind",
 					APIVersion: "v1mega1",
 					Name:       "a-name",
 				},
-				},
-			want: "Ref and [apiVersion, kind, name] can't be both present: [apiVersion, kind, name], ref",
+				DeprecatedKind:       kind,
+				DeprecatedAPIVersion: apiVersion,
+				DeprecatedName:       name,
 			},
+			want: "Ref and [apiVersion, kind, name] can't be both present: [apiVersion, kind, name], ref",
+		},
 		"invalid, both uri and ref, uri is absolute URL": {
 			dest: &Destination{
 				URI: &validURL,
@@ -162,8 +158,10 @@ func TestValidateDestination(t *testing.T) {
 		},
 		"invalid, both uri and [apiVersion, kind, name], uri is absolute URL": {
 			dest: &Destination{
-				URI: &validURL,
-				DeprecatedObjectReference: &validRef,
+				URI:                  &validURL,
+				DeprecatedKind:       kind,
+				DeprecatedAPIVersion: apiVersion,
+				DeprecatedName:       name,
 			},
 			want: "Absolute URI is not allowed when Ref or [apiVersion, kind, name] is present: [apiVersion, kind, name], ref, uri",
 		},
@@ -174,7 +172,7 @@ func TestValidateDestination(t *testing.T) {
 		},
 		"valid, both uri and ref, uri is not a absolute URL": {
 			dest: &Destination{
-				URI:  &apis.URL{
+				URI: &apis.URL{
 					Path: "/handler",
 				},
 				Ref: &validRef,
@@ -182,10 +180,12 @@ func TestValidateDestination(t *testing.T) {
 		},
 		"valid, both uri and [apiVersion, kind, name], uri is not a absolute URL": {
 			dest: &Destination{
-				URI:  &apis.URL{
+				URI: &apis.URL{
 					Path: "/handler",
 				},
-				DeprecatedObjectReference: &validRef,
+				DeprecatedKind:       kind,
+				DeprecatedAPIVersion: apiVersion,
+				DeprecatedName:       name,
 			},
 		},
 	}
@@ -204,4 +204,3 @@ func TestValidateDestination(t *testing.T) {
 		})
 	}
 }
-

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -33,6 +33,11 @@ func (in *Destination) DeepCopyInto(out *Destination) {
 		*out = new(v1.ObjectReference)
 		**out = **in
 	}
+	if in.DeprecatedObjectReference != nil {
+		in, out := &in.DeprecatedObjectReference, &out.DeprecatedObjectReference
+		*out = new(v1.ObjectReference)
+		**out = **in
+	}
 	if in.URI != nil {
 		in, out := &in.URI, &out.URI
 		*out = new(apis.URL)

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -33,11 +33,6 @@ func (in *Destination) DeepCopyInto(out *Destination) {
 		*out = new(v1.ObjectReference)
 		**out = **in
 	}
-	if in.DeprecatedObjectReference != nil {
-		in, out := &in.DeprecatedObjectReference, &out.DeprecatedObjectReference
-		*out = new(v1.ObjectReference)
-		**out = **in
-	}
 	if in.URI != nil {
 		in, out := &in.URI, &out.URI
 		*out = new(apis.URL)

--- a/resolver/addressable_resolver_test.go
+++ b/resolver/addressable_resolver_test.go
@@ -65,7 +65,7 @@ func TestGetURI_ObjectReference(t *testing.T) {
 		wantURI string
 		wantErr error
 	}{"nil everything": {
-		wantErr: fmt.Errorf("destination missing Ref, DeprecatedObjectReference and URI, expected at least one"),
+		wantErr: fmt.Errorf("destination missing Ref, [apiVersion, kind, name] and URI, expected at least one"),
 	}, "Happy URI with path": {
 		dest: apisv1alpha1.Destination{
 			URI: &apis.URL{
@@ -94,13 +94,13 @@ func TestGetURI_ObjectReference(t *testing.T) {
 			objects: []runtime.Object{
 				getAddressable(),
 			},
-			dest: apisv1alpha1.Destination{Ref: getAddressableRef(), DeprecatedObjectReference: &corev1.ObjectReference{
-				Kind:       addressableKind,
-				Name:       addressableName,
-				APIVersion: addressableAPIVersion,
-				Namespace:  testNS,
-			}},
-			wantErr: fmt.Errorf("ref and DeprecatedObjectReference can't be both present"),
+			dest: apisv1alpha1.Destination{Ref: getAddressableRef(),
+				DeprecatedKind:       addressableKind,
+				DeprecatedName:       addressableName,
+				DeprecatedAPIVersion: addressableAPIVersion,
+				DeprecatedNamespace:  testNS,
+			},
+			wantErr: fmt.Errorf("ref and [apiVersion, kind, name] can't be both present"),
 		},
 		"happy ref": {
 			objects: []runtime.Object{
@@ -192,7 +192,11 @@ func TestGetURI_ObjectReference(t *testing.T) {
 			objects: []runtime.Object{
 				getAddressable(),
 			},
-			dest:    apisv1alpha1.Destination{DeprecatedObjectReference: getAddressableRef()},
+			dest:    apisv1alpha1.Destination{
+				DeprecatedKind:       addressableKind,
+				DeprecatedName:       addressableName,
+				DeprecatedAPIVersion: addressableAPIVersion,
+				DeprecatedNamespace:  testNS,},
 			wantURI: addressableDNS,
 		},
 		"DeprecatedObjectReference with relative uri": {
@@ -200,7 +204,10 @@ func TestGetURI_ObjectReference(t *testing.T) {
 				getAddressable(),
 			},
 			dest: apisv1alpha1.Destination{
-				DeprecatedObjectReference: getAddressableRef(),
+				DeprecatedKind:       addressableKind,
+				DeprecatedName:       addressableName,
+				DeprecatedAPIVersion: addressableAPIVersion,
+				DeprecatedNamespace:  testNS,
 				URI: &apis.URL{
 					Path: "/foo",
 				},
@@ -211,7 +218,10 @@ func TestGetURI_ObjectReference(t *testing.T) {
 				getAddressable(),
 			},
 			dest: apisv1alpha1.Destination{
-				DeprecatedObjectReference: getAddressableRef(),
+				DeprecatedKind:       addressableKind,
+				DeprecatedName:       addressableName,
+				DeprecatedAPIVersion: addressableAPIVersion,
+				DeprecatedNamespace:  testNS,
 				URI: &apis.URL{
 					Path: "foo",
 				},
@@ -222,7 +232,10 @@ func TestGetURI_ObjectReference(t *testing.T) {
 				getAddressableWithPathAndTrailingSlash(),
 			},
 			dest: apisv1alpha1.Destination{
-				DeprecatedObjectReference: getAddressableRef(),
+				DeprecatedKind:       addressableKind,
+				DeprecatedName:       addressableName,
+				DeprecatedAPIVersion: addressableAPIVersion,
+				DeprecatedNamespace:  testNS,
 				URI: &apis.URL{
 					Path: "foo",
 				},
@@ -233,7 +246,10 @@ func TestGetURI_ObjectReference(t *testing.T) {
 				getAddressableWithPathAndTrailingSlash(),
 			},
 			dest: apisv1alpha1.Destination{
-				DeprecatedObjectReference: getAddressableRef(),
+				DeprecatedKind:       addressableKind,
+				DeprecatedName:       addressableName,
+				DeprecatedAPIVersion: addressableAPIVersion,
+				DeprecatedNamespace:  testNS,
 				URI: &apis.URL{
 					Path: "/foo",
 				},
@@ -244,7 +260,10 @@ func TestGetURI_ObjectReference(t *testing.T) {
 				getAddressableWithPathAndNoTrailingSlash(),
 			},
 			dest: apisv1alpha1.Destination{
-				DeprecatedObjectReference: getAddressableRef(),
+				DeprecatedKind:       addressableKind,
+				DeprecatedName:       addressableName,
+				DeprecatedAPIVersion: addressableAPIVersion,
+				DeprecatedNamespace:  testNS,
 				URI: &apis.URL{
 					Path: "foo",
 				},
@@ -255,7 +274,10 @@ func TestGetURI_ObjectReference(t *testing.T) {
 				getAddressableWithPathAndNoTrailingSlash(),
 			},
 			dest: apisv1alpha1.Destination{
-				DeprecatedObjectReference: getAddressableRef(),
+				DeprecatedKind:       addressableKind,
+				DeprecatedName:       addressableName,
+				DeprecatedAPIVersion: addressableAPIVersion,
+				DeprecatedNamespace:  testNS,
 				URI: &apis.URL{
 					Path: "/foo",
 				},
@@ -266,7 +288,10 @@ func TestGetURI_ObjectReference(t *testing.T) {
 				getAddressable(),
 			},
 			dest: apisv1alpha1.Destination{
-				DeprecatedObjectReference: getAddressableRef(),
+				DeprecatedKind:       addressableKind,
+				DeprecatedName:       addressableName,
+				DeprecatedAPIVersion: addressableAPIVersion,
+				DeprecatedNamespace:  testNS,
 				URI: &apis.URL{
 					Scheme: "http",
 					Host:   "example.com",


### PR DESCRIPTION
Regarding discussion of https://github.com/knative/eventing/issues/1918, to avoid the breaking api change for sources, we can add DeprecatedObjectReference in Destination to support backwards compatibility. This is a suggestion change. We have not made a decision yet.
## Proposed Changes

- added DeprecatedObjectReference in Destination to support backwards compatible
- Added unit tests for new business logic

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
This is a suggestion change. We have not made a decision yet. Please don't merge it now.
```