### PR TITLE
Add glog/klog->Zap redirect designs to repo

### DIFF
--- a/test/logging/glog/glog.go
+++ b/test/logging/glog/glog.go
@@ -42,7 +42,7 @@ func Flush() {
 
 // V is a shim
 func V(level Level) Verbose {
-	return Verbose(level <= logging.Verbosity)
+	return Verbose(int(level) <= logging.Verbosity)
 }
 
 // Info is a shim

--- a/test/logging/glog/glog.go
+++ b/test/logging/glog/glog.go
@@ -1,0 +1,181 @@
+// Copyright 2019 Knative Authors
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package glog exposes an API subset of the [glog](https://github.com/golang/glog) package.
+// All logging state delivered to this package is shunted to the global [zap logger](https://github.com/uber-go/zap).
+//
+// Istio is built on top of zap logger. We depend on some downstream components that use glog for logging.
+// This package makes it so we can intercept the calls to glog and redirect them to zap and thus produce
+// a consistent log for our processes.
+package glog
+
+import (
+	"fmt"
+	"os"
+
+	"go.uber.org/zap"
+	"knative.dev/pkg/test/logging"
+)
+
+// Level is a shim
+type Level int32
+
+// Verbose is a shim
+type Verbose bool
+
+// Flush is a shim
+func Flush() {
+	zap.L().Sync()
+}
+
+// V is a shim
+func V(level Level) Verbose {
+	return Verbose(level <= logging.Verbosity)
+}
+
+// Info is a shim
+func (v Verbose) Info(args ...interface{}) {
+	if v {
+		zap.S().Debug(args...)
+	}
+}
+
+// Infoln is a shim
+func (v Verbose) Infoln(args ...interface{}) {
+	if v {
+		s := fmt.Sprint(args)
+		zap.S().Debug(s, "\n")
+	}
+}
+
+// Infof is a shim
+func (v Verbose) Infof(format string, args ...interface{}) {
+	if v {
+		zap.S().Debugf(format, args...)
+	}
+}
+
+// Info is a shim
+func Info(args ...interface{}) {
+	zap.S().Info(args...)
+}
+
+// InfoDepth is a shim
+func InfoDepth(depth int, args ...interface{}) {
+	zap.S().Info(args...)
+}
+
+// Infoln is a shim
+func Infoln(args ...interface{}) {
+	s := fmt.Sprint(args)
+	zap.S().Info(s, "\n")
+}
+
+// Infof is a shim
+func Infof(format string, args ...interface{}) {
+	zap.S().Infof(format, args...)
+}
+
+// Warning is a shim
+func Warning(args ...interface{}) {
+	zap.S().Warn(args...)
+}
+
+// WarningDepth is a shim
+func WarningDepth(depth int, args ...interface{}) {
+	zap.S().Warn(args...)
+}
+
+// Warningln is a shim
+func Warningln(args ...interface{}) {
+	s := fmt.Sprint(args)
+	zap.S().Warn(s, "\n")
+}
+
+// Warningf is a shim
+func Warningf(format string, args ...interface{}) {
+	zap.S().Warnf(format, args...)
+}
+
+// Error is a shim
+func Error(args ...interface{}) {
+	zap.S().Error(args...)
+}
+
+// ErrorDepth is a shim
+func ErrorDepth(depth int, args ...interface{}) {
+	zap.S().Error(args...)
+}
+
+// Errorln is a shim
+func Errorln(args ...interface{}) {
+	s := fmt.Sprint(args)
+	zap.S().Error(s, "\n")
+}
+
+// Errorf is a shim
+func Errorf(format string, args ...interface{}) {
+	zap.S().Errorf(format, args...)
+}
+
+// Fatal is a shim
+func Fatal(args ...interface{}) {
+	zap.S().Error(args...)
+	os.Exit(255)
+}
+
+// FatalDepth is a shim
+func FatalDepth(depth int, args ...interface{}) {
+	zap.S().Error(args...)
+	os.Exit(255)
+}
+
+// Fatalln is a shim
+func Fatalln(args ...interface{}) {
+	s := fmt.Sprint(args)
+	zap.S().Error(s, "\n")
+	os.Exit(255)
+}
+
+// Fatalf is a shim
+func Fatalf(format string, args ...interface{}) {
+	zap.S().Errorf(format, args...)
+	os.Exit(255)
+}
+
+// Exit is a shim
+func Exit(args ...interface{}) {
+	zap.S().Error(args...)
+	os.Exit(1)
+}
+
+// ExitDepth is a shim
+func ExitDepth(depth int, args ...interface{}) {
+	zap.S().Error(args...)
+	os.Exit(1)
+}
+
+// Exitln is a shim
+func Exitln(args ...interface{}) {
+	s := fmt.Sprint(args)
+	zap.S().Error(s, "\n")
+	os.Exit(1)
+}
+
+// Exitf is a shim
+func Exitf(format string, args ...interface{}) {
+	zap.S().Errorf(format, args...)
+	os.Exit(1)
+}

--- a/test/logging/glog/glog.go
+++ b/test/logging/glog/glog.go
@@ -55,7 +55,7 @@ func (v Verbose) Info(args ...interface{}) {
 // Infoln is a shim
 func (v Verbose) Infoln(args ...interface{}) {
 	if v {
-		s := fmt.Sprint(args)
+		s := fmt.Sprint(args...)
 		zap.S().Debug(s, "\n")
 	}
 }
@@ -79,7 +79,7 @@ func InfoDepth(depth int, args ...interface{}) {
 
 // Infoln is a shim
 func Infoln(args ...interface{}) {
-	s := fmt.Sprint(args)
+	s := fmt.Sprint(args...)
 	zap.S().Info(s, "\n")
 }
 
@@ -100,7 +100,7 @@ func WarningDepth(depth int, args ...interface{}) {
 
 // Warningln is a shim
 func Warningln(args ...interface{}) {
-	s := fmt.Sprint(args)
+	s := fmt.Sprint(args...)
 	zap.S().Warn(s, "\n")
 }
 
@@ -121,7 +121,7 @@ func ErrorDepth(depth int, args ...interface{}) {
 
 // Errorln is a shim
 func Errorln(args ...interface{}) {
-	s := fmt.Sprint(args)
+	s := fmt.Sprint(args...)
 	zap.S().Error(s, "\n")
 }
 
@@ -144,7 +144,7 @@ func FatalDepth(depth int, args ...interface{}) {
 
 // Fatalln is a shim
 func Fatalln(args ...interface{}) {
-	s := fmt.Sprint(args)
+	s := fmt.Sprint(args...)
 	zap.S().Error(s, "\n")
 	os.Exit(255)
 }
@@ -169,7 +169,7 @@ func ExitDepth(depth int, args ...interface{}) {
 
 // Exitln is a shim
 func Exitln(args ...interface{}) {
-	s := fmt.Sprint(args)
+	s := fmt.Sprint(args...)
 	zap.S().Error(s, "\n")
 	os.Exit(1)
 }

--- a/test/logging/glog/glog_test.go
+++ b/test/logging/glog/glog_test.go
@@ -1,0 +1,46 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package glog
+
+import (
+	"testing"
+)
+
+func TestAll(t *testing.T) {
+	// just making sure this stuff doesn't crash...
+
+	Errorf("%s %s", "One", "Two")
+	Error("One", "Two")
+	Errorln("One", "Two")
+	ErrorDepth(2, "One", "Two")
+
+	Warningf("%s %s", "One", "Two")
+	Warning("One", "Two")
+	Warningln("One", "Two")
+	WarningDepth(2, "One", "Two")
+
+	Infof("%s %s", "One", "Two")
+	Info("One", "Two")
+	Infoln("One", "Two")
+	InfoDepth(2, "One", "Two")
+
+	for i := 0; i < 10; i++ {
+		V(Level(i)).Infof("%s %s", "One", "Two")
+		V(Level(i)).Info("One", "Two")
+		V(Level(i)).Infoln("One", "Two")
+	}
+
+	Flush()
+}

--- a/test/logging/glog/glog_test.go
+++ b/test/logging/glog/glog_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 )
 
-func TestAll(t *testing.T) {
+func TestGlogDoesntCrash(t *testing.T) {
 	// just making sure this stuff doesn't crash...
 
 	Errorf("%s %s", "One", "Two")

--- a/test/logging/klog/klog.go
+++ b/test/logging/klog/klog.go
@@ -55,7 +55,7 @@ func (v Verbose) Info(args ...interface{}) {
 // Infoln is a shim
 func (v Verbose) Infoln(args ...interface{}) {
 	if v {
-		s := fmt.Sprint(args)
+		s := fmt.Sprint(args...)
 		zap.S().Debug(s, "\n")
 	}
 }

--- a/test/logging/klog/klog.go
+++ b/test/logging/klog/klog.go
@@ -42,7 +42,7 @@ func Flush() {
 
 // V is a shim
 func V(level Level) Verbose {
-	return Verbose(level <= logging.Verbosity)
+	return Verbose(int(level) <= logging.Verbosity)
 }
 
 // Info is a shim

--- a/test/logging/klog/klog.go
+++ b/test/logging/klog/klog.go
@@ -1,0 +1,181 @@
+// Copyright 2019 Knative Authors
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package klog exposes an API subset of the [log](https://github.com/kubernetes/klog) package.
+// All logging state delivered to this package is shunted to the global [zap logger](https://github.com/uber-go/zap).
+//
+// Istio is built on top of zap logger. We depend on some downstream components that use klog for logging.
+// This package makes it so we can intercept the calls to klog and redirect them to zap and thus produce
+// a consistent log for our processes.
+package klog
+
+import (
+	"fmt"
+	"os"
+
+	"go.uber.org/zap"
+	"knative.dev/pkg/test/logging"
+)
+
+// Level is a shim
+type Level int32
+
+// Verbose is a shim
+type Verbose bool
+
+// Flush is a shim
+func Flush() {
+	zap.L().Sync()
+}
+
+// V is a shim
+func V(level Level) Verbose {
+	return Verbose(level <= logging.Verbosity)
+}
+
+// Info is a shim
+func (v Verbose) Info(args ...interface{}) {
+	if v {
+		zap.S().Debug(args...)
+	}
+}
+
+// Infoln is a shim
+func (v Verbose) Infoln(args ...interface{}) {
+	if v {
+		s := fmt.Sprint(args)
+		zap.S().Debug(s, "\n")
+	}
+}
+
+// Infof is a shim
+func (v Verbose) Infof(format string, args ...interface{}) {
+	if v {
+		zap.S().Debugf(format, args...)
+	}
+}
+
+// Info is a shim
+func Info(args ...interface{}) {
+	zap.S().Info(args...)
+}
+
+// InfoDepth is a shim
+func InfoDepth(depth int, args ...interface{}) {
+	zap.S().Info(args...)
+}
+
+// Infoln is a shim
+func Infoln(args ...interface{}) {
+	s := fmt.Sprint(args...)
+	zap.S().Info(s, "\n")
+}
+
+// Infof is a shim
+func Infof(format string, args ...interface{}) {
+	zap.S().Infof(format, args...)
+}
+
+// Warning is a shim
+func Warning(args ...interface{}) {
+	zap.S().Warn(args...)
+}
+
+// WarningDepth is a shim
+func WarningDepth(depth int, args ...interface{}) {
+	zap.S().Warn(args...)
+}
+
+// Warningln is a shim
+func Warningln(args ...interface{}) {
+	s := fmt.Sprint(args...)
+	zap.S().Warn(s, "\n")
+}
+
+// Warningf is a shim
+func Warningf(format string, args ...interface{}) {
+	zap.S().Warnf(format, args...)
+}
+
+// Error is a shim
+func Error(args ...interface{}) {
+	zap.S().Error(args...)
+}
+
+// ErrorDepth is a shim
+func ErrorDepth(depth int, args ...interface{}) {
+	zap.S().Error(args...)
+}
+
+// Errorln is a shim
+func Errorln(args ...interface{}) {
+	s := fmt.Sprint(args...)
+	zap.S().Error(s, "\n")
+}
+
+// Errorf is a shim
+func Errorf(format string, args ...interface{}) {
+	zap.S().Errorf(format, args...)
+}
+
+// Fatal is a shim
+func Fatal(args ...interface{}) {
+	zap.S().Error(args...)
+	os.Exit(255)
+}
+
+// FatalDepth is a shim
+func FatalDepth(depth int, args ...interface{}) {
+	zap.S().Error(args...)
+	os.Exit(255)
+}
+
+// Fatalln is a shim
+func Fatalln(args ...interface{}) {
+	s := fmt.Sprint(args...)
+	zap.S().Error(s, "\n")
+	os.Exit(255)
+}
+
+// Fatalf is a shim
+func Fatalf(format string, args ...interface{}) {
+	zap.S().Errorf(format, args...)
+	os.Exit(255)
+}
+
+// Exit is a shim
+func Exit(args ...interface{}) {
+	zap.S().Error(args...)
+	os.Exit(1)
+}
+
+// ExitDepth is a shim
+func ExitDepth(depth int, args ...interface{}) {
+	zap.S().Error(args...)
+	os.Exit(1)
+}
+
+// Exitln is a shim
+func Exitln(args ...interface{}) {
+	s := fmt.Sprint(args...)
+	zap.S().Error(s, "\n")
+	os.Exit(1)
+}
+
+// Exitf is a shim
+func Exitf(format string, args ...interface{}) {
+	zap.S().Errorf(format, args...)
+	os.Exit(1)
+}

--- a/test/logging/klog/klog_test.go
+++ b/test/logging/klog/klog_test.go
@@ -1,0 +1,46 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package klog
+
+import (
+	"testing"
+)
+
+func TestAll(t *testing.T) {
+	// just making sure this stuff doesn't crash...
+
+	Errorf("%s %s", "One", "Two")
+	Error("One", "Two")
+	Errorln("One", "Two")
+	ErrorDepth(2, "One", "Two")
+
+	Warningf("%s %s", "One", "Two")
+	Warning("One", "Two")
+	Warningln("One", "Two")
+	WarningDepth(2, "One", "Two")
+
+	Infof("%s %s", "One", "Two")
+	Info("One", "Two")
+	Infoln("One", "Two")
+	InfoDepth(2, "One", "Two")
+
+	for i := 0; i < 10; i++ {
+		V(Level(i)).Infof("%s %s", "One", "Two")
+		V(Level(i)).Info("One", "Two")
+		V(Level(i)).Infoln("One", "Two")
+	}
+
+	Flush()
+}

--- a/test/logging/klog/klog_test.go
+++ b/test/logging/klog/klog_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 )
 
-func TestAll(t *testing.T) {
+func TestKlogDoesntCrash(t *testing.T) {
 	// just making sure this stuff doesn't crash...
 
 	Errorf("%s %s", "One", "Two")

--- a/test/logging/logging.go
+++ b/test/logging/logging.go
@@ -125,11 +125,15 @@ func InitializeMetricExporter(context string) {
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 }
 
+var Verbosity = 0
+
 // InitializeLogger initializes the base logger
 func InitializeLogger(logVerbose bool) {
+	Verbosity = 2
 	logLevel := "info"
 	if logVerbose {
 		logLevel = "debug"
+		Verbosity = 8
 	}
 
 	logger = newLogger(logLevel)


### PR DESCRIPTION
This is progress toward #883.

It is not possible to test updating the Gopkg.toml to override usage
of glog or klog to these libraries until they are already in the repo.

logging.go has been updated to supply the value logging.Verbosity, but
it's not intended to be the final way it is setup.

Can't use istio/[gk]log because:

1. It doesn't compile
2. It doesn't use verbosity levels, and I don't want istio to need our changes.
3a. We usually don't need glog, so I don't want to force-include it just to set verbosity somehow
3. I don't want to be dependent on istio to make changes if any are needed (given the file is so small and simple)