### PR TITLE
Log type instead of <nil> in injection panic message

### DIFF
--- a/injection/clients/dynamicclient/dynamicclient.go
+++ b/injection/clients/dynamicclient/dynamicclient.go
@@ -42,8 +42,8 @@ func withClient(ctx context.Context, cfg *rest.Config) context.Context {
 func Get(ctx context.Context) dynamic.Interface {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
-		logging.FromContext(ctx).Panicf(
-			"Unable to fetch %T from context.", (dynamic.Interface)(nil))
+		logging.FromContext(ctx).Panic(
+			"Unable to fetch k8s.io/client-go/dynamic.Interface from context.")
 	}
 	return untyped.(dynamic.Interface)
 }


### PR DESCRIPTION
The current error message gets formatted as `Unable to fetch <nil> from context.`, which is not useful.

`injection-gen` makes the type part of the error string, unformated, so I just did the same here.