### PR TITLE
This refactors our core webhook logic to be reconciler-based.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1383,6 +1383,7 @@
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/core/v1",
+    "k8s.io/client-go/listers/admissionregistration/v1beta1",
     "k8s.io/client-go/listers/apps/v1",
     "k8s.io/client-go/listers/autoscaling/v2beta1",
     "k8s.io/client-go/listers/core/v1",

--- a/test/webhook-apicoverage/webhook/apicoverage_recorder.go
+++ b/test/webhook-apicoverage/webhook/apicoverage_recorder.go
@@ -33,7 +33,7 @@ import (
 	"knative.dev/pkg/test/webhook-apicoverage/coveragecalculator"
 	"knative.dev/pkg/test/webhook-apicoverage/resourcetree"
 	"knative.dev/pkg/test/webhook-apicoverage/view"
-	"knative.dev/pkg/webhook"
+	"knative.dev/pkg/webhook/resourcesemantics"
 )
 
 var (
@@ -67,7 +67,7 @@ type resourceChannelMsg struct {
 type APICoverageRecorder struct {
 	Logger          *zap.SugaredLogger
 	ResourceForest  resourcetree.ResourceForest
-	ResourceMap     map[schema.GroupVersionKind]webhook.GenericCRD
+	ResourceMap     map[schema.GroupVersionKind]resourcesemantics.GenericCRD
 	NodeRules       resourcetree.NodeRules
 	FieldRules      resourcetree.FieldRules
 	DisplayRules    view.DisplayRules

--- a/test/webhook-apicoverage/webhook/webhook.go
+++ b/test/webhook-apicoverage/webhook/webhook.go
@@ -36,8 +36,8 @@ import (
 	"k8s.io/client-go/rest"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/webhook"
 	certresources "knative.dev/pkg/webhook/certificates/resources"
+	"knative.dev/pkg/webhook/resourcesemantics"
 )
 
 var (
@@ -152,7 +152,7 @@ func (acw *APICoverageWebhook) registerWebhook(rules []admissionregistrationv1be
 	return nil
 }
 
-func (acw *APICoverageWebhook) getValidationRules(resources map[schema.GroupVersionKind]webhook.GenericCRD) []admissionregistrationv1beta1.RuleWithOperations {
+func (acw *APICoverageWebhook) getValidationRules(resources map[schema.GroupVersionKind]resourcesemantics.GenericCRD) []admissionregistrationv1beta1.RuleWithOperations {
 	var rules []admissionregistrationv1beta1.RuleWithOperations
 	for gvk := range resources {
 		plural := strings.ToLower(inflect.Pluralize(gvk.Kind))
@@ -173,7 +173,7 @@ func (acw *APICoverageWebhook) getValidationRules(resources map[schema.GroupVers
 }
 
 // SetupWebhook sets up the webhook with the provided http.handler, resourcegroup Map, namespace and stop channel.
-func (acw *APICoverageWebhook) SetupWebhook(handler http.Handler, resources map[schema.GroupVersionKind]webhook.GenericCRD, namespace string, stop <-chan struct{}) error {
+func (acw *APICoverageWebhook) SetupWebhook(handler http.Handler, resources map[schema.GroupVersionKind]resourcesemantics.GenericCRD, namespace string, stop <-chan struct{}) error {
 	server, err := acw.getWebhookServer(handler)
 	rules := acw.getValidationRules(resources)
 	if err != nil {

--- a/webhook/README.md
+++ b/webhook/README.md
@@ -1,0 +1,101 @@
+## Knative Webhooks
+
+Knative provides infrastructure for authoring webhooks under
+`knative.dev/pkg/webhook` and has a few built-in helpers for certain
+common admission control scenarios.  The built-in admission controllers
+are:
+1. Resource validation and defaulting (builds around `apis.Validatable`
+  and `apis.Defaultable` under `knative.dev/pkg/apis`).
+2. ConfigMap validation, which builds around similar patterns from
+  `knative.dev/pkg/configmap` (in particular the `store` concept)
+
+To illustrate standing up the webhook, let's start with one of these
+built-in admission controllers and then talk about how you can write
+your own admission controller.
+
+## Standing up a Webhook from an Admission Controller
+
+We provide facilities in `knative.dev/pkg/injection/sharedmain` to try and
+eliminate much of the boilerplate involved in standing up a webhook. For this
+example we will show how to stand up the webhook using the built-in admission
+controller for validating and defaulting resources.
+
+The code to stand up such a webhook looks roughly like this:
+
+```go
+// Create a function matching this signature to pass into sharedmain.
+func NewResourceAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	return resourcesemantics.NewAdmissionController(ctx,
+		// Name of the resource webhook (created via yaml)
+		fmt.Sprintf("resources.webhook.%s.knative.dev", system.Namespace()),
+
+		// The path on which to serve the webhook.
+		"/resource-validation",
+
+		// The resources to validate and default.
+		map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
+			// List the types to validate, this from knative.dev/sample-controller
+			v1alpha1.SchemeGroupVersion.WithKind("AddressableService"): &v1alpha1.AddressableService{},
+		},
+
+		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
+		func(ctx context.Context) context.Context {
+			// Here is where you would infuse the context with state
+			// (e.g. attach a store with configmap data, like knative.dev/serving attaches config-defaults)
+			return ctx
+		},
+
+		// Whether to disallow unknown fields when parsing the resources' JSON.
+		true,
+	)
+}
+
+func main() {
+	// Set up a signal context with our webhook options.
+	ctx := webhook.WithOptions(signals.NewContext(), webhook.Options{
+		// The name of the Kubernetes service selecting over this deployment's pods.
+		ServiceName: "webhook",
+
+		// The port on which to serve.
+		Port:        8443,
+
+		// The name of the secret containing certificate data.
+		SecretName:  "webhook-certs",
+	})
+
+	sharedmain.MainWithContext(ctx, "webhook",
+		// The certificate controller will ensure that the named secret (above) has
+		// the appropriate shape for our webhook's admission controllers.
+		certificates.NewController,
+
+		// This invokes the method defined above to instantiate the resource admission
+		// controller.
+		NewResourceAdmissionController,
+	)
+}
+```
+
+There is also a config map validation admission controller built in under
+`knative.dev/pkg/webhook/configmaps`.
+
+## Writing new Admission Controllers
+
+To implement your own admission controller akin to the resource defaulting and
+validation controller above, you implement a `knative.dev/pkg/controller.Reconciler` as with
+any you would with any other type of controller, but the `Reconciler` that gets
+embedded in the `*controller.Impl` should *also* implement:
+
+```go
+// AdmissionController provides the interface for different admission controllers
+type AdmissionController interface {
+	// Path returns the path that this particular admission controller serves on.
+	Path() string
+
+	// Admit is the callback which is invoked when an HTTPS request comes in on Path().
+	Admit(context.Context, *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse
+}
+```
+
+The `Reconciler` part is responsible for the mutating or validating webhook configuration.
+The `AdmissionController` part is responsible for guiding request dispatch (`Path()`) and
+handling admission requests (`Admit()`).

--- a/webhook/configmaps/configmaps.go
+++ b/webhook/configmaps/configmaps.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package webhook
+package configmaps
 
 import (
 	"bytes"
@@ -26,49 +26,62 @@ import (
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
+	admissionlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
+	corelisters "k8s.io/client-go/listers/core/v1"
 
 	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
+	certresources "knative.dev/pkg/webhook/certificates/resources"
 )
 
-// ConfigValidationController implements the AdmissionController for ConfigMaps
-type ConfigValidationController struct {
-	// name of the ValidatingWebhookConfiguration
-	name string
-	// path that the webhook should serve on
+// reconciler implements the AdmissionController for ConfigMaps
+type reconciler struct {
+	name         string
 	path         string
 	constructors map[string]reflect.Value
+
+	client       kubernetes.Interface
+	vwhlister    admissionlisters.ValidatingWebhookConfigurationLister
+	secretlister corelisters.SecretLister
+
+	secretName string
 }
 
-// NewConfigValidationController constructs a ConfigValidationController
-func NewConfigValidationController(
-	name, path string,
-	constructors configmap.Constructors) AdmissionController {
-	cfgValidations := &ConfigValidationController{
-		name:         name,
-		path:         path,
-		constructors: make(map[string]reflect.Value),
+var _ controller.Reconciler = (*reconciler)(nil)
+var _ webhook.AdmissionController = (*reconciler)(nil)
+
+// Reconcile implements controller.Reconciler
+func (ac *reconciler) Reconcile(ctx context.Context, key string) error {
+	logger := logging.FromContext(ctx)
+
+	secret, err := ac.secretlister.Secrets(system.Namespace()).Get(ac.secretName)
+	if err != nil {
+		logger.Errorf("Error fetching secret: %v", err)
+		return err
 	}
 
-	for configName, constructor := range constructors {
-		cfgValidations.registerConfig(configName, constructor)
+	caCert, ok := secret.Data[certresources.CACert]
+	if !ok {
+		return fmt.Errorf("secret %q is missing %q key", ac.secretName, certresources.CACert)
 	}
 
-	return cfgValidations
+	return ac.reconcileValidatingWebhook(ctx, caCert)
 }
 
 // Path implements AdmissionController
-func (ac *ConfigValidationController) Path() string {
+func (ac *reconciler) Path() string {
 	return ac.path
 }
 
 // Admit implements AdmissionController
-func (ac *ConfigValidationController) Admit(ctx context.Context, request *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (ac *reconciler) Admit(ctx context.Context, request *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
 	logger := logging.FromContext(ctx)
 	switch request.Operation {
 	case admissionv1beta1.Create, admissionv1beta1.Update:
@@ -78,7 +91,7 @@ func (ac *ConfigValidationController) Admit(ctx context.Context, request *admiss
 	}
 
 	if err := ac.validate(ctx, request); err != nil {
-		return makeErrorStatus("validation failed: %v", err)
+		return webhook.MakeErrorStatus("validation failed: %v", err)
 	}
 
 	return &admissionv1beta1.AdmissionResponse{
@@ -86,9 +99,7 @@ func (ac *ConfigValidationController) Admit(ctx context.Context, request *admiss
 	}
 }
 
-// Register implements AdmissionController
-func (ac *ConfigValidationController) Register(ctx context.Context, kubeClient kubernetes.Interface, caCert []byte) error {
-	client := kubeClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
+func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []byte) error {
 	logger := logging.FromContext(ctx)
 
 	ruleScope := admissionregistrationv1beta1.NamespacedScope
@@ -105,7 +116,7 @@ func (ac *ConfigValidationController) Register(ctx context.Context, kubeClient k
 		},
 	}}
 
-	configuredWebhook, err := client.Get(ac.name, metav1.GetOptions{})
+	configuredWebhook, err := ac.vwhlister.Get(ac.name)
 	if err != nil {
 		return fmt.Errorf("error retrieving webhook: %v", err)
 	}
@@ -125,14 +136,15 @@ func (ac *ConfigValidationController) Register(ctx context.Context, kubeClient k
 		if webhook.Webhooks[i].ClientConfig.Service == nil {
 			return fmt.Errorf("missing service reference for webhook: %s", wh.Name)
 		}
-		webhook.Webhooks[i].ClientConfig.Service.Path = ptr.String(ac.path)
+		webhook.Webhooks[i].ClientConfig.Service.Path = ptr.String(ac.Path())
 	}
 
 	if ok, err := kmp.SafeEqual(configuredWebhook, webhook); err != nil {
 		return fmt.Errorf("error diffing webhooks: %v", err)
 	} else if !ok {
 		logger.Info("Updating webhook")
-		if _, err := client.Update(webhook); err != nil {
+		vwhclient := ac.client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
+		if _, err := vwhclient.Update(webhook); err != nil {
 			return fmt.Errorf("failed to update webhook: %v", err)
 		}
 	} else {
@@ -142,7 +154,7 @@ func (ac *ConfigValidationController) Register(ctx context.Context, kubeClient k
 	return nil
 }
 
-func (ac *ConfigValidationController) validate(ctx context.Context, req *admissionv1beta1.AdmissionRequest) error {
+func (ac *reconciler) validate(ctx context.Context, req *admissionv1beta1.AdmissionRequest) error {
 	logger := logging.FromContext(ctx)
 	kind := req.Kind
 	newBytes := req.Object.Raw
@@ -186,7 +198,7 @@ func (ac *ConfigValidationController) validate(ctx context.Context, req *admissi
 	return err
 }
 
-func (ac *ConfigValidationController) registerConfig(name string, constructor interface{}) {
+func (ac *reconciler) registerConfig(name string, constructor interface{}) {
 	if err := configmap.ValidateConstructor(constructor); err != nil {
 		panic(err)
 	}

--- a/webhook/configmaps/configmaps_test.go
+++ b/webhook/configmaps/configmaps_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package webhook
+package configmaps
 
 import (
 	"context"
@@ -23,20 +23,25 @@ import (
 	"strconv"
 	"testing"
 
+	// Injection stuff
+	_ "knative.dev/pkg/client/injection/kube/client/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/admissionregistration/v1beta1/validatingwebhookconfiguration/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
+
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
-	"knative.dev/pkg/apis"
 	"knative.dev/pkg/configmap"
-	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
 
 	_ "knative.dev/pkg/system/testing"
 
 	. "knative.dev/pkg/logging/testing"
+	. "knative.dev/pkg/reconciler/testing"
 	. "knative.dev/pkg/webhook/testing"
 )
 
@@ -46,6 +51,9 @@ const (
 )
 
 var (
+	validations = configmap.Constructors{
+		"test-config": newConfigFromConfigMap,
+	}
 	initialConfigWebhook = &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testConfigValidationName,
@@ -70,36 +78,22 @@ var (
 
 func newNonRunningTestConfigValidationController(t *testing.T) (
 	kubeClient *fakekubeclientset.Clientset,
-	ac AdmissionController) {
+	ac *reconciler) {
 	t.Helper()
 	// Create fake clients
 	kubeClient = fakekubeclientset.NewSimpleClientset(initialConfigWebhook)
 
-	ac = NewTestConfigValidationController()
+	ac = NewTestConfigValidationController(t)
 	return
 }
 
-func NewTestConfigValidationController() AdmissionController {
-	validations := configmap.Constructors{"test-config": newConfigFromConfigMap}
-	return NewConfigValidationController(testConfigValidationName, testConfigValidationPath, validations)
-}
-
-func TestUpdatingConfigValidationController(t *testing.T) {
-	kubeClient, ac := newNonRunningTestConfigValidationController(t)
-
-	err := ac.Register(TestContextWithLogger(t), kubeClient, []byte{})
-	if err != nil {
-		t.Fatalf("Failed to create webhook: %s", err)
-	}
-
-	currentWebhook, _ := kubeClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(initialConfigWebhook.Name, metav1.GetOptions{})
-	if ok, err := kmp.SafeEqual(currentWebhook.Webhooks, initialConfigWebhook.Webhooks); ok || err != nil {
-		t.Fatalf("Expected webhook to be updated: %v", err)
-	}
-
-	if len(currentWebhook.OwnerReferences) > 0 {
-		t.Errorf("Expected no OwnerReferences, got %d", len(currentWebhook.OwnerReferences))
-	}
+func NewTestConfigValidationController(t *testing.T) *reconciler {
+	ctx, _ := SetupFakeContext(t)
+	ctx = webhook.WithOptions(ctx, webhook.Options{
+		SecretName: "webhook-secret",
+	})
+	return NewAdmissionController(ctx, testConfigValidationName, testConfigValidationPath,
+		validations).Reconciler.(*reconciler)
 }
 
 func TestDeleteAllowedForConfigMap(t *testing.T) {
@@ -146,9 +140,7 @@ func TestAdmitCreateValidConfigMap(t *testing.T) {
 	_, ac := newNonRunningTestConfigValidationController(t)
 
 	r := createValidConfigMap()
-	ctx := apis.WithinCreate(apis.WithUserInfo(
-		TestContextWithLogger(t),
-		&authenticationv1.UserInfo{Username: user1}))
+	ctx := TestContextWithLogger(t)
 
 	resp := ac.Admit(ctx, createCreateConfigMapRequest(ctx, r))
 
@@ -159,9 +151,7 @@ func TestDenyInvalidCreateConfigMapWithWrongType(t *testing.T) {
 	_, ac := newNonRunningTestConfigValidationController(t)
 
 	r := createWrongTypeConfigMap()
-	ctx := apis.WithinCreate(apis.WithUserInfo(
-		TestContextWithLogger(t),
-		&authenticationv1.UserInfo{Username: user1}))
+	ctx := TestContextWithLogger(t)
 
 	resp := ac.Admit(ctx, createCreateConfigMapRequest(ctx, r))
 
@@ -172,9 +162,7 @@ func TestDenyInvalidCreateConfigMapOutOfRange(t *testing.T) {
 	_, ac := newNonRunningTestConfigValidationController(t)
 
 	r := createWrongValueConfigMap()
-	ctx := apis.WithinCreate(apis.WithUserInfo(
-		TestContextWithLogger(t),
-		&authenticationv1.UserInfo{Username: user1}))
+	ctx := TestContextWithLogger(t)
 
 	resp := ac.Admit(ctx, createCreateConfigMapRequest(ctx, r))
 
@@ -185,9 +173,7 @@ func TestAdmitUpdateValidConfigMap(t *testing.T) {
 	_, ac := newNonRunningTestConfigValidationController(t)
 
 	r := createValidConfigMap()
-	ctx := apis.WithinCreate(apis.WithUserInfo(
-		TestContextWithLogger(t),
-		&authenticationv1.UserInfo{Username: user1}))
+	ctx := TestContextWithLogger(t)
 
 	resp := ac.Admit(ctx, updateCreateConfigMapRequest(ctx, r))
 
@@ -198,9 +184,7 @@ func TestDenyInvalidUpdateConfigMapWithWrongType(t *testing.T) {
 	_, ac := newNonRunningTestConfigValidationController(t)
 
 	r := createWrongTypeConfigMap()
-	ctx := apis.WithinCreate(apis.WithUserInfo(
-		TestContextWithLogger(t),
-		&authenticationv1.UserInfo{Username: user1}))
+	ctx := TestContextWithLogger(t)
 
 	resp := ac.Admit(ctx, createCreateConfigMapRequest(ctx, r))
 
@@ -211,9 +195,7 @@ func TestDenyInvalidUpdateConfigMapOutOfRange(t *testing.T) {
 	_, ac := newNonRunningTestConfigValidationController(t)
 
 	r := createWrongValueConfigMap()
-	ctx := apis.WithinCreate(apis.WithUserInfo(
-		TestContextWithLogger(t),
-		&authenticationv1.UserInfo{Username: user1}))
+	ctx := TestContextWithLogger(t)
 
 	resp := ac.Admit(ctx, createCreateConfigMapRequest(ctx, r))
 
@@ -266,7 +248,7 @@ func createWrongValueConfigMap() *corev1.ConfigMap {
 func createConfigMap(value string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
+			Namespace: system.Namespace(),
 			Name:      "test-config",
 		},
 		Data: map[string]string{
@@ -276,17 +258,16 @@ func createConfigMap(value string) *corev1.ConfigMap {
 }
 
 func createCreateConfigMapRequest(ctx context.Context, r *corev1.ConfigMap) *admissionv1beta1.AdmissionRequest {
-	return configMapRequest(r, admissionv1beta1.Create, *apis.GetUserInfo(ctx))
+	return configMapRequest(r, admissionv1beta1.Create)
 }
 
 func updateCreateConfigMapRequest(ctx context.Context, r *corev1.ConfigMap) *admissionv1beta1.AdmissionRequest {
-	return configMapRequest(r, admissionv1beta1.Update, *apis.GetUserInfo(ctx))
+	return configMapRequest(r, admissionv1beta1.Update)
 }
 
 func configMapRequest(
 	r *corev1.ConfigMap,
 	o admissionv1beta1.Operation,
-	u authenticationv1.UserInfo,
 ) *admissionv1beta1.AdmissionRequest {
 	req := &admissionv1beta1.AdmissionRequest{
 		Operation: o,
@@ -295,7 +276,7 @@ func configMapRequest(
 			Version: "v1",
 			Kind:    "ConfigMap",
 		},
-		UserInfo: u,
+		UserInfo: authenticationv1.UserInfo{Username: "mattmoor"},
 	}
 	marshaled, err := json.Marshal(r)
 	if err != nil {

--- a/webhook/configmaps/controller.go
+++ b/webhook/configmaps/controller.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmaps
+
+import (
+	"context"
+	"reflect"
+
+	// Injection stuff
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	vwhinformer "knative.dev/pkg/client/injection/kube/informers/admissionregistration/v1beta1/validatingwebhookconfiguration"
+	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
+
+	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
+)
+
+// NewAdmissionController constructs a reconciler
+func NewAdmissionController(
+	ctx context.Context,
+	name, path string,
+	constructors configmap.Constructors,
+) *controller.Impl {
+
+	client := kubeclient.Get(ctx)
+	vwhInformer := vwhinformer.Get(ctx)
+	secretInformer := secretinformer.Get(ctx)
+	options := webhook.GetOptions(ctx)
+
+	wh := &reconciler{
+		name: name,
+		path: path,
+
+		constructors: make(map[string]reflect.Value),
+		secretName:   options.SecretName,
+
+		client:       client,
+		vwhlister:    vwhInformer.Lister(),
+		secretlister: secretInformer.Lister(),
+	}
+
+	for configName, constructor := range constructors {
+		wh.registerConfig(configName, constructor)
+	}
+
+	logger := logging.FromContext(ctx)
+	c := controller.NewImpl(wh, logger, "ConfigMapWebhook")
+
+	// Reconcile when the named ValidatingWebhookConfiguration changes.
+	vwhInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterWithName(name),
+		// It doesn't matter what we enqueue because we will always Reconcile
+		// the named VWH resource.
+		Handler: controller.HandleAll(c.Enqueue),
+	})
+
+	// Reconcile when the cert bundle changes.
+	secretInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterWithNameAndNamespace(system.Namespace(), wh.secretName),
+		// It doesn't matter what we enqueue because we will always Reconcile
+		// the named VWH resource.
+		Handler: controller.HandleAll(c.Enqueue),
+	})
+
+	return c
+}

--- a/webhook/configmaps/table_test.go
+++ b/webhook/configmaps/table_test.go
@@ -1,0 +1,323 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmaps
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	kubeclient "knative.dev/pkg/client/injection/kube/client/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
+
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgotesting "k8s.io/client-go/testing"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/ptr"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
+	certresources "knative.dev/pkg/webhook/certificates/resources"
+
+	. "knative.dev/pkg/reconciler/testing"
+	. "knative.dev/pkg/webhook/testing"
+)
+
+func TestReconcile(t *testing.T) {
+	name, path := "foo.bar.baz", "/blah"
+	secretName := "webhook-secret"
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: system.Namespace(),
+		},
+		Data: map[string][]byte{
+			certresources.ServerKey:  []byte("present"),
+			certresources.ServerCert: []byte("present"),
+			certresources.CACert:     []byte("present"),
+		},
+	}
+
+	ruleScope := admissionregistrationv1beta1.NamespacedScope
+
+	// These are the rules we expect given the context of "validations".
+	expectedRules := []admissionregistrationv1beta1.RuleWithOperations{{
+		Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE"},
+		Rule: admissionregistrationv1beta1.Rule{
+			APIGroups:   []string{""},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"configmaps/*"},
+			Scope:       &ruleScope,
+		},
+	}}
+
+	// The key to use, which for this singleton reconciler doesn't matter (although the
+	// namespace matters for namespace validation).
+	key := system.Namespace() + "/does not matter"
+
+	table := TableTest{{
+		Name:    "no secret",
+		Key:     key,
+		WantErr: true,
+	}, {
+		Name: "secret missing CA Cert",
+		Key:  key,
+		Objects: []runtime.Object{&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: system.Namespace(),
+			},
+			Data: map[string][]byte{
+				certresources.ServerKey:  []byte("present"),
+				certresources.ServerCert: []byte("present"),
+				// certresources.CACert:     []byte("missing"),
+			},
+		}},
+		WantErr: true,
+	}, {
+		Name:    "secret exists, but VWH does not",
+		Key:     key,
+		Objects: []runtime.Object{secret},
+		WantErr: true,
+	}, {
+		Name: "secret and VWH exist, missing service reference",
+		Key:  key,
+		Objects: []runtime.Object{secret,
+			&admissionregistrationv1beta1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1beta1.ValidatingWebhook{{
+					Name: name,
+				}},
+			},
+		},
+		WantErr: true,
+	}, {
+		Name: "secret and VWH exist, missing other stuff",
+		Key:  key,
+		Objects: []runtime.Object{secret,
+			&admissionregistrationv1beta1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1beta1.ValidatingWebhook{{
+					Name: name,
+					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+						Service: &admissionregistrationv1beta1.ServiceReference{
+							Namespace: system.Namespace(),
+							Name:      "webhook",
+						},
+					},
+				}},
+			},
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1beta1.ValidatingWebhook{{
+					Name: name,
+					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+						Service: &admissionregistrationv1beta1.ServiceReference{
+							Namespace: system.Namespace(),
+							Name:      "webhook",
+							// Path is added.
+							Path: ptr.String(path),
+						},
+						// CABundle is added.
+						CABundle: []byte("present"),
+					},
+					// Rules are added.
+					Rules: expectedRules,
+				}},
+			},
+		}},
+	}, {
+		Name: "secret and VWH exist, added fields are incorrect",
+		Key:  key,
+		Objects: []runtime.Object{secret,
+			&admissionregistrationv1beta1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1beta1.ValidatingWebhook{{
+					Name: name,
+					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+						Service: &admissionregistrationv1beta1.ServiceReference{
+							Namespace: system.Namespace(),
+							Name:      "webhook",
+							// Incorrect
+							Path: ptr.String("incorrect"),
+						},
+						// Incorrect
+						CABundle: []byte("incorrect"),
+					},
+					// Incorrect
+					Rules: []admissionregistrationv1beta1.RuleWithOperations{{
+						Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE"},
+						Rule: admissionregistrationv1beta1.Rule{
+							APIGroups:   []string{"pkg.knative.dev"},
+							APIVersions: []string{"v1alpha1"},
+							Resources:   []string{"innerdefaultresources/*"},
+						},
+					}},
+				}},
+			},
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1beta1.ValidatingWebhook{{
+					Name: name,
+					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+						Service: &admissionregistrationv1beta1.ServiceReference{
+							Namespace: system.Namespace(),
+							Name:      "webhook",
+							// Path is fixed.
+							Path: ptr.String(path),
+						},
+						// CABundle is fixed.
+						CABundle: []byte("present"),
+					},
+					// Rules are fixed.
+					Rules: expectedRules,
+				}},
+			},
+		}},
+	}, {
+		Name:    "failure updating VWH",
+		Key:     key,
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			InduceFailure("update", "validatingwebhookconfigurations"),
+		},
+		Objects: []runtime.Object{secret,
+			&admissionregistrationv1beta1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1beta1.ValidatingWebhook{{
+					Name: name,
+					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+						Service: &admissionregistrationv1beta1.ServiceReference{
+							Namespace: system.Namespace(),
+							Name:      "webhook",
+							// Incorrect
+							Path: ptr.String("incorrect"),
+						},
+						// Incorrect
+						CABundle: []byte("incorrect"),
+					},
+					// Incorrect
+					Rules: []admissionregistrationv1beta1.RuleWithOperations{{
+						Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE"},
+						Rule: admissionregistrationv1beta1.Rule{
+							APIGroups:   []string{"pkg.knative.dev"},
+							APIVersions: []string{"v1alpha1"},
+							Resources:   []string{"innerdefaultresources/*"},
+						},
+					}},
+				}},
+			},
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1beta1.ValidatingWebhook{{
+					Name: name,
+					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+						Service: &admissionregistrationv1beta1.ServiceReference{
+							Namespace: system.Namespace(),
+							Name:      "webhook",
+							// Path is fixed.
+							Path: ptr.String(path),
+						},
+						// CABundle is fixed.
+						CABundle: []byte("present"),
+					},
+					// Rules are fixed.
+					Rules: expectedRules,
+				}},
+			},
+		}},
+	}, {
+		Name: ":fire: everything is fine :fire:",
+		Key:  key,
+		Objects: []runtime.Object{secret,
+			&admissionregistrationv1beta1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1beta1.ValidatingWebhook{{
+					Name: name,
+					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+						Service: &admissionregistrationv1beta1.ServiceReference{
+							Namespace: system.Namespace(),
+							Name:      "webhook",
+							// Path is fine.
+							Path: ptr.String(path),
+						},
+						// CABundle is fine.
+						CABundle: []byte("present"),
+					},
+					// Rules are fine.
+					Rules: expectedRules,
+				}},
+			},
+		},
+	}}
+
+	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
+		wh := &reconciler{
+			name: name,
+			path: path,
+
+			client:       kubeclient.Get(ctx),
+			vwhlister:    listers.GetValidatingWebhookConfigurationLister(),
+			secretlister: listers.GetSecretLister(),
+
+			constructors: make(map[string]reflect.Value),
+			secretName:   secretName,
+		}
+
+		for configName, constructor := range validations {
+			wh.registerConfig(configName, constructor)
+		}
+
+		return wh
+	}))
+}
+
+func TestNew(t *testing.T) {
+	ctx, _ := SetupFakeContext(t)
+	ctx = webhook.WithOptions(ctx, webhook.Options{})
+
+	c := NewAdmissionController(ctx, "foo", "/bar", validations)
+	if c == nil {
+		t.Fatal("Expected NewController to return a non-nil value")
+	}
+}

--- a/webhook/resourcesemantics/controller.go
+++ b/webhook/resourcesemantics/controller.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcesemantics
+
+import (
+	"context"
+
+	// Injection stuff
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	mwhinformer "knative.dev/pkg/client/injection/kube/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration"
+	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
+)
+
+// NewAdmissionController constructs a reconciler
+func NewAdmissionController(
+	ctx context.Context,
+	name, path string,
+	handlers map[schema.GroupVersionKind]GenericCRD,
+	wc func(context.Context) context.Context,
+	disallowUnknownFields bool,
+) *controller.Impl {
+
+	client := kubeclient.Get(ctx)
+	mwhInformer := mwhinformer.Get(ctx)
+	secretInformer := secretinformer.Get(ctx)
+	options := webhook.GetOptions(ctx)
+
+	wh := &reconciler{
+		name:     name,
+		path:     path,
+		handlers: handlers,
+
+		withContext:           wc,
+		disallowUnknownFields: disallowUnknownFields,
+		secretName:            options.SecretName,
+
+		client:       client,
+		mwhlister:    mwhInformer.Lister(),
+		secretlister: secretInformer.Lister(),
+	}
+
+	logger := logging.FromContext(ctx)
+	c := controller.NewImpl(wh, logger, "ConfigMapWebhook")
+
+	// Reconcile when the named MutatingWebhookConfiguration changes.
+	mwhInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterWithName(name),
+		// It doesn't matter what we enqueue because we will always Reconcile
+		// the named MWH resource.
+		Handler: controller.HandleAll(c.Enqueue),
+	})
+
+	// Reconcile when the cert bundle changes.
+	secretInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterWithNameAndNamespace(system.Namespace(), wh.secretName),
+		// It doesn't matter what we enqueue because we will always Reconcile
+		// the named MWH resource.
+		Handler: controller.HandleAll(c.Enqueue),
+	})
+
+	return c
+}

--- a/webhook/resourcesemantics/resourcesemantics_deprecated_test.go
+++ b/webhook/resourcesemantics/resourcesemantics_deprecated_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package webhook
+package resourcesemantics
 
 import (
 	"testing"

--- a/webhook/resourcesemantics/table_test.go
+++ b/webhook/resourcesemantics/table_test.go
@@ -1,0 +1,340 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcesemantics
+
+import (
+	"context"
+	"testing"
+
+	kubeclient "knative.dev/pkg/client/injection/kube/client/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
+
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgotesting "k8s.io/client-go/testing"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/ptr"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
+	certresources "knative.dev/pkg/webhook/certificates/resources"
+
+	. "knative.dev/pkg/reconciler/testing"
+	. "knative.dev/pkg/webhook/testing"
+)
+
+func TestReconcile(t *testing.T) {
+	name, path := "foo.bar.baz", "/blah"
+	secretName := "webhook-secret"
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: system.Namespace(),
+		},
+		Data: map[string][]byte{
+			certresources.ServerKey:  []byte("present"),
+			certresources.ServerCert: []byte("present"),
+			certresources.CACert:     []byte("present"),
+		},
+	}
+
+	// These are the rules we expect given the context of "handlers".
+	expectedRules := []admissionregistrationv1beta1.RuleWithOperations{{
+		Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE"},
+		Rule: admissionregistrationv1beta1.Rule{
+			APIGroups:   []string{"pkg.knative.dev"},
+			APIVersions: []string{"v1alpha1"},
+			Resources:   []string{"innerdefaultresources/*"},
+		},
+	}, {
+		Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE"},
+		Rule: admissionregistrationv1beta1.Rule{
+			APIGroups:   []string{"pkg.knative.dev"},
+			APIVersions: []string{"v1alpha1"},
+			Resources:   []string{"resources/*"},
+		},
+	}, {
+		Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE"},
+		Rule: admissionregistrationv1beta1.Rule{
+			APIGroups:   []string{"pkg.knative.dev"},
+			APIVersions: []string{"v1beta1"},
+			Resources:   []string{"resources/*"},
+		},
+	}, {
+		Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE"},
+		Rule: admissionregistrationv1beta1.Rule{
+			APIGroups:   []string{"pkg.knative.io"},
+			APIVersions: []string{"v1alpha1"},
+			Resources:   []string{"innerdefaultresources/*"},
+		},
+	}}
+
+	// The key to use, which for this singleton reconciler doesn't matter (although the
+	// namespace matters for namespace validation).
+	key := system.Namespace() + "/does not matter"
+
+	table := TableTest{{
+		Name:    "no secret",
+		Key:     key,
+		WantErr: true,
+	}, {
+		Name: "secret missing CA Cert",
+		Key:  key,
+		Objects: []runtime.Object{&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: system.Namespace(),
+			},
+			Data: map[string][]byte{
+				certresources.ServerKey:  []byte("present"),
+				certresources.ServerCert: []byte("present"),
+				// certresources.CACert:     []byte("missing"),
+			},
+		}},
+		WantErr: true,
+	}, {
+		Name:    "secret exists, but MWH does not",
+		Key:     key,
+		Objects: []runtime.Object{secret},
+		WantErr: true,
+	}, {
+		Name: "secret and MWH exist, missing service reference",
+		Key:  key,
+		Objects: []runtime.Object{secret,
+			&admissionregistrationv1beta1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1beta1.MutatingWebhook{{
+					Name: name,
+				}},
+			},
+		},
+		WantErr: true,
+	}, {
+		Name: "secret and MWH exist, missing other stuff",
+		Key:  key,
+		Objects: []runtime.Object{secret,
+			&admissionregistrationv1beta1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1beta1.MutatingWebhook{{
+					Name: name,
+					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+						Service: &admissionregistrationv1beta1.ServiceReference{
+							Namespace: system.Namespace(),
+							Name:      "webhook",
+						},
+					},
+				}},
+			},
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: &admissionregistrationv1beta1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1beta1.MutatingWebhook{{
+					Name: name,
+					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+						Service: &admissionregistrationv1beta1.ServiceReference{
+							Namespace: system.Namespace(),
+							Name:      "webhook",
+							// Path is added.
+							Path: ptr.String(path),
+						},
+						// CABundle is added.
+						CABundle: []byte("present"),
+					},
+					// Rules are added.
+					Rules: expectedRules,
+				}},
+			},
+		}},
+	}, {
+		Name: "secret and MWH exist, added fields are incorrect",
+		Key:  key,
+		Objects: []runtime.Object{secret,
+			&admissionregistrationv1beta1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1beta1.MutatingWebhook{{
+					Name: name,
+					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+						Service: &admissionregistrationv1beta1.ServiceReference{
+							Namespace: system.Namespace(),
+							Name:      "webhook",
+							// Incorrect
+							Path: ptr.String("incorrect"),
+						},
+						// Incorrect
+						CABundle: []byte("incorrect"),
+					},
+					// Incorrect (really just incomplete)
+					Rules: []admissionregistrationv1beta1.RuleWithOperations{{
+						Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE"},
+						Rule: admissionregistrationv1beta1.Rule{
+							APIGroups:   []string{"pkg.knative.dev"},
+							APIVersions: []string{"v1alpha1"},
+							Resources:   []string{"innerdefaultresources/*"},
+						},
+					}},
+				}},
+			},
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: &admissionregistrationv1beta1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1beta1.MutatingWebhook{{
+					Name: name,
+					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+						Service: &admissionregistrationv1beta1.ServiceReference{
+							Namespace: system.Namespace(),
+							Name:      "webhook",
+							// Path is fixed.
+							Path: ptr.String(path),
+						},
+						// CABundle is fixed.
+						CABundle: []byte("present"),
+					},
+					// Rules are fixed.
+					Rules: expectedRules,
+				}},
+			},
+		}},
+	}, {
+		Name:    "failure updating MWH",
+		Key:     key,
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			InduceFailure("update", "mutatingwebhookconfigurations"),
+		},
+		Objects: []runtime.Object{secret,
+			&admissionregistrationv1beta1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1beta1.MutatingWebhook{{
+					Name: name,
+					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+						Service: &admissionregistrationv1beta1.ServiceReference{
+							Namespace: system.Namespace(),
+							Name:      "webhook",
+							// Incorrect
+							Path: ptr.String("incorrect"),
+						},
+						// Incorrect
+						CABundle: []byte("incorrect"),
+					},
+					// Incorrect (really just incomplete)
+					Rules: []admissionregistrationv1beta1.RuleWithOperations{{
+						Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE"},
+						Rule: admissionregistrationv1beta1.Rule{
+							APIGroups:   []string{"pkg.knative.dev"},
+							APIVersions: []string{"v1alpha1"},
+							Resources:   []string{"innerdefaultresources/*"},
+						},
+					}},
+				}},
+			},
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: &admissionregistrationv1beta1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1beta1.MutatingWebhook{{
+					Name: name,
+					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+						Service: &admissionregistrationv1beta1.ServiceReference{
+							Namespace: system.Namespace(),
+							Name:      "webhook",
+							// Path is fixed.
+							Path: ptr.String(path),
+						},
+						// CABundle is fixed.
+						CABundle: []byte("present"),
+					},
+					// Rules are fixed.
+					Rules: expectedRules,
+				}},
+			},
+		}},
+	}, {
+		Name: ":fire: everything is fine :fire:",
+		Key:  key,
+		Objects: []runtime.Object{secret,
+			&admissionregistrationv1beta1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1beta1.MutatingWebhook{{
+					Name: name,
+					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+						Service: &admissionregistrationv1beta1.ServiceReference{
+							Namespace: system.Namespace(),
+							Name:      "webhook",
+							// Path is fine.
+							Path: ptr.String(path),
+						},
+						// CABundle is fine.
+						CABundle: []byte("present"),
+					},
+					// Rules are fine.
+					Rules: expectedRules,
+				}},
+			},
+		},
+	}}
+
+	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
+		return &reconciler{
+			name: name,
+			path: path,
+
+			handlers: handlers,
+
+			client:       kubeclient.Get(ctx),
+			mwhlister:    listers.GetMutatingWebhookConfigurationLister(),
+			secretlister: listers.GetSecretLister(),
+
+			secretName: secretName,
+		}
+	}))
+}
+
+func TestNew(t *testing.T) {
+	ctx, _ := SetupFakeContext(t)
+	ctx = webhook.WithOptions(ctx, webhook.Options{})
+
+	c := NewAdmissionController(ctx, "foo", "/bar",
+		map[schema.GroupVersionKind]GenericCRD{},
+		func(ctx context.Context) context.Context {
+			return ctx
+		}, true /* disallow unknown field */)
+	if c == nil {
+		t.Fatal("Expected NewController to return a non-nil value")
+	}
+}

