### PR TITLE
Assorted linting fixes.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1326,7 +1326,6 @@
     "go.uber.org/zap/zaptest",
     "golang.org/x/net/context",
     "golang.org/x/oauth2",
-    "golang.org/x/oauth2/google",
     "golang.org/x/sync/errgroup",
     "google.golang.org/api/container/v1beta1",
     "google.golang.org/api/iterator",

--- a/cloudevents/event_v01.go
+++ b/cloudevents/event_v01.go
@@ -28,11 +28,6 @@ const (
 	// V01CloudEventsVersion is the version of the CloudEvents spec targeted
 	// by this library.
 	V01CloudEventsVersion = "0.1"
-
-	// v0.1 field names
-	fieldCloudEventsVersion = "CloudEventsVersion"
-	fieldEventID            = "EventID"
-	fieldEventType          = "EventType"
 )
 
 // V01EventContext holds standard metadata about an event. See

--- a/cloudevents/handler_test.go
+++ b/cloudevents/handler_test.go
@@ -62,7 +62,7 @@ func TestHandlerTypeErrors(t *testing.T) {
 		},
 		{
 			name: "wrong return count",
-			param: func() (interface{}, cloudevents.EventContext, error, interface{}) {
+			param: func() (interface{}, cloudevents.EventContext, interface{}, error) {
 				return nil, cloudevents.EventContext{}, nil, nil
 			},
 			err: "Expected a function returning either nothing, an error, (any, error), or (any, SendContext, error); function has too many return types (4)",

--- a/codegen/cmd/injection-gen/generators/fakeinformer.go
+++ b/codegen/cmd/injection-gen/generators/fakeinformer.go
@@ -32,7 +32,6 @@ type fakeInformerGenerator struct {
 	generator.DefaultGen
 	outputPackage string
 	imports       namer.ImportTracker
-	filtered      bool
 
 	typeToGenerate          *types.Type
 	groupVersion            clientgentypes.GroupVersion

--- a/controller/stats_reporter.go
+++ b/controller/stats_reporter.go
@@ -174,15 +174,9 @@ func init() {
 		Aggregation: reconcileDistribution,
 		TagKeys:     []tag.Key{reconcilerTagKey, keyTagKey, successTagKey},
 	}}
-	for _, view := range wp.DefaultViews() {
-		views = append(views, view)
-	}
-	for _, view := range rp.DefaultViews() {
-		views = append(views, view)
-	}
-	for _, view := range cp.DefaultViews() {
-		views = append(views, view)
-	}
+	views = append(views, wp.DefaultViews()...)
+	views = append(views, rp.DefaultViews()...)
+	views = append(views, cp.DefaultViews()...)
 
 	// Create views to see our measurements. This can return an error if
 	// a previously-registered view has the same name with a different value.

--- a/injection/informers_test.go
+++ b/injection/informers_test.go
@@ -61,8 +61,8 @@ func TestRegisterInformersAndSetup(t *testing.T) {
 	i.RegisterInformer(injectFooInformer)
 	i.RegisterInformer(injectBarInformer)
 
-	ctx, infs := context.Background(), []controller.Informer{}
-	ctx, infs = i.SetupInformers(ctx, &rest.Config{})
+	ctx, _ := context.Background(), []controller.Informer{}
+	_, infs := i.SetupInformers(ctx, &rest.Config{})
 
 	if want, got := 2, len(infs); got != want {
 		t.Errorf("SetupInformers() = %d, wanted %d", want, got)

--- a/injection/informers_test.go
+++ b/injection/informers_test.go
@@ -61,8 +61,7 @@ func TestRegisterInformersAndSetup(t *testing.T) {
 	i.RegisterInformer(injectFooInformer)
 	i.RegisterInformer(injectBarInformer)
 
-	ctx, _ := context.Background(), []controller.Informer{}
-	_, infs := i.SetupInformers(ctx, &rest.Config{})
+	_, infs := i.SetupInformers(context.Background(), &rest.Config{})
 
 	if want, got := 2, len(infs); got != want {
 		t.Errorf("SetupInformers() = %d, wanted %d", want, got)

--- a/kmp/reporters_test.go
+++ b/kmp/reporters_test.go
@@ -31,7 +31,8 @@ type testStruct struct {
 	Omit        string      `json:"omit,omitempty"`
 	Ignore      string      `json:"-"`
 	Dash        string      `json:"-,"`
-	MultiComma  string      `json:"multi,omitempty,somethingelse"`
+	//lint:ignore SA5008 we actually want to test this broken json options work
+	MultiComma string `json:"multi,omitempty,somethingelse"`
 }
 
 type childStruct struct {

--- a/logging/config.go
+++ b/logging/config.go
@@ -38,7 +38,7 @@ const (
 	fallbackLoggerName = "fallback-logger"
 )
 
-var emptyLoggerConfigError = errors.New("empty logger configuration")
+var errEmptyLoggerConfig = errors.New("empty logger configuration")
 
 // NewLogger creates a logger with the supplied configuration.
 // In addition to the logger, it returns AtomicLevel that can
@@ -112,7 +112,7 @@ func newLoggerFromConfig(configJSON string, levelOverride string, opts []zap.Opt
 
 func zapConfigFromJSON(configJSON string) (*zap.Config, error) {
 	if configJSON == "" {
-		return nil, emptyLoggerConfigError
+		return nil, errEmptyLoggerConfig
 	}
 
 	loggingCfg := &zap.Config{}
@@ -206,7 +206,7 @@ func UpdateLevelFromConfigMap(logger *zap.SugaredLogger, atomicLevel zap.AtomicL
 			// reset to global level
 			loggingCfg, err := zapConfigFromJSON(config.LoggingConfig)
 			switch {
-			case err == emptyLoggerConfigError:
+			case err == errEmptyLoggerConfig:
 				level = zap.NewAtomicLevel().Level()
 			case err != nil:
 				logger.With(zap.Error(err)).Errorf("Failed to parse logger configuration. "+

--- a/test/ghutil/fakeghutil/fakeghutil.go
+++ b/test/ghutil/fakeghutil/fakeghutil.go
@@ -349,7 +349,7 @@ func (fgc *FakeGithubClient) AddFileToCommit(org, repo, SHA, filename, patch str
 		Patch:    &patch,
 	}
 	if _, ok := fgc.CommitFiles[SHA]; !ok {
-		fgc.CommitFiles[SHA] = make([]*github.CommitFile, 0, 0)
+		fgc.CommitFiles[SHA] = make([]*github.CommitFile, 0)
 	}
 	fgc.CommitFiles[SHA] = append(fgc.CommitFiles[SHA], f)
 	return nil
@@ -366,7 +366,7 @@ func (fgc *FakeGithubClient) AddCommitToPullRequest(org, repo string, ID int, SH
 		return fmt.Errorf("Pull Request %d not exist", ID)
 	}
 	if _, ok = fgc.PRCommits[ID]; !ok {
-		fgc.PRCommits[ID] = make([]*github.RepositoryCommit, 0, 0)
+		fgc.PRCommits[ID] = make([]*github.RepositoryCommit, 0)
 	}
 	fgc.PRCommits[ID] = append(fgc.PRCommits[ID], &github.RepositoryCommit{SHA: &SHA})
 	return nil

--- a/test/ghutil/fakeghutil/fakeghutil.go
+++ b/test/ghutil/fakeghutil/fakeghutil.go
@@ -214,8 +214,8 @@ func (fgc *FakeGithubClient) ListPullRequests(org, repo, head, base string) ([]*
 	}
 	for _, PR := range PRs {
 		// Filter with consistent logic of CreatePullRequest function below
-		if ("" == head || *PR.Head.Label == head) &&
-			("" == base || *PR.Base.Ref == base) {
+		if (head == "" || head == *PR.Head.Label) &&
+			(base == "" || base == *PR.Base.Ref) {
 			res = append(res, PR)
 		}
 	}
@@ -304,7 +304,7 @@ func (fgc *FakeGithubClient) CreatePullRequest(org, repo, head, base, title, bod
 		State:               &stateStr,
 		Number:              &PRNumber,
 	}
-	if "" != head {
+	if head != "" {
 		tokens := strings.Split(head, ":")
 		if len(tokens) != 2 {
 			return nil, fmt.Errorf("invalid head, want: 'user:ref', got: '%s'", head)
@@ -314,7 +314,7 @@ func (fgc *FakeGithubClient) CreatePullRequest(org, repo, head, base, title, bod
 			Ref:   &tokens[1],
 		}
 	}
-	if "" != base {
+	if base != "" {
 		l := fmt.Sprintf("%s:%s", repo, base)
 		PR.Base = &github.PullRequestBranch{
 			Label: &l,

--- a/test/gke/client.go
+++ b/test/gke/client.go
@@ -22,7 +22,6 @@ import (
 	container "google.golang.org/api/container/v1beta1"
 
 	"golang.org/x/net/context"
-	"golang.org/x/oauth2/google"
 )
 
 // SDKOperations wraps GKE SDK related functions
@@ -43,13 +42,7 @@ type sdkClient struct {
 
 // NewSDKClient returns an SDKClient that implements SDKOperations
 func NewSDKClient() (SDKOperations, error) {
-	ctx := context.Background()
-	c, err := google.DefaultClient(ctx, container.CloudPlatformScope)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Google client: '%v'", err)
-	}
-
-	containerService, err := container.New(c)
+	containerService, err := container.NewService(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create container service: '%v'", err)
 	}

--- a/test/gke/wait.go
+++ b/test/gke/wait.go
@@ -43,13 +43,14 @@ func Wait(gsc SDKOperations, project, region, zone, opName string, wait time.Dur
 	var err error
 
 	timeout := time.After(wait)
-	tick := time.Tick(500 * time.Millisecond)
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
 	for {
 		select {
 		// Got a timeout! fail with a timeout error
 		case <-timeout:
 			return errors.New("timed out waiting")
-		case <-tick:
+		case <-ticker.C:
 			// Retry 3 times in case of weird network error, or rate limiting
 			for r, w := 0, 50*time.Microsecond; r < 3; r, w = r+1, w*2 {
 				op, err = gsc.GetOperation(project, region, zone, opName)

--- a/test/helpers/dryrun.go
+++ b/test/helpers/dryrun.go
@@ -26,7 +26,7 @@ func Run(message string, call func() error, dryrun bool) error {
 		log.Printf("[dry run] %s", message)
 		return nil
 	}
-	log.Printf(message)
+	log.Print(message)
 
 	return call()
 }

--- a/test/junit/junit_test.go
+++ b/test/junit/junit_test.go
@@ -144,7 +144,7 @@ func TestAddTestSuite(t *testing.T) {
 		t.Fatalf("Expected '', actual '%v'", err)
 	}
 
-	if 2 != len(testSuites.Suites) {
+	if len(testSuites.Suites) != 2 {
 		t.Fatalf("Expected 2, actual %d", len(testSuites.Suites))
 	}
 }

--- a/test/mako/alerter/github/issue.go
+++ b/test/mako/alerter/github/issue.go
@@ -177,7 +177,7 @@ func (gih *IssueHandler) CloseIssueForTest(testName string) error {
 		return nil
 	}
 	// If the issue is still active, do not close it.
-	if time.Now().Sub(issue.GetUpdatedAt()) < daysConsideredActive*24*time.Hour {
+	if time.Since(issue.GetUpdatedAt()) < daysConsideredActive*24*time.Hour {
 		return nil
 	}
 
@@ -233,7 +233,7 @@ func (gih *IssueHandler) findIssue(title string) (*github.Issue, error) {
 		if *issue.Title == title {
 			// If the issue has been closed a long time ago, ignore this issue.
 			if issue.GetState() == string(ghutil.IssueCloseState) &&
-				time.Now().Sub(*issue.UpdatedAt) > daysConsideredOld*24*time.Hour {
+				time.Since(*issue.UpdatedAt) > daysConsideredOld*24*time.Hour {
 				continue
 			}
 

--- a/test/webhook-apicoverage/resourcetree/test_util.go
+++ b/test/webhook-apicoverage/resourcetree/test_util.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcetree
 
 //test_util contains types defined and used by types and their corresponding verification methods.
+//lint:file-ignore U1000 Ignore all unused code, it's needed
 
 import (
 	"container/list"

--- a/testutils/clustermanager/e2e-tests/gke.go
+++ b/testutils/clustermanager/e2e-tests/gke.go
@@ -234,7 +234,7 @@ func (gc *GKECluster) Acquire() error {
 			if i != len(regions)-1 {
 				errMsg = fmt.Sprintf("%sRetry another region %q for cluster creation", errMsg, regions[i+1])
 			}
-			log.Printf(errMsg)
+			log.Print(errMsg)
 		} else {
 			log.Print("Cluster creation completed")
 			gc.Cluster = cluster

--- a/webhook/resourcesemantics/resourcesemantics_test.go
+++ b/webhook/resourcesemantics/resourcesemantics_test.go
@@ -548,17 +548,6 @@ func createInnerDefaultResourceWithSpecAndStatus(t *testing.T, spec *InnerDefaul
 	return b
 }
 
-func setUserAnnotation(userC, userU string) jsonpatch.JsonPatchOperation {
-	return jsonpatch.JsonPatchOperation{
-		Operation: "add",
-		Path:      "/metadata/annotations",
-		Value: map[string]interface{}{
-			"pkg.knative.dev/creator":      userC,
-			"pkg.knative.dev/lastModifier": userU,
-		},
-	}
-}
-
 func NewTestResourceAdmissionController(t *testing.T) *reconciler {
 	ctx, _ := SetupFakeContext(t)
 	ctx = webhook.WithOptions(ctx, webhook.Options{

--- a/webhook/testing/testing.go
+++ b/webhook/testing/testing.go
@@ -28,21 +28,20 @@ import (
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/system"
+	pkgtest "knative.dev/pkg/testing"
 
 	// Makes system.Namespace work in tests.
 	_ "knative.dev/pkg/system/testing"
-
-	. "knative.dev/pkg/testing"
 )
 
 // CreateResource creates a testing.Resource with the given name in the system namespace.
-func CreateResource(name string) *Resource {
-	return &Resource{
+func CreateResource(name string) *pkgtest.Resource {
+	return &pkgtest.Resource{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
 			Name:      name,
 		},
-		Spec: ResourceSpec{
+		Spec: pkgtest.ResourceSpec{
 			FieldWithValidation: "magic value",
 		},
 	}

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -41,10 +41,6 @@ import (
 	certresources "knative.dev/pkg/webhook/certificates/resources"
 )
 
-var (
-	errMissingNewObject = errors.New("the new object may not be nil")
-)
-
 // Options contains the configuration for the webhook
 type Options struct {
 	// ServiceName is the service name of the webhook.

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -44,12 +44,6 @@ const (
 	testResourceName = "test-resource"
 	user1            = "brutto@knative.dev"
 	user2            = "arrabbiato@knative.dev"
-
-	testResourceValidationPath = "/foo"
-	testResourceValidationName = "webhook.knative.dev"
-
-	testConfigValidationName = "configmap.webhook.knative.dev"
-	testConfigValidationPath = "/cm"
 )
 
 func newNonRunningTestWebhook(t *testing.T, options Options, acs ...AdmissionController) (


### PR DESCRIPTION
There's a lot of linter juice in knative.dev/pkg. This fixes almost all of the warnings except for capitalized error strings.