### PR TITLE
Remove ugly constant string being printed in every log.

### DIFF
--- a/logging/config.go
+++ b/logging/config.go
@@ -105,7 +105,7 @@ func newLoggerFromConfig(configJSON string, levelOverride string, opts []zap.Opt
 		return nil, zap.AtomicLevel{}, err
 	}
 
-	logger.Info("Successfully created the logger.", zap.String(logkey.JSONConfig, configJSON))
+	logger.Info("Successfully created the logger.")
 	logger.Sugar().Infof("Logging level set to %v", loggingCfg.Level)
 	return logger, loggingCfg.Level, nil
 }


### PR DESCRIPTION
In every log we get the ugly string printed:
2019-11-13T08:44:42.421-0800    info    logging/config.go:50
Successfully created the logger.    {"knative.dev/jsonconfig": "{\n\t
\"level\": \"debug\",\n\t  \"encoding\": \"console\",\n\t
\"outputPaths\": [\"stdout\"],\n\t  \"errorOutputPaths\":
[\"stderr\"],\n\t  \"encoderConfig\": {\n\t    \"timeKey\":
\"ts\",\n\t    \"messageKey\": \"message\",\n\t    \"levelKey\":
\"level\",\n\t    \"nameKey\": \"logger\",\n\t    \"callerKey\":
\"caller\",\n\t    \"messageKey\": \"msg\",\n\t    \"stacktraceKey\":
\"stacktrace\",\n\t    \"lineEnding\": \"\",\n\t    \"levelEncoder\":
\"\",\n\t    \"timeEncoder\": \"iso8601\",\n\t    \"durationEncoder\":
\"\",\n\t    \"callerEncoder\": \"\"\n\t  }\n\t}"}

It's all a constant (see test/logging/logging.go:newLogger), except
"level", which is then printed immediately afterward. So just remove
printing this string.