### PR TITLE
Add extra flags for cluster creation in test

### DIFF
--- a/test/gke/request_test.go
+++ b/test/gke/request_test.go
@@ -136,27 +136,6 @@ func TestNewCreateClusterRequest(t *testing.T) {
 				MaxNodes:    1,
 			},
 			errorExpected: true,
-		}, {
-			req: &Request{
-				Project:                "project-g",
-				GKEVersion:             "1-2-3",
-				ClusterName:            "name-g",
-				MinNodes:               1,
-				MaxNodes:               1,
-				NodeType:               "n1-standard-4",
-				EnableWorkloadIdentity: true,
-			},
-			errorExpected: false,
-		}, {
-			req: &Request{
-				GKEVersion:             "1-2-3",
-				ClusterName:            "name-h",
-				MinNodes:               3,
-				MaxNodes:               3,
-				NodeType:               "n1-standard-4",
-				EnableWorkloadIdentity: true,
-			},
-			errorExpected: true,
 		}}
 	for _, data := range datas {
 		createReq, err := NewCreateClusterRequest(data.req)

--- a/test/gke/request_test.go
+++ b/test/gke/request_test.go
@@ -136,6 +136,38 @@ func TestNewCreateClusterRequest(t *testing.T) {
 				MaxNodes:    1,
 			},
 			errorExpected: true,
+		}, {
+			req: &Request{
+				Project:                "project-g",
+				GKEVersion:             "1-2-3",
+				ClusterName:            "name-g",
+				MinNodes:               1,
+				MaxNodes:               1,
+				NodeType:               "n1-standard-4",
+				EnableWorkloadIdentity: true,
+			},
+			errorExpected: false,
+		}, {
+			req: &Request{
+				GKEVersion:             "1-2-3",
+				ClusterName:            "name-h",
+				MinNodes:               3,
+				MaxNodes:               3,
+				NodeType:               "n1-standard-4",
+				EnableWorkloadIdentity: true,
+			},
+			errorExpected: true,
+		}, {
+			req: &Request{
+				Project:        "project-i",
+				GKEVersion:     "1-2-3",
+				ClusterName:    "name-i",
+				MinNodes:       3,
+				MaxNodes:       3,
+				NodeType:       "n1-standard-4",
+				ServiceAccount: "sa-i",
+			},
+			errorExpected: false,
 		}}
 	for _, data := range datas {
 		createReq, err := NewCreateClusterRequest(data.req)

--- a/testutils/clustermanager/e2e-tests/gke.go
+++ b/testutils/clustermanager/e2e-tests/gke.go
@@ -22,7 +22,9 @@ import (
 	"log"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	container "google.golang.org/api/container/v1beta1"
+
 	"knative.dev/pkg/test/gke"
 	"knative.dev/pkg/testutils/clustermanager/e2e-tests/boskos"
 	"knative.dev/pkg/testutils/clustermanager/e2e-tests/common"
@@ -36,7 +38,6 @@ const (
 	DefaultGKEZone      = ""
 	regionEnv           = "E2E_CLUSTER_REGION"
 	backupRegionEnv     = "E2E_CLUSTER_BACKUP_REGIONS"
-	defaultGKEVersion   = "latest"
 	DefaultResourceType = boskos.GKEProjectResource
 
 	ClusterRunning = "RUNNING"
@@ -231,7 +232,7 @@ func (gc *GKECluster) Acquire() error {
 			return nil
 		}
 		// Creating cluster
-		log.Printf("Creating cluster %q in region %q zone %q with:\n%+v", clusterName, region, request.Zone, gc.Request)
+		log.Printf("Creating cluster %q in region %q zone %q with:\n%+v", clusterName, region, request.Zone, spew.Sdump(rb))
 		err = gc.operations.CreateCluster(gc.Project, region, request.Zone, rb)
 		if err == nil {
 			cluster, err = gc.operations.GetCluster(gc.Project, region, request.Zone, rb.Cluster.Name)

--- a/testutils/clustermanager/perf-tests/pkg/cluster.go
+++ b/testutils/clustermanager/perf-tests/pkg/cluster.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pkg
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"strings"
@@ -39,6 +40,12 @@ const (
 	statusProvisioning = "PROVISIONING"
 	statusRunning      = "RUNNING"
 	statusStopping     = "STOPPING"
+)
+
+// Extra configurations we want to support for cluster creation request.
+var (
+	enableWorkloadIdentity = flag.Bool("enable-workload-identity", false, "whether to enable Workload Identity")
+	serviceAccount         = flag.String("service-account", "", "service account that will be used on this cluster")
 )
 
 type gkeClient struct {
@@ -237,12 +244,14 @@ func (gc *gkeClient) createClusterWithRetries(gcpProject, name string, config Cl
 		addons = strings.Split(config.Addons, ",")
 	}
 	req := &gke.Request{
-		Project:     gcpProject,
-		ClusterName: name,
-		MinNodes:    config.NodeCount,
-		MaxNodes:    config.NodeCount,
-		NodeType:    config.NodeType,
-		Addons:      addons,
+		Project:                gcpProject,
+		ClusterName:            name,
+		MinNodes:               config.NodeCount,
+		MaxNodes:               config.NodeCount,
+		NodeType:               config.NodeType,
+		Addons:                 addons,
+		EnableWorkloadIdentity: *enableWorkloadIdentity,
+		ServiceAccount:         *serviceAccount,
 	}
 	creq, err := gke.NewCreateClusterRequest(req)
 	if err != nil {

--- a/testutils/clustermanager/prow-cluster-operation/main.go
+++ b/testutils/clustermanager/prow-cluster-operation/main.go
@@ -51,7 +51,7 @@ func main() {
 	case get:
 		_, err = actions.Get(o)
 	default:
-		err = errors.New("Must pass one of --create, --delete, --get")
+		err = errors.New("must pass one of --create, --delete, --get")
 	}
 
 	if err != nil {


### PR DESCRIPTION
Support `--enable-workload-identity` and `--service-account` for cluster creation request.
I add them in the gke lib as all the tools built on it will automatically support these two flags.

/cc @chaodaiG 