### PR TITLE
BugFix: Returning errors and adding scheme.

### DIFF
--- a/codegen/cmd/injection-gen/generators/packages.go
+++ b/codegen/cmd/injection-gen/generators/packages.go
@@ -409,6 +409,7 @@ func reconcilerPackages(basePackage string, groupPkgName string, gv clientgentyp
 					imports:             generator.NewImportTracker(),
 					clientPkg:           clientPackagePath,
 					informerPackagePath: informerPackagePath,
+					schemePkg:           filepath.Join(customArgs.VersionedClientSetPackage, "scheme"),
 				})
 
 				return generators

--- a/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -33,6 +33,7 @@ type reconcilerControllerGenerator struct {
 	filtered      bool
 
 	clientPkg           string
+	schemePkg           string
 	informerPackagePath string
 }
 
@@ -85,6 +86,14 @@ func (g *reconcilerControllerGenerator) GenerateType(c *generator.Context, t *ty
 			Package: g.informerPackagePath,
 			Name:    "Get",
 		}),
+		"schemeScheme": c.Universe.Function(types.Name{
+			Package: "k8s.io/client-go/kubernetes/scheme",
+			Name:    "Scheme",
+		}),
+		"schemeAddToScheme": c.Universe.Function(types.Name{
+			Package: g.schemePkg,
+			Name:    "Scheme",
+		}),
 	}
 
 	sw.Do(reconcilerControllerNewImpl, m)
@@ -116,4 +125,7 @@ func NewImpl(ctx context.Context, r Interface) *{{.controllerImpl|raw}} {
 	return impl
 }
 
+func init() {
+	{{.schemeAddToScheme|raw}}({{.schemeScheme|raw}})
+}
 `

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -245,11 +245,13 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		var event *{{.reconcilerReconcilerEvent|raw}}
 		if reconciler.EventAs(reconcileEvent, &event) {
 			r.Recorder.Eventf(resource, event.EventType, event.Reason, event.Format, event.Args...)
+			return nil
 		} else {
 			r.Recorder.Event(resource, {{.corev1EventTypeWarning|raw}}, "InternalError", reconcileEvent.Error())
+			return reconcileEvent.Error()
 		}
 	}
-	return reconcileEvent
+	return nil
 }
 `
 


### PR DESCRIPTION
In attempting to integrate with a more complicated reconciler, I found two issues:

1. If the reconciler does not use reconciler.Base, then the scheme is not added to the k8s scheme.Scheme and k8s events can not be created. This is fixed by adding the init method.
1. If the reconciler uses reconciler.Events, and returns a non-nil event the reconciler will report these as errors in the log. To prevent this the wrapped error logic nils out handled errors.