### PR TITLE
Resolvev1destination

### DIFF
--- a/resolver/addressable_resolver.go
+++ b/resolver/addressable_resolver.go
@@ -50,15 +50,7 @@ func NewURIResolver(ctx context.Context, callback func(types.NamespacedName)) *U
 	ret.tracker = tracker.New(callback, controller.GetTrackerLease(ctx))
 	ret.informerFactory = &pkgapisduck.CachedInformerFactory{
 		Delegate: &pkgapisduck.EnqueueInformerFactory{
-			Delegate: addressable.Get(ctx),
-			/*
-				Delegate: &pkgapisduck.TypedInformerFactory{
-					Client:       dynamicclient.Get(ctx),
-					Type:         &duckv1.AddressableType{},
-					ResyncPeriod: controller.GetResyncPeriod(ctx),
-					StopChannel:  ctx.Done(),
-				},
-			*/
+			Delegate:     addressable.Get(ctx),
 			EventHandler: controller.HandleAll(ret.tracker.OnChanged),
 		},
 	}

--- a/resolver/addressable_resolver.go
+++ b/resolver/addressable_resolver.go
@@ -72,7 +72,7 @@ func (r *URIResolver) URIFromDestination(dest duckv1beta1.Destination, parent in
 		}
 	}
 	if dest.Ref != nil && deprecatedObjectReference != nil {
-		return "", fmt.Errorf("ref and [apiVersion, kind, name] can't be both present")
+		return "", errors.New("ref and [apiVersion, kind, name] can't be both present")
 	}
 	var ref *corev1.ObjectReference
 	if dest.Ref != nil {
@@ -87,7 +87,7 @@ func (r *URIResolver) URIFromDestination(dest duckv1beta1.Destination, parent in
 		}
 		if dest.URI != nil {
 			if dest.URI.URL().IsAbs() {
-				return "", fmt.Errorf("absolute URI is not allowed when Ref or [apiVersion, kind, name] exists")
+				return "", errors.New("absolute URI is not allowed when Ref or [apiVersion, kind, name] exists")
 			}
 			return url.URL().ResolveReference(dest.URI.URL()).String(), nil
 		}
@@ -102,7 +102,7 @@ func (r *URIResolver) URIFromDestination(dest duckv1beta1.Destination, parent in
 		return dest.URI.String(), nil
 	}
 
-	return "", fmt.Errorf("destination missing Ref, [apiVersion, kind, name] and URI, expected at least one")
+	return "", errors.New("destination missing Ref, [apiVersion, kind, name] and URI, expected at least one")
 }
 
 // URIFromDestinationV1 resolves a v1.Destination into a URI string.
@@ -114,7 +114,7 @@ func (r *URIResolver) URIFromDestinationV1(dest duckv1.Destination, parent inter
 		}
 		if dest.URI != nil {
 			if dest.URI.URL().IsAbs() {
-				return "", fmt.Errorf("absolute URI is not allowed when Ref or [apiVersion, kind, name] exists")
+				return "", errors.New("absolute URI is not allowed when Ref or [apiVersion, kind, name] exists")
 			}
 			return url.URL().ResolveReference(dest.URI.URL()).String(), nil
 		}
@@ -129,7 +129,7 @@ func (r *URIResolver) URIFromDestinationV1(dest duckv1.Destination, parent inter
 		return dest.URI.String(), nil
 	}
 
-	return "", fmt.Errorf("destination missing Ref and URI, expected at least one")
+	return "", errors.New("destination missing Ref and URI, expected at least one")
 }
 
 // URIFromObjectReference resolves an ObjectReference to a URI string.

--- a/resolver/addressable_resolver.go
+++ b/resolver/addressable_resolver.go
@@ -33,7 +33,7 @@ import (
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/tracker"
 
-	"knative.dev/pkg/client/injection/ducks/duck/v1beta1/addressable"
+	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
 )
 
 // URIResolver resolves Destinations and ObjectReferences into a URI.

--- a/resolver/addressable_resolver_test.go
+++ b/resolver/addressable_resolver_test.go
@@ -31,7 +31,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
-	"knative.dev/pkg/client/injection/ducks/duck/v1beta1/addressable"
+	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	"knative.dev/pkg/resolver"
 )
