### PR TITLE
Expand sharedmain to support launching our webhook.

### DIFF
--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -44,6 +44,8 @@ import (
 	"knative.dev/pkg/profiling"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
+	"knative.dev/pkg/version"
+	"knative.dev/pkg/webhook"
 )
 
 // GetConfig returns a rest.Config to be used for kubernetes client creation.
@@ -138,13 +140,25 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 	defer flush(logger)
 	ctx = logging.WithLogger(ctx, logger)
 
+	kc := kubeclient.Get(ctx)
+	if err := version.CheckMinimumVersion(kc.Discovery()); err != nil {
+		logger.Fatalw("Version check failed", zap.Error(err))
+	}
+
 	// TODO(mattmoor): This should itself take a context and be injection-based.
-	cmw := configmap.NewInformedWatcher(kubeclient.Get(ctx), system.Namespace())
+	cmw := configmap.NewInformedWatcher(kc, system.Namespace())
 
 	// Based on the reconcilers we have linked, build up the set of controllers to run.
 	controllers := make([]*controller.Impl, 0, len(ctors))
+	webhooks := make([]webhook.AdmissionController, 0)
 	for _, cf := range ctors {
-		controllers = append(controllers, cf(ctx, cmw))
+		ctrl := cf(ctx, cmw)
+		controllers = append(controllers, ctrl)
+
+		// Build a list of any reconcilers that implement webhook.AdmissionController
+		if ac, ok := ctrl.Reconciler.(webhook.AdmissionController); ok {
+			webhooks = append(webhooks, ac)
+		}
 	}
 
 	profilingHandler := profiling.NewHandler(logger, false)
@@ -175,6 +189,21 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 
 	eg, egCtx := errgroup.WithContext(ctx)
 	eg.Go(profilingServer.ListenAndServe)
+
+	// If we have one or more admission controllers, then start the webhook
+	// and pass them in.
+	if len(webhooks) > 0 {
+		// Register webhook metrics
+		webhook.RegisterMetrics()
+
+		wh, err := webhook.New(ctx, webhooks)
+		if err != nil {
+			logger.Fatalw("Failed to create admission controller", zap.Error(err))
+		}
+		eg.Go(func() error {
+			return wh.Run(ctx.Done())
+		})
+	}
 
 	// This will block until either a signal arrives or one of the grouped functions
 	// returns an error.


### PR DESCRIPTION
With the simplified `webhook.New` signature, this supports detecting when one or more of the controllers we have launched has a `Reconciler` that implements `webhook.AdmissionController` and launching the webhook with this admission controllers registered.

There is still work that needs to be done to refactor the webhooks to follow this shape, but this hopefully starts to paint the picture of where things are headed.