### PR TITLE
status.ConvertTo can optionally accept predicates

### DIFF
--- a/apis/duck/v1/status_types.go
+++ b/apis/duck/v1/status_types.go
@@ -99,17 +99,32 @@ func (s *Status) GetCondition(t apis.ConditionType) *apis.Condition {
 }
 
 // ConvertTo helps implement apis.Convertible for types embedding this Status.
-func (source *Status) ConvertTo(ctx context.Context, sink *Status) {
+//
+// By default apis.ConditionReady and apis.ConditionSucceeded will be copied over to the
+// sink. Other conditions types are tested against a list of predicates. If any of the predicates
+// return true the condition type will be copied to the sink
+func (source *Status) ConvertTo(ctx context.Context, sink *Status, predicates ...func(apis.ConditionType) bool) {
 	sink.ObservedGeneration = source.ObservedGeneration
+
+	conditions := make(apis.Conditions, 0, len(source.Conditions))
 	for _, c := range source.Conditions {
 		switch c.Type {
 		// Copy over the "happy" condition, which is the only condition that
 		// we can reliably transfer.
 		case apis.ConditionReady, apis.ConditionSucceeded:
-			sink.SetConditions(apis.Conditions{c})
-			return
+			conditions = append(conditions, c)
+			break
+		}
+
+		for _, predicate := range predicates {
+			if predicate(c.Type) {
+				conditions = append(conditions, c)
+				break
+			}
 		}
 	}
+
+	sink.SetConditions(conditions)
 }
 
 // Populate implements duck.Populatable

--- a/apis/duck/v1/status_types_test.go
+++ b/apis/duck/v1/status_types_test.go
@@ -135,4 +135,24 @@ func TestConditionSet(t *testing.T) {
 		t.Errorf("len(s2.ObservedGeneration) = %d, wanted %d",
 			gotGeneration, wantGeneration)
 	}
+
+	s2 = &Status{}
+	s.ConvertTo(context.Background(), s2, func(cond apis.ConditionType) bool {
+		return cond == "Foo"
+	})
+
+	if !condSet.Manage(s2).IsHappy() {
+		t.Error("s2.IsHappy() = false, wanted true")
+	}
+	for _, c := range []apis.ConditionType{apis.ConditionReady, "Foo"} {
+		if cond := mgr.GetCondition(c); cond == nil {
+			t.Errorf("GetCondition(%q) = nil, wanted non-nil", c)
+		} else if got, want := cond.Status, corev1.ConditionTrue; got != want {
+			t.Errorf("GetCondition(%q) = %v, wanted %v", c, got, want)
+		}
+	}
+	if gotGeneration := s2.ObservedGeneration; wantGeneration != gotGeneration {
+		t.Errorf("len(s2.ObservedGeneration) = %d, wanted %d",
+			gotGeneration, wantGeneration)
+	}
 }


### PR DESCRIPTION
the intent is to allow the inclusion of addition ConditionTypes to be copied over if a
a predicate returns true

Motivation: https://github.com/knative/serving/pull/6542/files?file-filters%5B%5D=.go#r368663116