### PR TITLE
Add support for client TLS and Resources to pkg/metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1388,6 +1388,7 @@
     "google.golang.org/api/iterator",
     "google.golang.org/api/option",
     "google.golang.org/grpc",
+    "google.golang.org/grpc/credentials",
     "gopkg.in/yaml.v2",
     "k8s.io/api/admission/v1beta1",
     "k8s.io/api/admissionregistration/v1beta1",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1372,6 +1372,7 @@
     "go.opencensus.io/metric/metricdata",
     "go.opencensus.io/plugin/ochttp",
     "go.opencensus.io/plugin/ochttp/propagation/b3",
+    "go.opencensus.io/resource",
     "go.opencensus.io/stats",
     "go.opencensus.io/stats/view",
     "go.opencensus.io/tag",

--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -37,6 +37,7 @@ import (
 	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	secrets "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
@@ -188,8 +189,9 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 	// Watch the observability config map
 	if _, err := kubeclient.Get(ctx).CoreV1().ConfigMaps(system.Namespace()).Get(metrics.ConfigMapName(),
 		metav1.GetOptions{}); err == nil {
+		secretLister := secrets.Get(ctx).Lister()
 		cmw.Watch(metrics.ConfigMapName(),
-			metrics.UpdateExporterFromConfigMap(component, logger),
+			metrics.UpdateExporterFromConfigMap3(component, secretLister, logger),
 			profilingHandler.UpdateFromConfigMap)
 	} else if !apierrors.IsNotFound(err) {
 		logger.With(zap.Error(err)).Fatalf("Error reading ConfigMap %q", metrics.ConfigMapName())

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -175,14 +175,13 @@ func (mc *metricsConfig) Record(ctx context.Context, ms stats.Measurement, ros .
 // the transition to using Resources).
 func resourceToTags(ctx context.Context, ros ...stats.Options) ([]stats.Options, error) {
 	if r, ok := metricskey.FromContext(ctx); ok && r != nil {
-		tags := []tag.Mutator{}
+		tags := make([]tag.Mutator, 0, len(r.Labels))
 		for label, v := range r.Labels {
 			key, err := tag.NewKey(label)
 			if err != nil {
-				return nil, fmt.Errorf("Bad resource label %q can't be converted to a tag: %+v", label, err)
+				return nil, fmt.Errorf("bad resource label %q can't be converted to a tag: %+v", label, err)
 			}
 			tags = append(tags, tag.Upsert(key, v))
-			fmt.Printf("Adding tag %q: %q\n", key, v)
 		}
 		return append(ros, stats.WithTags(tags...)), nil
 	}

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -159,9 +159,8 @@ func NewStackdriverClientConfigFromMap(config map[string]string) *StackdriverCli
 // Record applies the `ros` Options to `ms` and then records the resulting
 // measurements in the metricsConfig's designated backend.
 func (mc *metricsConfig) Record(ctx context.Context, ms stats.Measurement, ros ...stats.Options) error {
-	var err error
 	if mc == nil || mc.recorder == nil {
-		ros, err = resourceToTags(ctx, ros...)
+		ros, err := resourceToTags(ctx, ros...)
 		if err != nil {
 			return err
 		}

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -179,7 +179,7 @@ func resourceToTags(ctx context.Context, ros ...stats.Options) ([]stats.Options,
 		for label, v := range r.Labels {
 			key, err := tag.NewKey(label)
 			if err != nil {
-				return nil, fmt.Errorf("bad resource label %q can't be converted to a tag: %+v", label, err)
+				return nil, fmt.Errorf("bad resource label %q can't be converted to a tag: %w", label, err)
 			}
 			tags = append(tags, tag.Upsert(key, v))
 		}

--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -74,8 +74,8 @@ type ExporterOptions struct {
 // when a config map is updated.
 // DEPRECATED: Callers should migrate to UpdateExporterFromConfigMap3 (which will be renamed
 // when all callers are migrated).
-func UpdateExporterFromConfigMap(component string, secrets clientv1.SecretLister, logger *zap.SugaredLogger) func(configMap *corev1.ConfigMap) {
-	return UpdateExporterFromConfigMap3(component, secrets, logger)
+func UpdateExporterFromConfigMap(component string, logger *zap.SugaredLogger) func(configMap *corev1.ConfigMap) {
+	return UpdateExporterFromConfigMap3(component, nil, logger)
 }
 
 // UpdateExporterFromConfigMap3 includes a corev1.SecretLister which is used to configure

--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -20,6 +20,7 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	clientv1 "k8s.io/client-go/listers/core/v1"
 )
 
 var (
@@ -64,17 +65,31 @@ type ExporterOptions struct {
 	// See https://github.com/knative/serving/blob/master/config/config-observability.yaml
 	// for details.
 	ConfigMap map[string]string
+
+	// A lister for Secrets to allow dynamic configuration of outgoing TLS client cert.
+	Secrets clientv1.SecretLister `json:"-"`
 }
 
 // UpdateExporterFromConfigMap returns a helper func that can be used to update the exporter
 // when a config map is updated.
-func UpdateExporterFromConfigMap(component string, logger *zap.SugaredLogger) func(configMap *corev1.ConfigMap) {
+// DEPRECATED: Callers should migrate to UpdateExporterFromConfigMap3 (which will be renamed
+// when all callers are migrated).
+func UpdateExporterFromConfigMap(component string, secrets clientv1.SecretLister, logger *zap.SugaredLogger) func(configMap *corev1.ConfigMap) {
+	return UpdateExporterFromConfigMap3(component, secrets, logger)
+}
+
+// UpdateExporterFromConfigMap3 includes a corev1.SecretLister which is used to configure
+// mTLS with the opencensus agent.
+// Callers should migrate to this function, which will be renamed to UpdateExporterFromConfigMap
+// once all callers in all repos are renamed.
+func UpdateExporterFromConfigMap3(component string, secrets clientv1.SecretLister, logger *zap.SugaredLogger) func(*corev1.ConfigMap) {
 	domain := Domain()
 	return func(configMap *corev1.ConfigMap) {
 		UpdateExporter(ExporterOptions{
 			Domain:    domain,
 			Component: component,
 			ConfigMap: configMap.Data,
+			Secrets:   secrets,
 		}, logger)
 	}
 }

--- a/metrics/metricskey/context.go
+++ b/metrics/metricskey/context.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricskey
+
+import (
+	"context"
+
+	"go.opencensus.io/resource"
+)
+
+// key is an unexported type for keys defined in this package.
+// This prevents collisions with keys defined in other packages.
+type key int
+
+// userKey is the key for opencensus Resource values in Contexts. It is
+// unexported; clients use metricskey.NewContext and metricskey.FromContext
+// instead of using this key directly.
+var resourceKey key
+
+// NewContext returns a new Context that carries value u.
+func NewContext(ctx context.Context, r *resource.Resource) context.Context {
+	return context.WithValue(ctx, resourceKey, r)
+}
+
+// FromContext returns the User value stored in ctx, if any.
+func FromContext(ctx context.Context) (*resource.Resource, bool) {
+	r, ok := ctx.Value(resourceKey).(*resource.Resource)
+	return r, ok
+}

--- a/metrics/metricskey/context.go
+++ b/metrics/metricskey/context.go
@@ -22,14 +22,10 @@ import (
 	"go.opencensus.io/resource"
 )
 
-// key is an unexported type for keys defined in this package.
-// This prevents collisions with keys defined in other packages.
-type key int
-
-// userKey is the key for opencensus Resource values in Contexts. It is
+// resourceKey is the key for opencensus Resource values in Contexts. It is
 // unexported; clients use metricskey.NewContext and metricskey.FromContext
 // instead of using this key directly.
-var resourceKey key
+var resourceKey struct{}
 
 // NewContext returns a new Context that carries value u.
 func NewContext(ctx context.Context, r *resource.Resource) context.Context {

--- a/metrics/opencensus_exporter.go
+++ b/metrics/opencensus_exporter.go
@@ -90,7 +90,7 @@ func defaultResourceDescriptor(ctx context.Context) (*resource.Resource, error) 
 }
 
 func extractLabelsFromMap(t *tag.Map, labels ...string) map[string]string {
-	ret := make(map[string]string, 0, len(labels))
+	ret := make(map[string]string, len(labels))
 	for _, l := range labels {
 		k := tag.MustNewKey(l)
 		if v, ok := t.Value(k); ok {

--- a/metrics/opencensus_exporter.go
+++ b/metrics/opencensus_exporter.go
@@ -90,7 +90,7 @@ func defaultResourceDescriptor(ctx context.Context) (*resource.Resource, error) 
 }
 
 func extractLabelsFromMap(t *tag.Map, labels ...string) map[string]string {
-	ret := map[string]string{}
+	ret := make(map[string]string, 0, len(labels))
 	for _, l := range labels {
 		k := tag.MustNewKey(l)
 		if v, ok := t.Value(k); ok {

--- a/metrics/opencensus_exporter.go
+++ b/metrics/opencensus_exporter.go
@@ -14,9 +14,21 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
+	"crypto/tls"
+	"fmt"
+
+	"go.opencensus.io/resource"
+	"go.opencensus.io/tag"
+	"knative.dev/pkg/metrics/metricskey"
+
 	"contrib.go.opencensus.io/exporter/ocagent"
 	"go.opencensus.io/stats/view"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/credentials"
+	"k8s.io/apimachinery/pkg/api/errors"
+	clientv1 "k8s.io/client-go/listers/core/v1"
+	"knative.dev/pkg/system"
 )
 
 func newOpenCensusExporter(config *metricsConfig, logger *zap.SugaredLogger) (view.Exporter, error) {
@@ -24,9 +36,16 @@ func newOpenCensusExporter(config *metricsConfig, logger *zap.SugaredLogger) (vi
 	if config.collectorAddress != "" {
 		opts = append(opts, ocagent.WithAddress(config.collectorAddress))
 	}
-	if !config.requireSecure {
+	if config.requireSecure {
+		opts = append(opts, ocagent.WithTLSCredentials(credentialFetcher(config.component, config.secretsLister, logger)))
+	} else {
 		opts = append(opts, ocagent.WithInsecure())
 	}
+	rd := config.resourceDescriptor
+	if rd == nil {
+		rd = defaultResourceDescriptor
+	}
+	opts = append(opts, ocagent.WithResourceDetector(rd))
 	e, err := ocagent.NewExporter(opts...)
 	if err != nil {
 		logger.Errorw("Failed to create the OpenCensus exporter.", zap.Error(err))
@@ -35,4 +54,83 @@ func newOpenCensusExporter(config *metricsConfig, logger *zap.SugaredLogger) (vi
 	logger.Infof("Created OpenCensus exporter with config: %+v.", *config)
 	view.RegisterExporter(e)
 	return e, nil
+}
+
+func defaultResourceDescriptor(ctx context.Context) (*resource.Resource, error) {
+	if r, ok := metricskey.FromContext(ctx); ok {
+		return r, nil
+	}
+	m := tag.FromContext(ctx)
+
+	if _, ok := m.Value(tag.MustNewKey(metricskey.LabelRevisionName)); ok {
+		return &resource.Resource{
+			Type:   metricskey.ResourceTypeKnativeRevision,
+			Labels: extractLabelsFromMap(m, metricskey.KnativeRevisionLabels.UnsortedList()...),
+		}, nil
+	}
+	if _, ok := m.Value(tag.MustNewKey(metricskey.LabelTriggerName)); ok {
+		return &resource.Resource{
+			Type:   metricskey.ResourceTypeKnativeTrigger,
+			Labels: extractLabelsFromMap(m, metricskey.KnativeTriggerLabels.UnsortedList()...),
+		}, nil
+	}
+	if _, ok := m.Value(tag.MustNewKey(metricskey.LabelEventSource)); ok {
+		return &resource.Resource{
+			Type:   metricskey.ResourceTypeKnativeSource,
+			Labels: extractLabelsFromMap(m, metricskey.KnativeSourceLabels.UnsortedList()...),
+		}, nil
+	}
+	if _, ok := m.Value(tag.MustNewKey(metricskey.LabelBrokerName)); ok {
+		return &resource.Resource{
+			Type:   metricskey.ResourceTypeKnativeBroker,
+			Labels: extractLabelsFromMap(m, metricskey.KnativeBrokerLabels.UnsortedList()...),
+		}, nil
+	}
+	return nil, nil
+}
+
+func extractLabelsFromMap(t *tag.Map, labels ...string) map[string]string {
+	ret := map[string]string{}
+	for _, l := range labels {
+		k := tag.MustNewKey(l)
+		if v, ok := t.Value(k); ok {
+			ret[l] = v
+		} else {
+			ret[l] = "unknown"
+		}
+	}
+	return ret
+}
+
+// credentialFetcher attempts to locate a secret containing TLS credentials
+// for communicating with the OpenCensus Agent. To do this, it first looks
+// for a secret named "<component>-opencensus", then for a generic
+// "opencensus" secret.
+func credentialFetcher(component string, lister clientv1.SecretLister, logger *zap.SugaredLogger) credentials.TransportCredentials {
+	if lister == nil {
+		logger.Errorf("No secret lister provided for component %q; cannot use requireSecure=true", component)
+		return nil
+	}
+	return credentials.NewTLS(&tls.Config{
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			// We ignore the CertificateRequestInfo for now, and hand back a single fixed certificate.
+			// TODO(evankanderson): maybe do something SPIFFE-ier?
+			cert, err := certificateFetcher(component+"-opencensus", lister)
+			if errors.IsNotFound(err) {
+				cert, err = certificateFetcher("opencensus", lister)
+			}
+			if err != nil {
+				return nil, fmt.Errorf("Unable to fetch opencensus secret for %q, cannot use requireSecure=true: %+v", component, err)
+			}
+			return &cert, err
+		},
+	})
+}
+
+func certificateFetcher(secretName string, lister clientv1.SecretLister) (tls.Certificate, error) {
+	secret, err := lister.Secrets(system.Namespace()).Get(secretName)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	return tls.X509KeyPair(secret.Data["server-cert.pem"], secret.Data["server-key.pem"])
 }


### PR DESCRIPTION
Next steps here are to change all the clients to natively export resources and call the 3-argument form of `UpdateExporterFromConfigMap`, then update `UpdateExporterFromConfigMap` to take 3 arguments and remove the to/from Resource / tags code in `stackdriver_exporter.go`.

/assign @anniefu @yanweiguo 