### PR TITLE
Fixed knative activator handshake timeout issue

### DIFF
--- a/websocket/connection.go
+++ b/websocket/connection.go
@@ -106,10 +106,11 @@ func NewDurableSendingConnection(target string, logger *zap.SugaredLogger) *Mana
 // go func() {for range messageChan {}}
 func NewDurableConnection(target string, messageChan chan []byte, logger *zap.SugaredLogger) *ManagedConnection {
 	websocketConnectionFactory := func() (rawConnection, error) {
-		dialer := &websocket.Dialer{
-			HandshakeTimeout: 3 * time.Second,
-		}
+		dialer := websocket.DefaultDialer
 		conn, _, err := dialer.Dial(target, nil)
+		if err != nil {
+			logger.Errorw("Websocket connection could not be established", zap.Error(err))
+		}
 		return conn, err
 	}
 


### PR DESCRIPTION
The original handshake timeout is too short to dial connection
successfully under some situation. So the activator pod can not be
active. And the log message just say "Failed to send ping message to
ws://autoscaler.knative-serving.svc.cluster.local:8080", not easy to
figure out what's the problem underneeth.

The fix switch to websocket default dial, so the default handle shake
time is 45 seconds, and once dial error found, the error will be
reported as error.