### PR TITLE
Moved cluster name check to later so --get can use cluster name in kubeconfig

### DIFF
--- a/testutils/clustermanager/e2e-tests/gke.go
+++ b/testutils/clustermanager/e2e-tests/gke.go
@@ -91,14 +91,6 @@ func (gs *GKEClient) Setup(r GKERequest) ClusterOperations {
 		gc.NeedsCleanup = true
 	}
 
-	if r.ClusterName == "" {
-		var err error
-		r.ClusterName, err = getResourceName(ClusterResource)
-		if err != nil {
-			log.Fatalf("Failed getting cluster name: '%v'", err)
-		}
-	}
-
 	if r.MinNodes == 0 {
 		r.MinNodes = DefaultGKEMinNodes
 	}
@@ -192,6 +184,14 @@ func (gc *GKECluster) Acquire() error {
 	request := gc.Request.DeepCopy()
 	// We are going to use request for creating cluster, set its Project
 	request.Project = gc.Project
+	// Set the cluster name if it doesn't exist
+	if request.ClusterName == "" {
+		var err error
+		request.ClusterName, err = getResourceName(ClusterResource)
+		if err != nil {
+			log.Fatalf("Failed getting cluster name: '%v'", err)
+		}
+	}
 
 	// Combine Region with BackupRegions, these will be the regions used for
 	// retrying creation logic


### PR DESCRIPTION
**Bug:** Cannot get cluster from kubeconfig when the cluster name in the kubeconfig is different from [getResourceName](https://github.com/knative/pkg/blob/2ec0f8da50578dcc3d830571d0de24de834579c8/testutils/clustermanager/e2e-tests/util.go#L35). 

In [Setup](https://github.com/knative/pkg/blob/master/testutils/clustermanager/e2e-tests/gke.go#L94), it sets the ClusterName if it's "". Then in [checkEnvironment](https://github.com/knative/pkg/blob/master/testutils/clustermanager/e2e-tests/gke.go#L325), the cluster name check fails. 

**Repro steps:** Run `go run knative.dev/pkg/testutils/clustermanager/prow-cluster-operation --get  --project="" --name="" `

**Current behaviour:** Returns an error
```
go run knative.dev/pkg/testutils/clustermanager/prow-cluster-operation --get  --project="" --name="
2019/11/22 21:41:29 kubeconfig is: "gke_<project>_<region>_<cluster-name>"
2019/11/22 21:41:29 failed acquiring GKE cluster: 'cannot acquire cluster if SkipCreation is set'
exit status 1
```

**Expected:** 

```
$ go run knative.dev/pkg/testutils/clustermanager/prow-cluster-operation --get  --project="" --name="" 
2019/11/22 20:43:59 kubeconfig is: "gke_<project>_<region>_<cluster-name>"
2019/11/22 20:43:59 Getting artifacts dir from prow
2019/11/22 20:43:59 Writing metadata to: "/tmp/metadata.json"
...
2019/11/22 20:43:59 Done writing metadata
```

**E2E Test PR**: https://github.com/knative/test-infra/pull/1565