### PR TITLE
Add SecretWatcher for Stackdriver Secret to internal metrics package

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1393,6 +1393,7 @@
     "k8s.io/apimachinery/pkg/api/validation",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
+    "k8s.io/apimachinery/pkg/fields",
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",

--- a/metrics/internal/stackdriver/secret_watcher.go
+++ b/metrics/internal/stackdriver/secret_watcher.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stackdriver
+
+import (
+	"fmt"
+	"log"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+// Observer is the interface for callbacks that notify an Observer of the latest
+// state of a secret being watched by a secretWatcher.  An Observer should not modify the provided
+// Secrets, and should `.DeepCopy()` it for persistence (or otherwise process its
+// contents).
+type Observer interface {
+	OnAdd(*corev1.Secret)
+	OnUpdate(*corev1.Secret, *corev1.Secret)
+	OnDelete(*corev1.Secret)
+}
+
+// ObserverFuncs implements the observer interface.
+type ObserverFuncs struct {
+	AddFunc    func(*corev1.Secret)
+	UpdateFunc func(*corev1.Secret, *corev1.Secret)
+	DeleteFunc func(*corev1.Secret)
+}
+
+// OnAdd is the OnAdd of the observer interface.
+func (of *ObserverFuncs) OnAdd(s *corev1.Secret) {
+	// if of.AddFunc == nil {
+	// 	return
+	// }
+	of.AddFunc(s)
+}
+
+// OnUpdate is the OnUpdate of the observer interface.
+func (of *ObserverFuncs) OnUpdate(sOld *corev1.Secret, sNew *corev1.Secret) {
+	// if of.UpdateFunc == nil {
+	// 	return
+	// }
+	of.UpdateFunc(sOld, sNew)
+}
+
+// OnDelete is the OnDelete of the observer interface.
+func (of *ObserverFuncs) OnDelete(s *corev1.Secret) {
+	// if of.DeleteFunc == nil {
+	// 	return
+	// }
+	of.DeleteFunc(s)
+}
+
+// SecretWatcher defines the interface that a secret watcher must implement.
+type SecretWatcher interface {
+	// StartWatch starts the secret watch allowing observer callbacks to be triggered.
+	StartWatch() error
+
+	// StopWatch stops the secret watch.
+	StopWatch()
+
+	// GetSecret gets the value of the specified secret.
+	GetSecret(namespace string, name string) (*corev1.Secret, error)
+
+	// GetNamespaceWatched returns the namespace of the Secret being watched;
+	// returns empty string if more than one namespace is being watched.
+	GetNamespaceWatched() string
+
+	// GetNameWatched returns the name of the Secret being watched;
+	// returns empty string if more than one Secret is being watched.
+	GetNameWatched() string
+}
+
+var (
+	// createStackdriverKubeclientFunc provides a hook for setting up the kubeclient for testing.
+	// It is set to createKubeclient otherwise.
+	createStackdriverKubeclientFunc func() (kubernetes.Interface, error)
+)
+
+func init() {
+	createStackdriverKubeclientFunc = createKubeclient
+}
+
+// NewSecretWatcher constructs a secretWatcher that watches all Secrets.
+func NewSecretWatcher(observers ...Observer) (SecretWatcher, error) {
+	return newSecretWatcherInternal("", "", observers...)
+}
+
+// NewSecretWatcherSingleNamespace constructs a secretWatcher that watches all Secrets in a namespace.
+func NewSecretWatcherSingleNamespace(namespace string, observers ...Observer) (SecretWatcher, error) {
+	return newSecretWatcherInternal(namespace, "", observers...)
+}
+
+// NewSecretWatcherSingleSecret constructs a secretWatcher that watches all a single Secret.
+func NewSecretWatcherSingleSecret(namespace string, name string, observers ...Observer) (SecretWatcher, error) {
+	return newSecretWatcherInternal(namespace, name, observers...)
+}
+
+// newSecretWatcherInternal constructs a secretWatcher.
+func newSecretWatcherInternal(namespace string, name string, observers ...Observer) (SecretWatcher, error) {
+	impl := &secretWatcherImpl{
+		SecretNamespace: namespace,
+		SecretName:      name,
+		observers:       observers,
+	}
+
+	if clientErr := impl.setupKubeclient(); clientErr != nil {
+		return nil, clientErr
+	}
+
+	return impl, nil
+}
+
+// secretWatherImpl implmements the secretWatcher interface.
+type secretWatcherImpl struct {
+	// kubeclient is the in-cluster Kubernetes kubeclient, which is lazy-initialized on first use.
+	kubeclient kubernetes.Interface
+
+	// watchLock ensures that only one watch is being run at a time.
+	watchLock sync.Mutex
+	// informer watches the Stackdriver secret if useStackdriverSecretEnabled is true.
+	informer cache.SharedIndexInformer
+	// stopCh stops the secretWatcherInformer when required.
+	stopCh chan struct{}
+	// watchStarted is whether or not the informer is running for the secret being watched.
+	watchStarted bool
+
+	// SecretName is the name of the secret being watched.
+	SecretName string
+	// SecretNamespace is the namespace of the secret being watched.
+	SecretNamespace string
+	// observers is the list of observers to trigger when the Secret is changed.
+	observers []Observer
+}
+
+// StartWatch implements StartWatch of secretWatcher interface.
+func (s *secretWatcherImpl) StartWatch() error {
+	s.watchLock.Lock()
+	defer s.watchLock.Unlock()
+	if s.watchStarted {
+		return nil
+	}
+	s.watchStarted = true
+
+	s.setupInformer()
+	s.stopCh = make(chan struct{})
+	go s.informer.Run(s.stopCh)
+
+	return nil
+}
+
+// StopWatch implements StopWatch secretWatcher interface.
+func (s *secretWatcherImpl) StopWatch() {
+	s.watchLock.Lock()
+	defer s.watchLock.Unlock()
+	if !s.watchStarted {
+		return
+	}
+	s.watchStarted = false
+
+	close(s.stopCh)
+}
+
+// GetSecret implements GetSecret of secretWatcher interface.
+func (s *secretWatcherImpl) GetSecret(namespace string, name string) (*corev1.Secret, error) {
+	if namespace == "" || name == "" {
+		return nil, fmt.Errorf("Must specify a non-empty Secret namespace and name to get, namespace specified: %v, name specified: %v", namespace, name)
+	}
+	sec, secErr := s.kubeclient.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
+
+	if secErr != nil {
+		return nil, fmt.Errorf("Error getting Secret [%v] in namespace [%v]: %v", name, namespace, secErr)
+	}
+
+	return sec, nil
+}
+
+// GetNamespaceWatched implements GetNamespaceWatched of secretWatcher interface.
+func (s *secretWatcherImpl) GetNamespaceWatched() string {
+	return s.SecretNamespace
+}
+
+// GetNameWatched implements GetNameWatched of secretWatcher interface.
+func (s *secretWatcherImpl) GetNameWatched() string {
+	return s.SecretName
+}
+
+// setupInformer sets up a kubernetes informer to watch Secrets.
+func (s *secretWatcherImpl) setupInformer() {
+	var sharedInformerOpts []informers.SharedInformerOption
+	if s.SecretNamespace != "" {
+		namespaceOpt := informers.WithNamespace(s.SecretNamespace)
+		sharedInformerOpts = append(sharedInformerOpts, namespaceOpt)
+
+		if s.SecretName != "" {
+			nameFieldSelectorFunc := func(listOpts *metav1.ListOptions) {
+				listOpts.FieldSelector = fields.OneTermEqualSelector("metadata.name", s.SecretName).String()
+			}
+			nameOpt := informers.WithTweakListOptions(nameFieldSelectorFunc)
+			sharedInformerOpts = append(sharedInformerOpts, nameOpt)
+		}
+	}
+
+	informers := informers.NewSharedInformerFactoryWithOptions(s.kubeclient, 0, sharedInformerOpts...)
+	s.informer = informers.Core().V1().Secrets().Informer()
+
+	s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			log.Println("AddFunc")
+			sec := obj.(*corev1.Secret)
+			for _, obs := range s.observers {
+				obs.OnAdd(sec)
+			}
+		},
+		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+			sOld := oldObj.(*corev1.Secret)
+			sNew := newObj.(*corev1.Secret)
+
+			for _, obs := range s.observers {
+				obs.OnUpdate(sOld, sNew)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			log.Println("DeleteFunc")
+			sec := obj.(*corev1.Secret)
+			for _, obs := range s.observers {
+				obs.OnDelete(sec)
+			}
+		},
+	})
+}
+
+// createKubeclient creates a kubeclient from the in-cluster config.
+// This only works when running on a kubernetes cluster.
+func createKubeclient() (kubernetes.Interface, error) {
+	config, configErr := rest.InClusterConfig()
+	if configErr != nil {
+		return nil, configErr
+	}
+
+	cs, clientErr := kubernetes.NewForConfig(config)
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	return cs, nil
+}
+
+// setupKubeclient initializes the kubeclient.
+func (s *secretWatcherImpl) setupKubeclient() error {
+	client, err := createStackdriverKubeclientFunc()
+	if err != nil {
+		return err
+	}
+
+	s.kubeclient = client
+
+	return nil
+}

