### PR TITLE
Move hook-specific configuration options out of shared options.

### DIFF
--- a/webhook/resource_admission_controller_deprecated_test.go
+++ b/webhook/resource_admission_controller_deprecated_test.go
@@ -504,7 +504,7 @@ func TestStrictValidation(t *testing.T) {
 				ctx = apis.DisallowDeprecated(ctx)
 			}
 
-			_, ac := newNonRunningTestResourceAdmissionController(t, newDefaultOptions())
+			_, ac := newNonRunningTestResourceAdmissionController(t)
 			resp := ac.Admit(ctx, tc.req)
 
 			if len(tc.wantErrs) > 0 {
@@ -534,7 +534,7 @@ func TestStrictValidation_Spec_Create(t *testing.T) {
 
 	ctx := apis.DisallowDeprecated(TestContextWithLogger(t))
 
-	_, ac := newNonRunningTestResourceAdmissionController(t, newDefaultOptions())
+	_, ac := newNonRunningTestResourceAdmissionController(t)
 	resp := ac.Admit(ctx, req)
 
 	expectFailsWith(t, resp, "must not set")
@@ -558,7 +558,7 @@ func TestStrictValidation_Spec_Update(t *testing.T) {
 
 	ctx := apis.DisallowDeprecated(TestContextWithLogger(t))
 
-	_, ac := newNonRunningTestResourceAdmissionController(t, newDefaultOptions())
+	_, ac := newNonRunningTestResourceAdmissionController(t)
 	resp := ac.Admit(ctx, req)
 
 	expectFailsWith(t, resp, "must not update")

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -51,14 +51,6 @@ var (
 
 // ControllerOptions contains the configuration for the webhook
 type ControllerOptions struct {
-	// ResourceMutatingWebhookName is the name of the webhook we create to handle
-	// mutations before they get stored in the storage.
-	ResourceMutatingWebhookName string
-
-	// ConfigValidationWebhookName is the name of the webhook we create to handle
-	// mutations before they get stored in the storage.
-	ConfigValidationWebhookName string
-
 	// ServiceName is the service name of the webhook.
 	ServiceName string
 
@@ -88,14 +80,6 @@ type ControllerOptions struct {
 	// StatsReporter reports metrics about the webhook.
 	// This will be automatically initialized by the constructor if left uninitialized.
 	StatsReporter StatsReporter
-
-	// Service path for ResourceAdmissionController webhook
-	// Default is "/" for backward compatibility and is set by the constructor
-	ResourceAdmissionControllerPath string
-
-	// Service path for ConfigValidationController webhook
-	// Default is "/config-validation" and is set by the constructor
-	ConfigValidationControllerPath string
 }
 
 // AdmissionController provides the interface for different admission controllers

--- a/webhook/webhook_integration_test.go
+++ b/webhook/webhook_integration_test.go
@@ -197,7 +197,14 @@ func TestValidResponseForResource(t *testing.T) {
 		t.Fatalf("Failed to marshal admission review: %v", err)
 	}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s", serverURL), reqBuf)
+	u, err := url.Parse(fmt.Sprintf("https://%s", serverURL))
+	if err != nil {
+		t.Fatalf("bad url %v", err)
+	}
+
+	u.Path = path.Join(u.Path, testResourceValidationPath)
+
+	req, err := http.NewRequest("GET", u.String(), reqBuf)
 	if err != nil {
 		t.Fatalf("http.NewRequest() = %v", err)
 	}
@@ -283,7 +290,14 @@ func TestValidResponseForResourceWithContextDefault(t *testing.T) {
 		t.Fatalf("Failed to marshal admission review: %v", err)
 	}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s", serverURL), reqBuf)
+	u, err := url.Parse(fmt.Sprintf("https://%s", serverURL))
+	if err != nil {
+		t.Fatalf("bad url %v", err)
+	}
+
+	u.Path = path.Join(u.Path, testResourceValidationPath)
+
+	req, err := http.NewRequest("GET", u.String(), reqBuf)
 	if err != nil {
 		t.Fatalf("http.NewRequest() = %v", err)
 	}
@@ -384,7 +398,14 @@ func TestInvalidResponseForResource(t *testing.T) {
 		t.Fatalf("Failed to marshal admission review: %v", err)
 	}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s", serverURL), reqBuf)
+	u, err := url.Parse(fmt.Sprintf("https://%s", serverURL))
+	if err != nil {
+		t.Fatalf("bad url %v", err)
+	}
+
+	u.Path = path.Join(u.Path, testResourceValidationPath)
+
+	req, err := http.NewRequest("GET", u.String(), reqBuf)
 	if err != nil {
 		t.Fatalf("http.NewRequest() = %v", err)
 	}
@@ -502,7 +523,7 @@ func TestValidResponseForConfigMap(t *testing.T) {
 		t.Fatalf("bad url %v", err)
 	}
 
-	u.Path = path.Join(u.Path, ac.Options.ConfigValidationControllerPath)
+	u.Path = path.Join(u.Path, testConfigValidationPath)
 	req, err := http.NewRequest("GET", u.String(), reqBuf)
 	if err != nil {
 		t.Fatalf("http.NewRequest() = %v", err)
@@ -581,7 +602,7 @@ func TestInvalidResponseForConfigMap(t *testing.T) {
 		t.Fatalf("bad url %v", err)
 	}
 
-	u.Path = path.Join(u.Path, ac.Options.ConfigValidationControllerPath)
+	u.Path = path.Join(u.Path, testConfigValidationPath)
 	req, err := http.NewRequest("GET", u.String(), reqBuf)
 	if err != nil {
 		t.Fatalf("http.NewRequest() = %v", err)

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -39,13 +39,9 @@ import (
 
 func newDefaultOptions() ControllerOptions {
 	return ControllerOptions{
-		ServiceName:                     "webhook",
-		Port:                            443,
-		SecretName:                      "webhook-certs",
-		ResourceMutatingWebhookName:     "webhook.knative.dev",
-		ResourceAdmissionControllerPath: "/",
-		ConfigValidationWebhookName:     "configmap.webhook.knative.dev",
-		ConfigValidationControllerPath:  "/config-validation",
+		ServiceName: "webhook",
+		Port:        443,
+		SecretName:  "webhook-certs",
 	}
 }
 
@@ -180,8 +176,10 @@ func NewTestWebhook(client kubernetes.Interface, options ControllerOptions, logg
 	validations := configmap.Constructors{"test-config": newConfigFromConfigMap}
 
 	admissionControllers := map[string]AdmissionController{
-		options.ResourceAdmissionControllerPath: NewResourceAdmissionController(handlers, options, true),
-		options.ConfigValidationControllerPath:  NewConfigValidationController(validations, options),
+		testResourceValidationPath: NewResourceAdmissionController(
+			testResourceValidationName, testResourceValidationPath, handlers, true),
+		testConfigValidationPath: NewConfigValidationController(
+			testConfigValidationName, testConfigValidationPath, validations),
 	}
 	return New(client, options, admissionControllers, logger, nil)
 }


### PR DESCRIPTION
This builds on https://github.com/knative/pkg/pull/817 and makes further
breaking changes. The options pertinent to each admission controller are
now passed to their respective constructors, which leads to a cleaner
options struct, and better prepares for greater webhook diversity.

This is WIP until the baseline change merges.