### PR TITLE
Return GKECluster info in PCO

### DIFF
--- a/testutils/clustermanager/prow-cluster-operation/actions/get.go
+++ b/testutils/clustermanager/prow-cluster-operation/actions/get.go
@@ -17,11 +17,12 @@ limitations under the License.
 package actions
 
 import (
+	clm "knative.dev/pkg/testutils/clustermanager/e2e-tests"
 	"knative.dev/pkg/testutils/clustermanager/prow-cluster-operation/options"
 )
 
 // Get gets a GKE cluster
-func Get(o *options.RequestWrapper) error {
+func Get(o *options.RequestWrapper) (*clm.GKECluster, error) {
 	o.Prep()
 	o.Request.SkipCreation = true
 	// Reuse `Create` for getting operation, so that we can reuse the same logic

--- a/testutils/clustermanager/prow-cluster-operation/main.go
+++ b/testutils/clustermanager/prow-cluster-operation/main.go
@@ -45,11 +45,11 @@ func main() {
 	}
 	switch {
 	case create:
-		err = actions.Create(o)
+		_, err = actions.Create(o)
 	case delete:
 		err = actions.Delete(o)
 	case get:
-		err = actions.Get(o)
+		_, err = actions.Get(o)
 	default:
 		err = errors.New("Must pass one of --create, --delete, --get")
 	}


### PR DESCRIPTION
Returns gkeOps in `create`, `get` in prow-cluster-operation actions to fetch the Cluster info that's just created/fetched without reading the metadata file when calling from Go directly. 