### PR TITLE
Add field to metrics config for configuring Stackdriver exporter client

### DIFF
--- a/metrics/config.go
+++ b/metrics/config.go
@@ -46,11 +46,11 @@ const (
 	ReportingPeriodKey                  = "metrics.reporting-period-seconds"
 	StackdriverCustomMetricSubDomainKey = "metrics.stackdriver-custom-metrics-subdomain"
 	// Stackdriver client configuration keys
-	StackdriverProjectIDKey          = "metrics.stackdriver-project-id"
-	StackdriverGCPLocationKey        = "metrics.stackdriver-gcp-location"
-	StackdriverClusterNameKey        = "metrics.stackdriver-cluster-name"
-	StackdriverGCPSecretNameKey      = "metrics.stackdriver-gcp-secret-name"
-	StackdriverGCPSecretNamespaceKey = "metrics.stackdriver-gcp-secret-namespace"
+	stackdriverProjectIDKey          = "metrics.stackdriver-project-id"
+	stackdriverGCPLocationKey        = "metrics.stackdriver-gcp-location"
+	stackdriverClusterNameKey        = "metrics.stackdriver-cluster-name"
+	stackdriverGCPSecretNameKey      = "metrics.stackdriver-gcp-secret-name"
+	stackdriverGCPSecretNamespaceKey = "metrics.stackdriver-gcp-secret-namespace"
 
 	// Stackdriver is used for Stackdriver backend
 	Stackdriver metricsBackend = "stackdriver"
@@ -131,17 +131,17 @@ type stackdriverClientConfig struct {
 
 // newStackdriverClientConfigFromMap creates a stackdriverClientConfig from the given map
 func newStackdriverClientConfigFromMap(config map[string]string) *stackdriverClientConfig {
-	sc := &stackdriverClientConfig{}
-	sc.ProjectID = config[StackdriverProjectIDKey]
-	sc.GCPLocation = config[StackdriverGCPLocationKey]
-	sc.ClusterName = config[StackdriverClusterNameKey]
-	sc.GCPSecretName = config[StackdriverGCPSecretNameKey]
-	sc.GCPSecretNamespace = config[StackdriverGCPSecretNamespaceKey]
-	return sc
+	return &stackdriverClientConfig{
+		ProjectID:          config[stackdriverProjectIDKey],
+		GCPLocation:        config[stackdriverGCPLocationKey],
+		ClusterName:        config[stackdriverClusterNameKey],
+		GCPSecretName:      config[stackdriverGCPSecretNameKey],
+		GCPSecretNamespace: config[stackdriverGCPSecretNamespaceKey],
+	}
 }
 
 func createMetricsConfig(ops ExporterOptions, logger *zap.SugaredLogger) (*metricsConfig, error) {
-	mc := metricsConfig{stackdriverClientConfig: stackdriverClientConfig{}}
+	var mc metricsConfig
 
 	if ops.Domain == "" {
 		return nil, errors.New("metrics domain cannot be empty")

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -130,30 +130,14 @@ type stackdriverClientConfig struct {
 }
 
 // newStackdriverClientConfigFromMap creates a stackdriverClientConfig from the given map
-func newStackdriverClientConfigFromMap(config map[string]string) (*stackdriverClientConfig, error) {
+func newStackdriverClientConfigFromMap(config map[string]string) *stackdriverClientConfig {
 	sc := &stackdriverClientConfig{}
-
-	if pi, ok := config[StackdriverProjectIDKey]; ok {
-		sc.ProjectID = pi
-	}
-
-	if gl, ok := config[StackdriverGCPLocationKey]; ok {
-		sc.GCPLocation = gl
-	}
-
-	if cn, ok := config[StackdriverClusterNameKey]; ok {
-		sc.ClusterName = cn
-	}
-
-	if gsn, ok := config[StackdriverGCPSecretNameKey]; ok {
-		sc.GCPSecretName = gsn
-	}
-
-	if gsns, ok := config[StackdriverGCPSecretNamespaceKey]; ok {
-		sc.GCPSecretNamespace = gsns
-	}
-
-	return sc, nil
+	sc.ProjectID = config[StackdriverProjectIDKey]
+	sc.GCPLocation = config[StackdriverGCPLocationKey]
+	sc.ClusterName = config[StackdriverClusterNameKey]
+	sc.GCPSecretName = config[StackdriverGCPSecretNameKey]
+	sc.GCPSecretNamespace = config[StackdriverGCPSecretNamespaceKey]
+	return sc
 }
 
 func createMetricsConfig(ops ExporterOptions, logger *zap.SugaredLogger) (*metricsConfig, error) {
@@ -206,10 +190,7 @@ func createMetricsConfig(ops ExporterOptions, logger *zap.SugaredLogger) (*metri
 	// use the application default credentials. If that is not available, Opencensus would fail to create the
 	// metrics exporter.
 	if mc.backendDestination == Stackdriver {
-		scc, err := newStackdriverClientConfigFromMap(m)
-		if err != nil {
-			return nil, err
-		}
+		scc := newStackdriverClientConfigFromMap(m)
 		mc.stackdriverClientConfig = *scc
 		mc.isStackdriverBackend = true
 		mc.stackdriverMetricTypePrefix = path.Join(mc.domain, mc.component)

--- a/metrics/config_test.go
+++ b/metrics/config_test.go
@@ -207,6 +207,7 @@ var (
 			ops: ExporterOptions{
 				ConfigMap: map[string]string{
 					"metrics.backend-destination":      "stackdriver",
+					"metrics.stackdriver-project-id":   anotherProj,
 					"metrics.stackdriver-gcp-location": "us-west1",
 					"metrics.stackdriver-cluster-name": "cluster",
 				},
@@ -223,6 +224,7 @@ var (
 				stackdriverCustomMetricTypePrefix: path.Join(customMetricTypePrefix, defaultCustomMetricSubDomain, testComponent),
 				stackdriverCustomMetricsSubDomain: defaultCustomMetricSubDomain,
 				stackdriverClientConfig: stackdriverClientConfig{
+					ProjectID:   anotherProj,
 					GCPLocation: "us-west1",
 					ClusterName: "cluster",
 				},
@@ -659,7 +661,6 @@ func TestIsNewExporterRequired(t *testing.T) {
 }
 
 func TestUpdateExporter(t *testing.T) {
-	getStackdriverSecretFunc = fakeGetStackdriverSecret
 	setCurMetricsConfig(nil)
 	oldConfig := getCurMetricsConfig()
 	for _, test := range successTests[1:] {

--- a/metrics/config_test.go
+++ b/metrics/config_test.go
@@ -809,10 +809,7 @@ func TestNewStackdriverConfigFromMap(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			c, err := newStackdriverClientConfigFromMap(test.stringMap)
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-			}
+			c := newStackdriverClientConfigFromMap(test.stringMap)
 			if test.expectedConfig != *c {
 				t.Errorf("Incorrect stackdriver config. Expected: [%v], Got: [%v]", test.expectedConfig, *c)
 			}

--- a/metrics/config_test.go
+++ b/metrics/config_test.go
@@ -174,8 +174,12 @@ var (
 			name: "validStackdriver",
 			ops: ExporterOptions{
 				ConfigMap: map[string]string{
-					"metrics.backend-destination":    "stackdriver",
-					"metrics.stackdriver-project-id": anotherProj,
+					"metrics.backend-destination":              "stackdriver",
+					"metrics.stackdriver-project-id":           anotherProj,
+					"metrics.stackdriver-gcp-location":         "us-west1",
+					"metrics.stackdriver-cluster-name":         "cluster",
+					"metrics.stackdriver-gcp-secret-name":      "secret",
+					"metrics.stackdriver-gcp-secret-namespace": "secret-ns",
 				},
 				Domain:    servingDomain,
 				Component: testComponent,
@@ -184,12 +188,44 @@ var (
 				domain:                            servingDomain,
 				component:                         testComponent,
 				backendDestination:                Stackdriver,
-				stackdriverProjectID:              anotherProj,
 				reportingPeriod:                   60 * time.Second,
 				isStackdriverBackend:              true,
 				stackdriverMetricTypePrefix:       path.Join(servingDomain, testComponent),
 				stackdriverCustomMetricTypePrefix: path.Join(customMetricTypePrefix, defaultCustomMetricSubDomain, testComponent),
 				stackdriverCustomMetricsSubDomain: defaultCustomMetricSubDomain,
+				stackdriverClientConfig: stackdriverClientConfig{
+					ProjectID:          anotherProj,
+					GCPLocation:        "us-west1",
+					ClusterName:        "cluster",
+					GCPSecretName:      "secret",
+					GCPSecretNamespace: "secret-ns",
+				},
+			},
+			expectedNewExporter: true,
+		}, {
+			name: "validPartialStackdriver",
+			ops: ExporterOptions{
+				ConfigMap: map[string]string{
+					"metrics.backend-destination":      "stackdriver",
+					"metrics.stackdriver-gcp-location": "us-west1",
+					"metrics.stackdriver-cluster-name": "cluster",
+				},
+				Domain:    servingDomain,
+				Component: testComponent,
+			},
+			expectedConfig: metricsConfig{
+				domain:                            servingDomain,
+				component:                         testComponent,
+				backendDestination:                Stackdriver,
+				reportingPeriod:                   60 * time.Second,
+				isStackdriverBackend:              true,
+				stackdriverMetricTypePrefix:       path.Join(servingDomain, testComponent),
+				stackdriverCustomMetricTypePrefix: path.Join(customMetricTypePrefix, defaultCustomMetricSubDomain, testComponent),
+				stackdriverCustomMetricsSubDomain: defaultCustomMetricSubDomain,
+				stackdriverClientConfig: stackdriverClientConfig{
+					GCPLocation: "us-west1",
+					ClusterName: "cluster",
+				},
 			},
 			expectedNewExporter: true,
 		}, {
@@ -223,12 +259,14 @@ var (
 				domain:                            servingDomain,
 				component:                         testComponent,
 				backendDestination:                Stackdriver,
-				stackdriverProjectID:              testProj,
 				reportingPeriod:                   60 * time.Second,
 				isStackdriverBackend:              true,
 				stackdriverMetricTypePrefix:       path.Join(servingDomain, testComponent),
 				stackdriverCustomMetricTypePrefix: path.Join(customMetricTypePrefix, defaultCustomMetricSubDomain, testComponent),
 				stackdriverCustomMetricsSubDomain: defaultCustomMetricSubDomain,
+				stackdriverClientConfig: stackdriverClientConfig{
+					ProjectID: testProj,
+				},
 			},
 			expectedNewExporter: true,
 		}, {
@@ -264,12 +302,14 @@ var (
 				domain:                            servingDomain,
 				component:                         testComponent,
 				backendDestination:                Stackdriver,
-				stackdriverProjectID:              "test2",
 				reportingPeriod:                   7 * time.Second,
 				isStackdriverBackend:              true,
 				stackdriverMetricTypePrefix:       path.Join(servingDomain, testComponent),
 				stackdriverCustomMetricTypePrefix: path.Join(customMetricTypePrefix, defaultCustomMetricSubDomain, testComponent),
 				stackdriverCustomMetricsSubDomain: defaultCustomMetricSubDomain,
+				stackdriverClientConfig: stackdriverClientConfig{
+					ProjectID: "test2",
+				},
 			},
 			expectedNewExporter: true,
 		}, {
@@ -287,12 +327,14 @@ var (
 				domain:                            servingDomain,
 				component:                         testComponent,
 				backendDestination:                Stackdriver,
-				stackdriverProjectID:              "test2",
 				reportingPeriod:                   3 * time.Second,
 				isStackdriverBackend:              true,
 				stackdriverMetricTypePrefix:       path.Join(servingDomain, testComponent),
 				stackdriverCustomMetricTypePrefix: path.Join(customMetricTypePrefix, defaultCustomMetricSubDomain, testComponent),
 				stackdriverCustomMetricsSubDomain: defaultCustomMetricSubDomain,
+				stackdriverClientConfig: stackdriverClientConfig{
+					ProjectID: "test2",
+				},
 			},
 		}, {
 			name: "emptyReportingPeriodPrometheus",
@@ -327,12 +369,14 @@ var (
 				domain:                            servingDomain,
 				component:                         testComponent,
 				backendDestination:                Stackdriver,
-				stackdriverProjectID:              "test2",
 				reportingPeriod:                   60 * time.Second,
 				isStackdriverBackend:              true,
 				stackdriverMetricTypePrefix:       path.Join(servingDomain, testComponent),
 				stackdriverCustomMetricTypePrefix: path.Join(customMetricTypePrefix, defaultCustomMetricSubDomain, testComponent),
 				stackdriverCustomMetricsSubDomain: defaultCustomMetricSubDomain,
+				stackdriverClientConfig: stackdriverClientConfig{
+					ProjectID: "test2",
+				},
 			},
 			expectedNewExporter: true,
 		}, {
@@ -351,13 +395,15 @@ var (
 				domain:                            servingDomain,
 				component:                         testComponent,
 				backendDestination:                Stackdriver,
-				stackdriverProjectID:              "test2",
 				reportingPeriod:                   60 * time.Second,
 				isStackdriverBackend:              true,
 				stackdriverMetricTypePrefix:       path.Join(servingDomain, testComponent),
 				stackdriverCustomMetricTypePrefix: path.Join(customMetricTypePrefix, defaultCustomMetricSubDomain, testComponent),
 				allowStackdriverCustomMetrics:     true,
 				stackdriverCustomMetricsSubDomain: defaultCustomMetricSubDomain,
+				stackdriverClientConfig: stackdriverClientConfig{
+					ProjectID: "test2",
+				},
 			},
 		}, {
 			name: "allowStackdriverCustomMetric with subdomain",
@@ -375,12 +421,14 @@ var (
 				domain:                            servingDomain,
 				component:                         testComponent,
 				backendDestination:                Stackdriver,
-				stackdriverProjectID:              "test2",
 				reportingPeriod:                   60 * time.Second,
 				isStackdriverBackend:              true,
 				stackdriverMetricTypePrefix:       path.Join(servingDomain, testComponent),
 				stackdriverCustomMetricTypePrefix: path.Join(customMetricTypePrefix, customSubDomain, testComponent),
 				stackdriverCustomMetricsSubDomain: customSubDomain,
+				stackdriverClientConfig: stackdriverClientConfig{
+					ProjectID: "test2",
+				},
 			},
 		}, {
 			name: "overridePrometheusPort",
@@ -482,7 +530,7 @@ func TestGetMetricsConfig_fromEnv(t *testing.T) {
 	os.Unsetenv(defaultBackendEnvName)
 }
 
-func TestIsNewExporterRequired(t *testing.T) {
+func TestIsNewExporterRequiredFromNilConfig(t *testing.T) {
 	setCurMetricsConfig(nil)
 	for _, test := range successTests {
 		t.Run(test.name, func(t *testing.T) {
@@ -498,24 +546,120 @@ func TestIsNewExporterRequired(t *testing.T) {
 			setCurMetricsConfig(mc)
 		})
 	}
+}
 
-	setCurMetricsConfig(&metricsConfig{
-		domain:             servingDomain,
-		component:          testComponent,
-		backendDestination: Prometheus})
-	newConfig := &metricsConfig{
-		domain:               servingDomain,
-		component:            testComponent,
-		backendDestination:   Prometheus,
-		stackdriverProjectID: testProj,
-	}
-	changed := isNewExporterRequired(newConfig)
-	if changed {
-		t.Error("isNewExporterRequired should be false if stackdriver project ID changes for prometheus backend")
+func TestIsNewExporterRequired(t *testing.T) {
+	tests := []struct {
+		name                string
+		oldConfig           metricsConfig
+		newConfig           metricsConfig
+		newExporterRequired bool
+	}{{
+		name: "backendPrometheusChangeStackdriverClientConfig",
+		oldConfig: metricsConfig{
+			domain:             servingDomain,
+			component:          testComponent,
+			backendDestination: Prometheus,
+		},
+		newConfig: metricsConfig{
+			domain:             servingDomain,
+			component:          testComponent,
+			backendDestination: Prometheus,
+			stackdriverClientConfig: stackdriverClientConfig{
+				ProjectID:   testProj,
+				ClusterName: "cluster",
+			},
+		},
+		newExporterRequired: false,
+	}, {
+		name: "changeMetricsBackend",
+		oldConfig: metricsConfig{
+			domain:                            servingDomain,
+			component:                         testComponent,
+			backendDestination:                Stackdriver,
+			reportingPeriod:                   60 * time.Second,
+			isStackdriverBackend:              true,
+			stackdriverMetricTypePrefix:       path.Join(servingDomain, testComponent),
+			stackdriverCustomMetricTypePrefix: path.Join(customMetricTypePrefix, defaultCustomMetricSubDomain, testComponent),
+			stackdriverCustomMetricsSubDomain: defaultCustomMetricSubDomain,
+		},
+		newConfig: metricsConfig{
+			domain:                            servingDomain,
+			component:                         testComponent,
+			backendDestination:                Prometheus,
+			reportingPeriod:                   60 * time.Second,
+			isStackdriverBackend:              true,
+			stackdriverMetricTypePrefix:       path.Join(servingDomain, testComponent),
+			stackdriverCustomMetricTypePrefix: path.Join(customMetricTypePrefix, defaultCustomMetricSubDomain, testComponent),
+			stackdriverCustomMetricsSubDomain: defaultCustomMetricSubDomain,
+		},
+		newExporterRequired: true,
+	}, {
+		name: "changeComponent",
+		oldConfig: metricsConfig{
+			domain:    servingDomain,
+			component: "component1",
+		},
+		newConfig: metricsConfig{
+			domain:    servingDomain,
+			component: "component2",
+		},
+		newExporterRequired: false,
+	}, {
+		name: "backendStackdriverChangeProjectID",
+		oldConfig: metricsConfig{
+			domain:             servingDomain,
+			component:          testComponent,
+			backendDestination: Stackdriver,
+			stackdriverClientConfig: stackdriverClientConfig{
+				ProjectID: "proj1",
+			},
+		},
+		newConfig: metricsConfig{
+			domain:             servingDomain,
+			component:          testComponent,
+			backendDestination: Stackdriver,
+			stackdriverClientConfig: stackdriverClientConfig{
+				ProjectID: "proj2",
+			},
+		},
+		newExporterRequired: true,
+	}, {
+		name: "backendStackdriverChangeStackdriverClientConfig",
+		oldConfig: metricsConfig{
+			domain:             servingDomain,
+			component:          testComponent,
+			backendDestination: Stackdriver,
+			stackdriverClientConfig: stackdriverClientConfig{
+				ProjectID:   testProj,
+				ClusterName: "cluster1",
+			},
+		},
+		newConfig: metricsConfig{
+			domain:             servingDomain,
+			component:          testComponent,
+			backendDestination: Stackdriver,
+			stackdriverClientConfig: stackdriverClientConfig{
+				ProjectID:   testProj,
+				ClusterName: "cluster2",
+			},
+		},
+		newExporterRequired: true,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setCurMetricsConfig(&test.oldConfig)
+			actualNewExporterRequired := isNewExporterRequired(&test.newConfig)
+			if test.newExporterRequired != actualNewExporterRequired {
+				t.Errorf("isNewExporterRequired returned incorrect value. Expected: [%v], Got: [%v]. Old config: [%v], New config: [%v]", test.newExporterRequired, actualNewExporterRequired, test.oldConfig, test.newConfig)
+			}
+		})
 	}
 }
 
 func TestUpdateExporter(t *testing.T) {
+	getStackdriverSecretFunc = fakeGetStackdriverSecret
 	setCurMetricsConfig(nil)
 	oldConfig := getCurMetricsConfig()
 	for _, test := range successTests[1:] {
@@ -615,6 +759,62 @@ func TestMetricsOptions(t *testing.T) {
 					t.Errorf("unexpected (-want, +got) = %v", diff)
 					t.Log(got)
 				}
+			}
+		})
+	}
+}
+
+func TestNewStackdriverConfigFromMap(t *testing.T) {
+	tests := []struct {
+		name           string
+		stringMap      map[string]string
+		expectedConfig stackdriverClientConfig
+	}{{
+		name: "fullSdConfig",
+		stringMap: map[string]string{
+			"metrics.stackdriver-project-id":           "project",
+			"metrics.stackdriver-gcp-location":         "us-west1",
+			"metrics.stackdriver-cluster-name":         "cluster",
+			"metrics.stackdriver-gcp-secret-name":      "secret",
+			"metrics.stackdriver-gcp-secret-namespace": "non-default",
+		},
+		expectedConfig: stackdriverClientConfig{
+			ProjectID:          "project",
+			GCPLocation:        "us-west1",
+			ClusterName:        "cluster",
+			GCPSecretName:      "secret",
+			GCPSecretNamespace: "non-default",
+		},
+	}, {
+		name:           "emptySdConfig",
+		stringMap:      map[string]string{},
+		expectedConfig: stackdriverClientConfig{},
+	}, {
+		name: "partialSdConfig",
+		stringMap: map[string]string{
+			"metrics.stackdriver-project-id":   "project",
+			"metrics.stackdriver-gcp-location": "us-west1",
+			"metrics.stackdriver-cluster-name": "cluster",
+		},
+		expectedConfig: stackdriverClientConfig{
+			ProjectID:   "project",
+			GCPLocation: "us-west1",
+			ClusterName: "cluster",
+		},
+	}, {
+		name:           "nil",
+		stringMap:      nil,
+		expectedConfig: stackdriverClientConfig{},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c, err := newStackdriverClientConfigFromMap(test.stringMap)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if test.expectedConfig != *c {
+				t.Errorf("Incorrect stackdriver config. Expected: [%v], Got: [%v]", test.expectedConfig, *c)
 			}
 		})
 	}

--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -79,12 +79,9 @@ func UpdateExporterFromConfigMap(component string, logger *zap.SugaredLogger) fu
 // to prevent a race condition between reading the current configuration
 // and updating the current exporter.
 func UpdateExporter(ops ExporterOptions, logger *zap.SugaredLogger) error {
-	metricsMux.Lock()
-	defer metricsMux.Unlock()
-
 	newConfig, err := createMetricsConfig(ops, logger)
 	if err != nil {
-		if curMetricsExporter == nil {
+		if getCurMetricsConfig() == nil {
 			// Fail the process if there doesn't exist an exporter.
 			logger.Errorw("Failed to get a valid metrics config", zap.Error(err))
 		} else {
@@ -95,18 +92,18 @@ func UpdateExporter(ops ExporterOptions, logger *zap.SugaredLogger) error {
 
 	if isNewExporterRequired(newConfig) {
 		logger.Info("Flushing the existing exporter before setting up the new exporter.")
-		flushExporterUnlocked(curMetricsExporter)
+		FlushExporter()
 		e, err := newMetricsExporter(newConfig, logger)
 		if err != nil {
 			logger.Errorf("Failed to update a new metrics exporter based on metric config %v. error: %v", newConfig, err)
 			return err
 		}
-		existingConfig := curMetricsConfig
-		setCurMetricsExporterUnlocked(e)
+		existingConfig := getCurMetricsConfig()
+		setCurMetricsExporter(e)
 		logger.Infof("Successfully updated the metrics exporter; old config: %v; new config %v", existingConfig, newConfig)
 	}
 
-	setCurMetricsConfigUnlocked(newConfig)
+	setCurMetricsConfig(newConfig)
 	return nil
 }
 
@@ -114,7 +111,7 @@ func UpdateExporter(ops ExporterOptions, logger *zap.SugaredLogger) error {
 // or stackdriver project ID changes for stackdriver backend, we need to update the metrics exporter.
 // This function is not implicitly thread-safe.
 func isNewExporterRequired(newConfig *metricsConfig) bool {
-	cc := curMetricsConfig
+	cc := getCurMetricsConfig()
 	if cc == nil || newConfig.backendDestination != cc.backendDestination {
 		return true
 	}
@@ -125,7 +122,7 @@ func isNewExporterRequired(newConfig *metricsConfig) bool {
 // newMetricsExporter gets a metrics exporter based on the config.
 // This function is not implicitly thread-safe.
 func newMetricsExporter(config *metricsConfig, logger *zap.SugaredLogger) (view.Exporter, error) {
-	ce := curMetricsExporter
+	ce := getCurMetricsExporter()
 	// If there is a Prometheus Exporter server running, stop it.
 	resetCurPromSrv()
 
@@ -159,10 +156,6 @@ func getCurMetricsExporter() view.Exporter {
 func setCurMetricsExporter(e view.Exporter) {
 	metricsMux.Lock()
 	defer metricsMux.Unlock()
-	setCurMetricsExporterUnlocked(e)
-}
-
-func setCurMetricsExporterUnlocked(e view.Exporter) {
 	view.RegisterExporter(e)
 	curMetricsExporter = e
 }
@@ -176,10 +169,6 @@ func getCurMetricsConfig() *metricsConfig {
 func setCurMetricsConfig(c *metricsConfig) {
 	metricsMux.Lock()
 	defer metricsMux.Unlock()
-	setCurMetricsConfigUnlocked(c)
-}
-
-func setCurMetricsConfigUnlocked(c *metricsConfig) {
 	if c != nil {
 		view.SetReportingPeriod(c.reportingPeriod)
 	} else {
@@ -194,10 +183,6 @@ func setCurMetricsConfigUnlocked(c *metricsConfig) {
 // Return value indicates whether the exporter is flushable or not.
 func FlushExporter() bool {
 	e := getCurMetricsExporter()
-	return flushExporterUnlocked(e)
-}
-
-func flushExporterUnlocked(e view.Exporter) bool {
 	if e == nil {
 		return false
 	}

--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -119,7 +119,7 @@ func isNewExporterRequired(newConfig *metricsConfig) bool {
 		return true
 	}
 
-	return newConfig.backendDestination == Stackdriver && newConfig.stackdriverProjectID != cc.stackdriverProjectID
+	return newConfig.backendDestination == Stackdriver && newConfig.stackdriverClientConfig != cc.stackdriverClientConfig
 }
 
 // newMetricsExporter gets a metrics exporter based on the config.

--- a/metrics/exporter_test.go
+++ b/metrics/exporter_test.go
@@ -293,6 +293,8 @@ func TestInterlevedExporters(t *testing.T) {
 }
 
 func TestFlushExporter(t *testing.T) {
+	// Capture this to reset it at the end of test so that other tests are not impacted.
+	tmpFunc := newStackdriverExporterFunc
 	// No exporter - no action should be taken
 	setCurMetricsConfig(nil)
 	if want, got := false, FlushExporter(); got != want {
@@ -353,4 +355,6 @@ func TestFlushExporter(t *testing.T) {
 			t.Errorf("Expected %v, got %v.", want, got)
 		}
 	}
+
+	newStackdriverExporterFunc = tmpFunc
 }

--- a/metrics/exporter_test.go
+++ b/metrics/exporter_test.go
@@ -95,13 +95,7 @@ func getResourceLabelValue(key string, tags []tag.Tag) string {
 
 func TestMain(m *testing.M) {
 	resetCurPromSrv()
-	// Set gcpMetadataFunc for testing
-	gcpMetadataFunc = emptyGcpMetadataFunc
 	os.Exit(m.Run())
-}
-
-func emptyGcpMetadataFunc() *gcpMetadata {
-	return &gcpMetadata{}
 }
 
 func TestMetricsExporter(t *testing.T) {
@@ -221,7 +215,7 @@ func TestMetricsExporter(t *testing.T) {
 				GCPSecretNamespace: "secret-ns",
 			},
 		},
-		expectSuccess: false,
+		expectSuccess: true,
 	}, {
 		name: "partialStackdriverConfig",
 		config: &metricsConfig{

--- a/metrics/exporter_test.go
+++ b/metrics/exporter_test.go
@@ -180,6 +180,8 @@ func TestMetricsExporter(t *testing.T) {
 		},
 		expectSuccess: true,
 	}, {
+		// GCP specifies a list of valid locations, check the exporter can be created
+		// even if an invalid location is passed in.
 		name: "invalidStackdriverGcpLocation",
 		config: &metricsConfig{
 			domain:                            servingDomain,

--- a/metrics/gcp_metadata.go
+++ b/metrics/gcp_metadata.go
@@ -33,17 +33,21 @@ func retrieveGCPMetadata() *gcpMetadata {
 		location: metricskey.ValueUnknown,
 		cluster:  metricskey.ValueUnknown,
 	}
-	project, err := metadata.NumericProjectID()
-	if err == nil && project != "" {
-		gm.project = project
+
+	if metadata.OnGCE() {
+		project, err := metadata.NumericProjectID()
+		if err == nil && project != "" {
+			gm.project = project
+		}
+		location, err := metadata.InstanceAttributeValue("cluster-location")
+		if err == nil && location != "" {
+			gm.location = location
+		}
+		cluster, err := metadata.InstanceAttributeValue("cluster-name")
+		if err == nil && cluster != "" {
+			gm.cluster = cluster
+		}
 	}
-	location, err := metadata.InstanceAttributeValue("cluster-location")
-	if err == nil && location != "" {
-		gm.location = location
-	}
-	cluster, err := metadata.InstanceAttributeValue("cluster-name")
-	if err == nil && cluster != "" {
-		gm.cluster = cluster
-	}
+
 	return &gm
 }

--- a/metrics/stackdriver_exporter.go
+++ b/metrics/stackdriver_exporter.go
@@ -101,7 +101,7 @@ func getStackdriverExporterClientOptions(sdconfig *stackdriverClientConfig) ([]o
 			return co, err
 		}
 
-		co = []option.ClientOption{convertSecretToExporterOption(secret)}
+		co = append(co, convertSecretToExporterOption(secret))
 	}
 
 	return co, nil
@@ -165,14 +165,13 @@ func getMetricTypeFunc(metricTypePrefix, customMetricTypePrefix string) func(vie
 
 // getStackdriverSecret returns the Kubernetes Secret specified in the given config.
 func getStackdriverSecret(sdconfig *stackdriverClientConfig) (*corev1.Secret, error) {
-	err := ensureKubeclient()
-	if err != nil {
+	if err := ensureKubeclient(); err != nil {
 		return nil, err
 	}
 
-	ns := secretNamespaceDefault
-	if sdconfig.GCPSecretNamespace != "" {
-		ns = sdconfig.GCPSecretNamespace
+	ns := sdconfig.GCPSecretNamespace
+	if ns == "" {
+		ns = secretNamespaceDefault
 	}
 
 	sec, secErr := kubeclient.CoreV1().Secrets(ns).Get(sdconfig.GCPSecretName, metav1.GetOptions{})

--- a/metrics/stackdriver_exporter.go
+++ b/metrics/stackdriver_exporter.go
@@ -46,12 +46,6 @@ const (
 )
 
 var (
-	// gcpMetadataFunc is the function used to fetch GCP metadata.
-	// In product usage, this is always set to function retrieveGCPMetadata.
-	// In unit tests this is set to a fake one to avoid calling GCP metadata
-	// service.
-	gcpMetadataFunc func() *gcpMetadata
-
 	// kubeclient is the in-cluster Kubernetes kubeclient, which is lazy-initialized on first use.
 	kubeclient *kubernetes.Clientset
 	// initClientOnce is the lazy initializer for kubeclient.
@@ -61,9 +55,6 @@ var (
 )
 
 func init() {
-	// Set gcpMetadataFunc to call GCP metadata service.
-	gcpMetadataFunc = retrieveGCPMetadata
-
 	kubeclientInitErr = nil
 }
 
@@ -118,7 +109,7 @@ func getStackdriverExporterClientOptions(sdconfig *stackdriverClientConfig) ([]o
 // getGCPMetadata returns GCP metadata required to export metrics
 // to Stackdriver. Values explicitly set in the config take the highest precedent.
 func getGCPMetadata(config *metricsConfig) *gcpMetadata {
-	gm := gcpMetadataFunc()
+	gm := retrieveGCPMetadata()
 	if config.stackdriverClientConfig.ProjectID != "" {
 		gm.project = config.stackdriverClientConfig.ProjectID
 	}

--- a/metrics/stackdriver_exporter.go
+++ b/metrics/stackdriver_exporter.go
@@ -93,14 +93,14 @@ func newOpencensusSDExporter(o stackdriver.Options) (view.Exporter, error) {
 func newStackdriverExporter(config *metricsConfig, logger *zap.SugaredLogger) (view.Exporter, error) {
 	gm := getGCPMetadata(config)
 	mtf := getMetricTypeFunc(config.stackdriverMetricTypePrefix, config.stackdriverCustomMetricTypePrefix)
-	co, err := getStackdriverExporterOptions(&config.stackdriverClientConfig)
+	co, err := getStackdriverExporterClientOptions(&config.stackdriverClientConfig)
 	if err != nil {
 		logger.Warnw("Issue configuring Stackdriver exporter client options, no additional client options will be used: ", zap.Error(err))
 	}
 	// Automatically fall back on Google application default credentials
 	e, err := newStackdriverExporterFunc(stackdriver.Options{
-		ProjectID:               config.stackdriverClientConfig.ProjectID,
-		Location:                config.stackdriverClientConfig.GCPLocation,
+		ProjectID:               gm.project,
+		Location:                gm.location,
 		MonitoringClientOptions: co,
 		TraceClientOptions:      co,
 		GetMetricDisplayName:    mtf, // Use metric type for display name for custom metrics. No impact on built-in metrics.
@@ -116,9 +116,9 @@ func newStackdriverExporter(config *metricsConfig, logger *zap.SugaredLogger) (v
 	return e, nil
 }
 
-// getStackdriverExporterOptions creates client options for the opencensus Stackdriver exporter from the given stackdriverClientConfig.
+// getStackdriverExporterClientOptions creates client options for the opencensus Stackdriver exporter from the given stackdriverClientConfig.
 // On error, an empty array of client options is returned.
-func getStackdriverExporterOptions(sdconfig *stackdriverClientConfig) ([]option.ClientOption, error) {
+func getStackdriverExporterClientOptions(sdconfig *stackdriverClientConfig) ([]option.ClientOption, error) {
 	var co []option.ClientOption
 	if sdconfig.GCPSecretName != "" {
 		secret, err := getStackdriverSecretFunc(sdconfig)

--- a/metrics/stackdriver_exporter_test.go
+++ b/metrics/stackdriver_exporter_test.go
@@ -446,7 +446,7 @@ func TestNewStackdriverExporterWithMetadata(t *testing.T) {
 				GCPSecretNamespace: "secret-ns",
 			},
 		},
-		expectSuccess: false,
+		expectSuccess: true,
 	}, {
 		name: "partialStackdriverConfig",
 		config: &metricsConfig{

--- a/metrics/stackdriver_exporter_test.go
+++ b/metrics/stackdriver_exporter_test.go
@@ -426,7 +426,7 @@ func TestNewStackdriverExporterWithMetadata(t *testing.T) {
 				GCPSecretNamespace: "secret-ns",
 			},
 		},
-		expectSuccess: false,
+		expectSuccess: true,
 	}, {
 		name: "partialStackdriverConfig",
 		config: &metricsConfig{

--- a/metrics/stackdriver_exporter_test.go
+++ b/metrics/stackdriver_exporter_test.go
@@ -17,16 +17,13 @@ limitations under the License.
 package metrics
 
 import (
-	"errors"
 	"path"
 	"testing"
 	"time"
 
-	"contrib.go.opencensus.io/exporter/stackdriver"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
-	corev1 "k8s.io/api/core/v1"
 	. "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/metrics/metricskey"
 )
@@ -136,23 +133,6 @@ var (
 		metricName: "unsupported",
 	}}
 )
-
-func fakeGcpMetadataFun() *gcpMetadata {
-	return &testGcpMetadata
-}
-
-func fakeGetStackdriverSecret(config *stackdriverClientConfig) (*corev1.Secret, error) {
-	return nil, errors.New("tests do no have access to Kubernetes client to retrieve Kubernetes Secrets")
-}
-
-type fakeExporter struct{}
-
-func (fe *fakeExporter) ExportView(vd *view.Data) {}
-func (fe *fakeExporter) Flush()                   {}
-
-func newFakeExporter(o stackdriver.Options) (view.Exporter, error) {
-	return &fakeExporter{}, nil
-}
 
 func TestGetMonitoredResourceFunc_UseKnativeRevision(t *testing.T) {
 	for _, testCase := range supportedServingMetricsTestCases {
@@ -446,7 +426,7 @@ func TestNewStackdriverExporterWithMetadata(t *testing.T) {
 				GCPSecretNamespace: "secret-ns",
 			},
 		},
-		expectSuccess: true,
+		expectSuccess: false,
 	}, {
 		name: "partialStackdriverConfig",
 		config: &metricsConfig{
@@ -465,7 +445,6 @@ func TestNewStackdriverExporterWithMetadata(t *testing.T) {
 		expectSuccess: true,
 	}}
 
-	getStackdriverSecretFunc = fakeGetStackdriverSecret
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			e, err := newStackdriverExporter(test.config, TestLogger(t))


### PR DESCRIPTION
Add ability to configure Stackdriver client metadata for the metrics package's Stackdriver exporter.

Currently, Stackdriver metrics rely on the Google Compute Engine metadata server, which is only accessible on GCE, to configure the Stackdriver client. This allows sending metrics to Stackdriver on any compute platform.

The new fields are optional and purely additive and do not break existing usage. If omitted, Stackdriver will fall back on Google Application Credentials defaults (https://cloud.google.com/docs/authentication/production).

Configuration required for knative/serving#5777