--- a/metrics/internal/stackdriver/secret_watcher.go
+++ b/metrics/internal/stackdriver/secret_watcher.go
@@ -121,8 +121,8 @@ func NewSecretWatcherSingleSecret(namespace string, name string, observers ...Ob
 // newSecretWatcherInternal constructs a secretWatcher.
 func newSecretWatcherInternal(namespace string, name string, observers ...Observer) (SecretWatcher, error) {
 	impl := &secretWatcherImpl{
-		SecretNamespace: namespace,
-		SecretName:      name,
+		secretNamespace: namespace,
+		secretName:      name,
 		observers:       observers,
 	}
 
@@ -148,9 +148,9 @@ type secretWatcherImpl struct {
 	watchStarted bool
 
 	// SecretName is the name of the secret being watched.
-	SecretName string
+	secretName string
 	// SecretNamespace is the namespace of the secret being watched.
-	SecretNamespace string
+	secretNamespace string
 	// observers is the list of observers to trigger when the Secret is changed.
 	observers []Observer
 }
@@ -174,7 +174,7 @@ func (s *secretWatcherImpl) StartWatch() error {
 // StopWatch implements StopWatch secretWatcher interface.
 func (s *secretWatcherImpl) StopWatch() {
 	s.watchLock.Lock()
-	defer s.watchLock.Unlock()
+	defer s.watchLock.Unlock()	
 	if !s.watchStarted {
 		return
 	}
@@ -185,24 +185,24 @@ func (s *secretWatcherImpl) StopWatch() {
 
 // GetNamespaceWatched implements GetNamespaceWatched of secretWatcher interface.
 func (s *secretWatcherImpl) GetNamespaceWatched() string {
-	return s.SecretNamespace
+	return s.secretNamespace
 }
 
 // GetNameWatched implements GetNameWatched of secretWatcher interface.
 func (s *secretWatcherImpl) GetNameWatched() string {
-	return s.SecretName
+	return s.secretName
 }
 
 // setupInformer sets up a kubernetes informer to watch Secrets.
 func (s *secretWatcherImpl) setupInformer() {
 	var sharedInformerOpts []informers.SharedInformerOption
-	if s.SecretNamespace != "" {
-		namespaceOpt := informers.WithNamespace(s.SecretNamespace)
+	if s.secretNamespace != "" {
+		namespaceOpt := informers.WithNamespace(s.secretNamespace)
 		sharedInformerOpts = append(sharedInformerOpts, namespaceOpt)
 
-		if s.SecretName != "" {
+		if s.secretName != "" {
 			nameFieldSelectorFunc := func(listOpts *metav1.ListOptions) {
-				listOpts.FieldSelector = fields.OneTermEqualSelector("metadata.name", s.SecretName).String()
+				listOpts.FieldSelector = fields.OneTermEqualSelector("metadata.name", s.secretName).String()
 			}
 			nameOpt := informers.WithTweakListOptions(nameFieldSelectorFunc)
 			sharedInformerOpts = append(sharedInformerOpts, nameOpt)

--- a/metrics/internal/stackdriver/secret_watcher.go
+++ b/metrics/internal/stackdriver/secret_watcher.go
@@ -18,7 +18,6 @@ package stackdriver
 
 import (
 	"fmt"
-	"log"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
@@ -226,7 +225,6 @@ func (s *secretWatcherImpl) setupInformer() {
 
 	s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			log.Println("AddFunc")
 			sec := obj.(*corev1.Secret)
 			for _, obs := range s.observers {
 				obs.OnAdd(sec)
@@ -241,7 +239,6 @@ func (s *secretWatcherImpl) setupInformer() {
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			log.Println("DeleteFunc")
 			sec := obj.(*corev1.Secret)
 			for _, obs := range s.observers {
 				obs.OnDelete(sec)

--- a/metrics/internal/stackdriver/secret_watcher_test.go
+++ b/metrics/internal/stackdriver/secret_watcher_test.go
@@ -148,12 +148,8 @@ type testObserver struct {
 
 // newTestObserver constructs a testObserver from observerFuncs.
 func newTestObserver(inputObsFuncs *ObserverFuncs) *testObserver {
-	// If a callback is nil, consider it to be called by default.
 	return &testObserver{
-		oFuncs:         inputObsFuncs,
-		onAddCalled:    inputObsFuncs.AddFunc == nil,
-		onUpdateCalled: inputObsFuncs.UpdateFunc == nil,
-		onDeleteCalled: inputObsFuncs.DeleteFunc == nil,
+		oFuncs: inputObsFuncs,
 	}
 }
 
@@ -194,12 +190,6 @@ func (tObs *testObserver) wasCallbackCalled(callbackSentinel *bool) bool {
 	tObs.mux.Lock()
 	defer tObs.mux.Unlock()
 	return *callbackSentinel
-}
-
-func (tObs *testObserver) AllCallbacksCalled() bool {
-	tObs.mux.Lock()
-	defer tObs.mux.Unlock()
-	return tObs.onAddCalled && tObs.onUpdateCalled && tObs.onDeleteCalled
 }
 
 func testSetupWithCustomKubeclient(customKubeclient kubernetes.Interface) {
@@ -458,18 +448,12 @@ func TestSecretWatcherCallbacks(t *testing.T) {
 				testSetup()
 			}
 
-			obsFuncs := &ObserverFuncs{
-				AddFunc:    func(s *corev1.Secret) {},
-				UpdateFunc: func(sOld *corev1.Secret, sNew *corev1.Secret) {},
-				DeleteFunc: func(s *corev1.Secret) {},
-			}
-
 			kubeclientForTest.CoreV1().Secrets(test.secretToCreate.namespace).Create(&test.secretToCreate.secret)
 
 			testObs := make([]*testObserver, defaultNumTestObservers)
 			watchers := make([]SecretWatcher, defaultNumTestObservers)
 			for i := 0; i < defaultNumTestObservers; i++ {
-				testObs[i] = newTestObserver(obsFuncs)
+				testObs[i] = newTestObserver(defaultObserverFuncs)
 				watchers[i] = test.watcherConstructor(testObs[i])
 				watchers[i].StartWatch()
 			}

--- a/metrics/internal/stackdriver/secret_watcher_test.go
+++ b/metrics/internal/stackdriver/secret_watcher_test.go
@@ -1,0 +1,580 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stackdriver
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	fclient "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// secretForTest encapsulates Secret metadata and a Secret for re-using and verifying values.
+type secretForTest struct {
+	namespace string
+	name      string
+	dataKey   string
+	dataValue string
+	secret    corev1.Secret
+}
+
+func (s *secretForTest) UpdateDataKey(dataKey string) *secretForTest {
+	s.dataKey = dataKey
+	s.secret.Data = map[string][]byte{
+		s.dataKey: []byte(s.dataValue),
+	}
+
+	return s
+}
+
+func (s *secretForTest) UpdateDataValue(dataValue string) *secretForTest {
+	s.dataValue = dataValue
+	s.secret.Data = map[string][]byte{
+		s.dataKey: []byte(s.dataValue),
+	}
+
+	return s
+}
+
+// newSecretForTest constructs a secretForTest.
+func newSecretForTest(namespace string, name string) *secretForTest {
+	return &secretForTest{
+		namespace: namespace,
+		name:      name,
+		dataKey:   defaultSecretDataKey,
+		dataValue: defaultSecretDataValue,
+		secret: corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "apps/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				defaultSecretDataKey: []byte(defaultSecretDataValue),
+			},
+			Type: "Opaque",
+		},
+	}
+}
+
+// testObserver is an implementation of the the secretWatcher observer interface
+// that also holds state about whether the observer's callbacks have been triggered.
+type testObserver struct {
+	oFuncs         *ObserverFuncs
+	OnAddCalled    bool
+	OnUpdateCalled bool
+	OnDeleteCalled bool
+}
+
+// newTestObserver constructs a testObserver from observerFuncs.
+func newTestObserver(inputObsFuncs *ObserverFuncs) *testObserver {
+	// If a callback is nil, consider it to be called by default.
+	return &testObserver{
+		oFuncs:         inputObsFuncs,
+		OnAddCalled:    inputObsFuncs.AddFunc == nil,
+		OnUpdateCalled: inputObsFuncs.UpdateFunc == nil,
+		OnDeleteCalled: inputObsFuncs.DeleteFunc == nil,
+	}
+}
+
+func (tObs *testObserver) OnAdd(s *corev1.Secret) {
+	tObs.oFuncs.OnAdd(s)
+	tObs.OnAddCalled = true
+}
+
+func (tObs *testObserver) OnUpdate(sOld *corev1.Secret, sNew *corev1.Secret) {
+	tObs.oFuncs.OnUpdate(sOld, sNew)
+	tObs.OnUpdateCalled = true
+}
+
+func (tObs *testObserver) OnDelete(s *corev1.Secret) {
+	tObs.oFuncs.OnDelete(s)
+	tObs.OnDeleteCalled = true
+}
+
+func (tObs *testObserver) AllCallbacksCalled() bool {
+	return tObs.OnAddCalled && tObs.OnUpdateCalled && tObs.OnDeleteCalled
+}
+
+const (
+	defaultSecretDataKey   = "key.json"
+	defaultSecretDataValue = "token"
+	defaultSecretName      = "test"
+	defaultSecretNamespace = "test-secret"
+)
+
+var (
+	// kubeclientForTest is a fake kubeclient that can be use for testing.
+	// This should be passed to any functionality being tested that require a kubeclient.
+	kubeclientForTest kubernetes.Interface
+
+	// dsft is a default secret for tests, for convenience.
+	dsft = newSecretForTest(defaultSecretName, defaultSecretNamespace)
+	// defaultNumTestObservers is the default number of observer callbacks for tests.
+	defaultNumTestObservers = 2
+
+	defaultGlobalSecretWatcherConstructor = func(t *testing.T, obs ...Observer) SecretWatcher {
+		return mustNewSecretWatcher(t, obs...)
+	}
+
+	defaultSingleNamespaceSecretWatcherConstructor = func(t *testing.T, obs ...Observer) SecretWatcher {
+		return mustNewSecretWatcherSingleNamespace(t, dsft.namespace, obs...)
+	}
+
+	defaultSingleSecretSecretWatcherConstructor = func(t *testing.T, obs ...Observer) SecretWatcher {
+		return mustNewSecretWatcherSingleSecret(t, dsft.namespace, dsft.name, obs...)
+	}
+
+	defaultWatchersToTest = []struct {
+		name        string
+		constructor func(t *testing.T, obs ...Observer) SecretWatcher
+	}{
+		{
+			name:        "GlobalSecretWatcher",
+			constructor: defaultGlobalSecretWatcherConstructor,
+		},
+		{
+			name:        "SingleNamespaceSecretWatcher",
+			constructor: defaultSingleSecretSecretWatcherConstructor,
+		},
+		{
+			name:        "SingleSecretSecretWatcher",
+			constructor: defaultSingleSecretSecretWatcherConstructor,
+		},
+	}
+
+	defaultObserverFuncs = &ObserverFuncs{
+		AddFunc: func(s *corev1.Secret) {
+		},
+		UpdateFunc: func(sOld *corev1.Secret, sNew *corev1.Secret) {
+		},
+		DeleteFunc: func(s *corev1.Secret) {
+		},
+	}
+)
+
+func testSetupWithCustomKubeclient(customKubeclient kubernetes.Interface) {
+	// Reset kubeclient on every test to clear out state
+	kubeclientForTest = customKubeclient
+	// Ensure test and secret watcher share the same kubeclient
+	createStackdriverKubeclientFunc = func() (kubernetes.Interface, error) {
+		return kubeclientForTest, nil
+	}
+
+	// Always reset secret
+	dsft = newSecretForTest(defaultSecretName, defaultSecretNamespace)
+}
+
+// testSetup sets up tests.
+func testSetup() {
+	testSetupWithCustomKubeclient(fclient.NewSimpleClientset())
+	fakeclient := fclient.NewSimpleClientset()
+	fakeclient.Fake.PrependReactor("list", "secrets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		listAction := action.(k8stesting.ListAction)
+		listRestrictions := listAction.GetListRestrictions()
+		log.Printf("LIST %#v", listAction.GetListRestrictions())
+		if listRestrictions.Fields != nil {
+			log.Print(listRestrictions.Fields.String())
+		}
+
+		secrets := &corev1.SecretList{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "SecretList",
+				APIVersion: "apps/v1",
+			},
+			Items: []corev1.Secret{newSecretForTest("orange", "two").secret},
+		}
+		return true, secrets, nil
+	})
+
+	fakeclient.Fake.PrependReactor("create", "secrets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		createAction := action.(k8stesting.CreateAction)
+		log.Printf("CREATE %#v", createAction)
+		return true, nil, errors.New("What")
+	})
+
+	fakeclient.Fake.PrependReactor("get", "secrets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		getAction := action.(k8stesting.GetAction)
+		log.Printf("watch %#v", getAction)
+		return true, nil, errors.New("What")
+	})
+
+	fakeclient.Fake.PrependReactor("watch", "secrets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		watchAction := action.(k8stesting.WatchAction)
+		log.Printf("WATCH %#v", watchAction)
+		return true, nil, errors.New("What")
+	})
+}
+
+// testCleanup cleans up tests.
+func testCleanup() {
+	createStackdriverKubeclientFunc = createKubeclient
+}
+
+func TestNewSecretWatcher(t *testing.T) {
+	for _, test := range defaultWatchersToTest {
+		t.Run(test.name, func(t *testing.T) {
+			testSetup()
+			test.constructor(t, defaultObserverFuncs)
+			testCleanup()
+		})
+	}
+}
+
+func TestStartStopWatch(t *testing.T) {
+	added := false
+	o := &ObserverFuncs{
+		AddFunc: func(s *corev1.Secret) {
+			added = true
+		},
+	}
+
+	for _, test := range defaultWatchersToTest {
+		t.Run(test.name, func(t *testing.T) {
+			testSetup()
+
+			watcher := test.constructor(t, o)
+			// Test weird patterns of stop/start
+			watcher.StopWatch()
+			watcher.StartWatch()
+			watcher.StartWatch()
+			watcher.StopWatch()
+			watcher.StopWatch()
+
+			watcher.StartWatch()
+			defer watcher.StopWatch()
+
+			kubeclientForTest.CoreV1().Secrets(dsft.namespace).Create(&dsft.secret)
+			waitForCondition(t, func() bool {
+				return added
+			}, 3)
+
+			testCleanup()
+		})
+	}
+}
+
+func TestSecretWatcherGetSecret(t *testing.T) {
+	for _, test := range defaultWatchersToTest {
+		t.Run(test.name, func(t *testing.T) {
+			testSetup()
+
+			watcher := test.constructor(t)
+			if _, err := watcher.GetSecret(dsft.namespace, dsft.name); err == nil {
+				t.Errorf("Expected GetSecret() for Secret %v/%v to fail because secret doesn't exist yet", dsft.namespace, dsft.name)
+			}
+
+			kubeclientForTest.CoreV1().Secrets(dsft.namespace).Create(&dsft.secret)
+
+			waitForCondition(t, func() bool {
+				sec, err := watcher.GetSecret(dsft.namespace, dsft.name)
+				if err != nil {
+					return false
+				}
+				assertSecretValue(t, sec, dsft.namespace, dsft.name, dsft.dataKey, dsft.dataValue)
+				return true
+			}, 3)
+
+			testCleanup()
+		})
+	}
+}
+
+func TestSecretWatcherGetSecretInvalidInputs(t *testing.T) {
+	testSetup()
+	defer testCleanup()
+
+	var invalidCases = []struct {
+		name            string
+		secretNamespace string
+		secretName      string
+	}{
+		{
+			name:            "EmptyNamespace",
+			secretNamespace: "",
+			secretName:      dsft.name,
+		},
+		{
+			name:            "EmptyName",
+			secretNamespace: dsft.namespace,
+			secretName:      "",
+		},
+		{
+			name:            "BothEmpty",
+			secretNamespace: "",
+			secretName:      "",
+		},
+	}
+
+	for _, watcherToTest := range defaultWatchersToTest {
+		for _, test := range invalidCases {
+			t.Run(test.name+watcherToTest.name, func(t *testing.T) {
+				watcher := watcherToTest.constructor(t)
+				if _, err := watcher.GetSecret(test.secretNamespace, test.secretName); err == nil {
+					t.Errorf("Calls to GetSecret() should fail if namespace or name are invalid; namespace: %v, name: %v", test.secretNamespace, test.secretName)
+				}
+			})
+		}
+	}
+}
+
+func TestSecretWatcherCallbacks(t *testing.T) {
+	nsApple := "apple"
+	nsOrange := "orange"
+	nameOne := "one"
+	nameTwo := "two"
+
+	// These secrets will be created in the order they are declared
+	sOrangeOne := newSecretForTest(nsOrange, nameOne)
+	sAppleOne := newSecretForTest(nsApple, nameOne)
+	sAppleTwo := newSecretForTest(nsApple, nameTwo)
+
+	globalSecretWatcherConstructor := func(obs ...Observer) SecretWatcher { return mustNewSecretWatcher(t, obs...) }
+	appleNamespaceWatcherConstructor := func(obs ...Observer) SecretWatcher {
+		return mustNewSecretWatcherSingleNamespace(t, sAppleOne.namespace, obs...)
+	}
+	appleTwoSecretWatcherConstructor := func(obs ...Observer) SecretWatcher {
+		return mustNewSecretWatcherSingleSecret(t, sAppleTwo.namespace, sAppleTwo.name, obs...)
+	}
+
+	// When using the fake kubernetes client to list resources, label and field filters passed through meta ListOptions are not applied.
+	// The filtering is normally done server side and is not implemented on the fake kubernetes client (https://github.com/kubernetes/client-go/issues/326).
+	// Modify the fake kubernetes client to fake out list filtering for this one test, it specifically filters out Secret named "apple/one".
+	appleNameTwoSecretWatcherChangeAppleOneTestSetup := func() {
+		f := fclient.NewSimpleClientset()
+		// Intercept all list actions by the fake kubeclient and modify the return.
+		// List is used by SharedInformers for detecting OnAdd and OnUpdate notifications.
+		f.Fake.PrependReactor("list", "secrets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			listAction := action.(k8stesting.ListAction)
+			listRestrictions := listAction.GetListRestrictions()
+			// There's no way to get the actual results of the list action, but we can check that the list action was for the "apple" namespace.
+			// And verify that the SharedInformer passed ListOptions that filtered by "metadata.name".
+			if listAction.GetNamespace() == nsApple && listRestrictions.Fields.String() == fmt.Sprintf("metadata.name=%v", nameTwo) {
+				secrets := &corev1.SecretList{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "SecretList",
+						APIVersion: "apps/v1",
+					},
+					Items: []corev1.Secret{}, // omit "apple/one"
+				}
+				return true, secrets, nil
+			}
+
+			return false, nil, nil
+		})
+
+		// Intercept all delete actions by the fake kubeclient and modify the return.
+		// Delete is used by SharedInformers for detecting OnDelete notifications.
+		f.Fake.PrependReactor("delete", "secrets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			act := action.(k8stesting.DeleteAction)
+			ns := act.GetNamespace()
+			name := act.GetName()
+
+			// Omit "apple/one"
+			if ns == nsApple && name == nameOne {
+				return true, nil, nil
+			}
+
+			return false, nil, nil
+		})
+
+		testSetupWithCustomKubeclient(f)
+	}
+
+	var tests = []struct {
+		name                 string
+		testSetupFunc        func()
+		watcherConstructor   func(observers ...Observer) SecretWatcher
+		secretToCreate       *secretForTest
+		shouldTriggerWatcher bool
+	}{
+		{
+			name:                 "GlobalWatcherChangeOrangeOne",
+			watcherConstructor:   globalSecretWatcherConstructor,
+			secretToCreate:       sOrangeOne,
+			shouldTriggerWatcher: true,
+		},
+		{
+			name:                 "GlobalWatcherChangeAppleOne",
+			watcherConstructor:   globalSecretWatcherConstructor,
+			secretToCreate:       sAppleOne,
+			shouldTriggerWatcher: true,
+		},
+		{
+			name:                 "GlobalWatcherChangeAppleTwo",
+			watcherConstructor:   globalSecretWatcherConstructor,
+			secretToCreate:       sAppleTwo,
+			shouldTriggerWatcher: true,
+		},
+		{
+			name:                 "AppleNamespaceWatcherChangeOrangeOne",
+			watcherConstructor:   appleNamespaceWatcherConstructor,
+			secretToCreate:       sOrangeOne,
+			shouldTriggerWatcher: false,
+		},
+		{
+			name:                 "AppleNamespaceWatcherChangeAppleOne",
+			watcherConstructor:   appleNamespaceWatcherConstructor,
+			secretToCreate:       sAppleOne,
+			shouldTriggerWatcher: true,
+		},
+		{
+			name:                 "AppleNamespaceWatcherChangeAppleTwo",
+			watcherConstructor:   appleNamespaceWatcherConstructor,
+			secretToCreate:       sAppleTwo,
+			shouldTriggerWatcher: true,
+		},
+		{
+			name:                 "AppleNameTwoSecretWatcherChangeOrangeOne",
+			watcherConstructor:   appleTwoSecretWatcherConstructor,
+			secretToCreate:       sOrangeOne,
+			shouldTriggerWatcher: false,
+		},
+		{
+			name:                 "AppleNameTwoSecretWatcherChangeAppleOne",
+			testSetupFunc:        appleNameTwoSecretWatcherChangeAppleOneTestSetup,
+			watcherConstructor:   appleTwoSecretWatcherConstructor,
+			secretToCreate:       sAppleOne,
+			shouldTriggerWatcher: false,
+		},
+		{
+			name:                 "AppleNameTwoSecretWatcherChangeAppleTwo",
+			watcherConstructor:   appleTwoSecretWatcherConstructor,
+			secretToCreate:       sAppleTwo,
+			shouldTriggerWatcher: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.testSetupFunc != nil {
+				test.testSetupFunc()
+			} else {
+				testSetup()
+			}
+
+			obsFuncs := &ObserverFuncs{
+				AddFunc:    func(s *corev1.Secret) {},
+				UpdateFunc: func(sOld *corev1.Secret, sNew *corev1.Secret) {},
+				DeleteFunc: func(s *corev1.Secret) {},
+			}
+
+			testObs := make([]*testObserver, defaultNumTestObservers)
+			watchers := make([]SecretWatcher, defaultNumTestObservers)
+			for i := 0; i < defaultNumTestObservers; i++ {
+				testObs[i] = newTestObserver(obsFuncs)
+				watchers[i] = test.watcherConstructor(testObs[i])
+				watchers[i].StartWatch()
+			}
+
+			kubeclientForTest.CoreV1().Secrets(test.secretToCreate.namespace).Create(&test.secretToCreate.secret)
+			waitForObserverTriggers(t, testObs, func(tObs *testObserver) bool { return tObs.OnAddCalled }, test.shouldTriggerWatcher)
+
+			// Modify secret value and update
+			test.secretToCreate.UpdateDataValue("newToken")
+			kubeclientForTest.CoreV1().Secrets(test.secretToCreate.namespace).Update(&test.secretToCreate.secret)
+			waitForObserverTriggers(t, testObs, func(tObs *testObserver) bool { return tObs.OnUpdateCalled }, test.shouldTriggerWatcher)
+
+			kubeclientForTest.CoreV1().Secrets(test.secretToCreate.namespace).Delete(test.secretToCreate.name, &metav1.DeleteOptions{})
+			waitForObserverTriggers(t, testObs, func(tObs *testObserver) bool { return tObs.OnDeleteCalled }, test.shouldTriggerWatcher)
+
+			for i := 0; i < defaultNumTestObservers; i++ {
+				watchers[i].StopWatch()
+			}
+
+			testCleanup()
+		})
+	}
+}
+
+// waitForObserverTriggers is a helper function for testing multiple observers and minimizing the time spent waiting.
+// If shouldTrigger is true, the function waits up to 1 second for obsTrigger to be true for each *testObserver in tObs, otherwise the test errors.
+// If shouldTrigger is false, the function waits 1 second and then ensures that obsTrigger is false, otherwise the test errors.
+func waitForObserverTriggers(t *testing.T, tObs []*testObserver, obsTrigger func(*testObserver) bool, shouldTrigger bool) {
+	if shouldTrigger {
+		// Waits up to 1 second, but can return instantaneously.
+		waitForCondition(t, func() bool {
+			for _, o := range tObs {
+				if !obsTrigger(o) {
+					return false
+				}
+			}
+			return true
+		}, 1)
+	} else {
+		// Wait 1 second to give triggers time to trigger, otherwise assume the triggers will never trigger.
+		time.Sleep(1 * time.Second)
+		for i, o := range tObs {
+			if obsTrigger(o) {
+				t.Errorf("Secret watcher at idx[%d] did not trigger as expected on Secret change. Expected to trigger? %v. OnAdd triggered? %v. OnUpdate triggered? %v. OnDelete triggered? %v",
+					i, shouldTrigger, o.OnAddCalled, o.OnUpdateCalled, o.OnDeleteCalled)
+			}
+		}
+	}
+}
+
+func waitForCondition(t *testing.T, condition func() bool, timeoutSec int) {
+	for i := 0; i < (timeoutSec*2)+1; i++ {
+		if condition() {
+			return
+		}
+
+		time.Sleep(time.Millisecond * 500)
+	}
+
+	t.Errorf("Timed out waiting for condition to become true, checked every 0.5s for %d seconds", timeoutSec)
+}
+
+func mustNewSecretWatcher(t *testing.T, observers ...Observer) SecretWatcher {
+	return mustNewSecretWatcherHelper(t, func() (SecretWatcher, error) { return NewSecretWatcher(observers...) })
+}
+
+func mustNewSecretWatcherSingleNamespace(t *testing.T, namespace string, observers ...Observer) SecretWatcher {
+	return mustNewSecretWatcherHelper(t, func() (SecretWatcher, error) { return NewSecretWatcherSingleNamespace(namespace, observers...) })
+}
+
+func mustNewSecretWatcherSingleSecret(t *testing.T, namespace string, name string, observers ...Observer) SecretWatcher {
+	return mustNewSecretWatcherHelper(t, func() (SecretWatcher, error) { return NewSecretWatcherSingleSecret(namespace, name, observers...) })
+}
+
+func mustNewSecretWatcherHelper(t *testing.T, constructor func() (SecretWatcher, error)) SecretWatcher {
+	watcher, err := constructor()
+	if err != nil {
+		t.Errorf("Failed to create secret watcher: %v", err)
+	}
+
+	return watcher
+}
+
+func assertSecretValue(t *testing.T, secret *corev1.Secret, namespace string, name string, expectedDataKey string, expectedDataValue string) {
+	if val, ok := secret.Data[expectedDataKey]; !ok {
+		t.Errorf("Retrieved incorrect Secret data for Secret %v/%v from secret watcher. Expected data to contain field '%v'. Got secret data: %v", namespace, name, expectedDataKey, secret.Data)
+	} else if string(val) != expectedDataValue {
+		t.Errorf("Retrieved incorrect Secret data for Secret %v/%v from secret watcher. Expected field '%v' to have value '%v'. Got secret data: %v", namespace, name, expectedDataKey, []byte(expectedDataValue), secret.Data)
+	}
+}


### PR DESCRIPTION
Add a SecretWatcher that can be used to update the metrics exporter when the Stackdriver Secret is changed.

Changes 
- Add "knative.dev/metrics/internal/stackdriver" pkg
- Add SecretWatcher interface and implementation that can be used to watch Secret

Part of #842, using SecretWatcher in stackdriver_exporter.go will come in a follow-up PR.

Because we would like to be able to extract custom metrics backend code out of Knative at some point, this explicitly does not take a dependency on "knative.dev/pkg/injection". 