### PR TITLE
Eliminate the Namespace config option in favor of system.Namespace.

### DIFF
--- a/webhook/helper_test.go
+++ b/webhook/helper_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	. "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/system"
 	. "knative.dev/pkg/testing"
 )
 
@@ -108,7 +109,7 @@ func createSecureTLSClient(t *testing.T, kubeClient kubernetes.Interface, acOpts
 
 	tlsClientConfig := &tls.Config{
 		// Add knative namespace as CN
-		ServerName:   "webhook.knative-something",
+		ServerName:   "webhook." + system.Namespace(),
 		RootCAs:      pool,
 		Certificates: tlsServerConfig.Certificates,
 	}

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -33,11 +33,12 @@ import (
 
 	"knative.dev/pkg/configmap"
 	. "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/system"
+	_ "knative.dev/pkg/system/testing"
 )
 
 func newDefaultOptions() ControllerOptions {
 	return ControllerOptions{
-		Namespace:                       "knative-something",
 		ServiceName:                     "webhook",
 		Port:                            443,
 		SecretName:                      "webhook-certs",
@@ -94,10 +95,9 @@ func TestRegistrationStopChanFire(t *testing.T) {
 
 func TestCertConfigurationForAlreadyGeneratedSecret(t *testing.T) {
 	secretName := "test-secret"
-	ns := "test-namespace"
+	ns := system.Namespace()
 	opts := newDefaultOptions()
 	opts.SecretName = secretName
-	opts.Namespace = ns
 	kubeClient, ac := newNonRunningTestWebhook(t, opts)
 
 	ctx := TestContextWithLogger(t)
@@ -139,10 +139,8 @@ func TestCertConfigurationForAlreadyGeneratedSecret(t *testing.T) {
 
 func TestCertConfigurationForGeneratedSecret(t *testing.T) {
 	secretName := "test-secret"
-	ns := "test-namespace"
 	opts := newDefaultOptions()
 	opts.SecretName = secretName
-	opts.Namespace = ns
 	kubeClient, ac := newNonRunningTestWebhook(t, opts)
 
 	ctx := TestContextWithLogger(t)


### PR DESCRIPTION
This is the first of a series of breaking changes that I'll stage and land in the downstream repositories after the 0.10 cuts happen.