### PR TITLE
De-race webhook integration tests

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -164,7 +164,7 @@ func (ac *Webhook) Run(stop <-chan struct{}) error {
 
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		if err := server.ListenAndServeTLS("", ""); err != nil {
+		if err := server.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
 			logger.Errorw("ListenAndServeTLS for admission webhook returned error", zap.Error(err))
 			return err
 		}
@@ -173,7 +173,10 @@ func (ac *Webhook) Run(stop <-chan struct{}) error {
 
 	select {
 	case <-stop:
-		return server.Close()
+		if err := server.Close(); err != nil {
+			return err
+		}
+		return eg.Wait()
 	case <-ctx.Done():
 		return fmt.Errorf("webhook server bootstrap failed %v", ctx.Err())
 	}


### PR DESCRIPTION
Webhook integration tests occasionally fail with on testgrid, e.g.
  https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-pkg-continuous/1204193472353931264
  https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-pkg-continuous/1203166664988823552

Fix this by waiting for all goroutines to finish before each test ends.