### PR TITLE
Feature: lookup node external ip

### DIFF
--- a/nodes/address.go
+++ b/nodes/address.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nodes
+
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// GuessNodeExternalAddress tries to guess external address of a node
+func (n *NodesClient) GuessNodeExternalAddress(node *corev1.Node) *corev1.NodeAddress {
+	sorted := make([]*corev1.NodeAddress, len(node.Status.Addresses))
+	for i := 0; i < len(node.Status.Addresses); i++ {
+		sorted[i] = &node.Status.Addresses[i]
+	}
+	sort.Sort(byAddressType{sorted})
+	first := sorted[0]
+	priority := addressTypePriority[first.Type]
+	if priority >= 2 {
+		n.logger.Warnf("Chosen address is probably an internal type: %s, "+
+			"and might be unaccessible", first.Type)
+	}
+	return first
+}
+
+type nodeAddresses []*corev1.NodeAddress
+
+type byAddressType struct {
+	nodeAddresses
+}
+
+func (s byAddressType) Len() int {
+	return len(s.nodeAddresses)
+}
+
+func (s byAddressType) Swap(i, j int) {
+	s.nodeAddresses[i], s.nodeAddresses[j] = s.nodeAddresses[j], s.nodeAddresses[i]
+}
+
+func (s byAddressType) Less(i, j int) bool {
+	return addressTypePriority[s.nodeAddresses[i].Type] <
+		addressTypePriority[s.nodeAddresses[j].Type]
+}
+
+var addressTypePriority = map[corev1.NodeAddressType]int{
+	corev1.NodeExternalDNS: 0,
+	corev1.NodeExternalIP:  1,
+	corev1.NodeInternalIP:  2,
+	corev1.NodeInternalDNS: 3,
+	corev1.NodeHostName:    4,
+}

--- a/nodes/address_test.go
+++ b/nodes/address_test.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nodes
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNodesClientGuessNodeExternalAddress(t *testing.T) {
+	clientset := kubernetesfake.NewSimpleClientset()
+	c := Client(clientset, newLogger())
+	node := &corev1.Node{
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{{
+				Type:    corev1.NodeInternalIP,
+				Address: "10.0.2.17",
+			}, {
+				Type:    corev1.NodeHostName,
+				Address: "node-17",
+			}, {
+				Type:    corev1.NodeInternalDNS,
+				Address: "node-17.europe3.internal",
+			}, {
+				Type:    corev1.NodeExternalIP,
+				Address: "35.123.11.234",
+			}},
+		},
+	}
+
+	address := c.GuessNodeExternalAddress(node)
+
+	if address.Address != "35.123.11.234" {
+		t.Errorf("Address: %s want: 35.123.11.234", address.Address)
+	}
+}
+
+func TestNodesClientGuessNodeExternalAddress_PrivateOnly(t *testing.T) {
+	clientset := kubernetesfake.NewSimpleClientset()
+	c := Client(clientset, newLogger())
+	node := &corev1.Node{
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{{
+				Type:    corev1.NodeInternalIP,
+				Address: "10.0.2.17",
+			}, {
+				Type:    corev1.NodeHostName,
+				Address: "node-17",
+			}, {
+				Type:    corev1.NodeInternalDNS,
+				Address: "node-17.europe3.internal",
+			}},
+		},
+	}
+
+	address := c.GuessNodeExternalAddress(node)
+
+	if address.Address != "10.0.2.17" {
+		t.Errorf("Address: %s want: 10.0.2.17", address.Address)
+	}
+}

--- a/nodes/kind.go
+++ b/nodes/kind.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nodes
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	roleLabelFormat = "node-role.kubernetes.io/"
+)
+
+// FilterOutByRole returns a new slice without nodes that have given role
+func FilterOutByRole(nodes []corev1.Node, role string) []corev1.Node {
+	result := make([]corev1.Node, 0, len(nodes))
+	for _, node := range nodes {
+		if !hasRole(role, node) {
+			result = append(result, node)
+		}
+	}
+	return result
+}
+
+func hasRole(role string, node corev1.Node) bool {
+	if node.Labels == nil {
+		return false
+	}
+	label := roleLabelFormat + role
+	_, has := node.Labels[label]
+	return has
+}

