### PR TITLE
golang format tools

### DIFF
--- a/metrics/config.go
+++ b/metrics/config.go
@@ -27,8 +27,8 @@ import (
 	"strings"
 	"time"
 
-	"go.uber.org/zap"
 	"go.opencensus.io/stats"
+	"go.uber.org/zap"
 	"knative.dev/pkg/metrics/metricskey"
 )
 
@@ -213,7 +213,7 @@ func createMetricsConfig(ops ExporterOptions, logger *zap.SugaredLogger) (*metri
 		if !allowCustomMetrics {
 			servingOrEventing := metricskey.KnativeRevisionMetrics.Union(
 				metricskey.KnativeTriggerMetrics)
-			mc.recorder = func(ctx context.Context, ms stats.Measurement, ros... stats.Options) error {
+			mc.recorder = func(ctx context.Context, ms stats.Measurement, ros ...stats.Options) error {
 				metricType := path.Join(mc.stackdriverMetricTypePrefix, ms.Measure().Name())
 
 				if servingOrEventing.Has(metricType) {

--- a/metrics/config_test.go
+++ b/metrics/config_test.go
@@ -857,8 +857,8 @@ func TestStackdriverRecord(t *testing.T) {
 			setCurMetricsConfig(mc)
 			ctx := context.Background()
 			v := []*view.View{
-				&view.View{Measure: servedCount, Aggregation: view.Count()},
-				&view.View{Measure: statCount, Aggregation: view.Count()},
+				{Measure: servedCount, Aggregation: view.Count()},
+				{Measure: statCount, Aggregation: view.Count()},
 			}
 			err = view.Register(v...)
 			if err != nil {

--- a/metrics/record_test.go
+++ b/metrics/record_test.go
@@ -22,8 +22,8 @@ import (
 	"path"
 	"testing"
 
-	"knative.dev/pkg/metrics/metricstest"
 	"knative.dev/pkg/metrics/metricskey"
+	"knative.dev/pkg/metrics/metricstest"
 
 	"github.com/google/go-cmp/cmp"
 	"go.opencensus.io/stats"
@@ -55,8 +55,8 @@ func TestRecordServing(t *testing.T) {
 		}, {
 			name: "stackdriver backend with unsupported metric and allow custom metric",
 			metricsConfig: &metricsConfig{
-				isStackdriverBackend:          true,
-				stackdriverMetricTypePrefix:   "knative.dev/unsupported",
+				isStackdriverBackend:        true,
+				stackdriverMetricTypePrefix: "knative.dev/unsupported",
 			},
 			measurement: measure.M(3),
 		}, {
@@ -86,8 +86,8 @@ func TestRecordEventing(t *testing.T) {
 		}, {
 			name: "stackdriver backend with unsupported metric and allow custom metric",
 			metricsConfig: &metricsConfig{
-				isStackdriverBackend:          true,
-				stackdriverMetricTypePrefix:   "knative.dev/unsupported",
+				isStackdriverBackend:        true,
+				stackdriverMetricTypePrefix: "knative.dev/unsupported",
 			},
 			measurement: measure.M(3),
 		}, {

--- a/test/gke/client_test.go
+++ b/test/gke/client_test.go
@@ -18,13 +18,14 @@ package gke
 
 import (
 	"testing"
+
 	option "google.golang.org/api/option"
 )
 
 // func NewSDKClient(opts ...option.ClientOption) (SDKOperations, error) {
 func TestNewSDKClient(t *testing.T) {
 	datas := []struct {
-		req           option.ClientOption
+		req option.ClientOption
 	}{{
 		// No options.
 		nil,


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign n3wscott
