### PR TITLE
Add a simple ToUnstructured method for converting our types to unstructured.

### DIFF
--- a/apis/duck/unstructured.go
+++ b/apis/duck/unstructured.go
@@ -18,16 +18,49 @@ package duck
 
 import (
 	"encoding/json"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"knative.dev/pkg/kmeta"
 )
 
-// Marshallable is implementated by the Unstructured K8s types.
-type Marshalable interface {
-	MarshalJSON() ([]byte, error)
+// OneOfOurs is the union of our Accessor interface and the OwnerRefable interface
+// that is implemented by our resources that implement the kmeta.Accessor.
+type OneOfOurs interface {
+	kmeta.Accessor
+	kmeta.OwnerRefable
+}
+
+// ToUnstructured takes an instance of a OneOfOurs compatible type and
+// converts it to unstructured.Unstructured.  We take OneOfOurs in place
+// or runtime.Object because sometimes we get resources that do not have their
+// TypeMeta populated but that is required for unstructured.Unstructured to
+// deserialize things, so we leverage our content-agnostic GroupVersionKind()
+// method to populate this as-needed (in a copy, so that we don't modify the
+// informer's copy, if that is what we are passed).
+func ToUnstructured(desired OneOfOurs) (*unstructured.Unstructured, error) {
+	// If the TypeMeta is not populated, then unmarshalling will fail, so ensure
+	// the TypeMeta is populated.  See also EnsureTypeMeta.
+	if gvk := desired.GroupVersionKind(); gvk.Version == "" || gvk.Kind == "" {
+		gvk = desired.GetGroupVersionKind()
+		desired = desired.DeepCopyObject().(OneOfOurs)
+		desired.SetGroupVersionKind(gvk)
+	}
+
+	// Convert desired to unstructured.Unstructured
+	b, err := json.Marshal(desired)
+	if err != nil {
+		return nil, err
+	}
+	ud := &unstructured.Unstructured{}
+	if err := json.Unmarshal(b, ud); err != nil {
+		return nil, err
+	}
+	return ud, nil
 }
 
 // FromUnstructured takes unstructured object from (say from client-go/dynamic) and
 // converts it into our duck types.
-func FromUnstructured(obj Marshalable, target interface{}) error {
+func FromUnstructured(obj json.Marshaler, target interface{}) error {
 	// Use the unstructured marshaller to ensure it's proper JSON
 	raw, err := obj.MarshalJSON()
 	if err != nil {

--- a/testing/resource.go
+++ b/testing/resource.go
@@ -22,6 +22,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 )
 
@@ -47,6 +48,11 @@ type ResourceSpec struct {
 	FieldWithValidation            string `json:"fieldWithValidation,omitempty"`
 	FieldThatsImmutable            string `json:"fieldThatsImmutable,omitempty"`
 	FieldThatsImmutableWithDefault string `json:"fieldThatsImmutableWithDefault,omitempty"`
+}
+
+// GetGroupVersionKind returns the GroupVersionKind.
+func (r *Resource) GetGroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind("Resource")
 }
 
 // GetUntypedSpec returns the spec of the resource.


### PR DESCRIPTION
This adds a ToUnstructured method to complement the FromUnstructured method
we have had for some time.  The ToUnstructured method is effectively scoped
to Knative-style types since we expect it to implement both kmeta.Accessor
and kmeta.OwnerRefable in order to ensure that the TypeMeta is always
properly populated.