### PR TITLE
Slack MessageHistory only returns messages sent by the current user

### DIFF
--- a/test/mako/alerter/slack/message.go
+++ b/test/mako/alerter/slack/message.go
@@ -32,7 +32,7 @@ var minInterval = flag.Duration("min-alert-interval", 24*time.Hour, "The minimum
 
 const (
 	messageTemplate = `
-As of %s, there is a new performance regression detected from test automation for *%s*:
+As of %s, there is a new performance regression detected from test automation for %s:
 %s`
 )
 
@@ -86,16 +86,18 @@ func (smh *MessageHandler) SendAlert(testName, summary string) error {
 			); err != nil {
 				errCh <- fmt.Errorf("failed to retrieve message history in channel %q", channel.Name)
 			}
+			// decorate the test name for more accurate match
+			decoratedTestName := decoratedName(testName)
 			// do not send message again if alert for this test has been sent to
 			// the channel a short while ago
 			for _, message := range messageHistory {
-				if strings.Contains(message, testName) {
+				if strings.Contains(message, decoratedTestName) {
 					return
 				}
 			}
 
 			// send the alert message to the channel
-			message := fmt.Sprintf(messageTemplate, time.Now().UTC(), testName, summary)
+			message := fmt.Sprintf(messageTemplate, time.Now().UTC(), decoratedTestName, summary)
 			if err := helpers.Run(
 				fmt.Sprintf("sending message %q to channel %q", message, channel.Name),
 				func() error {
@@ -119,4 +121,9 @@ func (smh *MessageHandler) SendAlert(testName, summary string) error {
 	}
 
 	return helpers.CombineErrors(errs)
+}
+
+// decoratedName returns a name with decoration for easy identification.
+func decoratedName(name string) string {
+	return fmt.Sprintf("[%s]", name)
 }

--- a/test/mako/alerter/slack/message_test.go
+++ b/test/mako/alerter/slack/message_test.go
@@ -70,3 +70,19 @@ func TestMessaging(t *testing.T) {
 		}
 	}
 }
+
+func TestDecoratedName(t *testing.T) {
+	testCases := []struct {
+		name           string
+		expectedResult string
+	}{
+		{"demo test1", "[demo test1]"},
+		{"[demo test2]", "[[demo test2]]"},
+	}
+	for _, tc := range testCases {
+		actualResult := decoratedName(tc.name)
+		if tc.expectedResult != actualResult {
+			t.Fatalf("expected to get %q for decoratedName(%s), but got %q", tc.expectedResult, tc.name, actualResult)
+		}
+	}
+}

--- a/test/mako/sidecar.go
+++ b/test/mako/sidecar.go
@@ -53,7 +53,7 @@ const (
 	// These token settings are for alerter.
 	// If we want to enable the alerter for a benchmark, we need to mount the
 	// token to the pod, with the same name and path.
-	// See https://github.com/knative/serving/blob/master/test/performance/dataplane-probe/dataplane-probe.yaml
+	// See https://github.com/knative/serving/blob/master/test/performance/benchmarks/dataplane-probe/continuous/dataplane-probe.yaml
 	tokenFolder     = "/var/secret"
 	githubToken     = "github-token"
 	slackReadToken  = "slack-read-token"

--- a/test/slackutil/message_read.go
+++ b/test/slackutil/message_read.go
@@ -58,7 +58,6 @@ func NewReadClient(userName, tokenPath string) (ReadOperations, error) {
 func (c *readClient) MessageHistory(channel string, startTime time.Time) ([]string, error) {
 	u, _ := url.Parse(conversationHistoryURL)
 	q := u.Query()
-	q.Add("username", c.userName)
 	q.Add("token", c.tokenStr)
 	q.Add("channel", channel)
 	q.Add("oldest", strconv.FormatInt(startTime.Unix(), 10))

--- a/test/slackutil/message_read.go
+++ b/test/slackutil/message_read.go
@@ -53,6 +53,8 @@ func NewReadClient(userName, tokenPath string) (ReadOperations, error) {
 	}, nil
 }
 
+// MessageHistory returns the list of messages sent by the user in the given
+// channel since the given startTime.
 func (c *readClient) MessageHistory(channel string, startTime time.Time) ([]string, error) {
 	u, _ := url.Parse(conversationHistoryURL)
 	q := u.Query()
@@ -69,7 +71,8 @@ func (c *readClient) MessageHistory(channel string, startTime time.Time) ([]stri
 
 	// response code could also be 200 if channel doesn't exist, parse response body to find out
 	type m struct {
-		Text string `json:"text"`
+		Text     string `json:"text"`
+		UserName string `json:"username"`
 	}
 	var r struct {
 		OK       bool `json:"ok"`
@@ -79,9 +82,11 @@ func (c *readClient) MessageHistory(channel string, startTime time.Time) ([]stri
 		return nil, fmt.Errorf("response not ok '%s'", string(content))
 	}
 
-	res := make([]string, len(r.Messages))
-	for i, message := range r.Messages {
-		res[i] = message.Text
+	res := make([]string, 0)
+	for _, message := range r.Messages {
+		if message.UserName == c.userName {
+			res = append(res, message.Text)
+		}
 	}
 
 	return res, nil


### PR DESCRIPTION
Slack MessageHistory should only return messages sent by the current user.

/cc @vagababov 