### PR TITLE
Add Namespace index to listers in tests.

### DIFF
--- a/reconciler/testing/sorter.go
+++ b/reconciler/testing/sorter.go
@@ -89,5 +89,5 @@ func (o *ObjectSorter) IndexerForObjectType(obj runtime.Object) cache.Indexer {
 }
 
 func emptyIndexer() cache.Indexer {
-	return cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	return cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }


### PR DESCRIPTION
Not having this causes the listers to log an annoying log message like

```
W1108 02:48:54.848573  211995 listers.go:77] can not retrieve list of objects using index : Index with name namespace does not exist
```

That message doesn't cause the tests to fail because the cache logic works around by doing a "slow indexing". I was very confused by this log though and sunk a bit of time into debugging it, so here we go.