### PR TITLE
Feature to serve the version using /version endpoint

### DIFF
--- a/version/version_exporter.go
+++ b/version/version_exporter.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type versionRequestHandler struct {
+	version string
+}
+
+func (vrh *versionRequestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+  w.Write([]byte(fmt.Sprintf("%+v", vrh.version)))
+}
+
+func StartVersionSrv(version string) {
+	vs := http.NewServeMux()
+
+	vrh := &versionRequestHandler{version : version}
+	vs.Handle("/version", vrh)
+
+	http.ListenAndServe(":5678", vs)
+}


### PR DESCRIPTION
Using this feature it should be possible for knative products
to be able to leverage this featureto serve the curent version
of product in use. This would help in debugging based on the
version as well as facilitate checking cli + controller
compatibility.

Related to 
https://github.com/tektoncd/pipeline/pull/1650
https://github.com/tektoncd/cli/pull/503

cc @vdemeester

Signed-off-by: Vibhav Bobade <vibhav.bobde@gmail.com>