### PR TITLE
golang format tools

### DIFF
--- a/resolver/addressable_resolver.go
+++ b/resolver/addressable_resolver.go
@@ -65,14 +65,14 @@ func NewURIResolver(ctx context.Context, callback func(types.NamespacedName)) *U
 // URIFromDestination resolves a Destination into a URI string.
 func (r *URIResolver) URIFromDestination(dest apisv1alpha1.Destination, parent interface{}) (string, error) {
 	var deprecatedObjectReference *corev1.ObjectReference
-	if dest.DeprecatedAPIVersion == "" && dest.DeprecatedKind == "" && dest.DeprecatedName == "" && dest.DeprecatedNamespace == ""{
+	if dest.DeprecatedAPIVersion == "" && dest.DeprecatedKind == "" && dest.DeprecatedName == "" && dest.DeprecatedNamespace == "" {
 		deprecatedObjectReference = nil
 	} else {
 		deprecatedObjectReference = &corev1.ObjectReference{
-			Kind:            dest.DeprecatedKind,
-			APIVersion:       dest.DeprecatedAPIVersion,
-			Name:            dest.DeprecatedName,
-			Namespace:       dest.DeprecatedNamespace,
+			Kind:       dest.DeprecatedKind,
+			APIVersion: dest.DeprecatedAPIVersion,
+			Name:       dest.DeprecatedName,
+			Namespace:  dest.DeprecatedNamespace,
 		}
 	}
 	if dest.Ref != nil && deprecatedObjectReference != nil {

--- a/resolver/addressable_resolver_test.go
+++ b/resolver/addressable_resolver_test.go
@@ -103,23 +103,23 @@ func TestGetURI_ObjectReference(t *testing.T) {
 			wantErr: fmt.Errorf("ref and [apiVersion, kind, name] can't be both present"),
 		},
 		"happy ref": {
-		objects: []runtime.Object{
-			getAddressable(),
-		},
-		dest:    apisv1alpha1.Destination{Ref: getAddressableRef()},
-		wantURI: addressableDNS,
-	}, "ref with relative uri": {
-		objects: []runtime.Object{
-			getAddressable(),
-		},
-		dest: apisv1alpha1.Destination{
-			Ref: getAddressableRef(),
-			URI: &apis.URL{
-			Path:   "/foo",
+			objects: []runtime.Object{
+				getAddressable(),
 			},
-		},
-		wantURI: addressableDNS + "/foo",
-	}, "ref with relative URI without leading slash": {
+			dest:    apisv1alpha1.Destination{Ref: getAddressableRef()},
+			wantURI: addressableDNS,
+		}, "ref with relative uri": {
+			objects: []runtime.Object{
+				getAddressable(),
+			},
+			dest: apisv1alpha1.Destination{
+				Ref: getAddressableRef(),
+				URI: &apis.URL{
+					Path: "/foo",
+				},
+			},
+			wantURI: addressableDNS + "/foo",
+		}, "ref with relative URI without leading slash": {
 			objects: []runtime.Object{
 				getAddressable(),
 			},
@@ -192,11 +192,11 @@ func TestGetURI_ObjectReference(t *testing.T) {
 			objects: []runtime.Object{
 				getAddressable(),
 			},
-			dest:    apisv1alpha1.Destination{
+			dest: apisv1alpha1.Destination{
 				DeprecatedKind:       addressableKind,
 				DeprecatedName:       addressableName,
 				DeprecatedAPIVersion: addressableAPIVersion,
-				DeprecatedNamespace:  testNS,},
+				DeprecatedNamespace:  testNS},
 			wantURI: addressableDNS,
 		},
 		"[apiVersion, kind, name] with relative uri": {


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign mattmoor
