### PR TITLE
Remove options to specify ClientAuth.

### DIFF
--- a/webhook/webhook_integration_test.go
+++ b/webhook/webhook_integration_test.go
@@ -19,7 +19,6 @@ package webhook
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -455,29 +454,6 @@ func TestInvalidResponseForResource(t *testing.T) {
 
 	// Stats should be reported for requests that have admission disallowed
 	metricstest.CheckStatsReported(t, requestCountName, requestLatenciesName)
-}
-
-func TestWebhookClientAuth(t *testing.T) {
-	ac, serverURL, err := testSetup(t)
-	if err != nil {
-		t.Fatalf("testSetup() = %v", err)
-	}
-	ac.Options.ClientAuth = tls.RequireAndVerifyClientCert
-
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
-	go func() {
-		err := ac.Run(stopCh)
-		if err != nil {
-			t.Errorf("Unable to run controller: %s", err)
-		}
-	}()
-
-	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
-	if pollErr != nil {
-		t.Fatalf("waitForServerAvailable() = %v", err)
-	}
 }
 
 func TestValidResponseForConfigMap(t *testing.T) {

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -167,14 +167,6 @@ func TestCertConfigurationForGeneratedSecret(t *testing.T) {
 	}
 }
 
-func TestSettingWebhookClientAuth(t *testing.T) {
-	opts := newDefaultOptions()
-	if opts.ClientAuth != tls.NoClientCert {
-		t.Fatalf("Expected default ClientAuth to be NoClientCert (%v) but got (%v)",
-			tls.NoClientCert, opts.ClientAuth)
-	}
-}
-
 func NewTestWebhook(ctx context.Context) (*Webhook, error) {
 	validations := configmap.Constructors{"test-config": newConfigFromConfigMap}
 


### PR DESCRIPTION
We don't use this anywhere in Knative downstream and it adds a bunch of complexity.