### PR TITLE
check KReference namespace matches parent. Allow escape hatch.

### DIFF
--- a/apis/contexts.go
+++ b/apis/contexts.go
@@ -180,3 +180,21 @@ func DisallowDeprecated(ctx context.Context) context.Context {
 func IsDeprecatedAllowed(ctx context.Context) bool {
 	return ctx.Value(disallowDeprecated{}) == nil
 }
+
+// This is attached to contexts as they are passed down through a resource
+// being validated to direct them to allow namespaces (or missing namespace)
+// outside the parent (as indicated by WithinParent.
+type allowDifferentNamespace struct{}
+
+// AllowDifferentNamespace notes on the context that further validation
+// should allow different namespaces from the encapsulating object. Mainly
+// used by KReference, since it by default requires namespaces to match.
+func AllowDifferentNamespace(ctx context.Context) context.Context {
+	return context.WithValue(ctx, allowDifferentNamespace{}, struct{}{})
+}
+
+// IsDifferentNamespaceAllowed checks the context to see whether different
+// namespace is allowed from the encapsulating object.
+func IsDifferentNamespaceAllowed(ctx context.Context) bool {
+	return ctx.Value(allowDifferentNamespace{}) != nil
+}

--- a/apis/contexts_test.go
+++ b/apis/contexts_test.go
@@ -118,6 +118,16 @@ func TestContexts(t *testing.T) {
 		ctx:   ctx,
 		check: IsDeprecatedAllowed,
 		want:  true,
+	}, {
+		name:  "allow different namespace",
+		ctx:   AllowDifferentNamespace(ctx),
+		check: IsDifferentNamespaceAllowed,
+		want:  true,
+	}, {
+		name:  "don't allow different namespace",
+		ctx:   ctx,
+		check: IsDifferentNamespaceAllowed,
+		want:  false,
 	}}
 
 	for _, tc := range tests {

--- a/apis/duck/v1/destination.go
+++ b/apis/duck/v1/destination.go
@@ -33,6 +33,8 @@ type Destination struct {
 	URI *apis.URL `json:"uri,omitempty"`
 }
 
+// Validate the Destination has all the necessary fields and check the
+// Namespace matches that of the parent object (using apis.ParentMeta).
 func (dest *Destination) Validate(ctx context.Context) *apis.FieldError {
 	if dest == nil {
 		return nil

--- a/apis/duck/v1/knative_reference.go
+++ b/apis/duck/v1/knative_reference.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	"context"
+	"fmt"
 
 	"knative.dev/pkg/apis"
 )
@@ -59,6 +60,23 @@ func (kr *KReference) Validate(ctx context.Context) *apis.FieldError {
 	}
 	if kr.Kind == "" {
 		errs = errs.Also(apis.ErrMissingField("kind"))
+	}
+	// Only if namespace is empty validate it. This is to deal with legacy
+	// objects in the storage that may now have the namespace filled in.
+	// Because things get defaulted in other cases, moving forward the
+	// kr.Namespace will not be empty.
+	if kr.Namespace != "" {
+		parentNS := apis.ParentMeta(ctx).Namespace
+		if !apis.IsDifferentNamespaceAllowed(ctx) {
+			if parentNS != "" && kr.Namespace != parentNS {
+				errs = errs.Also(&apis.FieldError{
+					Message: "mismatched namespaces",
+					Paths:   []string{"namespace"},
+					Details: fmt.Sprintf("parent namespace: %q does not match ref: %q", parentNS, kr.Namespace),
+				})
+			}
+
+		}
 	}
 	return errs
 }


### PR DESCRIPTION
 - Add a check to see if KReference namespace matches that of the encapsulating object via context.
 - skip the check if the namespace is null to ensure legacy objects will keep working.