### PR TITLE
This has three small table testing changes.

### DIFF
--- a/webhook/testing/listers.go
+++ b/webhook/testing/listers.go
@@ -32,12 +32,14 @@ import (
 	fakeistioclientset "knative.dev/pkg/client/istio/clientset/versioned/fake"
 	istiolisters "knative.dev/pkg/client/istio/listers/networking/v1alpha3"
 	"knative.dev/pkg/reconciler/testing"
+	pkgtesting "knative.dev/pkg/testing"
 )
 
 var clientSetSchemes = []func(*runtime.Scheme) error{
 	fakekubeclientset.AddToScheme,
 	fakeistioclientset.AddToScheme,
 	autoscalingv2beta1.AddToScheme,
+	pkgtesting.AddToScheme,
 }
 
 // Listers is used to synthesize informer-style Listers from fixed lists of resources in tests.
@@ -86,6 +88,11 @@ func (l *Listers) GetKubeObjects() []runtime.Object {
 // GetIstioObjects filters the Listers initial list of objects to types defined in knative/pkg
 func (l *Listers) GetIstioObjects() []runtime.Object {
 	return l.sorter.ObjectsForSchemeFunc(fakeistioclientset.AddToScheme)
+}
+
+// GetIstioObjects filters the Listers initial list of objects to types defined in knative/pkg
+func (l *Listers) GetTestObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(pkgtesting.AddToScheme)
 }
 
 // GetHorizontalPodAutoscalerLister gets lister for HorizontalPodAutoscaler resources.


### PR DESCRIPTION
I'm splitting this off of another change that needed them, the three changes are:

1. Give the PostConditions callbacks in TableRow access to the Reconciler
  resource.  It turns out this is incredibly useful to have the `TableRow`
  program an admission controller and then test that programming by calling
  `Admit()`.

1. Surface the test resources in our webhook "listers", and add the testing
  scheme.

1. Change the `objKey` to only use reflection as a fallback.  The existing logic
  doesn't work properly when a mix of real resources and unstructured.Unstructured
  is used for the same resource.