### PR TITLE
Allow glog to coexist with klog

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1290,6 +1290,7 @@
     "github.com/davecgh/go-spew/spew",
     "github.com/evanphx/json-patch",
     "github.com/ghodss/yaml",
+    "github.com/golang/glog",
     "github.com/golang/protobuf/jsonpb",
     "github.com/golang/protobuf/proto",
     "github.com/google/go-cmp/cmp",

--- a/test/e2e_flags_test.go
+++ b/test/e2e_flags_test.go
@@ -25,6 +25,7 @@ import (
 func TestE2eFlags(t *testing.T) {
 	v := flag.Lookup("v")
 	if v == nil {
+		printFlags()
 		t.Fatal("Could not find 'v' flag; klog was not init-ed")
 	}
 	if v.Value.String() != klogDefaultLogLevel {
@@ -78,7 +79,7 @@ func TestE2eFlags(t *testing.T) {
 				flag.Set("v", tc.nonDefaultV)
 			}
 			SetupLoggingFlags()
-			v := flag.Lookup("v").Value.String()
+			v := klogFlags.Lookup("v").Value.String()
 			if tc.expectedV != v {
 				t.Errorf("v = '%s', want: '%s'\n", v, tc.expectedV)
 			}


### PR DESCRIPTION
glog isn't used in our repos with good reason, but performance tests
use it, for now. This commit removes the ability to set klog flags
that aren't shared with glog, in return for the ability of glog to be imported.

/assign @chizhg 