### PR TITLE
Allow Custom `dep ensure` args in hack/update-deps.sh

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -24,7 +24,7 @@ set -o pipefail
 cd ${ROOT_DIR}
 
 # Ensure we have everything we need under vendor/
-dep ensure
+dep ensure $@
 
 rm -rf $(find vendor/ -name 'OWNERS')
 rm -rf $(find vendor/ -name '*_test.go')


### PR DESCRIPTION
Same as knative/serving#6361

Usual workflow for updating custom deps is running dep ensure -update some/go/path, followed by running ./hack/update-deps.sh. This
results in dep ensure being called a second time and slows the
process down an annoying amount. Now user can just run
./hack/update-deps.sh -update some/go/path and it works.