### PR TITLE
perf-tests cluster manager supports creating clusters in other environment

### DIFF
--- a/test/gke/endpoint.go
+++ b/test/gke/endpoint.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gke
+
+import (
+    "regexp"
+)
+
+const (
+    testEnv = "test"
+    stagingEnv = "staging"
+    staging2Env = "staging2"
+    prodEnv = "prod"
+
+    testEndpoint = "https://test-container.sandbox.googleapis.com/"
+    stagingEndpoint = "https://staging-container.sandbox.googleapis.com/"
+    staging2Endpoint = "https://staging2-container.sandbox.googleapis.com/"
+    prodEndpoint = "https://container.googleapis.com/"
+)
+
+var urlRe = regexp.MustCompile(`https://.*/`)
+
+// ServiceEndpoint returns the container service endpoint for the given environment.
+func ServiceEndpoint(environment string) string {
+    var endpoint string
+    if environment != "" {
+        switch env := environment; {
+        case env == testEnv:
+            endpoint = testEndpoint
+        case env == stagingEnv:
+            endpoint = stagingEndpoint
+        case env == staging2Env:
+            endpoint = staging2Endpoint
+        case env == prodEnv:
+            endpoint = prodEndpoint
+        case urlRe.MatchString(env):
+            endpoint = env
+        }
+    }
+    return endpoint
+}

--- a/test/gke/endpoint.go
+++ b/test/gke/endpoint.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gke
 
 import (
+    "fmt"
     "regexp"
 )
 
