### PR TITLE
modify boskos in cluster manager to make the boskos resource type customizable

### DIFF
--- a/testutils/clustermanager/e2e-tests/boskos/boskos.go
+++ b/testutils/clustermanager/e2e-tests/boskos/boskos.go
@@ -38,7 +38,7 @@ var (
 )
 
 type Operation interface {
-	AcquireGKEProject(*string) (*boskoscommon.Resource, error)
+	AcquireGKEProject(*string, string) (*boskoscommon.Resource, error)
 	ReleaseGKEProject(*string, string) error
 }
 
@@ -57,15 +57,15 @@ func newClient(host *string) *boskosclient.Client {
 // AcquireGKEProject acquires GKE Boskos Project with "free" state, and not
 // owned by anyone, sets its state to "busy" and assign it an owner of *host,
 // which by default is env var `JOB_NAME`.
-func (c *Client) AcquireGKEProject(host *string) (*boskoscommon.Resource, error) {
+func (c *Client) AcquireGKEProject(host *string, resType string) (*boskoscommon.Resource, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultWaitDuration)
 	defer cancel()
-	p, err := newClient(host).AcquireWait(ctx, GKEProjectResource, boskoscommon.Free, boskoscommon.Busy)
+	p, err := newClient(host).AcquireWait(ctx, resType, boskoscommon.Free, boskoscommon.Busy)
 	if err != nil {
 		return nil, fmt.Errorf("boskos failed to acquire GKE project: %v", err)
 	}
 	if p == nil {
-		return nil, fmt.Errorf("boskos does not have a free %s at the moment", GKEProjectResource)
+		return nil, fmt.Errorf("boskos does not have a free %s at the moment", resType)
 	}
 	return p, nil
 }

--- a/testutils/clustermanager/e2e-tests/boskos/boskos_test.go
+++ b/testutils/clustermanager/e2e-tests/boskos/boskos_test.go
@@ -89,7 +89,7 @@ func TestAcquireGKEProject(t *testing.T) {
 		})
 		defer ts.Close()
 		boskosURI = ts.URL
-		_, err := client.AcquireGKEProject(data.host)
+		_, err := client.AcquireGKEProject(data.host, GKEProjectResource)
 		if data.expErr && (err == nil) {
 			t.Fatalf("testing acquiring GKE project, want: err, got: no err")
 		}

--- a/testutils/clustermanager/e2e-tests/boskos/fake/fake.go
+++ b/testutils/clustermanager/e2e-tests/boskos/fake/fake.go
@@ -44,11 +44,12 @@ func (c *FakeBoskosClient) GetResources() []*boskoscommon.Resource {
 }
 
 // AcquireGKEProject fakes to be no op
-func (c *FakeBoskosClient) AcquireGKEProject(host *string) (*boskoscommon.Resource, error) {
+func (c *FakeBoskosClient) AcquireGKEProject(host *string, resType string) (*boskoscommon.Resource, error) {
 	for _, res := range c.resources {
 		if res.State == boskoscommon.Free {
 			res.State = boskoscommon.Busy
 			res.Owner = c.getOwner(host)
+			res.Type = resType
 			return res, nil
 		}
 	}

--- a/testutils/clustermanager/e2e-tests/gke_test.go
+++ b/testutils/clustermanager/e2e-tests/gke_test.go
@@ -55,6 +55,7 @@ func TestSetup(t *testing.T) {
 	nodeTypeOverride := "foonode"
 	regionOverride := "fooregion"
 	zoneOverride := "foozone"
+	boskosResTypeOverride := "customResType"
 	fakeAddons := "fake-addon"
 	fakeBuildID := "1234"
 	type env struct {
@@ -84,6 +85,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{"us-west1", "us-east1"},
+					ResourceType:  DefaultResourceType,
 				},
 			},
 		}, {
@@ -102,6 +104,26 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{"us-west1", "us-east1"},
+					ResourceType:  DefaultResourceType,
+				},
+			},
+		}, {
+			name: "Custom Boskos Resource type, running in Prow",
+			arg:  GKERequest{ResourceType: boskosResTypeOverride},
+			env:  env{true, "", ""},
+			want: &GKECluster{
+				Request: &GKERequest{
+					Request: gke.Request{
+						ClusterName: "",
+						MinNodes:    1,
+						MaxNodes:    3,
+						NodeType:    "n1-standard-4",
+						Region:      "us-central1",
+						Zone:        "",
+						Addons:      nil,
+					},
+					BackupRegions: []string{"us-west1", "us-east1"},
+					ResourceType:  boskosResTypeOverride,
 				},
 			},
 		}, {
@@ -125,6 +147,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{"us-west1", "us-east1"},
+					ResourceType:  DefaultResourceType,
 				},
 				Project:      fakeProj,
 				NeedsCleanup: true,
