### PR TITLE
Fix the childname where trimming caused a dash in the end.

### DIFF
--- a/kmeta/names.go
+++ b/kmeta/names.go
@@ -19,6 +19,7 @@ package kmeta
 import (
 	"crypto/md5"
 	"fmt"
+	"strings"
 )
 
 // The longest name supported by the K8s is 63.
@@ -53,7 +54,9 @@ func ChildName(parent, suffix string) string {
 			if d := longest - len(ret); d > 0 {
 				ret += suffix[:d]
 			}
-			return ret
+			// If due to trumming above we're terminating the string with a `-`,
+			// remove it.
+			return strings.TrimRight(ret, "-")
 		}
 		n = fmt.Sprintf("%s%x", parent[:head-len(suffix)], md5.Sum([]byte(parent)))
 	}

--- a/kmeta/names_test.go
+++ b/kmeta/names_test.go
@@ -52,6 +52,10 @@ func TestChildName(t *testing.T) {
 		parent: strings.Repeat("b", 32),
 		suffix: strings.Repeat("f", 32),
 		want:   "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb329c7c81b9ab3ba71aa139066aa5625d",
+	}, {
+		parent: "aaaa",
+		suffix: strings.Repeat("b---a", 20),
+		want:   "aaaa7a3f7966594e3f0849720eced8212c18b---ab---ab---ab---ab---ab",
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
If suffix name itself contained dashes, when we append the trimmed suffix
we might end up on the dash, which is a non valid k8s name.
So fix that.

/assign mattmoor