@@ -35,22 +36,21 @@ const (
 var urlRe = regexp.MustCompile(`https://.*/`)
 
 // ServiceEndpoint returns the container service endpoint for the given environment.
-func ServiceEndpoint(environment string) string {
-    // Default to be prod.
-    var endpoint = prodEndpoint
-    if environment != "" {
-        switch env := environment; {
-        case env == testEnv:
-            endpoint = testEndpoint
-        case env == stagingEnv:
-            endpoint = stagingEndpoint
-        case env == staging2Env:
-            endpoint = staging2Endpoint
-        case env == prodEnv:
-            endpoint = prodEndpoint
-        case urlRe.MatchString(env):
-            endpoint = env
-        }
+func ServiceEndpoint(environment string) (string, error) {
+    var endpoint string
+    switch env := environment; {
+    case env == testEnv:
+        endpoint = testEndpoint
+    case env == stagingEnv:
+        endpoint = stagingEndpoint
+    case env == staging2Env:
+        endpoint = staging2Endpoint
+    case env == prodEnv:
+        endpoint = prodEndpoint
+    case urlRe.MatchString(env):
+        endpoint = env
+    default:
+        return "", fmt.Errorf("the environment '%s' is invalid, must be one of 'test', 'staging', 'staging2', 'prod', or a custom https:// URL", environment)
     }
-    return endpoint
+    return endpoint, nil
 }

--- a/test/gke/endpoint.go
+++ b/test/gke/endpoint.go
@@ -36,7 +36,8 @@ var urlRe = regexp.MustCompile(`https://.*/`)
 
 // ServiceEndpoint returns the container service endpoint for the given environment.
 func ServiceEndpoint(environment string) string {
-    var endpoint string
+    // Default to be prod.
+    var endpoint = prodEndpoint
     if environment != "" {
         switch env := environment; {
         case env == testEnv:

--- a/test/gke/endpoint_test.go
+++ b/test/gke/endpoint_test.go
@@ -23,12 +23,12 @@ func TestServiceEndpoint(t *testing.T) {
         env  string
         want string
     }{
-        {"", ""},
+        {"", prodEndpoint},
         {testEnv, testEndpoint},
         {stagingEnv, stagingEndpoint},
         {staging2Env, staging2Endpoint},
         {prodEnv, prodEndpoint},
-        {"invalid_url", ""},
+        {"invalid_url", prodEndpoint},
         {"https://custom.container.googleapis.com/", "https://custom.container.googleapis.com/"},
     }
     for _, data := range datas {

--- a/test/gke/endpoint_test.go
+++ b/test/gke/endpoint_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gke
+
+import "testing"
+
+func TestServiceEndpoint(t *testing.T) {
+    datas := []struct {
+        env  string
+        want string
+    }{
+        {"", ""},
+        {testEnv, testEndpoint},
+        {stagingEnv, stagingEndpoint},
+        {staging2Env, staging2Endpoint},
+        {prodEnv, prodEndpoint},
+        {"invalid_url", ""},
+        {"https://custom.container.googleapis.com/", "https://custom.container.googleapis.com/"},
+    }
+    for _, data := range datas {
+        if got := ServiceEndpoint(data.env); got != data.want {
+            t.Errorf("Service endpoint for %q = %q, want: %q",
+                data.env, got, data.want)
+        }
+    }
+}

--- a/test/gke/endpoint_test.go
+++ b/test/gke/endpoint_test.go
@@ -20,21 +20,29 @@ import "testing"
 
 func TestServiceEndpoint(t *testing.T) {
     datas := []struct {
-        env  string
-        want string
+        env           string
+        want          string
+        errorExpected bool
     }{
-        {"", prodEndpoint},
-        {testEnv, testEndpoint},
-        {stagingEnv, stagingEndpoint},
-        {staging2Env, staging2Endpoint},
-        {prodEnv, prodEndpoint},
-        {"invalid_url", prodEndpoint},
-        {"https://custom.container.googleapis.com/", "https://custom.container.googleapis.com/"},
+        {"", "", true},
+        {testEnv, testEndpoint, false},
+        {stagingEnv, stagingEndpoint, false},
+        {staging2Env, staging2Endpoint, false},
+        {prodEnv, prodEndpoint, false},
+        {"invalid_url", "", true},
+        {"https://custom.container.googleapis.com/", "https://custom.container.googleapis.com/", false},
     }
     for _, data := range datas {
-        if got := ServiceEndpoint(data.env); got != data.want {
+        got, err := ServiceEndpoint(data.env)
+        if got != data.want {
             t.Errorf("Service endpoint for %q = %q, want: %q",
                 data.env, got, data.want)
+        }
+        if err != nil && !data.errorExpected {
+            t.Errorf("Error is not expected by got %v", err)
+        }
+        if err == nil && data.errorExpected {
+            t.Error("Expected one error but got nil")
         }
     }
 }

--- a/testutils/clustermanager/perf-tests/main.go
+++ b/testutils/clustermanager/perf-tests/main.go
@@ -30,10 +30,12 @@ var (
 	gcpProjectName      string
 	repoName            string
 	benchmarkRootFolder string
+	gkeEnvironment      string
 )
 
 func main() {
 	flag.StringVar(&gcpProjectName, "gcp-project", "", "name of the GCP project for cluster operations")
+	flag.StringVar(&gkeEnvironment, "gke-environment", "", "Container API endpoint to use, one of 'test', 'staging', 'prod', or a custom https:// URL")
 	flag.StringVar(&repoName, "repository", "", "name of the repository")
 	flag.StringVar(&benchmarkRootFolder, "benchmark-root", "", "root folder of the benchmarks")
 	flag.BoolVar(&isRecreate, "recreate", false, "is recreate operation or not")
@@ -44,7 +46,7 @@ func main() {
 		log.Fatal("Only one operation can be specified, either recreate or reconcile")
 	}
 
-	client, err := testPkg.NewClient()
+	client, err := testPkg.NewClient(gkeEnvironment)
 	if err != nil {
 		log.Fatalf("Failed setting up GKE client, cannot proceed: %v", err)
 	}

--- a/testutils/clustermanager/perf-tests/main.go
+++ b/testutils/clustermanager/perf-tests/main.go
@@ -35,7 +35,7 @@ var (
 
 func main() {
 	flag.StringVar(&gcpProjectName, "gcp-project", "", "name of the GCP project for cluster operations")
-	flag.StringVar(&gkeEnvironment, "gke-environment", "", "Container API endpoint to use, one of 'test', 'staging', 'prod', or a custom https:// URL")
+	flag.StringVar(&gkeEnvironment, "gke-environment", "prod", "Container API endpoint to use, one of 'test', 'staging', 'prod', or a custom https:// URL. Default to be prod.")
 	flag.StringVar(&repoName, "repository", "", "name of the repository")
 	flag.StringVar(&benchmarkRootFolder, "benchmark-root", "", "root folder of the benchmarks")
 	flag.BoolVar(&isRecreate, "recreate", false, "is recreate operation or not")

--- a/testutils/clustermanager/perf-tests/main.go
+++ b/testutils/clustermanager/perf-tests/main.go
@@ -35,7 +35,7 @@ var (
 
 func main() {
 	flag.StringVar(&gcpProjectName, "gcp-project", "", "name of the GCP project for cluster operations")
-	flag.StringVar(&gkeEnvironment, "gke-environment", "prod", "Container API endpoint to use, one of 'test', 'staging', 'prod', or a custom https:// URL. Default to be prod.")
+	flag.StringVar(&gkeEnvironment, "gke-environment", "prod", "Container API endpoint to use, one of 'test', 'staging', 'staging2', 'prod', or a custom https:// URL. Default to be prod.")
 	flag.StringVar(&repoName, "repository", "", "name of the repository")
 	flag.StringVar(&benchmarkRootFolder, "benchmark-root", "", "root folder of the benchmarks")
 	flag.BoolVar(&isRecreate, "recreate", false, "is recreate operation or not")

--- a/testutils/clustermanager/perf-tests/pkg/cluster.go
+++ b/testutils/clustermanager/perf-tests/pkg/cluster.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"sync"
 
+	"google.golang.org/api/option"
+
 	"knative.dev/pkg/test/gke"
 	"knative.dev/pkg/test/helpers"
 
@@ -44,8 +46,9 @@ type gkeClient struct {
 }
 
 // NewClient will create a new gkeClient.
-func NewClient() (*gkeClient, error) {
-	operations, err := gke.NewSDKClient()
+func NewClient(environment string) (*gkeClient, error) {
+	endpointOption := option.WithEndpoint(gke.ServiceEndpoint(environment))
+	operations, err := gke.NewSDKClient(endpointOption)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set up GKE client: %v", err)
 	}

--- a/testutils/clustermanager/perf-tests/pkg/cluster.go
+++ b/testutils/clustermanager/perf-tests/pkg/cluster.go
@@ -47,7 +47,11 @@ type gkeClient struct {
 
 // NewClient will create a new gkeClient.
 func NewClient(environment string) (*gkeClient, error) {
-	endpointOption := option.WithEndpoint(gke.ServiceEndpoint(environment))
+	endpoint, err := gke.ServiceEndpoint(environment)
+	if err != nil {
+		return nil, err
+	}
+	endpointOption := option.WithEndpoint(endpoint)
 	operations, err := gke.NewSDKClient(endpointOption)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set up GKE client: %v", err)


### PR DESCRIPTION
perf-tests cluster manager tool supports creating clusters in other environment, including `test`, `staging`, `prod` or with any other custom endpoint.

Note:
1. Part of the code is borrowed from `kubetest` in kubernetes test-infra - https://github.com/kubernetes/test-infra/blob/9d3c810352d830d3a29b8625df7f5dab25924eb7/kubetest/gke.go#L184, thanks @yt3liu for digging it out 
2. I believe the e2e-tests cluster manager tool will also need this, but I did not make the change in this PR as I do want to keep it smaller.

/cc @adrcunha 
/cc @yt3liu 
/cc @chaodaiG 