--- a/webhook/resourcesemantics/user_info.go
+++ b/webhook/resourcesemantics/user_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package webhook
+package resourcesemantics
 
 import (
 	"context"

--- a/webhook/resourcesemantics/user_info_test.go
+++ b/webhook/resourcesemantics/user_info_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package webhook
+package resourcesemantics
 
 import (
 	"context"

--- a/webhook/testing/listers.go
+++ b/webhook/testing/listers.go
@@ -17,11 +17,13 @@ limitations under the License.
 package testing
 
 import (
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	admissionlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	autoscalingv2beta1listers "k8s.io/client-go/listers/autoscaling/v2beta1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -129,4 +131,14 @@ func (l *Listers) GetConfigMapLister() corev1listers.ConfigMapLister {
 // GetNamespaceLister gets lister for Namespace resource.
 func (l *Listers) GetNamespaceLister() corev1listers.NamespaceLister {
 	return corev1listers.NewNamespaceLister(l.IndexerFor(&corev1.Namespace{}))
+}
+
+// GetMutatingWebhookConfigurationLister gets lister for K8s MutatingWebhookConfiguration resource.
+func (l *Listers) GetMutatingWebhookConfigurationLister() admissionlisters.MutatingWebhookConfigurationLister {
+	return admissionlisters.NewMutatingWebhookConfigurationLister(l.IndexerFor(&admissionregistrationv1beta1.MutatingWebhookConfiguration{}))
+}
+
+// GetValidatingWebhookConfigurationLister gets lister for K8s ValidatingWebhookConfiguration resource.
+func (l *Listers) GetValidatingWebhookConfigurationLister() admissionlisters.ValidatingWebhookConfigurationLister {
+	return admissionlisters.NewValidatingWebhookConfigurationLister(l.IndexerFor(&admissionregistrationv1beta1.ValidatingWebhookConfiguration{}))
 }

--- a/webhook/webhook_integration_test.go
+++ b/webhook/webhook_integration_test.go
@@ -38,14 +38,28 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/metrics/metricstest"
 
-	. "knative.dev/pkg/testing"
 	. "knative.dev/pkg/webhook/testing"
 )
 
 const testTimeout = time.Duration(10 * time.Second)
 
+type fixedAdmissionController struct {
+	path     string
+	response *admissionv1beta1.AdmissionResponse
+}
+
+var _ AdmissionController = (*fixedAdmissionController)(nil)
+
+func (fac *fixedAdmissionController) Path() string {
+	return fac.path
+}
+
+func (fac *fixedAdmissionController) Admit(ctx context.Context, req *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+	return fac.response
+}
+
 func TestMissingContentType(t *testing.T) {
-	ac, serverURL, cancel, err := testSetup(t)
+	wh, serverURL, cancel, err := testSetup(t)
 	if err != nil {
 		t.Fatalf("testSetup() = %v", err)
 	}
@@ -54,7 +68,7 @@ func TestMissingContentType(t *testing.T) {
 	defer close(stopCh)
 
 	go func() {
-		err := ac.Run(stopCh)
+		err := wh.Run(stopCh)
 		if err != nil {
 			t.Errorf("Unable to run controller: %s", err)
 		}
@@ -65,7 +79,7 @@ func TestMissingContentType(t *testing.T) {
 		t.Fatalf("waitForServerAvailable() = %v", err)
 	}
 
-	tlsClient, err := createSecureTLSClient(t, ac.Client, &ac.Options)
+	tlsClient, err := createSecureTLSClient(t, wh.Client, &wh.Options)
 	if err != nil {
 		t.Fatalf("createSecureTLSClient() = %v", err)
 	}
@@ -99,7 +113,7 @@ func TestMissingContentType(t *testing.T) {
 }
 
 func TestEmptyRequestBody(t *testing.T) {
-	ac, serverURL, cancel, err := testSetup(t)
+	wh, serverURL, cancel, err := testSetup(t)
 	if err != nil {
 		t.Fatalf("testSetup() = %v", err)
 	}
@@ -108,7 +122,7 @@ func TestEmptyRequestBody(t *testing.T) {
 	stopCh := make(chan struct{})
 
 	go func() {
-		err := ac.Run(stopCh)
+		err := wh.Run(stopCh)
 		if err != nil {
 			t.Errorf("Unable to run controller: %s", err)
 		}
@@ -120,7 +134,7 @@ func TestEmptyRequestBody(t *testing.T) {
 		t.Fatalf("waitForServerAvailable() = %v", err)
 	}
 
-	tlsClient, err := createSecureTLSClient(t, ac.Client, &ac.Options)
+	tlsClient, err := createSecureTLSClient(t, wh.Client, &wh.Options)
 	if err != nil {
 		t.Fatalf("createSecureTLSClient() = %v", err)
 	}
@@ -153,7 +167,11 @@ func TestEmptyRequestBody(t *testing.T) {
 }
 
 func TestValidResponseForResource(t *testing.T) {
-	ac, serverURL, cancel, err := testSetup(t)
+	ac := &fixedAdmissionController{
+		path:     "/bazinga",
+		response: &admissionv1beta1.AdmissionResponse{},
+	}
+	wh, serverURL, cancel, err := testSetup(t, ac)
 	if err != nil {
 		t.Fatalf("testSetup() = %v", err)
 	}
@@ -163,7 +181,7 @@ func TestValidResponseForResource(t *testing.T) {
 	defer close(stopCh)
 
 	go func() {
-		err := ac.Run(stopCh)
+		err := wh.Run(stopCh)
 		if err != nil {
 			t.Errorf("Unable to run controller: %s", err)
 		}
@@ -173,7 +191,7 @@ func TestValidResponseForResource(t *testing.T) {
 	if pollErr != nil {
 		t.Fatalf("waitForServerAvailable() = %v", err)
 	}
-	tlsClient, err := createSecureTLSClient(t, ac.Client, &ac.Options)
+	tlsClient, err := createSecureTLSClient(t, wh.Client, &wh.Options)
 	if err != nil {
 		t.Fatalf("createSecureTLSClient() = %v", err)
 	}
@@ -209,7 +227,7 @@ func TestValidResponseForResource(t *testing.T) {
 		t.Fatalf("bad url %v", err)
 	}
 
-	u.Path = path.Join(u.Path, testResourceValidationPath)
+	u.Path = path.Join(u.Path, ac.Path())
 
 	req, err := http.NewRequest("GET", u.String(), reqBuf)
 	if err != nil {
@@ -242,117 +260,13 @@ func TestValidResponseForResource(t *testing.T) {
 	metricstest.CheckStatsReported(t, requestCountName, requestLatenciesName)
 }
 
-func TestValidResponseForResourceWithContextDefault(t *testing.T) {
-	ac, serverURL, cancel, err := testSetup(t)
-	if err != nil {
-		t.Fatalf("testSetup() = %v", err)
-	}
-	defer cancel()
-
-	theDefault := "Some default value"
-	rac := ac.admissionControllers[testResourceValidationPath].(*ResourceAdmissionController)
-	rac.WithContext = func(ctx context.Context) context.Context {
-		return WithValue(ctx, theDefault)
-	}
-
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
-	go func() {
-		err := ac.Run(stopCh)
-		if err != nil {
-			t.Errorf("Unable to run controller: %s", err)
-		}
-	}()
-
-	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
-	if pollErr != nil {
-		t.Fatalf("waitForServerAvailable() = %v", err)
-	}
-	tlsClient, err := createSecureTLSClient(t, ac.Client, &ac.Options)
-	if err != nil {
-		t.Fatalf("createSecureTLSClient() = %v", err)
-	}
-
-	admissionreq := &admissionv1beta1.AdmissionRequest{
-		Operation: admissionv1beta1.Create,
-		Kind: metav1.GroupVersionKind{
-			Group:   "pkg.knative.dev",
-			Version: "v1alpha1",
-			Kind:    "Resource",
-		},
-	}
-	testRev := CreateResource("testrev")
-	marshaled, err := json.Marshal(testRev)
-	if err != nil {
-		t.Fatalf("Failed to marshal resource: %s", err)
-	}
-
-	admissionreq.Resource.Group = "pkg.knative.dev"
-	admissionreq.Object.Raw = marshaled
-	rev := &admissionv1beta1.AdmissionReview{
-		Request: admissionreq,
-	}
-
-	reqBuf := new(bytes.Buffer)
-	err = json.NewEncoder(reqBuf).Encode(&rev)
-	if err != nil {
-		t.Fatalf("Failed to marshal admission review: %v", err)
-	}
-
-	u, err := url.Parse(fmt.Sprintf("https://%s", serverURL))
-	if err != nil {
-		t.Fatalf("bad url %v", err)
-	}
-
-	u.Path = path.Join(u.Path, testResourceValidationPath)
-
-	req, err := http.NewRequest("GET", u.String(), reqBuf)
-	if err != nil {
-		t.Fatalf("http.NewRequest() = %v", err)
-	}
-	req.Header.Add("Content-Type", "application/json")
-
-	response, err := tlsClient.Do(req)
-	if err != nil {
-		t.Fatalf("Failed to get response %v", err)
-	}
-
-	if got, want := response.StatusCode, http.StatusOK; got != want {
-		t.Errorf("Response status code = %v, wanted %v", got, want)
-	}
-
-	defer response.Body.Close()
-	responseBody, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		t.Fatalf("Failed to read response body %v", err)
-	}
-
-	reviewResponse := admissionv1beta1.AdmissionReview{}
-
-	err = json.NewDecoder(bytes.NewReader(responseBody)).Decode(&reviewResponse)
-	if err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
-	}
-
-	ExpectPatches(t, reviewResponse.Response.Patch, []jsonpatch.JsonPatchOperation{{
-		Operation: "add",
-		Path:      "/spec/fieldThatsImmutableWithDefault",
-		Value:     "this is another default value",
-	}, {
-		Operation: "add",
-		Path:      "/spec/fieldWithDefault",
-		Value:     "I'm a default.",
-	}, {
-		Operation: "add",
-		Path:      "/spec/fieldWithContextDefault",
-		Value:     theDefault,
-	}, setUserAnnotation("", ""),
-	})
-}
-
 func TestInvalidResponseForResource(t *testing.T) {
-	ac, serverURL, cancel, err := testSetup(t)
+	expectedError := "everything is fine."
+	ac := &fixedAdmissionController{
+		path:     "/booger",
+		response: MakeErrorStatus(expectedError),
+	}
+	wh, serverURL, cancel, err := testSetup(t, ac)
 	if err != nil {
 		t.Fatalf("testSetup() = %v", err)
 	}
@@ -362,7 +276,7 @@ func TestInvalidResponseForResource(t *testing.T) {
 	defer close(stopCh)
 
 	go func() {
-		err := ac.Run(stopCh)
+		err := wh.Run(stopCh)
 		if err != nil {
 			t.Errorf("Unable to run controller: %s", err)
 		}
@@ -372,7 +286,7 @@ func TestInvalidResponseForResource(t *testing.T) {
 	if pollErr != nil {
 		t.Fatalf("waitForServerAvailable() = %v", err)
 	}
-	tlsClient, err := createSecureTLSClient(t, ac.Client, &ac.Options)
+	tlsClient, err := createSecureTLSClient(t, wh.Client, &wh.Options)
 	if err != nil {
 		t.Fatalf("createSecureTLSClient() = %v", err)
 	}
@@ -414,7 +328,7 @@ func TestInvalidResponseForResource(t *testing.T) {
 		t.Fatalf("bad url %v", err)
 	}
 
-	u.Path = path.Join(u.Path, testResourceValidationPath)
+	u.Path = path.Join(u.Path, ac.Path())
 
 	req, err := http.NewRequest("GET", u.String(), reqBuf)
 	if err != nil {
@@ -455,186 +369,7 @@ func TestInvalidResponseForResource(t *testing.T) {
 		t.Errorf("Response status = %v, wanted %v", got, want)
 	}
 
-	if !strings.Contains(reviewResponse.Response.Result.Message, "invalid value") {
-		t.Errorf("Received unexpected response status message %s", reviewResponse.Response.Result.Message)
-	}
-	if !strings.Contains(reviewResponse.Response.Result.Message, "spec.fieldWithValidation") {
-		t.Errorf("Received unexpected response status message %s", reviewResponse.Response.Result.Message)
-	}
-
-	// Stats should be reported for requests that have admission disallowed
-	metricstest.CheckStatsReported(t, requestCountName, requestLatenciesName)
-}
-
-func TestValidResponseForConfigMap(t *testing.T) {
-	ac, serverURL, cancel, err := testSetup(t)
-	if err != nil {
-		t.Fatalf("testSetup() = %v", err)
-	}
-	defer cancel()
-
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
-	go func() {
-		err := ac.Run(stopCh)
-		if err != nil {
-			t.Errorf("Unable to run controller: %s", err)
-		}
-	}()
-
-	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
-	if pollErr != nil {
-		t.Fatalf("waitForServerAvailable() = %v", err)
-	}
-	tlsClient, err := createSecureTLSClient(t, ac.Client, &ac.Options)
-	if err != nil {
-		t.Fatalf("createSecureTLSClient() = %v", err)
-	}
-
-	admissionreq := configMapRequest(
-		createValidConfigMap(),
-		admissionv1beta1.Create,
-		authenticationv1.UserInfo{},
-	)
-	rev := &admissionv1beta1.AdmissionReview{
-		Request: admissionreq,
-	}
-
-	reqBuf := new(bytes.Buffer)
-	err = json.NewEncoder(reqBuf).Encode(&rev)
-	if err != nil {
-		t.Fatalf("Failed to marshal admission review: %v", err)
-	}
-
-	u, err := url.Parse(fmt.Sprintf("https://%s", serverURL))
-	if err != nil {
-		t.Fatalf("bad url %v", err)
-	}
-
-	u.Path = path.Join(u.Path, testConfigValidationPath)
-	req, err := http.NewRequest("GET", u.String(), reqBuf)
-	if err != nil {
-		t.Fatalf("http.NewRequest() = %v", err)
-	}
-	req.Header.Add("Content-Type", "application/json")
-
-	response, err := tlsClient.Do(req)
-	if err != nil {
-		t.Fatalf("Failed to get response %v", err)
-	}
-
-	if got, want := response.StatusCode, http.StatusOK; got != want {
-		t.Errorf("Response status code = %v, wanted %v", got, want)
-	}
-
-	defer response.Body.Close()
-	responseBody, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		t.Fatalf("Failed to read response body %v", err)
-	}
-
-	reviewResponse := admissionv1beta1.AdmissionReview{}
-
-	err = json.NewDecoder(bytes.NewReader(responseBody)).Decode(&reviewResponse)
-	if err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
-	}
-
-	ExpectAllowed(t, reviewResponse.Response)
-
-	metricstest.CheckStatsReported(t, requestCountName, requestLatenciesName)
-}
-
-func TestInvalidResponseForConfigMap(t *testing.T) {
-	ac, serverURL, cancel, err := testSetup(t)
-	if err != nil {
-		t.Fatalf("testSetup() = %v", err)
-	}
-	defer cancel()
-
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
-	go func() {
-		err := ac.Run(stopCh)
-		if err != nil {
-			t.Errorf("Unable to run controller: %s", err)
-		}
-	}()
-
-	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
-	if pollErr != nil {
-		t.Fatalf("waitForServerAvailable() = %v", err)
-	}
-	tlsClient, err := createSecureTLSClient(t, ac.Client, &ac.Options)
-	if err != nil {
-		t.Fatalf("createSecureTLSClient() = %v", err)
-	}
-
-	admissionreq := configMapRequest(
-		createWrongTypeConfigMap(),
-		admissionv1beta1.Create,
-		authenticationv1.UserInfo{},
-	)
-	rev := &admissionv1beta1.AdmissionReview{
-		Request: admissionreq,
-	}
-
-	reqBuf := new(bytes.Buffer)
-	err = json.NewEncoder(reqBuf).Encode(&rev)
-	if err != nil {
-		t.Fatalf("Failed to marshal admission review: %v", err)
-	}
-
-	u, err := url.Parse(fmt.Sprintf("https://%s", serverURL))
-	if err != nil {
-		t.Fatalf("bad url %v", err)
-	}
-
-	u.Path = path.Join(u.Path, testConfigValidationPath)
-	req, err := http.NewRequest("GET", u.String(), reqBuf)
-	if err != nil {
-		t.Fatalf("http.NewRequest() = %v", err)
-	}
-	req.Header.Add("Content-Type", "application/json")
-
-	response, err := tlsClient.Do(req)
-	if err != nil {
-		t.Fatalf("Failed to receive response %v", err)
-	}
-
-	if got, want := response.StatusCode, http.StatusOK; got != want {
-		t.Errorf("Response status code = %v, wanted %v", got, want)
-	}
-
-	defer response.Body.Close()
-	respBody, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		t.Fatalf("Failed to read response body %v", err)
-	}
-
-	reviewResponse := admissionv1beta1.AdmissionReview{}
-
-	err = json.NewDecoder(bytes.NewReader(respBody)).Decode(&reviewResponse)
-	if err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
-	}
-
-	var respPatch []jsonpatch.JsonPatchOperation
-	err = json.Unmarshal(reviewResponse.Response.Patch, &respPatch)
-	if err == nil {
-		t.Fatalf("Expected to fail JSON unmarshal of resposnse")
-	}
-
-	if got, want := reviewResponse.Response.Result.Status, "Failure"; got != want {
-		t.Errorf("Response status = %v, wanted %v", got, want)
-	}
-
-	if !strings.Contains(reviewResponse.Response.Result.Message, "invalid syntax") {
-		t.Errorf("Received unexpected response status message %s", reviewResponse.Response.Result.Message)
-	}
-	if !strings.Contains(reviewResponse.Response.Result.Message, "strconv.ParseFloat") {
+	if !strings.Contains(reviewResponse.Response.Result.Message, expectedError) {
 		t.Errorf("Received unexpected response status message %s", reviewResponse.Response.Result.Message)
 	}
 
@@ -645,7 +380,7 @@ func TestInvalidResponseForConfigMap(t *testing.T) {
 func TestSetupWebhookHTTPServerError(t *testing.T) {
 	defaultOpts := newDefaultOptions()
 	defaultOpts.Port = -1 // invalid port
-	ctx, ac, cancel := newNonRunningTestWebhook(t, defaultOpts)
+	ctx, wh, cancel := newNonRunningTestWebhook(t, defaultOpts)
 	defer cancel()
 	kubeClient := kubeclient.Get(ctx)
 
@@ -661,7 +396,7 @@ func TestSetupWebhookHTTPServerError(t *testing.T) {
 	stopCh := make(chan struct{})
 	errCh := make(chan error)
 	go func() {
-		if err := ac.Run(stopCh); err != nil {
+		if err := wh.Run(stopCh); err != nil {
 			errCh <- err
 		}
 	}()
@@ -676,7 +411,7 @@ func TestSetupWebhookHTTPServerError(t *testing.T) {
 	}
 }
 
-func testSetup(t *testing.T) (*Webhook, string, context.CancelFunc, error) {
+func testSetup(t *testing.T, acs ...AdmissionController) (*Webhook, string, context.CancelFunc, error) {
 	t.Helper()
 	port, err := newTestPort()
 	if err != nil {
@@ -685,19 +420,8 @@ func testSetup(t *testing.T) (*Webhook, string, context.CancelFunc, error) {
 
 	defaultOpts := newDefaultOptions()
 	defaultOpts.Port = port
-	ctx, ac, cancel := newNonRunningTestWebhook(t, defaultOpts)
-	kubeClient := kubeclient.Get(ctx)
-
-	nsErr := createNamespace(t, kubeClient, metav1.NamespaceSystem)
-	if nsErr != nil {
-		return nil, "", nil, nsErr
-	}
-
-	cMapsErr := createTestConfigMap(t, kubeClient)
-	if cMapsErr != nil {
-		return nil, "", nil, cMapsErr
-	}
+	_, wh, cancel := newNonRunningTestWebhook(t, defaultOpts, acs...)
 
 	resetMetrics()
-	return ac, fmt.Sprintf("0.0.0.0:%d", port), cancel, nil
+	return wh, fmt.Sprintf("0.0.0.0:%d", port), cancel, nil
 }


### PR DESCRIPTION
This is the culmination of a large number of changes to refactor our webhook logic, and adopt a reconciler-based approach to make it resilient to unexected system events (e.g. rogue GCs!).

For more details on how this is consumed, see the new `webhook/README.md`.

Fixes: https://github.com/knative/pkg/issues/782
Closes: https://github.com/knative/pkg/issues/529
Fixes: https://github.com/knative/pkg/issues/450
Related: https://github.com/knative/pkg/issues/141

/hold
... as I stage downstream changes.