### PR TITLE
Give cloud-platform scope by default in creating GKE clusters

### DIFF
--- a/test/gke/request.go
+++ b/test/gke/request.go
@@ -114,6 +114,15 @@ func NewCreateClusterRequest(request *Request) (*container.CreateClusterRequest,
 					},
 					Config: &container.NodeConfig{
 						MachineType: request.NodeType,
+						// The set of Google API scopes to be made available on all
+						// of the node VMs under the "default" service account.
+						// If unspecified, no scopes are added, unless Cloud Logging or
+						// Cloud Monitoring are enabled, in which case their required
+						// scopes will be added.
+						// `https://www.googleapis.com/auth/devstorage.read_only` is required
+						// for communicating with **gcr.io**, and it's included in cloud-platform scope.
+						// TODO(chizhg): give more fine granular scope based on the actual needs.
+						OauthScopes: []string{container.CloudPlatformScope},
 					},
 				},
 			},

--- a/testutils/clustermanager/e2e-tests/gke_test.go
+++ b/testutils/clustermanager/e2e-tests/gke_test.go
@@ -600,7 +600,7 @@ func TestAcquire(t *testing.T) {
 					{
 						Name:             "default-pool",
 						InitialNodeCount: DefaultGKEMinNodes,
-						Config:           &container.NodeConfig{MachineType: "n1-standard-4"},
+						Config:           &container.NodeConfig{MachineType: "n1-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 						Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 					},
 				},
@@ -630,7 +630,7 @@ func TestAcquire(t *testing.T) {
 						{
 							Name:             "default-pool",
 							InitialNodeCount: DefaultGKEMinNodes,
-							Config:           &container.NodeConfig{MachineType: "n1-standard-4"},
+							Config:           &container.NodeConfig{MachineType: "n1-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
 					},
@@ -657,7 +657,7 @@ func TestAcquire(t *testing.T) {
 						{
 							Name:             "default-pool",
 							InitialNodeCount: DefaultGKEMinNodes,
-							Config:           &container.NodeConfig{MachineType: "n1-standard-4"},
+							Config:           &container.NodeConfig{MachineType: "n1-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
 					},
@@ -698,7 +698,7 @@ func TestAcquire(t *testing.T) {
 						{
 							Name:             "default-pool",
 							InitialNodeCount: DefaultGKEMinNodes,
-							Config:           &container.NodeConfig{MachineType: "n1-standard-4"},
+							Config:           &container.NodeConfig{MachineType: "n1-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
 					},
@@ -724,7 +724,7 @@ func TestAcquire(t *testing.T) {
 						{
 							Name:             "default-pool",
 							InitialNodeCount: DefaultGKEMinNodes,
-							Config:           &container.NodeConfig{MachineType: "n1-standard-4"},
+							Config:           &container.NodeConfig{MachineType: "n1-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
 					},
@@ -752,7 +752,7 @@ func TestAcquire(t *testing.T) {
 						{
 							Name:             "default-pool",
 							InitialNodeCount: DefaultGKEMinNodes,
-							Config:           &container.NodeConfig{MachineType: "n1-standard-4"},
+							Config:           &container.NodeConfig{MachineType: "n1-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
 					},
@@ -779,7 +779,7 @@ func TestAcquire(t *testing.T) {
 						{
 							Name:             "default-pool",
 							InitialNodeCount: DefaultGKEMinNodes,
-							Config:           &container.NodeConfig{MachineType: "n1-standard-4"},
+							Config:           &container.NodeConfig{MachineType: "n1-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
 					},
@@ -818,7 +818,7 @@ func TestAcquire(t *testing.T) {
 						{
 							Name:             "default-pool",
 							InitialNodeCount: DefaultGKEMinNodes,
-							Config:           &container.NodeConfig{MachineType: "n1-standard-4"},
+							Config:           &container.NodeConfig{MachineType: "n1-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
 					},
@@ -846,7 +846,7 @@ func TestAcquire(t *testing.T) {
 						{
 							Name:             "default-pool",
 							InitialNodeCount: DefaultGKEMinNodes,
-							Config:           &container.NodeConfig{MachineType: "n1-standard-4"},
+							Config:           &container.NodeConfig{MachineType: "n1-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
 					},
@@ -872,7 +872,7 @@ func TestAcquire(t *testing.T) {
 						{
 							Name:             "default-pool",
 							InitialNodeCount: DefaultGKEMinNodes,
-							Config:           &container.NodeConfig{MachineType: "n1-standard-4"},
+							Config:           &container.NodeConfig{MachineType: "n1-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
 					},
@@ -897,7 +897,7 @@ func TestAcquire(t *testing.T) {
 						{
 							Name:             "default-pool",
 							InitialNodeCount: DefaultGKEMinNodes,
-							Config:           &container.NodeConfig{MachineType: "n1-standard-4"},
+							Config:           &container.NodeConfig{MachineType: "n1-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
 					},
@@ -1080,7 +1080,7 @@ func TestDelete(t *testing.T) {
 						{
 							Name:             "default-pool",
 							InitialNodeCount: DefaultGKEMinNodes,
-							Config:           &container.NodeConfig{MachineType: "n1-standard-4"},
+							Config:           &container.NodeConfig{MachineType: "n1-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
 					},
@@ -1171,7 +1171,7 @@ func TestDelete(t *testing.T) {
 						{
 							Name:             "default-pool",
 							InitialNodeCount: DefaultGKEMinNodes,
-							Config:           &container.NodeConfig{MachineType: "n1-standard-4"},
+							Config:           &container.NodeConfig{MachineType: "n1-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
 					},


### PR DESCRIPTION
Background:
When we create a GKE cluster, we can specify the scopes, which means the set of Google API scopes to be made available on all of the node VMs under the "default" service account. If it's not specified, no scopes will be added.
Plus, communicating and authenticating with **gcr.io** requires `https://www.googleapis.com/auth/devstorage.read_only`. If it's not specified, the workloads on that cluster won't be able to pull images from private GCR.

This PR adds CloudPlatformScope in the base gke lib, so all clusters will be able to talk to all Google APIs. We can make it more fine granular in the future if needed.

/cc @chaodaiG 
/cc @yt3liu 
/cc @adrcunha 