### PR TITLE
Remove emit-metrics flag in e2e tests base library

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -22,7 +22,6 @@ You can use the test library in this dir to:
 
 - [Use common test flags](#use-common-test-flags)
 - [Output logs](#output-logs)
-- [Emit metrics](#emit-metrics)
 - [Ensure test cleanup](#ensure-test-cleanup)
 
 ### Use common test flags
@@ -62,57 +61,6 @@ _, err = pkgTest.WaitForEndpointState(
 
 _See [logging.go](./logging/logging.go)._
 
-### Emit metrics
-
-You can emit metrics from your tests using
-[the opencensus library](https://github.com/census-instrumentation/opencensus-go),
-which
-[is being used inside Knative as well](https://github.com/knative/serving/blob/master/docs/telemetry.md).
-These metrics will be emitted by the test if the test is run with
-[the `--emitmetrics` option](#metrics-flag).
-
-You can record arbitrary metrics with
-[`stats.Record`](https://github.com/census-instrumentation/opencensus-go#stats)
-or measure latency by creating a instance of
-[`trace.Span`](https://github.com/census-instrumentation/opencensus-go#traces)
-by using the helper method [`logging.GetEmitableSpan()`](../logging/logger.go)
-
-```go
-span := logging.GetEmitableSpan(context.Background(), "MyMetric")
-```
-
-- These traces will be emitted automatically by
-  [the generic crd polling functions](#check-knative-serving-resources).
-- The traces are emitted by [a custom metric exporter](./logging/logging.go)
-  that uses the global logger instance.
-
-#### Metric format
-
-When a `trace` metric is emitted, the format is
-`metric <name> <startTime> <endTime> <duration>`. The name of the metric is
-arbitrary and can be any string. The values are:
-
-- `metric` - Indicates this log is a metric
-- `<name>` - Arbitrary string identifying the metric
-- `<startTime>` - Unix time in nanoseconds when measurement started
-- `<endTime>` - Unix time in nanoseconds when measurement ended
-- `<duration>` - The difference in ms between the startTime and endTime
-
-For example:
-
-```bash
-metric WaitForConfigurationState/prodxiparjxt/ConfigurationUpdatedWithRevision 1529980772357637397 1529980772431586609 73.949212ms
-```
-
-_The [`Wait` methods](#check-knative-serving-resources) (which poll resources)
-will prefix the metric names with the name of the function, and if applicable,
-the name of the resource, separated by `/`. In the example above,
-`WaitForConfigurationState` is the name of the function, and `prodxiparjxt` is
-the name of the configuration resource being polled.
-`ConfigurationUpdatedWithRevision` is the string passed to
-`WaitForConfigurationState` by the caller to identify what state is being polled
-for._
-
 ### Check Knative Serving resources
 
 _WARNING: this code also exists in
@@ -147,9 +95,6 @@ err := test.WaitForConfigurationState(
     }, "ConfigurationUpdatedWithRevision")
 ```
 
-_[Metrics will be emitted](#emit-metrics) for these `Wait` method tracking how
-long test poll for._
-
 _See [kube_checks.go](./kube_checks.go)._
 
 ### Ensure test cleanup
@@ -176,7 +121,6 @@ Tests importing [`knative.dev/pkg/test`](#test-library) recognize these flags:
 - [`--cluster`](#specifying-cluster)
 - [`--namespace`](#specifying-namespace)
 - [`--logverbose`](#output-verbose-logs)
-- [`--emitmetrics`](#metrics-flag)
 
 ### Specifying kubeconfig
 
@@ -233,22 +177,6 @@ The `--logverbose` argument lets you see verbose test logs and k8s logs.
 ```bash
 go test ./test --logverbose
 ```
-
-### Metrics flag
-
-Running tests with the `--emitmetrics` argument will cause latency metrics to be
-emitted by the tests.
-
-```bash
-go test ./test --emitmetrics
-```
-
-- To add additional metrics to a test, see
-  [emitting metrics](https://github.com/knative/pkg/tree/master/test#emit-metrics).
-- For more info on the format of the metrics, see
-  [metric format](https://github.com/knative/pkg/tree/master/test#emit-metrics).
-
-[minikube]: https://kubernetes.io/docs/setup/minikube/
 
 ---
 

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -35,9 +35,6 @@ import (
 )
 
 const (
-	// e2eMetricExporter is the name for the metrics exporter logger
-	e2eMetricExporter = "e2e-metrics"
-
 	// The recommended default log level https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
 	klogDefaultLogLevel = "2"
 )
@@ -57,7 +54,6 @@ type EnvironmentFlags struct {
 	Namespace       string // K8s namespace (blank by default, to be overwritten by test suite)
 	IngressEndpoint string // Host to use for ingress endpoint
 	LogVerbose      bool   // Enable verbose logging
-	EmitMetrics     bool   // Emit metrics
 	ImageTemplate   string // Template to build the image reference (defaults to {{.Repository}}/{{.Name}}:{{.Tag}})
 	DockerRepo      string // Docker repo (defaults to $KO_DOCKER_REPO)
 	Tag             string // Tag for test images
@@ -83,9 +79,6 @@ func initializeFlags() *EnvironmentFlags {
 
 	flag.BoolVar(&f.LogVerbose, "logverbose", false,
 		"Set this flag to true if you would like to see verbose logging.")
-
-	flag.BoolVar(&f.EmitMetrics, "emitmetrics", false,
-		"Set this flag to true if you would like tests to emit metrics, e.g. latency of resources being realized in the system.")
 
 	flag.StringVar(&f.ImageTemplate, "imagetemplate", "{{.Repository}}/{{.Name}}:{{.Tag}}",
 		"Provide a template to generate the reference to an image from the test. Defaults to `{{.Repository}}/{{.Name}}:{{.Tag}}`.")
@@ -134,10 +127,6 @@ func SetupLoggingFlags() {
 			printFlags()
 		}
 		logging.InitializeLogger(Flags.LogVerbose)
-
-		if Flags.EmitMetrics {
-			logging.InitializeMetricExporter(e2eMetricExporter)
-		}
 	})
 }
 


### PR DESCRIPTION
Fix https://github.com/knative/test-infra/issues/1568

Remove `emit-metrics` as the relevant job has been deprecated.

/cc @adrcunha 
/cc @chaodaiG 