### PR TITLE
Add RecordN method to permit recording of N measurements simultaneously.

### DIFF
--- a/metrics/config.go
+++ b/metrics/config.go
@@ -144,19 +144,13 @@ func NewStackdriverClientConfigFromMap(config map[string]string) *StackdriverCli
 	}
 }
 
-// RecordBatch applies the `ros` Options to each measurement in `mss` and then records the resulting
+// record applies the `ros` Options to each measurement in `mss` and then records the resulting
 // measurements in the metricsConfig's designated backend.
-func (mc *metricsConfig) RecordBatch(ctx context.Context, mss []stats.Measurement, ros ...stats.Options) error {
+func (mc *metricsConfig) record(ctx context.Context, mss []stats.Measurement, ros ...stats.Options) error {
 	if mc == nil || mc.recorder == nil {
 		return stats.RecordWithOptions(ctx, append(ros, stats.WithMeasurements(mss...))...)
 	}
 	return mc.recorder(ctx, mss, ros...)
-}
-
-// Record applies the `ros` Options to `ms` and then records the resulting
-// measurements in the metricsConfig's designated backend.
-func (mc *metricsConfig) Record(ctx context.Context, ms stats.Measurement, ros ...stats.Options) error {
-	return mc.RecordBatch(ctx, []stats.Measurement{ms}, ros...)
 }
 
 func createMetricsConfig(ops ExporterOptions, logger *zap.SugaredLogger) (*metricsConfig, error) {
@@ -252,12 +246,12 @@ func createMetricsConfig(ops ExporterOptions, logger *zap.SugaredLogger) (*metri
 					}
 					// Otherwise, skip the measurement (because it won't be accepted).
 				}
-				// Trim the list to the number of written objects.
-				mss = mss[:wIdx]
 				// Found no matched metrics.
-				if len(mss) == 0 {
+				if wIdx == 0 {
 					return nil
 				}
+				// Trim the list to the number of written objects.
+				mss = mss[:wIdx]
 				return stats.RecordWithOptions(ctx, append(ros, stats.WithMeasurements(mss...))...)
 			}
 		}

