### PR TITLE
Add default metrics backend to observability config

### DIFF
--- a/metrics/config_observability.go
+++ b/metrics/config_observability.go
@@ -27,6 +27,10 @@ import (
 const (
 	// The following is used to set the default log url template
 	DefaultLogURLTemplate = "http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))"
+
+	// The following is used to set the default metrics backend
+	DefaultRequestMetricsBackend = "prometheus"
+
 	// The env var name for config-observability
 	ConfigMapNameEnv = "CONFIG_OBSERVABILITY_NAME"
 )
@@ -84,6 +88,8 @@ func NewObservabilityConfigFromConfigMap(configMap *corev1.ConfigMap) (*Observab
 
 	if mb, ok := configMap.Data["metrics.request-metrics-backend-destination"]; ok {
 		oc.RequestMetricsBackend = mb
+	} else {
+		oc.RequestMetricsBackend = DefaultRequestMetricsBackend
 	}
 
 	if prof, ok := configMap.Data["profiling.enable"]; ok {

--- a/metrics/config_observability_test.go
+++ b/metrics/config_observability_test.go
@@ -64,7 +64,7 @@ func TestObservabilityConfiguration(t *testing.T) {
 			EnableVarLogCollection: false,
 			LoggingURLTemplate:     DefaultLogURLTemplate,
 			RequestLogTemplate:     "",
-			RequestMetricsBackend:  "",
+			RequestMetricsBackend:  DefaultRequestMetricsBackend,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
updating `config_observability.go` to match [serving/pkg/metrics/config.go](https://github.com/knative/serving/blob/master/pkg/metrics/config.go#L28) before getting rid of `config.go` in serving.

required for https://github.com/knative/serving/pull/5841

/cc @markusthoemmes @yanweiguo 