### PR TITLE
Filter tracked sharedmain ConfigMaps based on optional label selector

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1390,6 +1390,7 @@
     "k8s.io/client-go/informers/batch/v1",
     "k8s.io/client-go/informers/batch/v1beta1",
     "k8s.io/client-go/informers/core/v1",
+    "k8s.io/client-go/informers/internalinterfaces",
     "k8s.io/client-go/informers/rbac/v1",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",

--- a/configmap/manual_watcher.go
+++ b/configmap/manual_watcher.go
@@ -45,10 +45,12 @@ func (w *ManualWatcher) Watch(name string, o ...Observer) {
 	w.observers[name] = append(w.observers[name], o...)
 }
 
+// Start implements Watcher
 func (w *ManualWatcher) Start(<-chan struct{}) error {
 	return nil
 }
 
+// OnChange invokes the callbacks of all observers of the given ConfigMap.
 func (w *ManualWatcher) OnChange(configMap *corev1.ConfigMap) {
 	if configMap.Namespace != w.Namespace {
 		return

--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -30,6 +30,7 @@ import (
 	"go.opencensus.io/stats/view"
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -99,8 +100,10 @@ func Main(component string, ctors ...injection.ControllerConstructor) {
 
 func MainWithContext(ctx context.Context, component string, ctors ...injection.ControllerConstructor) {
 	var (
-		masterURL  = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
-		kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+		masterURL = flag.String("master", "",
+			"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+		kubeconfig = flag.String("kubeconfig", "",
+			"Path to a kubeconfig. Only required if out-of-cluster.")
 	)
 	flag.Parse()
 
@@ -140,13 +143,24 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 	defer flush(logger)
 	ctx = logging.WithLogger(ctx, logger)
 
+	// Obtain K8s clientset.
 	kc := kubeclient.Get(ctx)
 	if err := version.CheckMinimumVersion(kc.Discovery()); err != nil {
 		logger.Fatalw("Version check failed", zap.Error(err))
 	}
 
+	// Create ConfigMaps watcher with optional label-based filter.
+	var cmLabelReqs []labels.Requirement
+	if cmLabel := system.ResourceLabel(); cmLabel != "" {
+		req, err := configmap.FilterConfigByLabelExists(cmLabel)
+		if err != nil {
+			logger.With(zap.Error(err)).Fatalf("Failed to generate requirement for label %q")
+		}
+		logger.Infof("Setting up ConfigMap watcher with label selector %q", req)
+		cmLabelReqs = append(cmLabelReqs, *req)
+	}
 	// TODO(mattmoor): This should itself take a context and be injection-based.
-	cmw := configmap.NewInformedWatcher(kc, system.Namespace())
+	cmw := configmap.NewInformedWatcher(kc, system.Namespace(), cmLabelReqs...)
 
 	// Based on the reconcilers we have linked, build up the set of controllers to run.
 	controllers := make([]*controller.Impl, 0, len(ctors))

--- a/system/env.go
+++ b/system/env.go
@@ -22,11 +22,12 @@ import (
 )
 
 const (
-	NamespaceEnvKey = "SYSTEM_NAMESPACE"
+	NamespaceEnvKey     = "SYSTEM_NAMESPACE"
+	ResourceLabelEnvKey = "SYSTEM_RESOURCE_LABEL"
 )
 
-// Namespace holds the K8s namespace where our serving system
-// components run.
+// Namespace returns the name of the K8s namespace where our system components
+// run.
 func Namespace() string {
 	if ns := os.Getenv(NamespaceEnvKey); ns != "" {
 		return ns
@@ -49,4 +50,10 @@ following import:
 import (
 	_ "knative.dev/pkg/system/testing"
 )`, NamespaceEnvKey, NamespaceEnvKey))
+}
+
+// ResourceLabel returns the label key identifying K8s objects our system
+// components source their configuration from.
+func ResourceLabel() string {
+	return os.Getenv(ResourceLabelEnvKey)
 }


### PR DESCRIPTION
### Proposed change

Ensure the ConfigMap watcher only tracks the ConfigMaps which contain the label defined by the optional `SYSTEM_RESOURCE_LABEL` env var if the latter is set and not empty.

### Rationale

Custom components (event sources, channels, ...) may be deployed to various namespaces which sometimes contain a large amount of ConfigMaps. For example, a typical [Kyma](https://kyma-project.io/) installation deploys >80 ConfigMaps inside the `kyma-system` namespace. This creates a surge of memory usage when watches expire and get re-instantiated.

![image](https://user-images.githubusercontent.com/3299086/71683145-ff013b00-2d91-11ea-84d3-839e5fa7f368.png)
_jumps from 9MiB to **25MiB**_

![image](https://user-images.githubusercontent.com/3299086/71685970-222fe880-2d9a-11ea-862e-b845fa2cb25a.png)
_stable-ish usage between 9MiB and **11MiB** with a label selector applied_