### PR TITLE
Add QueryParams field in HTTPMatchRequest to istio CRDs

### DIFF
--- a/apis/istio/v1alpha3/virtualservice_types.go
+++ b/apis/istio/v1alpha3/virtualservice_types.go
@@ -350,6 +350,20 @@ type HTTPMatchRequest struct {
 	// at the top of the VirtualService (if any) are overridden. The gateway match is
 	// independent of sourceLabels.
 	Gateways []string `json:"gateways,omitempty"`
+
+	// Query parameters for matching.
+	//
+	// Ex:
+	// - For a query parameter like "?key=true", the map key would be "key" and
+	//   the string match could be defined as `exact: "true"`.
+	// - For a query parameter like "?key", the map key would be "key" and the
+	//   string match could be defined as `exact: ""`.
+	// - For a query parameter like "?key=123", the map key would be "key" and the
+	//   string match could be defined as `regex: "\d+$"`. Note that this
+	//   configuration will only match values like "123" but not "a123" or "123a".
+	//
+	// **Note:** `prefix` matching is currently not supported.
+	QueryParams map[string]v1alpha1.StringMatch `json:"queryParams,omitempty"`
 }
 
 type HTTPRouteDestination struct {

--- a/apis/istio/v1alpha3/zz_generated.deepcopy.go
+++ b/apis/istio/v1alpha3/zz_generated.deepcopy.go
@@ -392,6 +392,13 @@ func (in *HTTPMatchRequest) DeepCopyInto(out *HTTPMatchRequest) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.QueryParams != nil {
+		in, out := &in.QueryParams, &out.QueryParams
+		*out = make(map[string]v1alpha1.StringMatch, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
The istio VirtualService's subfield [HTTPMatchRequest](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPMatchRequest) has a field queryParams, which is missing in knative istio api.  

[The code of istio api](https://github.com/istio/api/blob/e0714535229bd6078e2ab57f8b9a5cf7f66b0b62/networking/v1alpha3/virtual_service.pb.go#L1160-L1172 ).

For now, I need to use the queryParams field. Therefore, I propose to add this field in this PR.