@@ -150,6 +173,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{"us-west1", "us-east1"},
+					ResourceType:  DefaultResourceType,
 				},
 				Project:      fakeProj,
 				NeedsCleanup: true,
@@ -174,6 +198,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{"us-west1", "us-east1"},
+					ResourceType:  DefaultResourceType,
 				},
 			},
 		}, {
@@ -196,6 +221,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{"us-west1", "us-east1"},
+					ResourceType:  DefaultResourceType,
 				},
 			},
 		}, {
@@ -222,6 +248,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{},
+					ResourceType:  DefaultResourceType,
 				},
 			},
 		}, {
@@ -247,6 +274,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: nil,
+					ResourceType:  DefaultResourceType,
 				},
 			},
 		}, {
@@ -271,6 +299,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: nil,
+					ResourceType:  DefaultResourceType,
 				},
 			},
 		}, {
@@ -289,6 +318,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{"us-west1", "us-east1"},
+					ResourceType:  DefaultResourceType,
 				},
 			},
 		}, {
@@ -307,6 +337,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{"backupregion1", "backupregion2"},
+					ResourceType:  DefaultResourceType,
 				},
 			},
 		}, {
@@ -329,6 +360,7 @@ func TestSetup(t *testing.T) {
 						Addons:      []string{fakeAddons},
 					},
 					BackupRegions: []string{"us-west1", "us-east1"},
+					ResourceType:  DefaultResourceType,
 				},
 			},
 		},
@@ -971,6 +1003,7 @@ func TestAcquire(t *testing.T) {
 					Addons:      tt.td.request.addons,
 				},
 				BackupRegions: DefaultGKEBackupRegions,
+				ResourceType:  DefaultResourceType,
 			}
 			opCount := 0
 			if data.existCluster != nil {
@@ -1213,7 +1246,7 @@ func TestDelete(t *testing.T) {
 			for _, bos := range data.boskosState {
 				fgc.boskosOps.(*boskosFake.FakeBoskosClient).NewGKEProject(bos.Name)
 				// Acquire with default user
-				fgc.boskosOps.(*boskosFake.FakeBoskosClient).AcquireGKEProject(nil)
+				fgc.boskosOps.(*boskosFake.FakeBoskosClient).AcquireGKEProject(nil, DefaultResourceType)
 			}
 			if data.requestCleanup {
 				fgc.Request = &GKERequest{

--- a/testutils/clustermanager/prow-cluster-operation/options/options.go
+++ b/testutils/clustermanager/prow-cluster-operation/options/options.go
@@ -55,6 +55,7 @@ func (rw *RequestWrapper) addOptions() {
 	flag.StringVar(&rw.Request.Zone, "zone", "", "GCP zone")
 	flag.StringVar(&rw.Request.Project, "project", "", "GCP project")
 	flag.StringVar(&rw.Request.ClusterName, "name", "", "cluster name")
+	flag.StringVar(&rw.Request.ResourceType, "resource-type", "", "Boskos Resource Type")
 	flag.StringVar(&rw.BackupRegionsStr, "backup-regions", "", "GCP regions as backup, separated by comma")
 	flag.StringVar(&rw.AddonsStr, "addons", "", "addons to be added, separated by comma")
 	flag.BoolVar(&rw.Request.SkipCreation, "skip-creation", false, "should skip creation or not")


### PR DESCRIPTION
Currently, the boskos library always acquire resource type "gke-project".
https://github.com/knative/pkg/blob/master/testutils/clustermanager/e2e-tests/boskos/boskos.go#L63

This change makes the boskos resource type customizable in Acquire. 

Test PR: https://github.com/knative/test-infra/pull/1570

/cc @chaodaiG 