### PR TITLE
Removing Namespace from Destination

### DIFF
--- a/apis/v1alpha1/destination.go
+++ b/apis/v1alpha1/destination.go
@@ -80,7 +80,7 @@ func ValidateDestination(dest Destination, allowDeprecatedFields bool) *apis.Fie
 
 	deprecatedObjectReference := dest.deprecatedObjectReference()
 	if dest.Ref != nil && deprecatedObjectReference != nil {
-		return apis.ErrGeneric("Ref and [apiVersion, kind, name] can't be both present", "[apiVersion, kind, name]", "ref")
+		return apis.ErrGeneric("ref and [apiVersion, kind, name] can't be both present", "[apiVersion, kind, name]", "ref")
 	}
 
 	var ref *corev1.ObjectReference
@@ -94,11 +94,11 @@ func ValidateDestination(dest Destination, allowDeprecatedFields bool) *apis.Fie
 	}
 
 	if ref != nil && dest.URI != nil && dest.URI.URL().IsAbs() {
-		return apis.ErrGeneric("Absolute URI is not allowed when Ref or [apiVersion, kind, name] is present", "[apiVersion, kind, name]", "ref", "uri")
+		return apis.ErrGeneric("absolute URI is not allowed when Ref or [apiVersion, kind, name] is present", "[apiVersion, kind, name]", "ref", "uri")
 	}
 	// IsAbs() check whether the URL has a non-empty scheme. Besides the non-empty scheme, we also require dest.URI has a non-empty host
 	if ref == nil && dest.URI != nil && (!dest.URI.URL().IsAbs() || dest.URI.Host == "") {
-		return apis.ErrInvalidValue("Relative URI is not allowed when Ref and [apiVersion, kind, name] is absent", "uri")
+		return apis.ErrInvalidValue("relative URI is not allowed when Ref and [apiVersion, kind, name] is absent", "uri")
 	}
 	if ref != nil && dest.URI == nil {
 		if dest.Ref != nil {

--- a/apis/v1alpha1/destination_test.go
+++ b/apis/v1alpha1/destination_test.go
@@ -86,6 +86,17 @@ func TestValidateDestination(t *testing.T) {
 			},
 			want: "missing field(s): ref.kind",
 		},
+		"invalid ref, extra namespace": {
+			dest: &Destination{
+				Ref: &corev1.ObjectReference{
+					Kind:       kind,
+					APIVersion: apiVersion,
+					Name:       name,
+					Namespace:  "invalid",
+				},
+			},
+			want: "must not set the field(s): ref.Namespace\nonly name, apiVersion and kind are supported fields",
+		},
 		"valid [apiVersion, kind, name]": {
 			dest: &Destination{
 				DeprecatedKind:       kind,
@@ -258,6 +269,17 @@ func TestValidateDestinationDisallowDeprecated(t *testing.T) {
 				},
 			},
 			want: "missing field(s): ref.kind",
+		},
+		"invalid ref, extra namespace": {
+			dest: &Destination{
+				Ref: &corev1.ObjectReference{
+					Kind:       kind,
+					APIVersion: apiVersion,
+					Name:       name,
+					Namespace:  "invalid",
+				},
+			},
+			want: "must not set the field(s): ref.Namespace\nonly name, apiVersion and kind are supported fields",
 		},
 		"invalid deprecated [apiVersion, kind, name]": {
 			dest: &Destination{

--- a/apis/v1alpha1/destination_test.go
+++ b/apis/v1alpha1/destination_test.go
@@ -137,7 +137,7 @@ func TestValidateDestination(t *testing.T) {
 					Scheme: "http",
 				},
 			},
-			want: "invalid value: Relative URI is not allowed when Ref and [apiVersion, kind, name] is absent: uri",
+			want: "invalid value: relative URI is not allowed when Ref and [apiVersion, kind, name] is absent: uri",
 		},
 		"invalid, uri is not absolute url": {
 			dest: &Destination{
@@ -145,7 +145,7 @@ func TestValidateDestination(t *testing.T) {
 					Host: "host",
 				},
 			},
-			want: "invalid value: Relative URI is not allowed when Ref and [apiVersion, kind, name] is absent: uri",
+			want: "invalid value: relative URI is not allowed when Ref and [apiVersion, kind, name] is absent: uri",
 		},
 		"invalid, both ref and [apiVersion, kind, name] are present ": {
 			dest: &Destination{
@@ -158,14 +158,14 @@ func TestValidateDestination(t *testing.T) {
 				DeprecatedAPIVersion: apiVersion,
 				DeprecatedName:       name,
 			},
-			want: "Ref and [apiVersion, kind, name] can't be both present: [apiVersion, kind, name], ref",
+			want: "ref and [apiVersion, kind, name] can't be both present: [apiVersion, kind, name], ref",
 		},
 		"invalid, both uri and ref, uri is absolute URL": {
 			dest: &Destination{
 				URI: &validURL,
 				Ref: &validRef,
 			},
-			want: "Absolute URI is not allowed when Ref or [apiVersion, kind, name] is present: [apiVersion, kind, name], ref, uri",
+			want: "absolute URI is not allowed when Ref or [apiVersion, kind, name] is present: [apiVersion, kind, name], ref, uri",
 		},
 		"invalid, both uri and [apiVersion, kind, name], uri is absolute URL": {
 			dest: &Destination{
@@ -174,7 +174,7 @@ func TestValidateDestination(t *testing.T) {
 				DeprecatedAPIVersion: apiVersion,
 				DeprecatedName:       name,
 			},
-			want: "Absolute URI is not allowed when Ref or [apiVersion, kind, name] is present: [apiVersion, kind, name], ref, uri",
+			want: "absolute URI is not allowed when Ref or [apiVersion, kind, name] is present: [apiVersion, kind, name], ref, uri",
 		},
 		"invalid, both ref, [apiVersion, kind, name] and uri  are nil": {
 			dest: &Destination{},
@@ -321,7 +321,7 @@ func TestValidateDestinationDisallowDeprecated(t *testing.T) {
 					Scheme: "http",
 				},
 			},
-			want: "invalid value: Relative URI is not allowed when Ref and [apiVersion, kind, name] is absent: uri",
+			want: "invalid value: relative URI is not allowed when Ref and [apiVersion, kind, name] is absent: uri",
 		},
 		"invalid, uri is not absolute url": {
 			dest: &Destination{
@@ -329,7 +329,7 @@ func TestValidateDestinationDisallowDeprecated(t *testing.T) {
 					Host: "host",
 				},
 			},
-			want: "invalid value: Relative URI is not allowed when Ref and [apiVersion, kind, name] is absent: uri",
+			want: "invalid value: relative URI is not allowed when Ref and [apiVersion, kind, name] is absent: uri",
 		},
 		"invalid deprecated, both ref and [apiVersion, kind, name] are present ": {
 			dest: &Destination{

--- a/apis/v1alpha1/destination_test.go
+++ b/apis/v1alpha1/destination_test.go
@@ -349,7 +349,7 @@ func TestValidateDestinationDisallowDeprecated(t *testing.T) {
 				URI: &validURL,
 				Ref: &validRef,
 			},
-			want: "Absolute URI is not allowed when Ref or [apiVersion, kind, name] is present: [apiVersion, kind, name], ref, uri",
+			want: "absolute URI is not allowed when Ref or [apiVersion, kind, name] is present: [apiVersion, kind, name], ref, uri",
 		},
 		"invalid, both uri and [apiVersion, kind, name], uri is absolute URL": {
 			dest: &Destination{

--- a/resolver/addressable_resolver.go
+++ b/resolver/addressable_resolver.go
@@ -63,50 +63,31 @@ func NewURIResolver(ctx context.Context, callback func(types.NamespacedName)) *U
 }
 
 // URIFromDestination resolves a Destination into a URI string.
-func (r *URIResolver) URIFromDestination(dest apisv1alpha1.Destination, parent interface{}) (string, error) {
-	var deprecatedObjectReference *corev1.ObjectReference
-	if dest.DeprecatedAPIVersion == "" && dest.DeprecatedKind == "" && dest.DeprecatedName == "" && dest.DeprecatedNamespace == "" {
-		deprecatedObjectReference = nil
-	} else {
-		deprecatedObjectReference = &corev1.ObjectReference{
-			Kind:       dest.DeprecatedKind,
-			APIVersion: dest.DeprecatedAPIVersion,
-			Name:       dest.DeprecatedName,
-			Namespace:  dest.DeprecatedNamespace,
-		}
+func (r *URIResolver) URIFromDestination(ctx context.Context, namespace string, dest apisv1alpha1.Destination, parent interface{}) (string, error) {
+	err := dest.Validate(ctx)
+	if err != nil {
+		return "", errors.New(err.Error())
 	}
-	if dest.Ref != nil && deprecatedObjectReference != nil {
-		return "", fmt.Errorf("ref and [apiVersion, kind, name] can't be both present")
-	}
-	var ref *corev1.ObjectReference
-	if dest.Ref != nil {
-		ref = dest.Ref
-	} else {
-		ref = deprecatedObjectReference
-	}
+	ref := dest.GetRef()
 	if ref != nil {
+		// Do not modify original copy w/o namespace.
+		ref = ref.DeepCopy()
+		ref.Namespace = namespace
 		url, err := r.URIFromObjectReference(ref, parent)
 		if err != nil {
 			return "", err
 		}
 		if dest.URI != nil {
-			if dest.URI.URL().IsAbs() {
-				return "", fmt.Errorf("absolute URI is not allowed when Ref or [apiVersion, kind, name] exists")
-			}
 			return url.URL().ResolveReference(dest.URI.URL()).String(), nil
 		}
 		return url.URL().String(), nil
 	}
 
 	if dest.URI != nil {
-		// IsAbs check whether the URL has a non-empty scheme. Besides the non non-empty scheme, we also require dest.URI has a non-empty host
-		if !dest.URI.URL().IsAbs() || dest.URI.Host == "" {
-			return "", fmt.Errorf("URI is not absolute(both scheme and host should be non-empty): %v", dest.URI.String())
-		}
 		return dest.URI.String(), nil
 	}
 
-	return "", fmt.Errorf("destination missing Ref, [apiVersion, kind, name] and URI, expected at least one")
+	return "", fmt.Errorf("cannot resolve uri from destination: %v", dest)
 }
 
 // URIFromObjectReference resolves an ObjectReference to a URI string.


### PR DESCRIPTION
- We do not allow cross namespace references in Destination... Also removing DeprecatedNamespace field. 
- Changing the signature of URIFromDestination resolver to explicitly pass a namespace. This further strengthens the fact that Destination does not have a namespace (for now).
- Using the Validate method from Destination inside the URIFromDestination method. Avoid duplicating code, and potentially corner cases we are not considering there...
