### PR TITLE
Spoofing client to retry on all error

### DIFF
--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -64,7 +64,7 @@ func (r *Response) String() string {
 // Interface defines the actions that can be performed by the spoofing client.
 type Interface interface {
 	Do(*http.Request) (*Response, error)
-	Poll(*http.Request, ResponseChecker) (*Response, error)
+	Poll(*http.Request, ResponseChecker, ...ErrorRetryChecker) (*Response, error)
 }
 
 // https://medium.com/stupid-gopher-tricks/ensuring-go-interface-satisfaction-at-compile-time-1ed158e8fa17
@@ -79,6 +79,10 @@ var (
 // See the apimachinery wait package:
 // https://github.com/kubernetes/apimachinery/blob/cf7ae2f57dabc02a3d215f15ca61ae1446f3be8f/pkg/util/wait/wait.go#L172
 type ResponseChecker func(resp *Response) (done bool, err error)
+
+// ErrorRetryChecker is used to determine if an error should be retried or not.
+// If an error should be retried, it should return true and the wrapped error to explain why to retry.
+type ErrorRetryChecker func(e error) (retry bool, err error)
 
 // SpoofingClient is a minimal HTTP client wrapper that spoofs the domain of requests
 // for non-resolvable domains.
@@ -199,7 +203,7 @@ func (sc *SpoofingClient) Do(req *http.Request) (*Response, error) {
 }
 
 // Poll executes an http request until it satisfies the inState condition or encounters an error.
-func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker) (*Response, error) {
+func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker, errorRetryCheckers ...ErrorRetryChecker) (*Response, error) {
 	var (
 		resp *Response
 		err  error
@@ -212,22 +216,15 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker) (*Res
 		req.Header.Add(pollReqHeader, "True")
 		resp, err = sc.Do(req)
 		if err != nil {
-			if isTCPTimeout(err) {
-				sc.Logf("Retrying %s for TCP timeout: %v", req.URL, err)
-				return false, nil
+			if len(errorRetryCheckers) == 0 {
+				errorRetryCheckers = []ErrorRetryChecker{DefaultErrorRetryChecker}
 			}
-			// Retrying on DNS error, since we may be using xip.io or nip.io in tests.
-			if isDNSError(err) {
-				sc.Logf("Retrying %s for DNS error: %v", req.URL, err)
-				return false, nil
-			}
-			// Repeat the poll on `connection refused` errors, which are usually transient Istio errors.
-			if isConnectionRefused(err) {
-				sc.Logf("Retrying %s for connection refused: %v", req.URL, err)
-				return false, nil
-			}
-			if isConnectionReset(err) {
-				sc.Logf("Retrying %s for connection reset: %v", req.URL, err)
+			for _, checker := range errorRetryCheckers {
+				retry, newErr := checker(err)
+				if retry {
+					sc.Logf("Retrying %s: %v", req.URL, newErr)
+					return false, nil
+				}
 			}
 			return true, err
 		}
@@ -243,6 +240,25 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker) (*Res
 		return resp, fmt.Errorf("response: %s did not pass checks: %w", resp, err)
 	}
 	return resp, nil
+}
+
+// DefaultErrorRetryChecker implements the defaults for retrying on error.
+func DefaultErrorRetryChecker(err error) (bool, error) {
+	if isTCPTimeout(err) {
+		return true, fmt.Errorf("Retrying for TCP timeout: %v", err)
+	}
+	// Retrying on DNS error, since we may be using xip.io or nip.io in tests.
+	if isDNSError(err) {
+		return true, fmt.Errorf("Retrying for DNS error: %v", err)
+	}
+	// Repeat the poll on `connection refused` errors, which are usually transient Istio errors.
+	if isConnectionRefused(err) {
+		return true, fmt.Errorf("Retrying for connection refused: %v", err)
+	}
+	if isConnectionReset(err) {
+		return true, fmt.Errorf("Retrying for connection reset: %v", err)
+	}
+	return false, err
 }
 
 // logZipkinTrace provides support to log Zipkin Trace for param: spoofResponse


### PR DESCRIPTION
Add option to have spoofing client always retry regardless what error encountered.

Prepare for https://github.com/knative/serving/issues/6224

/cc vagababov 