### PR TITLE
Add ref normalizing method to Destination

### DIFF
--- a/apis/v1alpha1/destination.go
+++ b/apis/v1alpha1/destination.go
@@ -149,13 +149,13 @@ func (dest *Destination) GetRef() *corev1.ObjectReference {
 	return nil
 }
 
-// NormalizeDeprecatedObjectReference copies the deprecated ObjectReference
+// NormalizeObjectReference copies the deprecated ObjectReference
 // fields to the Ref field and clears the deprecated fields. It uses the same
 // precedence rules as GetRef(). Use this to normalize code to use the Ref field
 // when deprecated fields may exist.
 // This method should be removed when the deprecated ObjectReference fields are
 // removed.
-func (dest *Destination) NormalizeDeprecatedObjectReference() {
+func (dest *Destination) NormalizeObjectReference() {
 	if dest == nil {
 		return
 	}

--- a/apis/v1alpha1/destination.go
+++ b/apis/v1alpha1/destination.go
@@ -149,16 +149,17 @@ func (dest *Destination) GetRef() *corev1.ObjectReference {
 	return nil
 }
 
-// NormalizeObjectReference copies the deprecated ObjectReference
-// fields to the Ref field and clears the deprecated fields. It uses the same
-// precedence rules as GetRef(). Use this to normalize code to use the Ref field
-// when deprecated fields may exist.
+// NormalizeDestinationObjectReference returns a new Destination with the
+// deprecated ObjectReference fields copied to the Ref field and cleared. It
+// uses the same precedence rules as GetRef(). Use this to normalize code to use
+// the Ref field when deprecated fields may exist.
 // This method should be removed when the deprecated ObjectReference fields are
 // removed.
-func (dest *Destination) NormalizeObjectReference() {
-	if dest == nil {
-		return
+func NormalizeDestinationObjectReference(in *Destination) *Destination {
+	if in == nil {
+		return nil
 	}
+	dest := in.DeepCopy()
 	if ref := dest.GetRef(); ref != nil {
 		dest.Ref = ref
 	}
@@ -166,6 +167,7 @@ func (dest *Destination) NormalizeObjectReference() {
 	dest.DeprecatedKind = ""
 	dest.DeprecatedName = ""
 	dest.DeprecatedNamespace = ""
+	return dest
 }
 
 func validateDestinationRef(ref corev1.ObjectReference) *apis.FieldError {

--- a/apis/v1alpha1/destination_test.go
+++ b/apis/v1alpha1/destination_test.go
@@ -426,7 +426,7 @@ func TestDestination_GetRef(t *testing.T) {
 	}
 }
 
-func TestDestination_NormalizeDeprecatedObjectReference(t *testing.T) {
+func TestDestination_NormalizeObjectReference(t *testing.T) {
 	tests := map[string]struct {
 		dest *Destination
 		want *Destination
@@ -488,7 +488,7 @@ func TestDestination_NormalizeDeprecatedObjectReference(t *testing.T) {
 
 	for n, tc := range tests {
 		t.Run(n, func(t *testing.T) {
-			tc.dest.NormalizeDeprecatedObjectReference()
+			tc.dest.NormalizeObjectReference()
 			if diff := cmp.Diff(tc.want, tc.dest); diff != "" {
 				t.Errorf("Unexpected result (-want +got): %s", diff)
 			}

--- a/apis/v1alpha1/destination_test.go
+++ b/apis/v1alpha1/destination_test.go
@@ -425,3 +425,73 @@ func TestDestination_GetRef(t *testing.T) {
 		})
 	}
 }
+
+func TestDestination_NormalizeDeprecatedObjectReference(t *testing.T) {
+	tests := map[string]struct {
+		dest *Destination
+		want *Destination
+	}{
+		"nil destination": {
+			dest: nil,
+			want: nil,
+		},
+		"contains deprecated fields": {
+			dest: &Destination{
+				DeprecatedAPIVersion: apiVersion,
+				DeprecatedKind:       kind,
+				DeprecatedName:       name,
+			},
+			want: &Destination{
+				Ref: &corev1.ObjectReference{
+					APIVersion: apiVersion,
+					Kind:       kind,
+					Name:       name,
+				},
+			},
+		},
+		"contains deprecated fields and ref": {
+			dest: &Destination{
+				DeprecatedAPIVersion: "depapiVersion",
+				DeprecatedKind:       "depKind",
+				DeprecatedName:       "depName",
+				Ref: &corev1.ObjectReference{
+					APIVersion: apiVersion,
+					Kind:       kind,
+					Name:       name,
+				},
+			},
+			want: &Destination{
+				Ref: &corev1.ObjectReference{
+					APIVersion: apiVersion,
+					Kind:       kind,
+					Name:       name,
+				},
+			},
+		},
+		"no deprecated fields": {
+			dest: &Destination{
+				Ref: &corev1.ObjectReference{
+					APIVersion: apiVersion,
+					Kind:       kind,
+					Name:       name,
+				},
+			},
+			want: &Destination{
+				Ref: &corev1.ObjectReference{
+					APIVersion: apiVersion,
+					Kind:       kind,
+					Name:       name,
+				},
+			},
+		},
+	}
+
+	for n, tc := range tests {
+		t.Run(n, func(t *testing.T) {
+			tc.dest.NormalizeDeprecatedObjectReference()
+			if diff := cmp.Diff(tc.want, tc.dest); diff != "" {
+				t.Errorf("Unexpected result (-want +got): %s", diff)
+			}
+		})
+	}
+}

--- a/resolver/addressable_resolver.go
+++ b/resolver/addressable_resolver.go
@@ -62,7 +62,10 @@ func NewURIResolver(ctx context.Context, callback func(types.NamespacedName)) *U
 	return ret
 }
 
-// URIFromDestination resolves a Destination into a URI string.
+// URIFromDestination resolves a Destination into a URI string. If an
+// ObjectReference is present, its Addressable URI is resolved. If a URI is
+// also present, it's resolved as a URI reference with the Addressable URI as
+// base. If no ObjectReference is present, the Destination's URI is returned.
 func (r *URIResolver) URIFromDestination(dest apisv1alpha1.Destination, parent interface{}) (string, error) {
 	var deprecatedObjectReference *corev1.ObjectReference
 	if dest.DeprecatedAPIVersion == "" && dest.DeprecatedKind == "" && dest.DeprecatedName == "" && dest.DeprecatedNamespace == "" {


### PR DESCRIPTION
`NormalizeDeprecatedObjectReference` updates the Destination to the desired end state post-deprecation. Using this method allows code to ignore the deprecated fields and just operate on Destination's Ref field.

We can use this in sources to first set the Ref, then update its namespace to the current source's namespace as required by URIResolver.

I left the resolver's deprecated fields handling code in place so other projects can continue to use the deprecated fields without normalizing first.

/cc @n3wscott @Harwayne @vaikas-google 