### PR TITLE
Stop using OwnerRefs for webhook config lifecycle

### DIFF
--- a/webhook/config_validation_controller_test.go
+++ b/webhook/config_validation_controller_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strconv"
 	"testing"
 
@@ -32,6 +31,7 @@ import (
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/system"
 
 	_ "knative.dev/pkg/system/testing"
@@ -88,8 +88,8 @@ func TestUpdatingConfigValidationController(t *testing.T) {
 	}
 
 	currentWebhook, _ := kubeClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(initialConfigWebhook.Name, metav1.GetOptions{})
-	if reflect.DeepEqual(currentWebhook.Webhooks, initialConfigWebhook.Webhooks) {
-		t.Fatalf("Expected webhook to be updated")
+	if ok, err := kmp.SafeEqual(currentWebhook.Webhooks, initialConfigWebhook.Webhooks); ok || err != nil {
+		t.Fatalf("Expected webhook to be updated: %v", err)
 	}
 
 	if len(currentWebhook.OwnerReferences) > 0 {

--- a/webhook/resource_admission_controller.go
+++ b/webhook/resource_admission_controller.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -32,7 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 
@@ -40,6 +40,7 @@ import (
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/ptr"
 )
 
 // ResourceCallback defines a signature for resource specific (Route, Configuration, etc.)
@@ -108,7 +109,6 @@ func (ac *ResourceAdmissionController) Admit(ctx context.Context, request *admis
 func (ac *ResourceAdmissionController) Register(ctx context.Context, kubeClient kubernetes.Interface, caCert []byte) error {
 	client := kubeClient.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
 	logger := logging.FromContext(ctx)
-	failurePolicy := admissionregistrationv1beta1.Fail
 
 	var rules []admissionregistrationv1beta1.RuleWithOperations
 	for gvk := range ac.handlers {
@@ -139,58 +139,32 @@ func (ac *ResourceAdmissionController) Register(ctx context.Context, kubeClient 
 		return lhs.Resources[0] < rhs.Resources[0]
 	})
 
-	webhook := &admissionregistrationv1beta1.MutatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ac.options.ResourceMutatingWebhookName,
-		},
-		Webhooks: []admissionregistrationv1beta1.MutatingWebhook{{
-			Name:  ac.options.ResourceMutatingWebhookName,
-			Rules: rules,
-			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
-				Service: &admissionregistrationv1beta1.ServiceReference{
-					Namespace: ac.options.Namespace,
-					Name:      ac.options.ServiceName,
-					Path:      &ac.options.ResourceAdmissionControllerPath,
-				},
-				CABundle: caCert,
-			},
-			FailurePolicy: &failurePolicy,
-		}},
+	configuredWebhook, err := client.Get(ac.options.ResourceMutatingWebhookName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error retrieving webhook: %v", err)
 	}
 
-	// Set the owner to our deployment.
-	deployment, err := kubeClient.AppsV1().Deployments(ac.options.Namespace).Get(ac.options.DeploymentName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to fetch our deployment: %v", err)
+	webhook := configuredWebhook.DeepCopy()
+	if len(webhook.Webhooks) != 1 {
+		return fmt.Errorf("unexpected number of webhook entries: %d", len(webhook.Webhooks))
 	}
-	deploymentRef := metav1.NewControllerRef(deployment, deploymentKind)
-	webhook.OwnerReferences = append(webhook.OwnerReferences, *deploymentRef)
+	webhook.OwnerReferences = nil
+	webhook.Webhooks[0].Rules = rules
+	webhook.Webhooks[0].ClientConfig.CABundle = caCert
+	if webhook.Webhooks[0].ClientConfig.Service == nil {
+		return errors.New("missing service reference")
+	}
+	webhook.Webhooks[0].ClientConfig.Service.Path = ptr.String(ac.options.ResourceAdmissionControllerPath)
 
-	// Try to create the webhook and if it already exists validate webhook rules.
-	_, err = client.Create(webhook)
-	if err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("failed to create a webhook: %v", err)
-		}
-		logger.Info("Webhook already exists")
-		configuredWebhook, err := client.Get(ac.options.ResourceMutatingWebhookName, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("error retrieving webhook: %v", err)
-		}
-		if ok, err := kmp.SafeEqual(configuredWebhook.Webhooks, webhook.Webhooks); err != nil {
-			return fmt.Errorf("error diffing webhooks: %v", err)
-		} else if !ok {
-			logger.Info("Updating webhook")
-			// Set the ResourceVersion as required by update.
-			webhook.ObjectMeta.ResourceVersion = configuredWebhook.ObjectMeta.ResourceVersion
-			if _, err := client.Update(webhook); err != nil {
-				return fmt.Errorf("failed to update webhook: %s", err)
-			}
-		} else {
-			logger.Info("Webhook is already valid")
+	if ok, err := kmp.SafeEqual(configuredWebhook, webhook); err != nil {
+		return fmt.Errorf("error diffing webhooks: %v", err)
+	} else if !ok {
+		logger.Info("Updating webhook")
+		if _, err := client.Update(webhook); err != nil {
+			return fmt.Errorf("failed to update webhook: %v", err)
 		}
 	} else {
-		logger.Info("Created a webhook")
+		logger.Info("Webhook is already valid")
 	}
 	return nil
 }


### PR DESCRIPTION
This changes the model by which we manage the lifecycle of our
`{mutating,validating}webhookconfiguration`, which previously used an owner ref
from the cluster-scoped configuration to the namespace-scoped Deployment.  The
new model adds an explicit yaml file for the webhook, which omits the fields
filled in by the deployment as it starts.

A few notable elements of this change:
1. Clear out OwnerReferences explicitly (avoids the linked bug),
2. Periodically reruna `Register()` to ensure our webhook exists,
3. Simplified logic around registration (all we need now is update!).

Related: https://github.com/knative/serving/issues/5845