### PR TITLE
Remove vestigial createDeployment

### DIFF
--- a/webhook/config_validation_controller_test.go
+++ b/webhook/config_validation_controller_test.go
@@ -86,7 +86,6 @@ func NewTestConfigValidationController() AdmissionController {
 func TestUpdatingConfigValidationController(t *testing.T) {
 	kubeClient, ac := newNonRunningTestConfigValidationController(t)
 
-	createDeployment(kubeClient)
 	err := ac.Register(TestContextWithLogger(t), kubeClient, []byte{})
 	if err != nil {
 		t.Fatalf("Failed to create webhook: %s", err)

--- a/webhook/resource_admission_controller_test.go
+++ b/webhook/resource_admission_controller_test.go
@@ -29,11 +29,9 @@ import (
 	"github.com/mattbaird/jsonpatch"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	appsv1 "k8s.io/api/apps/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/system"
@@ -548,7 +546,6 @@ func createInnerDefaultResourceWithSpecAndStatus(t *testing.T, spec *InnerDefaul
 func TestUpdatingResourceController(t *testing.T) {
 	kubeClient, ac := newNonRunningTestResourceAdmissionController(t)
 
-	createDeployment(kubeClient)
 	err := ac.Register(TestContextWithLogger(t), kubeClient, []byte{})
 	if err != nil {
 		t.Fatalf("Failed to create webhook: %s", err)
@@ -562,16 +559,6 @@ func TestUpdatingResourceController(t *testing.T) {
 	if len(currentWebhook.OwnerReferences) > 0 {
 		t.Errorf("Expected no OwnerReferences, got %d", len(currentWebhook.OwnerReferences))
 	}
-}
-
-func createDeployment(kubeClient kubernetes.Interface) {
-	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "whatever",
-			Namespace: "knative-something",
-		},
-	}
-	kubeClient.AppsV1().Deployments("knative-something").Create(deployment)
 }
 
 func expectAllowed(t *testing.T, resp *admissionv1beta1.AdmissionResponse) {

--- a/webhook/webhook_integration_test.go
+++ b/webhook/webhook_integration_test.go
@@ -643,7 +643,6 @@ func TestSetupWebhookHTTPServerError(t *testing.T) {
 	if cMapsErr != nil {
 		t.Fatalf("testSetup() = %v", cMapsErr)
 	}
-	createDeployment(kubeClient)
 
 	stopCh := make(chan struct{})
 	errCh := make(chan error)
@@ -684,7 +683,6 @@ func testSetup(t *testing.T) (*Webhook, string, error) {
 		return nil, "", cMapsErr
 	}
 
-	createDeployment(kubeClient)
 	resetMetrics()
 	return ac, fmt.Sprintf("0.0.0.0:%d", port), nil
 }


### PR DESCRIPTION
This is no longer necessary now that we have eliminated our usage of OwnerReferences in the webhook.