### PR TITLE
Use major/minor version of the k8s version to version check explicitly.

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -21,16 +21,8 @@ import (
 	"os"
 
 	"github.com/rogpeppe/go-internal/semver"
-	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
 )
-
-// ServerVersioner is an interface to mock the `ServerVersion`
-// method of the Kubernetes client's Discovery interface.
-// In an application `kubeClient.Discovery()` can be used to
-// suffice this interface.
-type ServerVersioner interface {
-	ServerVersion() (*version.Info, error)
-}
 
 const (
 	// KubernetesMinVersionKey is the environment variable that can be used to override
@@ -53,13 +45,13 @@ func getMinimumVersion() string {
 //
 // A Kubernetes discovery client can be passed in as the versioner
 // like `CheckMinimumVersion(kubeClient.Discovery())`.
-func CheckMinimumVersion(versioner ServerVersioner) error {
+func CheckMinimumVersion(versioner discovery.ServerVersionInterface) error {
 	v, err := versioner.ServerVersion()
 	if err != nil {
 		return err
 	}
-	currentVersion := semver.Canonical(v.String())
 
+	currentVersion := semver.Canonical(fmt.Sprintf("v%s.%s", v.Major, v.Minor))
 	minimumVersion := getMinimumVersion()
 
 	// Compare returns 1 if the first version is greater than the

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -25,12 +25,13 @@ import (
 )
 
 type testVersioner struct {
-	version string
-	err     error
+	major string
+	minor string
+	err   error
 }
 
 func (t *testVersioner) ServerVersion() (*version.Info, error) {
-	return &version.Info{GitVersion: t.version}, t.err
+	return &version.Info{Major: t.major, Minor: t.minor}, t.err
 }
 
 func TestVersionCheck(t *testing.T) {
@@ -40,17 +41,14 @@ func TestVersionCheck(t *testing.T) {
 		versionOverride string
 		wantError       bool
 	}{{
-		name:          "greater version (patch)",
-		actualVersion: &testVersioner{version: "v1.15.1"},
-	}, {
 		name:          "greater version (minor)",
-		actualVersion: &testVersioner{version: "v1.16.0"},
+		actualVersion: &testVersioner{major: "1", minor: "16"},
 	}, {
 		name:          "same version",
-		actualVersion: &testVersioner{version: "v1.15.0"},
+		actualVersion: &testVersioner{major: "1", minor: "15"},
 	}, {
 		name:          "smaller version",
-		actualVersion: &testVersioner{version: "v1.14.3"},
+		actualVersion: &testVersioner{major: "1", minor: "14"},
 		wantError:     true,
 	}, {
 		name:          "error while fetching",
@@ -59,7 +57,7 @@ func TestVersionCheck(t *testing.T) {
 	}, {
 		name:            "smaller version with overridden version",
 		versionOverride: "v1.13.0",
-		actualVersion:   &testVersioner{version: "v1.13.3"},
+		actualVersion:   &testVersioner{major: "1", minor: "13"},
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
Parsing the GitVersion is a little brittle as the parser doesn't seem to handle BUILD tags nicely. We can either do this or we can send a patch upstream to fix the parser. Or we use a different library 🤔 .

Alternative to #1013 