### PR TITLE
Remove all occurrences of github.com/pkg/errors.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1347,7 +1347,6 @@
     "github.com/openzipkin/zipkin-go/reporter",
     "github.com/openzipkin/zipkin-go/reporter/http",
     "github.com/openzipkin/zipkin-go/reporter/recorder",
-    "github.com/pkg/errors",
     "github.com/prometheus/client_golang/api",
     "github.com/prometheus/client_golang/api/prometheus/v1",
     "github.com/prometheus/common/model",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -12,7 +12,6 @@ required = [
   "github.com/evanphx/json-patch",
   "knative.dev/test-infra/scripts",
   "knative.dev/test-infra/tools/dep-collector",
-  "github.com/pkg/errors",
   "github.com/gogo/protobuf/proto",
   "istio.io/api/networking/v1alpha3",
   "istio.io/client-go/pkg/apis/networking/v1alpha3",

--- a/profiling/server.go
+++ b/profiling/server.go
@@ -17,12 +17,12 @@ limitations under the License.
 package profiling
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/pprof"
 	"strconv"
 	"sync"
 
-	perrors "github.com/pkg/errors"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -83,7 +83,7 @@ func ReadProfilingFlag(config map[string]string) (bool, error) {
 	}
 	enabled, err := strconv.ParseBool(profiling)
 	if err != nil {
-		return false, perrors.Wrapf(err, "failed to parse the profiling flag")
+		return false, fmt.Errorf("failed to parse the profiling flag: %w", err)
 	}
 	return enabled, nil
 }

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/test/ingress"
@@ -241,7 +240,7 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker) (*Res
 	}
 
 	if err != nil {
-		return resp, errors.Wrapf(err, "response: %s did not pass checks", resp)
+		return resp, fmt.Errorf("response: %s did not pass checks: %w", resp, err)
 	}
 	return resp, nil
 }

--- a/test/webhook-apicoverage/tools/tools.go
+++ b/test/webhook-apicoverage/tools/tools.go
@@ -28,7 +28,6 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/pkg/errors"
 	"knative.dev/pkg/test/webhook-apicoverage/coveragecalculator"
 	"knative.dev/pkg/test/webhook-apicoverage/view"
 	"knative.dev/pkg/test/webhook-apicoverage/webhook"
@@ -119,7 +118,7 @@ func GetResourceCoverage(webhookIP string, resourceName string) (string, error) 
 	}
 	resp, err := client.Get(fmt.Sprintf(WebhookResourceCoverageEndPoint, webhookIP, resourceName))
 	if err != nil {
-		return "", errors.Wrap(err, "encountered error making resource coverage request")
+		return "", fmt.Errorf("encountered error making resource coverage request: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("invalid HTTP Status received for resource coverage request. Status: %d", resp.StatusCode)
@@ -127,7 +126,7 @@ func GetResourceCoverage(webhookIP string, resourceName string) (string, error) 
 
 	var body []byte
 	if body, err = ioutil.ReadAll(resp.Body); err != nil {
-		return "", errors.Wrap(err, "Failed reading resource coverage response")
+		return "", fmt.Errorf("failed reading resource coverage response: %w", err)
 	}
 
 	return string(body), nil
@@ -156,7 +155,7 @@ func GetTotalCoverage(webhookIP string) (*coveragecalculator.CoverageValues, err
 
 	resp, err := client.Get(fmt.Sprintf(WebhookTotalCoverageEndPoint, webhookIP))
 	if err != nil {
-		return nil, errors.Wrap(err, "encountered error making total coverage request")
+		return nil, fmt.Errorf("encountered error making total coverage request")
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("invalid HTTP Status received for total coverage request. Status: %d", resp.StatusCode)
@@ -169,7 +168,7 @@ func GetTotalCoverage(webhookIP string) (*coveragecalculator.CoverageValues, err
 
 	var coverage coveragecalculator.CoverageValues
 	if err = json.Unmarshal(body, &coverage); err != nil {
-		return nil, errors.Wrap(err, "Failed unmarshalling response to CoverageValues instance")
+		return nil, fmt.Errorf("failed unmarshalling response to CoverageValues instance: %w", err)
 	}
 
 	return &coverage, nil
@@ -188,7 +187,7 @@ func GetAndWriteTotalCoverage(webhookIP string, outputFile string) error {
 
 	htmlData, err := view.GetHTMLCoverageValuesDisplay(totalCoverage)
 	if err != nil {
-		return errors.Wrap(err, "Failed building html file from total coverage. error")
+		return fmt.Errorf("failed building html file from total coverage: %w", err)
 	}
 
 	return ioutil.WriteFile(outputFile, []byte(htmlData), 0400)
@@ -206,21 +205,21 @@ func GetResourcePercentages(webhookIP string) (
 	resp, err := client.Get(fmt.Sprintf(WebhookResourcePercentageCoverageEndPoint,
 		webhookIP))
 	if err != nil {
-		return nil, errors.Wrap(err, "encountered error making resource percentage coverage request")
+		return nil, fmt.Errorf("encountered error making resource percentage coverage request: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Invalid HTTP Status received for resource"+
+		return nil, fmt.Errorf("invalid HTTP Status received for resource"+
 			" percentage coverage request. Status: %d", resp.StatusCode)
 	}
 
 	var body []byte
 	if body, err = ioutil.ReadAll(resp.Body); err != nil {
-		return nil, errors.Wrap(err, "Failed reading resource percentage coverage response")
+		return nil, fmt.Errorf("failed reading resource percentage coverage response: %w", err)
 	}
 
 	coveragePercentages := &coveragecalculator.CoveragePercentages{}
 	if err = json.Unmarshal(body, coveragePercentages); err != nil {
-		return nil, errors.Wrap(err, "Failed unmarshalling response to CoveragePercentages instance")
+		return nil, fmt.Errorf("failed unmarshalling response to CoveragePercentages instance: %w", err)
 	}
 
 	return coveragePercentages, nil
@@ -231,7 +230,7 @@ func WriteResourcePercentages(outputFile string,
 	coveragePercentages *coveragecalculator.CoveragePercentages) error {
 	htmlData, err := view.GetCoveragePercentageXMLDisplay(coveragePercentages)
 	if err != nil {
-		errors.Wrap(err, "Failed building coverage percentage xml file")
+		return fmt.Errorf("failed building coverage percentage xml file: %w", err)
 	}
 
 	return ioutil.WriteFile(outputFile, []byte(htmlData), 0400)

--- a/webhook/psbinding/reconciler.go
+++ b/webhook/psbinding/reconciler.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
@@ -322,7 +321,7 @@ func (r *BaseReconciler) ReconcileSubject(ctx context.Context, fb Bindable, muta
 			_, err = r.DynamicClient.Resource(gvr).Namespace(ps.Namespace).Patch(
 				ps.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 			if err != nil {
-				return errors.Wrap(err, "failed binding subject "+ps.Name)
+				return fmt.Errorf("failed binding subject %s: %w", ps.Name, err)
 			}
 			return nil
 		})


### PR DESCRIPTION
Title has it all. We don't really need this anymore since go1.13.