### PR TITLE
Avoid race on "server-key.pem" in `webhook.Run`.

### DIFF
--- a/webhook/certificates/certificates.go
+++ b/webhook/certificates/certificates.go
@@ -25,6 +25,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
 	certresources "knative.dev/pkg/webhook/certificates/resources"
 )
 
@@ -39,6 +40,13 @@ var _ controller.Reconciler = (*reconciler)(nil)
 
 // Reconcile implements controller.Reconciler
 func (r *reconciler) Reconcile(ctx context.Context, key string) error {
+	defer func() {
+		s := webhook.SecretsReconciled
+		webhook.SecretsReconciled = nil
+		if s != nil {
+			close(s)  // Notify current listeners that the channel is closed.
+		}
+	}()
 	return r.reconcileCertificate(ctx)
 }
 

--- a/webhook/certificates/certificates_test.go
+++ b/webhook/certificates/certificates_test.go
@@ -200,4 +200,8 @@ func TestNew(t *testing.T) {
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")
 	}
+
+	if webhook.SecretsReconciled == nil {
+		t.Fatal("Expected NewController to initialize webhook.SecretsReconciled")
+	}
 }

--- a/webhook/certificates/controller.go
+++ b/webhook/certificates/controller.go
@@ -40,6 +40,7 @@ func NewController(
 	cmw configmap.Watcher,
 ) *controller.Impl {
 
+	webhook.SecretsReconciled = make(chan struct{}, 1)
 	client := kubeclient.Get(ctx)
 	secretInformer := secretinformer.Get(ctx)
 	options := webhook.GetOptions(ctx)


### PR DESCRIPTION
@houshengbo reported webhook failures while running the operator test of the form:

```json
{
  "level":"error",
  "ts":"2019-11-04T17:52:51.002Z",
  "logger":"webhook",
  "caller":"webhook/webhook.go:160",
  "msg":"could not configure admission webhook certs",
  "commit":"33e4197",
  "knative.dev/controller":"webhook",
  "error":"server key missing",
  "stacktrace":"knative.dev/serving/vendor/knative.dev/pkg/webhook.(*Webhook).Run
      /Users/vincent/go/src/knative.dev/serving/vendor/knative.dev/pkg/webhook/webhook.go:160
main.main.func2
     /Users/vincent/go/src/knative.dev/serving/cmd/webhook/main.go:198
knative.dev/serving/vendor/golang.org/x/sync/errgroup.(*Group).Go.func1
     Users/vincent/go/src/knative.dev/serving/vendor/golang.org/x/sync/errgroup/errgroup.go:58"
}
{
  "level":"error",
  "ts":"2019-11-04T17:52:51.003Z",
  "logger":"webhook",
  "caller":"webhook/main.go:209",
  "msg":"Error while running server",
  "commit":"33e4197",
  "knative.dev/controller":"webhook",
  "error":"server key missing",
  "stacktrace":"main.main
     /Users/vincent/go/src/knative.dev/serving/cmd/webhook/main.go:209
runtime.main
     /usr/local/go/src/runtime/proc.go:203"
}
```

Debugging, it looks like knative-serving defines the `webhook-certs` Secret as:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: webhook-certs
  namespace: knative-serving
  labels:
    serving.knative.dev/release: devel
# The data is populated at install time.
```

Unfortunately, the "install time" population is done by the webhook controller by calling `certificates.NewController`:

https://github.com/knative/serving/tree/master/cmd/webhook/main.go#L138

Which is then batched with other controller startup in `controller.StartAll`:

https://github.com/knative/pkg/blob/master/injection/sharedmain/main.go#L186

Code then proceeds to start the Webhooks with `Webhook.Run()` while the controllers start to initialize. Unfortunately, if the Webhooks return an error, we call `logger.Fatalw()` with the error:

https://github.com/knative/pkg/blob/master/injection/sharedmain/main.go#L201

And the Webhook code will return an error if the secret doesn't exist in the Lister or if it doesn't contain the server key or server cert created by the `certificates.NewController`'s `Reconcile()` method:

https://github.com/knative/pkg/blob/master/webhook/webhook.go#L144


This change causes construction of the new controllers on [lines 154-162 of sharedmain/main.go](https://github.com/knative/pkg/blob/master/injection/sharedmain/main.go#154) to initialize a (package-shared global) `chan struct{}` which will be closed *after* the first reconcile loop of `certificates.reconciler.Reconcile()`.


I looked at the current webhook test and wasn't easily able to figure out how to test the await functionality there -- suggestions welcome.