@@ -518,6 +518,7 @@ func TestGetURI_DestinationV1(t *testing.T) {
 	for n, tc := range tests {
 		t.Run(n, func(t *testing.T) {
 			ctx, _ := fakedynamicclient.With(context.Background(), scheme.Scheme, tc.objects...)
+			ctx = addressable.WithDuck(ctx)
 			r := resolver.NewURIResolver(ctx, func(types.NamespacedName) {})
 
 			// Run it twice since this should be idempotent. URI Resolver should
@@ -563,6 +564,7 @@ Namespace: a DNS-1123 label must consist of lower case alphanumeric characters o
 	for n, tc := range tests {
 		t.Run(n, func(t *testing.T) {
 			ctx, _ := fakedynamicclient.With(context.Background(), scheme.Scheme, tc.objects...)
+			ctx = addressable.WithDuck(ctx)
 			r := resolver.NewURIResolver(ctx, func(types.NamespacedName) {})
 
 			// Run it twice since this should be idempotent. URI Resolver should

--- a/resolver/addressable_resolver_test.go
+++ b/resolver/addressable_resolver_test.go
@@ -64,9 +64,9 @@ func TestGetURI_DestinationV1Beta1(t *testing.T) {
 		objects []runtime.Object
 		dest    duckv1beta1.Destination
 		wantURI string
-		wantErr error
+		wantErr string
 	}{"nil everything": {
-		wantErr: fmt.Errorf("destination missing Ref, [apiVersion, kind, name] and URI, expected at least one"),
+		wantErr: fmt.Sprintf("destination missing Ref, [apiVersion, kind, name] and URI, expected at least one"),
 	}, "Happy URI with path": {
 		dest: duckv1beta1.Destination{
 			URI: &apis.URL{
@@ -82,14 +82,14 @@ func TestGetURI_DestinationV1Beta1(t *testing.T) {
 				Host: "example.com",
 			},
 		},
-		wantErr: fmt.Errorf("URI is not absolute(both scheme and host should be non-empty): %v", "//example.com"),
+		wantErr: fmt.Sprintf("URI is not absolute(both scheme and host should be non-empty): %v", "//example.com"),
 	}, "URI with no host": {
 		dest: duckv1beta1.Destination{
 			URI: &apis.URL{
 				Scheme: "http",
 			},
 		},
-		wantErr: fmt.Errorf("URI is not absolute(both scheme and host should be non-empty): %v", "http:"),
+		wantErr: fmt.Sprintf("URI is not absolute(both scheme and host should be non-empty): %v", "http:"),
 	},
 		"Ref and [apiVersion, kind, name] both exists": {
 			objects: []runtime.Object{
@@ -101,7 +101,7 @@ func TestGetURI_DestinationV1Beta1(t *testing.T) {
 				DeprecatedAPIVersion: addressableAPIVersion,
 				DeprecatedNamespace:  testNS,
 			},
-			wantErr: fmt.Errorf("ref and [apiVersion, kind, name] can't be both present"),
+			wantErr: fmt.Sprintf("ref and [apiVersion, kind, name] can't be both present"),
 		},
 		"happy ref": {
 			objects: []runtime.Object{
@@ -187,7 +187,7 @@ func TestGetURI_DestinationV1Beta1(t *testing.T) {
 					Path:   "/foo",
 				},
 			},
-			wantErr: fmt.Errorf("absolute URI is not allowed when Ref or [apiVersion, kind, name] exists"),
+			wantErr: fmt.Sprintf("absolute URI is not allowed when Ref or [apiVersion, kind, name] exists"),
 		},
 		"happy [apiVersion, kind, name]": {
 			objects: []runtime.Object{
@@ -299,36 +299,36 @@ func TestGetURI_DestinationV1Beta1(t *testing.T) {
 					Path:   "/foo",
 				},
 			},
-			wantErr: fmt.Errorf("absolute URI is not allowed when Ref or [apiVersion, kind, name] exists"),
+			wantErr: fmt.Sprintf("absolute URI is not allowed when Ref or [apiVersion, kind, name] exists"),
 		},
 		"nil url": {
 			objects: []runtime.Object{
 				getAddressableNilURL(),
 			},
 			dest:    duckv1beta1.Destination{Ref: getUnaddressableRef()},
-			wantErr: fmt.Errorf(`url missing in address of %+v`, getUnaddressableRef()),
+			wantErr: fmt.Sprintf(`url missing in address of %+v`, getUnaddressableRef()),
 		},
 		"nil address": {
 			objects: []runtime.Object{
 				getAddressableNilAddress(),
 			},
 			dest:    duckv1beta1.Destination{Ref: getUnaddressableRef()},
-			wantErr: fmt.Errorf(`address not set for %+v`, getUnaddressableRef()),
+			wantErr: fmt.Sprintf(`address not set for %+v`, getUnaddressableRef()),
 		}, "missing host": {
 			objects: []runtime.Object{
 				getAddressableNoHostURL(),
 			},
 			dest:    duckv1beta1.Destination{Ref: getUnaddressableRef()},
-			wantErr: fmt.Errorf(`hostname missing in address of %+v`, getUnaddressableRef()),
+			wantErr: fmt.Sprintf(`hostname missing in address of %+v`, getUnaddressableRef()),
 		}, "missing status": {
 			objects: []runtime.Object{
 				getAddressableNoStatus(),
 			},
 			dest:    duckv1beta1.Destination{Ref: getUnaddressableRef()},
-			wantErr: fmt.Errorf(`address not set for %+v`, getUnaddressableRef()),
+			wantErr: fmt.Sprintf(`address not set for %+v`, getUnaddressableRef()),
 		}, "notFound": {
 			dest:    duckv1beta1.Destination{Ref: getUnaddressableRef()},
-			wantErr: fmt.Errorf(`failed to get ref %+v: %s "%s" not found`, getUnaddressableRef(), unaddressableResource, unaddressableName),
+			wantErr: fmt.Sprintf(`failed to get ref %+v: %s "%s" not found`, getUnaddressableRef(), unaddressableResource, unaddressableName),
 		}}
 
 	for n, tc := range tests {
@@ -343,19 +343,17 @@ func TestGetURI_DestinationV1Beta1(t *testing.T) {
 			uri, gotErr := r.URIFromDestination(tc.dest, getAddressable())
 
 			if gotErr != nil {
-				if tc.wantErr != nil {
-					if diff := cmp.Diff(tc.wantErr.Error(), gotErr.Error()); diff != "" {
-						t.Errorf("%s: unexpected error (-want, +got) = %v", n, diff)
+				if tc.wantErr != "" {
+					if diff := cmp.Diff(tc.wantErr, gotErr.Error()); diff != "" {
+						t.Errorf("unexpected error (-want, +got) = %v", diff)
 					}
 				} else {
-					t.Errorf("%s: unexpected error: %v", n, gotErr.Error())
+					t.Errorf("unexpected error: %v", gotErr.Error())
 				}
+				return
 			}
-			if gotErr == nil {
-				got := uri
-				if diff := cmp.Diff(tc.wantURI, got); diff != "" {
-					t.Errorf("%s: unexpected object (-want, +got) = %v", n, diff)
-				}
+			if diff := cmp.Diff(tc.wantURI, uri); diff != "" {
+				t.Errorf("unexpected object (-want, +got) = %v", diff)
 			}
 		})
 	}
@@ -366,9 +364,9 @@ func TestGetURI_DestinationV1(t *testing.T) {
 		objects []runtime.Object
 		dest    duckv1.Destination
 		wantURI string
-		wantErr error
+		wantErr string
 	}{"nil everything": {
-		wantErr: fmt.Errorf("destination missing Ref and URI, expected at least one"),
+		wantErr: fmt.Sprintf("destination missing Ref and URI, expected at least one"),
 	}, "Happy URI with path": {
 		dest: duckv1.Destination{
 			URI: &apis.URL{
@@ -384,14 +382,14 @@ func TestGetURI_DestinationV1(t *testing.T) {
 				Host: "example.com",
 			},
 		},
-		wantErr: fmt.Errorf("URI is not absolute(both scheme and host should be non-empty): %v", "//example.com"),
+		wantErr: fmt.Sprintf("URI is not absolute(both scheme and host should be non-empty): %v", "//example.com"),
 	}, "URI with no host": {
 		dest: duckv1.Destination{
 			URI: &apis.URL{
 				Scheme: "http",
 			},
 		},
-		wantErr: fmt.Errorf("URI is not absolute(both scheme and host should be non-empty): %v", "http:"),
+		wantErr: fmt.Sprintf("URI is not absolute(both scheme and host should be non-empty): %v", "http:"),
 	},
 		"happy ref": {
 			objects: []runtime.Object{
@@ -483,36 +481,36 @@ func TestGetURI_DestinationV1(t *testing.T) {
 					Path:   "/foo",
 				},
 			},
-			wantErr: fmt.Errorf("absolute URI is not allowed when Ref or [apiVersion, kind, name] exists"),
+			wantErr: fmt.Sprintf("absolute URI is not allowed when Ref or [apiVersion, kind, name] exists"),
 		},
 		"nil url": {
 			objects: []runtime.Object{
 				getAddressableNilURL(),
 			},
 			dest:    duckv1.Destination{Ref: getUnaddressableRef()},
-			wantErr: fmt.Errorf(`url missing in address of %+v`, getUnaddressableRef()),
+			wantErr: fmt.Sprintf(`url missing in address of %+v`, getUnaddressableRef()),
 		},
 		"nil address": {
 			objects: []runtime.Object{
 				getAddressableNilAddress(),
 			},
 			dest:    duckv1.Destination{Ref: getUnaddressableRef()},
-			wantErr: fmt.Errorf(`address not set for %+v`, getUnaddressableRef()),
+			wantErr: fmt.Sprintf(`address not set for %+v`, getUnaddressableRef()),
 		}, "missing host": {
 			objects: []runtime.Object{
 				getAddressableNoHostURL(),
 			},
 			dest:    duckv1.Destination{Ref: getUnaddressableRef()},
-			wantErr: fmt.Errorf(`hostname missing in address of %+v`, getUnaddressableRef()),
+			wantErr: fmt.Sprintf(`hostname missing in address of %+v`, getUnaddressableRef()),
 		}, "missing status": {
 			objects: []runtime.Object{
 				getAddressableNoStatus(),
 			},
 			dest:    duckv1.Destination{Ref: getUnaddressableRef()},
-			wantErr: fmt.Errorf(`address not set for %+v`, getUnaddressableRef()),
+			wantErr: fmt.Sprintf(`address not set for %+v`, getUnaddressableRef()),
 		}, "notFound": {
 			dest:    duckv1.Destination{Ref: getUnaddressableRef()},
-			wantErr: fmt.Errorf(`failed to get ref %+v: %s "%s" not found`, getUnaddressableRef(), unaddressableResource, unaddressableName),
+			wantErr: fmt.Sprintf(`failed to get ref %+v: %s "%s" not found`, getUnaddressableRef(), unaddressableResource, unaddressableName),
 		}}
 
 	for n, tc := range tests {
@@ -527,19 +525,16 @@ func TestGetURI_DestinationV1(t *testing.T) {
 			uri, gotErr := r.URIFromDestinationV1(tc.dest, getAddressable())
 
 			if gotErr != nil {
-				if tc.wantErr != nil {
-					if diff := cmp.Diff(tc.wantErr.Error(), gotErr.Error()); diff != "" {
-						t.Errorf("%s: unexpected error (-want, +got) = %v", n, diff)
+				if tc.wantErr != "" {
+					if diff := cmp.Diff(tc.wantErr, gotErr.Error()); diff != "" {
+						t.Errorf("unexpected error (-want, +got) = %v", diff)
 					}
 				} else {
-					t.Errorf("%s: unexpected error: %v", n, gotErr.Error())
+					t.Errorf("unexpected error: %v", gotErr.Error())
 				}
 			}
-			if gotErr == nil {
-				got := uri
-				if diff := cmp.Diff(tc.wantURI, got); diff != "" {
-					t.Errorf("%s: unexpected object (-want, +got) = %v", n, diff)
-				}
+			if diff := cmp.Diff(tc.wantURI, uri); diff != "" {
+				t.Errorf("unexpected object (-want, +got) = %v", diff)
 			}
 		})
 	}
@@ -549,16 +544,16 @@ func TestURIFromObjectReferenceErrors(t *testing.T) {
 	tests := map[string]struct {
 		objects []runtime.Object
 		ref     *corev1.ObjectReference
-		wantErr error
+		wantErr string
 	}{"nil": {
-		wantErr: fmt.Errorf("ref is nil"),
+		wantErr: "ref is nil",
 	}, "fail tracker with bad object": {
 		ref: getInvalidObjectReference(),
-		wantErr: fmt.Errorf(`failed to track %+v: invalid Reference:
+		wantErr: fmt.Sprintf(`failed to track %+v: invalid Reference:
 Namespace: a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')`, getInvalidObjectReference()),
 	}, "fail get": {
 		ref:     getAddressableRef(),
-		wantErr: fmt.Errorf(`failed to get ref %+v: sinks.duck.knative.dev "testsink" not found`, getAddressableRef()),
+		wantErr: fmt.Sprintf(`failed to get ref %+v: sinks.duck.knative.dev "testsink" not found`, getAddressableRef()),
 	}}
 
 	for n, tc := range tests {
@@ -573,16 +568,17 @@ Namespace: a DNS-1123 label must consist of lower case alphanumeric characters o
 			_, gotErr := r.URIFromObjectReference(tc.ref, getAddressable())
 
 			if gotErr != nil {
-				if tc.wantErr != nil {
-					if diff := cmp.Diff(tc.wantErr.Error(), gotErr.Error()); diff != "" {
-						t.Errorf("%s: unexpected error (-want, +got) = %v", n, diff)
+				if tc.wantErr != "" {
+					if diff := cmp.Diff(tc.wantErr, gotErr.Error()); diff != "" {
+						t.Errorf("unexpected error (-want, +got) = %v", diff)
 					}
 				} else {
-					t.Errorf("%s: unexpected error: %v", n, gotErr.Error())
+					t.Errorf("unexpected error: %v", gotErr.Error())
 				}
+				return
 			}
-			if gotErr == nil && tc.wantErr != nil {
-				t.Errorf("%s: expected error: %v but got none", n, tc.wantErr)
+			if tc.wantErr != "" {
+				t.Errorf("expected error: %v but got none", tc.wantErr)
 			}
 		})
 	}

--- a/resolver/addressable_resolver_test.go
+++ b/resolver/addressable_resolver_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/client/injection/ducks/duck/v1beta1/addressable"
@@ -42,7 +43,7 @@ var (
 
 	addressableName       = "testsink"
 	addressableKind       = "Sink"
-	addressableAPIVersion = "duck.knative.dev/v1alpha1"
+	addressableAPIVersion = "duck.knative.dev/v1"
 
 	unaddressableName       = "testunaddressable"
 	unaddressableKind       = "KResource"
@@ -58,7 +59,7 @@ func init() {
 	duckv1beta1.AddToScheme(scheme.Scheme)
 }
 
-func TestGetURI_ObjectReference(t *testing.T) {
+func TestGetURI_DestinationV1Beta1(t *testing.T) {
 	tests := map[string]struct {
 		objects []runtime.Object
 		dest    duckv1beta1.Destination
@@ -360,6 +361,231 @@ func TestGetURI_ObjectReference(t *testing.T) {
 	}
 }
 
+func TestGetURI_DestinationV1(t *testing.T) {
+	tests := map[string]struct {
+		objects []runtime.Object
+		dest    duckv1.Destination
+		wantURI string
+		wantErr error
+	}{"nil everything": {
+		wantErr: fmt.Errorf("destination missing Ref and URI, expected at least one"),
+	}, "Happy URI with path": {
+		dest: duckv1.Destination{
+			URI: &apis.URL{
+				Scheme: "http",
+				Host:   "example.com",
+				Path:   "/foo",
+			},
+		},
+		wantURI: "http://example.com/foo",
+	}, "URI is not absolute URL": {
+		dest: duckv1.Destination{
+			URI: &apis.URL{
+				Host: "example.com",
+			},
+		},
+		wantErr: fmt.Errorf("URI is not absolute(both scheme and host should be non-empty): %v", "//example.com"),
+	}, "URI with no host": {
+		dest: duckv1.Destination{
+			URI: &apis.URL{
+				Scheme: "http",
+			},
+		},
+		wantErr: fmt.Errorf("URI is not absolute(both scheme and host should be non-empty): %v", "http:"),
+	},
+		"happy ref": {
+			objects: []runtime.Object{
+				getAddressable(),
+			},
+			dest:    duckv1.Destination{Ref: getAddressableRef()},
+			wantURI: addressableDNS,
+		}, "happy ref to k8s service": {
+			objects: []runtime.Object{
+				getAddressable(),
+			},
+			dest:    duckv1.Destination{Ref: getK8SServiceRef()},
+			wantURI: "http://testsink.testnamespace.svc.cluster.local/",
+		}, "ref with relative uri": {
+			objects: []runtime.Object{
+				getAddressable(),
+			},
+			dest: duckv1.Destination{
+				Ref: getAddressableRef(),
+				URI: &apis.URL{
+					Path: "/foo",
+				},
+			},
+			wantURI: addressableDNS + "/foo",
+		}, "ref with relative URI without leading slash": {
+			objects: []runtime.Object{
+				getAddressable(),
+			},
+			dest: duckv1.Destination{
+				Ref: getAddressableRef(),
+				URI: &apis.URL{
+					Path: "foo",
+				},
+			},
+			wantURI: addressableDNS + "/foo",
+		}, "ref ends with path and trailing slash and relative URI without leading slash ": {
+			objects: []runtime.Object{
+				getAddressableWithPathAndTrailingSlash(),
+			},
+			dest: duckv1.Destination{
+				Ref: getAddressableRef(),
+				URI: &apis.URL{
+					Path: "foo",
+				},
+			},
+			wantURI: addressableDNSWithPathAndTrailingSlash + "foo",
+		}, "ref ends with path and trailing slash and relative URI with leading slash ": {
+			objects: []runtime.Object{
+				getAddressableWithPathAndTrailingSlash(),
+			},
+			dest: duckv1.Destination{
+				Ref: getAddressableRef(),
+				URI: &apis.URL{
+					Path: "/foo",
+				},
+			},
+			wantURI: addressableDNS + "/foo",
+		}, "ref ends with path and no trailing slash and relative URI without leading slash ": {
+			objects: []runtime.Object{
+				getAddressableWithPathAndNoTrailingSlash(),
+			},
+			dest: duckv1.Destination{
+				Ref: getAddressableRef(),
+				URI: &apis.URL{
+					Path: "foo",
+				},
+			},
+			wantURI: addressableDNS + "/foo",
+		}, "ref ends with path and no trailing slash and relative URI with leading slash ": {
+			objects: []runtime.Object{
+				getAddressableWithPathAndNoTrailingSlash(),
+			},
+			dest: duckv1.Destination{
+				Ref: getAddressableRef(),
+				URI: &apis.URL{
+					Path: "/foo",
+				},
+			},
+			wantURI: addressableDNS + "/foo",
+		}, "ref with URI which is absolute URL": {
+			objects: []runtime.Object{
+				getAddressable(),
+			},
+			dest: duckv1.Destination{
+				Ref: getAddressableRef(),
+				URI: &apis.URL{
+					Scheme: "http",
+					Host:   "example.com",
+					Path:   "/foo",
+				},
+			},
+			wantErr: fmt.Errorf("absolute URI is not allowed when Ref or [apiVersion, kind, name] exists"),
+		},
+		"nil url": {
+			objects: []runtime.Object{
+				getAddressableNilURL(),
+			},
+			dest:    duckv1.Destination{Ref: getUnaddressableRef()},
+			wantErr: fmt.Errorf(`url missing in address of %+v`, getUnaddressableRef()),
+		},
+		"nil address": {
+			objects: []runtime.Object{
+				getAddressableNilAddress(),
+			},
+			dest:    duckv1.Destination{Ref: getUnaddressableRef()},
+			wantErr: fmt.Errorf(`address not set for %+v`, getUnaddressableRef()),
+		}, "missing host": {
+			objects: []runtime.Object{
+				getAddressableNoHostURL(),
+			},
+			dest:    duckv1.Destination{Ref: getUnaddressableRef()},
+			wantErr: fmt.Errorf(`hostname missing in address of %+v`, getUnaddressableRef()),
+		}, "missing status": {
+			objects: []runtime.Object{
+				getAddressableNoStatus(),
+			},
+			dest:    duckv1.Destination{Ref: getUnaddressableRef()},
+			wantErr: fmt.Errorf(`address not set for %+v`, getUnaddressableRef()),
+		}, "notFound": {
+			dest:    duckv1.Destination{Ref: getUnaddressableRef()},
+			wantErr: fmt.Errorf(`failed to get ref %+v: %s "%s" not found`, getUnaddressableRef(), unaddressableResource, unaddressableName),
+		}}
+
+	for n, tc := range tests {
+		t.Run(n, func(t *testing.T) {
+			ctx, _ := fakedynamicclient.With(context.Background(), scheme.Scheme, tc.objects...)
+			r := resolver.NewURIResolver(ctx, func(types.NamespacedName) {})
+
+			// Run it twice since this should be idempotent. URI Resolver should
+			// not modify the cache's copy.
+			_, _ = r.URIFromDestinationV1(tc.dest, getAddressable())
+			uri, gotErr := r.URIFromDestinationV1(tc.dest, getAddressable())
+
+			if gotErr != nil {
+				if tc.wantErr != nil {
+					if diff := cmp.Diff(tc.wantErr.Error(), gotErr.Error()); diff != "" {
+						t.Errorf("%s: unexpected error (-want, +got) = %v", n, diff)
+					}
+				} else {
+					t.Errorf("%s: unexpected error: %v", n, gotErr.Error())
+				}
+			}
+			if gotErr == nil {
+				got := uri
+				if diff := cmp.Diff(tc.wantURI, got); diff != "" {
+					t.Errorf("%s: unexpected object (-want, +got) = %v", n, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestURIFromObjectReferenceErrors(t *testing.T) {
+	tests := map[string]struct {
+		objects []runtime.Object
+		ref     *corev1.ObjectReference
+		wantErr error
+	}{"nil": {
+		wantErr: fmt.Errorf("ref is nil"),
+	}, "fail tracker with bad object": {
+		ref: getInvalidObjectReference(),
+		wantErr: fmt.Errorf(`failed to track %+v: invalid Reference:
+Namespace: a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')`, getInvalidObjectReference()),
+	}, "fail get": {
+		ref:     getAddressableRef(),
+		wantErr: fmt.Errorf(`failed to get ref %+v: sinks.duck.knative.dev "testsink" not found`, getAddressableRef()),
+	}}
+
+	for n, tc := range tests {
+		t.Run(n, func(t *testing.T) {
+			ctx, _ := fakedynamicclient.With(context.Background(), scheme.Scheme, tc.objects...)
+			r := resolver.NewURIResolver(ctx, func(types.NamespacedName) {})
+
+			// Run it twice since this should be idempotent. URI Resolver should
+			// not modify the cache's copy.
+			_, _ = r.URIFromObjectReference(tc.ref, getAddressable())
+			_, gotErr := r.URIFromObjectReference(tc.ref, getAddressable())
+
+			if gotErr != nil {
+				if tc.wantErr != nil {
+					if diff := cmp.Diff(tc.wantErr.Error(), gotErr.Error()); diff != "" {
+						t.Errorf("%s: unexpected error (-want, +got) = %v", n, diff)
+					}
+				} else {
+					t.Errorf("%s: unexpected error: %v", n, gotErr.Error())
+				}
+			}
+			if gotErr == nil && tc.wantErr != nil {
+				t.Errorf("%s: expected error: %v but got none", n, tc.wantErr)
+			}
+		})
+	}
+}
+
 func getAddressable() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -477,6 +703,26 @@ func getAddressableNoHostURL() *unstructured.Unstructured {
 			},
 		},
 	}
+}
+
+func getInvalidObjectReference() *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		Kind:       addressableKind,
+		Name:       addressableName,
+		APIVersion: addressableAPIVersion,
+		Namespace:  "-bad",
+	}
+
+}
+
+func getK8SServiceRef() *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		Kind:       "Service",
+		Name:       addressableName,
+		APIVersion: "v1",
+		Namespace:  testNS,
+	}
+
 }
 
 func getAddressableRef() *corev1.ObjectReference {

--- a/resolver/addressable_resolver_test.go
+++ b/resolver/addressable_resolver_test.go
@@ -66,7 +66,7 @@ func TestGetURI_DestinationV1Beta1(t *testing.T) {
 		wantURI string
 		wantErr string
 	}{"nil everything": {
-		wantErr: fmt.Sprintf("destination missing Ref, [apiVersion, kind, name] and URI, expected at least one"),
+		wantErr: "destination missing Ref, [apiVersion, kind, name] and URI, expected at least one",
 	}, "Happy URI with path": {
 		dest: duckv1beta1.Destination{
 			URI: &apis.URL{
@@ -101,7 +101,7 @@ func TestGetURI_DestinationV1Beta1(t *testing.T) {
 				DeprecatedAPIVersion: addressableAPIVersion,
 				DeprecatedNamespace:  testNS,
 			},
-			wantErr: fmt.Sprintf("ref and [apiVersion, kind, name] can't be both present"),
+			wantErr: "ref and [apiVersion, kind, name] can't be both present",
 		},
 		"happy ref": {
 			objects: []runtime.Object{
@@ -187,7 +187,7 @@ func TestGetURI_DestinationV1Beta1(t *testing.T) {
 					Path:   "/foo",
 				},
 			},
-			wantErr: fmt.Sprintf("absolute URI is not allowed when Ref or [apiVersion, kind, name] exists"),
+			wantErr: "absolute URI is not allowed when Ref or [apiVersion, kind, name] exists",
 		},
 		"happy [apiVersion, kind, name]": {
 			objects: []runtime.Object{
@@ -299,7 +299,7 @@ func TestGetURI_DestinationV1Beta1(t *testing.T) {
 					Path:   "/foo",
 				},
 			},
-			wantErr: fmt.Sprintf("absolute URI is not allowed when Ref or [apiVersion, kind, name] exists"),
+			wantErr: "absolute URI is not allowed when Ref or [apiVersion, kind, name] exists",
 		},
 		"nil url": {
 			objects: []runtime.Object{
@@ -328,7 +328,7 @@ func TestGetURI_DestinationV1Beta1(t *testing.T) {
 			wantErr: fmt.Sprintf(`address not set for %+v`, getUnaddressableRef()),
 		}, "notFound": {
 			dest:    duckv1beta1.Destination{Ref: getUnaddressableRef()},
-			wantErr: fmt.Sprintf(`failed to get ref %+v: %s "%s" not found`, getUnaddressableRef(), unaddressableResource, unaddressableName),
+			wantErr: fmt.Sprintf(`failed to get ref %+v: %s %q not found`, getUnaddressableRef(), unaddressableResource, unaddressableName),
 		}}
 
 	for n, tc := range tests {
@@ -366,7 +366,7 @@ func TestGetURI_DestinationV1(t *testing.T) {
 		wantURI string
 		wantErr string
 	}{"nil everything": {
-		wantErr: fmt.Sprintf("destination missing Ref and URI, expected at least one"),
+		wantErr: "destination missing Ref and URI, expected at least one",
 	}, "Happy URI with path": {
 		dest: duckv1.Destination{
 			URI: &apis.URL{
@@ -481,7 +481,7 @@ func TestGetURI_DestinationV1(t *testing.T) {
 					Path:   "/foo",
 				},
 			},
-			wantErr: fmt.Sprintf("absolute URI is not allowed when Ref or [apiVersion, kind, name] exists"),
+			wantErr: "absolute URI is not allowed when Ref or [apiVersion, kind, name] exists",
 		},
 		"nil url": {
 			objects: []runtime.Object{
@@ -510,7 +510,7 @@ func TestGetURI_DestinationV1(t *testing.T) {
 			wantErr: fmt.Sprintf(`address not set for %+v`, getUnaddressableRef()),
 		}, "notFound": {
 			dest:    duckv1.Destination{Ref: getUnaddressableRef()},
-			wantErr: fmt.Sprintf(`failed to get ref %+v: %s "%s" not found`, getUnaddressableRef(), unaddressableResource, unaddressableName),
+			wantErr: fmt.Sprintf(`failed to get ref %+v: %s %q not found`, getUnaddressableRef(), unaddressableResource, unaddressableName),
 		}}
 
 	for n, tc := range tests {


### PR DESCRIPTION
Fixes #890 

Add a new method URIFromDestinationV1 for resolving v1.Destination
Since v1beta1 and v1 Addressable are the same, watch for v1 duck addressable.