--- a/nodes/logger_test.go
+++ b/nodes/logger_test.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nodes
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func newLogger() *zap.SugaredLogger {
+	z, err := zap.NewDevelopment(zap.AddStacktrace(zapcore.ErrorLevel))
+	if err != nil {
+		panic(err)
+	}
+	return z.Sugar()
+}

--- a/nodes/nodes.go
+++ b/nodes/nodes.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nodes
+
+import (
+	"errors"
+	"math/rand"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// NodesClient contains interface for making requests to kubernetes client.
+type NodesClient struct {
+	kube   kubernetes.Interface
+	logger *zap.SugaredLogger
+}
+
+// Client creates a new nodes client
+func Client(clientset kubernetes.Interface, logger *zap.SugaredLogger) *NodesClient {
+	return &NodesClient{
+		kube:   clientset,
+		logger: logger,
+	}
+}
+
+// RandomWorkerNode gets a worker node randomly
+func (n *NodesClient) RandomWorkerNode() (*corev1.Node, error) {
+	nodes, err := n.kube.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	nodesCount := len(nodes.Items)
+	if nodesCount == 0 {
+		return nil, errors.New("fetched 0 nodes, so can't chose a worker")
+	}
+	if nodesCount == 1 {
+		node := nodes.Items[0]
+		n.logger.Infof("Only one node found (named: %s), returning it as"+
+			" it must be a worker (Minikube, CRC)", node.Name)
+		return &node, nil
+	} else {
+		role := "master"
+		n.logger.Infof("Filtering %d nodes, to not contain role: %s", nodesCount, role)
+		workers := FilterOutByRole(nodes.Items, role)
+		n.logger.Infof("Found %d worker(s)", len(workers))
+		worker := workers[rand.Intn(len(workers))]
+		n.logger.Infof("Chosen node: %s", worker.Name)
+		return &worker, nil
+	}
+}

--- a/nodes/nodes_test.go
+++ b/nodes/nodes_test.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nodes
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNodesClientRandomWorkerNode(t *testing.T) {
+	masterNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "master-1",
+			Labels: map[string]string{
+				roleLabelFormat + "master": "",
+			},
+		},
+	}
+	workerNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "worker-1",
+		},
+	}
+	clientset := kubernetesfake.NewSimpleClientset(masterNode, workerNode)
+	c := Client(clientset, newLogger())
+
+	node, err := c.RandomWorkerNode()
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	nodeName := workerNode.Name
+	assertProperNodeIsReturned(t, node, nodeName)
+}
+
+func TestNodesClientRandomWorkerNode_OneNode(t *testing.T) {
+	nodeName := "minikube"
+	minikube := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			Labels: map[string]string{
+				roleLabelFormat + "master": "",
+			},
+		},
+	}
+	clientset := kubernetesfake.NewSimpleClientset(minikube)
+	c := Client(clientset, newLogger())
+
+	node, err := c.RandomWorkerNode()
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	assertProperNodeIsReturned(t, node, nodeName)
+}
+
+func TestNodesClientRandomWorkerNode_NoNode(t *testing.T) {
+	clientset := kubernetesfake.NewSimpleClientset()
+	c := Client(clientset, newLogger())
+
+	_, err := c.RandomWorkerNode()
+
+	if err == nil {
+		t.Fatal("Expected error, but not received")
+	}
+	actual := err.Error()
+	if actual != "fetched 0 nodes, so can't chose a worker" {
+		t.Errorf("Unexpected error: %s", actual)
+	}
+}
+
+func assertProperNodeIsReturned(t *testing.T, node *corev1.Node, nodeName string) {
+	t.Helper()
+	if node == nil {
+		t.Fatal("Expect not to be nil")
+	}
+	if node.Name != nodeName {
+		t.Errorf("Got = %v, want: %s", node, nodeName)
+	}
+}


### PR DESCRIPTION
This functionality can be useful when trying to utilize `NodePort` services.

Using helpers added, one can chose a random worker node and get it's external address.