--- a/metrics/record.go
+++ b/metrics/record.go
@@ -27,12 +27,12 @@ import (
 
 // Record stores the given Measurement from `ms` in the current metrics backend.
 func Record(ctx context.Context, ms stats.Measurement, ros ...stats.Options) {
-	getCurMetricsConfig().Record(ctx, ms, ros...)
+	getCurMetricsConfig().record(ctx, []stats.Measurement{ms}, ros...)
 }
 
 // RecordBatch stores the given Measurements from `mss` in the current metrics backend.
 func RecordBatch(ctx context.Context, mss ...stats.Measurement) {
-	getCurMetricsConfig().RecordBatch(ctx, mss)
+	getCurMetricsConfig().record(ctx, mss)
 }
 
 // Buckets125 generates an array of buckets with approximate powers-of-two

--- a/metrics/record.go
+++ b/metrics/record.go
@@ -27,9 +27,12 @@ import (
 
 // Record stores the given Measurement from `ms` in the current metrics backend.
 func Record(ctx context.Context, ms stats.Measurement, ros ...stats.Options) {
-	mc := getCurMetricsConfig()
+	getCurMetricsConfig().Record(ctx, ms, ros...)
+}
 
-	mc.Record(ctx, ms, ros...)
+// RecordBatch stores the given Measurements from `mss` in the current metrics backend.
+func RecordBatch(ctx context.Context, mss []stats.Measurement, ros ...stats.Options) {
+	getCurMetricsConfig().RecordBatch(ctx, mss, ros...)
 }
 
 // Buckets125 generates an array of buckets with approximate powers-of-two

--- a/metrics/record.go
+++ b/metrics/record.go
@@ -31,8 +31,8 @@ func Record(ctx context.Context, ms stats.Measurement, ros ...stats.Options) {
 }
 
 // RecordBatch stores the given Measurements from `mss` in the current metrics backend.
-func RecordBatch(ctx context.Context, mss []stats.Measurement, ros ...stats.Options) {
-	getCurMetricsConfig().RecordBatch(ctx, mss, ros...)
+func RecordBatch(ctx context.Context, mss ...stats.Measurement) {
+	getCurMetricsConfig().RecordBatch(ctx, mss)
 }
 
 // Buckets125 generates an array of buckets with approximate powers-of-two

--- a/metrics/record_test.go
+++ b/metrics/record_test.go
@@ -38,68 +38,87 @@ type cases struct {
 
 func TestRecordServing(t *testing.T) {
 	measure := stats.Int64("request_count", "Number of reconcile operations", stats.UnitNone)
-	shouldReportCases := []cases{
-		// Increase the measurement value for each test case so that checking
-		// the last value ensures the measurement has been recorded.
-		{
-			name:          "none stackdriver backend",
-			metricsConfig: &metricsConfig{},
-			measurement:   measure.M(1),
-		}, {
-			name: "stackdriver backend with supported metric",
-			metricsConfig: &metricsConfig{
-				isStackdriverBackend:        true,
-				stackdriverMetricTypePrefix: "knative.dev/internal/serving/activator",
-			},
-			measurement: measure.M(2),
-		}, {
-			name: "stackdriver backend with unsupported metric and allow custom metric",
-			metricsConfig: &metricsConfig{
-				isStackdriverBackend:        true,
-				stackdriverMetricTypePrefix: "knative.dev/unsupported",
-			},
-			measurement: measure.M(3),
-		}, {
-			name:        "empty metricsConfig",
-			measurement: measure.M(4),
+	// Increase the measurement value for each test case so that checking
+	// the last value ensures the measurement has been recorded.
+	shouldReportCases := []cases{{
+		name:          "none stackdriver backend",
+		metricsConfig: &metricsConfig{},
+		measurement:   measure.M(1),
+	}, {
+		name: "stackdriver backend with supported metric",
+		metricsConfig: &metricsConfig{
+			isStackdriverBackend:        true,
+			stackdriverMetricTypePrefix: "knative.dev/internal/serving/activator",
 		},
-	}
+		measurement: measure.M(2),
+	}, {
+		name: "stackdriver backend with unsupported metric and allow custom metric",
+		metricsConfig: &metricsConfig{
+			isStackdriverBackend:        true,
+			stackdriverMetricTypePrefix: "knative.dev/unsupported",
+		},
+		measurement: measure.M(3),
+	}, {
+		name:        "empty metricsConfig",
+		measurement: measure.M(4),
+	}}
 	testRecord(t, measure, shouldReportCases)
 }
 
 func TestRecordEventing(t *testing.T) {
 	measure := stats.Int64("event_count", "Number of event received", stats.UnitNone)
-	shouldReportCases := []cases{
-		// Increase the measurement value for each test case so that checking
-		// the last value ensures the measurement has been recorded.
-		{
-			name:          "none stackdriver backend",
-			metricsConfig: &metricsConfig{},
-			measurement:   measure.M(1),
-		}, {
-			name: "stackdriver backend with supported metric",
-			metricsConfig: &metricsConfig{
-				isStackdriverBackend:        true,
-				stackdriverMetricTypePrefix: "knative.dev/eventing/broker",
-			},
-			measurement: measure.M(5),
-		}, {
-			name: "stackdriver backend with unsupported metric and allow custom metric",
-			metricsConfig: &metricsConfig{
-				isStackdriverBackend:        true,
-				stackdriverMetricTypePrefix: "knative.dev/unsupported",
-			},
-			measurement: measure.M(3),
-		}, {
-			name:        "empty metricsConfig",
-			measurement: measure.M(4),
+	// Increase the measurement value for each test case so that checking
+	// the last value ensures the measurement has been recorded.
+	shouldReportCases := []cases{{
+		name:          "none stackdriver backend",
+		metricsConfig: &metricsConfig{},
+		measurement:   measure.M(1),
+	}, {
+		name: "stackdriver backend with supported metric",
+		metricsConfig: &metricsConfig{
+			isStackdriverBackend:        true,
+			stackdriverMetricTypePrefix: "knative.dev/eventing/broker",
 		},
-	}
+		measurement: measure.M(2),
+	}, {
+		name: "stackdriver backend with unsupported metric and allow custom metric",
+		metricsConfig: &metricsConfig{
+			isStackdriverBackend:        true,
+			stackdriverMetricTypePrefix: "knative.dev/unsupported",
+		},
+		measurement: measure.M(3),
+	}, {
+		name:        "empty metricsConfig",
+		measurement: measure.M(4),
+	}}
 	testRecord(t, measure, shouldReportCases)
 }
 
+func TestRecordBatch(t *testing.T) {
+	ctx := context.Background()
+	measure1 := stats.Int64("count1", "First counter", stats.UnitNone)
+	measure2 := stats.Int64("count2", "Second counter", stats.UnitNone)
+	v := []*view.View{&view.View{
+		Measure:     measure1,
+		Aggregation: view.LastValue(),
+	}, &view.View{
+		Measure:     measure2,
+		Aggregation: view.LastValue(),
+	}}
+	view.Register(v...)
+	defer view.Unregister(v...)
+	metricsConfig := &metricsConfig{}
+	measurement1 := measure1.M(1984)
+	measurement2 := measure2.M(42)
+	setCurMetricsConfig(metricsConfig)
+	RecordBatch(ctx, []stats.Measurement{measurement1, measurement2})
+	metricstest.CheckLastValueData(t, measurement1.Measure().Name(), map[string]string{}, 1984)
+	metricstest.CheckLastValueData(t, measurement2.Measure().Name(), map[string]string{}, 42)
+}
+
 func testRecord(t *testing.T, measure *stats.Int64Measure, shouldReportCases []cases) {
-	ctx := context.TODO()
+	t.Helper()
+	ctx := context.Background()
 	v := &view.View{
 		Measure:     measure,
 		Aggregation: view.LastValue(),
@@ -117,30 +136,28 @@ func testRecord(t *testing.T, measure *stats.Int64Measure, shouldReportCases []c
 		name          string
 		metricsConfig *metricsConfig
 		measurement   stats.Measurement
-	}{
-		// Use a different value for the measurement other than the last one of shouldReportCases
-		{
-			name: "stackdriver backend with unsupported metric but not allow custom metric",
-			metricsConfig: &metricsConfig{
-				isStackdriverBackend:        true,
-				stackdriverMetricTypePrefix: "knative.dev/unsupported",
-				recorder: func(ctx context.Context, mss []stats.Measurement, ros ...stats.Options) error {
-					metricType := path.Join("knative.dev/unsupported", mss[0].Measure().Name())
-					if metricskey.KnativeRevisionMetrics.Has(metricType) || metricskey.KnativeTriggerMetrics.Has(metricType) {
-						ros = append(ros, stats.WithMeasurements(mss[0]))
-						return stats.RecordWithOptions(ctx, ros...)
-					}
-					return nil
-				},
+	}{{ // Use a different value for the measurement other than the last one of shouldReportCases
+		name: "stackdriver backend with unsupported metric but not allow custom metric",
+		metricsConfig: &metricsConfig{
+			isStackdriverBackend:        true,
+			stackdriverMetricTypePrefix: "knative.dev/unsupported",
+			recorder: func(ctx context.Context, mss []stats.Measurement, ros ...stats.Options) error {
+				metricType := path.Join("knative.dev/unsupported", mss[0].Measure().Name())
+				if metricskey.KnativeRevisionMetrics.Has(metricType) || metricskey.KnativeTriggerMetrics.Has(metricType) {
+					ros = append(ros, stats.WithMeasurements(mss[0]))
+					return stats.RecordWithOptions(ctx, ros...)
+				}
+				return nil
 			},
-			measurement: measure.M(5),
 		},
-	}
+		measurement: measure.M(5),
+	}}
 
 	for _, test := range shouldNotReportCases {
 		setCurMetricsConfig(test.metricsConfig)
 		Record(ctx, test.measurement)
-		metricstest.CheckLastValueData(t, test.measurement.Measure().Name(), map[string]string{}, 4) // The value is still the last one of shouldReportCases
+		metricstest.CheckLastValueData(t, test.measurement.Measure().Name(), map[string]string{},
+			float64(len(shouldReportCases))) // The value is still the last one of shouldReportCases
 	}
 }
 

--- a/metrics/record_test.go
+++ b/metrics/record_test.go
@@ -124,10 +124,10 @@ func testRecord(t *testing.T, measure *stats.Int64Measure, shouldReportCases []c
 			metricsConfig: &metricsConfig{
 				isStackdriverBackend:        true,
 				stackdriverMetricTypePrefix: "knative.dev/unsupported",
-				recorder: func(ctx context.Context, ms stats.Measurement, ros ...stats.Options) error {
-					metricType := path.Join("knative.dev/unsupported", ms.Measure().Name())
+				recorder: func(ctx context.Context, mss []stats.Measurement, ros ...stats.Options) error {
+					metricType := path.Join("knative.dev/unsupported", mss[0].Measure().Name())
 					if metricskey.KnativeRevisionMetrics.Has(metricType) || metricskey.KnativeTriggerMetrics.Has(metricType) {
-						ros = append(ros, stats.WithMeasurements(ms))
+						ros = append(ros, stats.WithMeasurements(mss[0]))
 						return stats.RecordWithOptions(ctx, ros...)
 					}
 					return nil

--- a/metrics/record_test.go
+++ b/metrics/record_test.go
@@ -111,7 +111,7 @@ func TestRecordBatch(t *testing.T) {
 	measurement1 := measure1.M(1984)
 	measurement2 := measure2.M(42)
 	setCurMetricsConfig(metricsConfig)
-	RecordBatch(ctx, []stats.Measurement{measurement1, measurement2})
+	RecordBatch(ctx, measurement1, measurement2)
 	metricstest.CheckLastValueData(t, measurement1.Measure().Name(), map[string]string{}, 1984)
 	metricstest.CheckLastValueData(t, measurement2.Measure().Name(), map[string]string{}, 42)
 }


### PR DESCRIPTION
In serving we have many places where we try to record several metrics at the same time.
Besides very repetetive code, this also brings inefficiences, since metrics code has to do _some_ work
for every call, which is completely avoidable.

This way we can record N measurements with one hit.

If we agree in principle, I'll extend the unit tests.

/assign @evankanderson @anniefu 