### PR TITLE
Change built-in metrics to use internal ones for activator and revision

### DIFF
--- a/metrics/config_test.go
+++ b/metrics/config_test.go
@@ -31,12 +31,13 @@ import (
 // 	See https://github.com/knative/pkg/issues/608
 
 const (
-	servingDomain   = "knative.dev/serving"
-	eventingDomain  = "knative.dev/eventing"
-	customSubDomain = "test.domain"
-	testComponent   = "testComponent"
-	testProj        = "test-project"
-	anotherProj     = "another-project"
+	servingDomain         = "knative.dev/serving"
+	internalServingDomain = "knative.dev/internal/serving"
+	eventingDomain        = "knative.dev/eventing"
+	customSubDomain       = "test.domain"
+	testComponent         = "testComponent"
+	testProj              = "test-project"
+	anotherProj           = "another-project"
 )
 
 var (

--- a/metrics/metricskey/constants_serving.go
+++ b/metrics/metricskey/constants_serving.go
@@ -53,8 +53,8 @@ var (
 	// KnativeRevisionMetrics stores a set of metric types which are supported
 	// by resource type knative_revision.
 	KnativeRevisionMetrics = sets.NewString(
-		"knative.dev/serving/activator/request_count",
-		"knative.dev/serving/activator/request_latencies",
+		"knative.dev/internal/serving/activator/request_count",
+		"knative.dev/internal/serving/activator/request_latencies",
 		"knative.dev/serving/autoscaler/desired_pods",
 		"knative.dev/serving/autoscaler/requested_pods",
 		"knative.dev/serving/autoscaler/actual_pods",
@@ -62,7 +62,7 @@ var (
 		"knative.dev/serving/autoscaler/panic_request_concurrency",
 		"knative.dev/serving/autoscaler/target_concurrency_per_pod",
 		"knative.dev/serving/autoscaler/panic_mode",
-		"knative.dev/serving/revision/request_count",
-		"knative.dev/serving/revision/request_latencies",
+		"knative.dev/internal/serving/revision/request_count",
+		"knative.dev/internal/serving/revision/request_latencies",
 	)
 )

--- a/metrics/record_test.go
+++ b/metrics/record_test.go
@@ -47,7 +47,7 @@ func TestRecordServing(t *testing.T) {
 			name: "stackdriver backend with supported metric",
 			metricsConfig: &metricsConfig{
 				isStackdriverBackend:        true,
-				stackdriverMetricTypePrefix: "knative.dev/serving/activator",
+				stackdriverMetricTypePrefix: "knative.dev/internal/serving/activator",
 			},
 			measurement: measure.M(2),
 		}, {

--- a/metrics/stackdriver_exporter_test.go
+++ b/metrics/stackdriver_exporter_test.go
@@ -45,7 +45,7 @@ var (
 		metricName string
 	}{{
 		name:       "activator metric",
-		domain:     servingDomain,
+		domain:     internalServingDomain,
 		component:  "activator",
 		metricName: "request_count",
 	}, {
@@ -313,7 +313,7 @@ func TestGetMonitoredResourceFunc_UseGlobal(t *testing.T) {
 	}
 }
 
-func TestGetgetMetricTypeFunc_UseKnativeDomain(t *testing.T) {
+func TestGetMetricTypeFunc_UseKnativeDomain(t *testing.T) {
 	for _, testCase := range supportedServingMetricsTestCases {
 		testView = &view.View{
 			Description: "Test View",


### PR DESCRIPTION
The internal ones accept pod and container names in order to fix https://github.com/knative/serving/issues/5691