### PR TITLE
Add check in informer to make controllers work when process invalid resources

### DIFF
--- a/apis/duck/typed.go
+++ b/apis/duck/typed.go
@@ -46,7 +46,8 @@ var _ InformerFactory = (*TypedInformerFactory)(nil)
 
 // Get implements InformerFactory.
 func (dif *TypedInformerFactory) Get(gvr schema.GroupVersionResource) (cache.SharedIndexInformer, cache.GenericLister, error) {
-	// Avoid error cases, like resource not exists.
+	// Avoid error cases, like the GVR does not exist.
+	// It is not a full check. Some RBACs might sneak by, but the window is very small.
 	if _, err := dif.Client.Resource(gvr).List(metav1.ListOptions{}); err != nil {
 		return nil, nil, err
 	}

--- a/apis/duck/typed.go
+++ b/apis/duck/typed.go
@@ -46,7 +46,7 @@ var _ InformerFactory = (*TypedInformerFactory)(nil)
 
 // Get implements InformerFactory.
 func (dif *TypedInformerFactory) Get(gvr schema.GroupVersionResource) (cache.SharedIndexInformer, cache.GenericLister, error) {
-	// Avoid error cases, like resource not exists
+	// Avoid error cases, like resource not exists.
 	if _, err := dif.Client.Resource(gvr).List(metav1.ListOptions{}); err != nil {
 		return nil, nil, err
 	}

--- a/apis/duck/typed_test.go
+++ b/apis/duck/typed_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/fake"
 
 	"knative.dev/pkg/apis/duck"
@@ -92,6 +93,26 @@ func TestSimpleList(t *testing.T) {
 	}
 
 	// TODO(mattmoor): Access through informer
+}
+
+func TestInvalidResource(t *testing.T) {
+	client := &invalidResourceClient{}
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	tif := &duck.TypedInformerFactory{
+		Client:       client,
+		Type:         &duckv1alpha1.AddressableType{},
+		ResyncPeriod: 1 * time.Second,
+		StopChannel:  stopCh,
+	}
+
+	want := errors.New("failed to get list")
+	_, _, got := tif.Get(SchemeGroupVersion.WithResource("resources"))
+
+	if got == nil || got.Error() != want.Error() {
+		t.Errorf("Didn't see expected error message. Got %v, wanted %v", got, want)
+	}
 }
 
 func TestAsStructuredWatcherNestedError(t *testing.T) {
@@ -274,4 +295,20 @@ func (bo *badObject) GetObjectKind() schema.ObjectKind {
 
 func (bo *badObject) DeepCopyObject() runtime.Object {
 	return &badObject{}
+}
+
+type invalidResourceClient struct {
+	*fake.FakeDynamicClient
+}
+
+func (*invalidResourceClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &invalidResource{}
+}
+
+type invalidResource struct {
+	dynamic.NamespaceableResourceInterface
+}
+
+func (*invalidResource) List(options metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return nil, errors.New("failed to get list")
 }

--- a/apis/duck/typed_test.go
+++ b/apis/duck/typed_test.go
@@ -107,11 +107,10 @@ func TestInvalidResource(t *testing.T) {
 		StopChannel:  stopCh,
 	}
 
-	want := errors.New("failed to get list")
 	_, _, got := tif.Get(SchemeGroupVersion.WithResource("resources"))
 
-	if got == nil || got.Error() != want.Error() {
-		t.Errorf("Didn't see expected error message. Got %v, wanted %v", got, want)
+	if got != testErr {
+		t.Errorf("Didn't see expected error message. Got: %v, wanted: %v", got, testErr)
 	}
 }
 
@@ -297,6 +296,8 @@ func (bo *badObject) DeepCopyObject() runtime.Object {
 	return &badObject{}
 }
 
+var testErr = errors.New("failed to get list")
+
 type invalidResourceClient struct {
 	*fake.FakeDynamicClient
 }
@@ -310,5 +311,5 @@ type invalidResource struct {
 }
 
 func (*invalidResource) List(options metav1.ListOptions) (*unstructured.UnstructuredList, error) {
-	return nil, errors.New("failed to get list")
+	return nil, testErr
 }

--- a/apis/duck/typed_test.go
+++ b/apis/duck/typed_test.go
@@ -110,7 +110,7 @@ func TestInvalidResource(t *testing.T) {
 	_, _, got := tif.Get(SchemeGroupVersion.WithResource("resources"))
 
 	if got != testErr {
-		t.Errorf("Didn't see expected error message. Got: %v, wanted: %v", got, testErr)
+		t.Errorf("Error = %v, want: %v", got, testErr)
 	}
 }
 


### PR DESCRIPTION
Related on issue in eventing repo
[#2047](https://github.com/knative/eventing/issues/2047) sources-controller can't recover from faulty sink 
If there has an invalid resource, the controller will keep showing error and not process new sources until the controller pod is deleted.

The root cause is explained in this [comment](https://github.com/knative/eventing/issues/2047#issuecomment-554084211)