### PR TITLE
Optimize locking behavior of the profiling handler.

### DIFF
--- a/profiling/server_test.go
+++ b/profiling/server_test.go
@@ -19,6 +19,7 @@ package profiling
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"go.uber.org/zap"
@@ -95,7 +96,7 @@ func TestUpdateFromConfigMap(t *testing.T) {
 				t.Errorf("StatusCode: %v, want: %v", rr.Code, tt.wantStatusCode)
 			}
 
-			if handler.enabled != tt.wantEnabled {
+			if atomic.LoadInt32(&handler.enabled) != boolToInt32(tt.wantEnabled) {
 				t.Fatalf("Test: %q; want %v, but got %v", tt.name, tt.wantEnabled, handler.enabled)
 			}
 		})


### PR DESCRIPTION
The profiling handler is in the path of our most performance critical components (especially the activator). Taking a write-lock on each request is probably a bad idea.

Replaced the mutex with an atomic flag. Lost reads are not critical in this code path and that should be the quickest solution in terms of avoiding contention.

/assign @vagababov 