### PR TITLE
Configurable SpoofRequestInterval and SpoofRequestTimeout

### DIFF
--- a/test/clients.go
+++ b/test/clients.go
@@ -39,7 +39,7 @@ type KubeClient struct {
 
 // NewSpoofingClient returns a spoofing client to make requests
 func NewSpoofingClient(client *KubeClient, logf logging.FormatLogger, domain string, resolvable bool, opts ...spoof.TransportOption) (*spoof.SpoofingClient, error) {
-	return spoof.New(client.Kube, logf, domain, resolvable, Flags.IngressEndpoint, opts...)
+	return spoof.New(client.Kube, logf, domain, resolvable, Flags.IngressEndpoint, Flags.SpoofRequestInterval, Flags.SpoofRequestTimeout, opts...)
 }
 
 // NewKubeClient instantiates and returns several clientsets required for making request to the

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -27,6 +27,7 @@ import (
 	"path"
 	"sync"
 	"text/template"
+	"time"
 
 	"knative.dev/pkg/test/logging"
 )
@@ -46,13 +47,15 @@ var (
 
 // EnvironmentFlags define the flags that are needed to run the e2e tests.
 type EnvironmentFlags struct {
-	Cluster         string // K8s cluster (defaults to cluster in kubeconfig)
-	Kubeconfig      string // Path to kubeconfig (defaults to ./kube/config)
-	Namespace       string // K8s namespace (blank by default, to be overwritten by test suite)
-	IngressEndpoint string // Host to use for ingress endpoint
-	ImageTemplate   string // Template to build the image reference (defaults to {{.Repository}}/{{.Name}}:{{.Tag}})
-	DockerRepo      string // Docker repo (defaults to $KO_DOCKER_REPO)
-	Tag             string // Tag for test images
+	Cluster              string        // K8s cluster (defaults to cluster in kubeconfig)
+	Kubeconfig           string        // Path to kubeconfig (defaults to ./kube/config)
+	Namespace            string        // K8s namespace (blank by default, to be overwritten by test suite)
+	IngressEndpoint      string        // Host to use for ingress endpoint
+	ImageTemplate        string        // Template to build the image reference (defaults to {{.Repository}}/{{.Name}}:{{.Tag}})
+	DockerRepo           string        // Docker repo (defaults to $KO_DOCKER_REPO)
+	Tag                  string        // Tag for test images
+	SpoofRequestInterval time.Duration // SpoofRequestInterval is the interval between requests in SpoofingClient
+	SpoofRequestTimeout  time.Duration // SpoofRequestTimeout is the timeout for polling requests in SpoofingClient
 }
 
 func initializeFlags() *EnvironmentFlags {
@@ -81,6 +84,12 @@ func initializeFlags() *EnvironmentFlags {
 
 	flag.StringVar(&f.ImageTemplate, "imagetemplate", "{{.Repository}}/{{.Name}}:{{.Tag}}",
 		"Provide a template to generate the reference to an image from the test. Defaults to `{{.Repository}}/{{.Name}}:{{.Tag}}`.")
+
+	flag.DurationVar(&f.SpoofRequestInterval, "spoofinterval", 1*time.Second,
+		"Provide an interval between requests for the SpoofingClient")
+
+	flag.DurationVar(&f.SpoofRequestTimeout, "spooftimeout", 5*time.Minute,
+		"Provide a request timeout for the SpoofingClient")
 
 	defaultRepo := os.Getenv("KO_DOCKER_REPO")
 	flag.StringVar(&f.DockerRepo, "dockerrepo", defaultRepo,

--- a/test/request.go
+++ b/test/request.go
@@ -142,7 +142,7 @@ func WaitForEndpointState(
 	desc string,
 	resolvable bool,
 	opts ...interface{}) (*spoof.Response, error) {
-	return WaitForEndpointStateWithTimeout(kubeClient, logf, url, inState, desc, resolvable, spoof.RequestTimeout, opts...)
+	return WaitForEndpointStateWithTimeout(kubeClient, logf, url, inState, desc, resolvable, Flags.SpoofRequestTimeout, opts...)
 }
 
 // WaitForEndpointStateWithTimeout will poll an endpoint until inState indicates the state is achieved

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -39,9 +39,6 @@ import (
 )
 
 const (
-	requestInterval = 1 * time.Second
-	// RequestTimeout is the default timeout for the polling requests.
-	RequestTimeout = 5 * time.Minute
 	// Name of the temporary HTTP header that is added to http.Request to indicate that
 	// it is a SpoofClient.Poll request. This header is removed before making call to backend.
 	pollReqHeader = "X-Kn-Poll-Request-Do-Not-Trace"
@@ -107,6 +104,8 @@ func New(
 	domain string,
 	resolvable bool,
 	endpointOverride string,
+	requestInterval time.Duration,
+	requestTimeout time.Duration,
 	opts ...TransportOption) (*SpoofingClient, error) {
 	endpoint, err := ResolveEndpoint(kubeClientset, domain, resolvable, endpointOverride)
 	if err != nil {
@@ -140,7 +139,7 @@ func New(
 	sc := SpoofingClient{
 		Client:          &http.Client{Transport: roundTripper},
 		RequestInterval: requestInterval,
-		RequestTimeout:  RequestTimeout,
+		RequestTimeout:  requestTimeout,
 		Logf:            logf,
 	}
 	return &sc, nil


### PR DESCRIPTION
It might be handy to configure the values in different environments or different kinds of tests. For example, sometimes I want to be able to send requests more frequently than once per second, like in the prober.test in knative/serving which runs during rolling upgrades.