### PR TITLE
[Gen Reconciler] Fix issue found with controllers without reconciler.Base

### DIFF
--- a/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -18,7 +18,6 @@ package generators
 
 import (
 	"io"
-
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
@@ -93,7 +92,27 @@ func (g *reconcilerControllerGenerator) GenerateType(c *generator.Context, t *ty
 		}),
 		"schemeAddToScheme": c.Universe.Function(types.Name{
 			Package: g.schemePkg,
-			Name:    "Scheme",
+			Name:    "AddToScheme",
+		}),
+		"kubeclientGet": c.Universe.Function(types.Name{
+			Package: "knative.dev/pkg/client/injection/kube/client",
+			Name:    "Get",
+		}),
+		"typedcorev1EventSinkImpl": c.Universe.Function(types.Name{
+			Package: "k8s.io/client-go/kubernetes/typed/core/v1",
+			Name:    "EventSinkImpl",
+		}),
+		"recordNewBroadcaster": c.Universe.Function(types.Name{
+			Package: "k8s.io/client-go/tools/record",
+			Name:    "NewBroadcaster",
+		}),
+		"watchInterface": c.Universe.Type(types.Name{
+			Package: "k8s.io/apimachinery/pkg/watch",
+			Name:    "Interface",
+		}),
+		"controllerGetEventRecorder": c.Universe.Function(types.Name{
+			Package: "knative.dev/pkg/controller",
+			Name:    "GetEventRecorder",
 		}),
 	}
 
@@ -113,11 +132,29 @@ func NewImpl(ctx context.Context, r Interface) *{{.controllerImpl|raw}} {
 
 	{{.type|lowercaseSingular}}Informer := {{.informerGet|raw}}(ctx)
 
+	recorder := {{.controllerGetEventRecorder|raw}}(ctx)
+	if recorder == nil {
+		// Create event broadcaster
+		logger.Debug("Creating event broadcaster")
+		eventBroadcaster := {{.recordNewBroadcaster|raw}}()
+		watches := []{{.watchInterface|raw}}{
+			eventBroadcaster.StartLogging(logger.Named("event-broadcaster").Infof),
+			eventBroadcaster.StartRecordingToSink(
+				&{{.typedcorev1EventSinkImpl|raw}}{Interface: {{.kubeclientGet|raw}}(ctx).CoreV1().Events("")}),
+		}
+		recorder = eventBroadcaster.NewRecorder({{.schemeScheme|raw}}, {{.corev1EventSource|raw}}{Component: defaultControllerAgentName})
+		go func() {
+			<-ctx.Done()
+			for _, w := range watches {
+				w.Stop()
+			}
+		}()
+	}
+
 	c := &reconcilerImpl{
 		Client:  {{.clientGet|raw}}(ctx),
 		Lister:  {{.type|lowercaseSingular}}Informer.Lister(),
-		Recorder: record.NewBroadcaster().NewRecorder(
-			scheme.Scheme, {{.corev1EventSource|raw}}{Component: defaultControllerAgentName}),
+		Recorder: recorder,
 		FinalizerName: defaultFinalizerName,
 		reconciler:    r,
 	}

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -241,14 +241,15 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	// Report the reconciler event, if any.
 	if reconcileEvent != nil {
-		logger.Errorw("ReconcileKind returned an event", zap.Error(reconcileEvent))
 		var event *{{.reconcilerReconcilerEvent|raw}}
 		if reconciler.EventAs(reconcileEvent, &event) {
+			logger.Infow("ReconcileKind returned an event", zap.Any("event", reconcileEvent))
 			r.Recorder.Eventf(resource, event.EventType, event.Reason, event.Format, event.Args...)
 			return nil
 		} else {
+			logger.Errorw("ReconcileKind returned an error", zap.Error(reconcileEvent))
 			r.Recorder.Event(resource, {{.corev1EventTypeWarning|raw}}, "InternalError", reconcileEvent.Error())
-			return reconcileEvent.Error()
+			return reconcileEvent
 		}
 	}
 	return nil


### PR DESCRIPTION
Knative normally sets up a base for the reconciler, if this happens then there is a recorder watch registered and is pulled from the context. The original gen reconciler was not checking for a nil event recorder and events were not being logged if reconciler.Base (from serving or eventing) was not used.

This fixes that issue.

Working events with sample-controller in https://github.com/knative/sample-source/pull/11