### PR TITLE
Skip watching the ConfigMaps if they are missing

### DIFF
--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -167,13 +167,18 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 	if _, err := kubeclient.Get(ctx).CoreV1().ConfigMaps(system.Namespace()).Get(logging.ConfigMapName(),
 		metav1.GetOptions{}); err == nil {
 		cmw.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
+	} else if !apierrors.IsNotFound(err) {
+		logger.Fatalw("Error reading ConfigMap: " + logging.ConfigMapName(), zap.Error(err))
 	}
+
 	// Watch the observability config map
 	if _, err := kubeclient.Get(ctx).CoreV1().ConfigMaps(system.Namespace()).Get(metrics.ConfigMapName(),
 		metav1.GetOptions{}); err == nil {
 		cmw.Watch(metrics.ConfigMapName(),
 			metrics.UpdateExporterFromConfigMap(component, logger),
 			profilingHandler.UpdateFromConfigMap)
+	} else if !apierrors.IsNotFound(err) {
+		logger.Fatalw("Error reading ConfigMap: " + metrics.ConfigMapName(), zap.Error(err))
 	}
 
 	if err := cmw.Start(ctx.Done()); err != nil {


### PR DESCRIPTION
This PR should be the most straightforward fix by NOT adding the ConfigMaps into the config map watcher, if config-logging or config-observability is missing. 