### PR TITLE
make namespace optional so existing objects keep working and we have flexibility for cluster level objects.

### DIFF
--- a/apis/duck/v1/destination_test.go
+++ b/apis/duck/v1/destination_test.go
@@ -61,16 +61,6 @@ func TestValidateDestination(t *testing.T) {
 			},
 			want: "",
 		},
-		"invalid ref, missing namespace": {
-			dest: &Destination{
-				Ref: &KnativeReference{
-					Name:       name,
-					Kind:       kind,
-					APIVersion: apiVersion,
-				},
-			},
-			want: "missing field(s): ref.namespace",
-		},
 		"invalid ref, missing name": {
 			dest: &Destination{
 				Ref: &KnativeReference{

--- a/apis/duck/v1/knative_reference.go
+++ b/apis/duck/v1/knative_reference.go
@@ -31,7 +31,9 @@ type KnativeReference struct {
 
 	// Namespace of the referent.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-	Namespace string `json:"namespace"`
+	// This is optional field, it gets defaulted to the object holding it if left out.
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
 
 	// Name of the referent.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -44,14 +46,10 @@ type KnativeReference struct {
 func (kr *KnativeReference) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
 	if kr == nil {
-		errs = errs.Also(apis.ErrMissingField("namespace"))
 		errs = errs.Also(apis.ErrMissingField("name"))
 		errs = errs.Also(apis.ErrMissingField("apiVersion"))
 		errs = errs.Also(apis.ErrMissingField("kind"))
 		return errs
-	}
-	if kr.Namespace == "" {
-		errs = errs.Also(apis.ErrMissingField("namespace"))
 	}
 	if kr.Name == "" {
 		errs = errs.Also(apis.ErrMissingField("name"))

--- a/apis/duck/v1/knative_reference_test.go
+++ b/apis/duck/v1/knative_reference_test.go
@@ -42,7 +42,7 @@ func TestValidate(t *testing.T) {
 		"nil valid": {
 			ref: nil,
 			want: func() *apis.FieldError {
-				fe := apis.ErrMissingField("name", "namespace", "kind", "apiVersion")
+				fe := apis.ErrMissingField("name", "kind", "apiVersion")
 				return fe
 			}(),
 		},
@@ -52,18 +52,7 @@ func TestValidate(t *testing.T) {
 		},
 		"invalid ref, empty": {
 			ref:  &KnativeReference{},
-			want: apis.ErrMissingField("name", "namespace", "kind", "apiVersion"),
-		},
-		"invalid ref, missing namespace": {
-			ref: &KnativeReference{
-				Name:       name,
-				Kind:       kind,
-				APIVersion: apiVersion,
-			},
-			want: func() *apis.FieldError {
-				fe := apis.ErrMissingField("namespace")
-				return fe
-			}(),
+			want: apis.ErrMissingField("name", "kind", "apiVersion"),
 		},
 		"invalid ref, missing kind": {
 			ref: &KnativeReference{


### PR DESCRIPTION
Make namespace optional for two reasons:
 - Existing objects will keep working without this restriction
 - This will allow us to have references to cluster level resources.