### PR TITLE
Avoid registering webhook metrics with init()

### DIFF
--- a/webhook/stats_reporter.go
+++ b/webhook/stats_reporter.go
@@ -60,10 +60,6 @@ var (
 	admissionAllowedKey  = tag.MustNewKey("admission_allowed")
 )
 
-func init() {
-	register()
-}
-
 // StatsReporter reports webhook metrics
 type StatsReporter interface {
 	ReportRequest(request *admissionv1beta1.AdmissionRequest, response *admissionv1beta1.AdmissionResponse, d time.Duration) error
@@ -111,7 +107,7 @@ func (r *reporter) ReportRequest(req *admissionv1beta1.AdmissionRequest, resp *a
 	return nil
 }
 
-func register() {
+func RegisterMetrics() {
 	tagKeys := []tag.Key{
 		requestOperationKey,
 		kindGroupKey,

--- a/webhook/stats_reporter_test.go
+++ b/webhook/stats_reporter_test.go
@@ -72,5 +72,5 @@ func setup() {
 // opencensus metrics carry global state that need to be reset between unit tests
 func resetMetrics() {
 	metricstest.Unregister(requestCountName, requestLatenciesName)
-	register()
+	RegisterMetrics()
 }


### PR DESCRIPTION
With this change folks will need to call `webhook.RegisterMetrics()` to register the opencensus view with the metrics for the webhook's StatsReporter.  This is needed to avoid having `sharedmain` crashloop the activator due to linking multiple on-`init()` views that register metrics named `request_latencies`.

In general, I believe that we should move away from registering these views via `init()` and more towards the broader K8s MetricsProvider pattern.