### PR TITLE
Do not enable workload identity for perf tests GKE clusters

### DIFF
--- a/testutils/clustermanager/perf-tests/pkg/cluster.go
+++ b/testutils/clustermanager/perf-tests/pkg/cluster.go
@@ -243,9 +243,6 @@ func (gc *gkeClient) createClusterWithRetries(gcpProject, name string, config Cl
 		MaxNodes:    config.NodeCount,
 		NodeType:    config.NodeType,
 		Addons:      addons,
-		// Enable Workload Identity for performance tests because we need to use a Kubernetes service account to act
-		// as a Google cloud service account, which is then used for authentication to the metrics data storage system.
-		EnableWorkloadIdentity: true,
 	}
 	creq, err := gke.NewCreateClusterRequest(req)
 	if err != nil {


### PR DESCRIPTION
This PR partially reverts https://github.com/knative/pkg/pull/954, do not enable workload identity for perf tests GKE clusters.

Explanation:
[Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) is still in beta, and it's brittle. And it has a caveat that "when Workload Identity is enabled, you can no longer use the Compute Engine default service account", so all workloads on that cluster will not use any Google service account by default.

Specially, GKE released `1.15.7-gke.23` last Friday, and all benchmarks were broken due to Workload Identity. The root cause is because the `prometheus-stackdriver` Pod cannot start since no Google service account is provided.
![image](https://user-images.githubusercontent.com/19399934/73220093-7799b400-4112-11ea-94a5-460e0f55961f.png)

It was a wrong decision to use Workload Identity, and for our internal use, I've found another workaround that does not require it, so here we can disable it for all perf tests GKE clusters.

/cc @vagababov 
/cc @adrcunha 