### PR TITLE
Fix defaulting bug in the converter for empty addressables.

### DIFF
--- a/apis/duck/v1alpha1/addressable_types.go
+++ b/apis/duck/v1alpha1/addressable_types.go
@@ -82,7 +82,7 @@ func (*Addressable) GetFullType() duck.Populatable {
 
 // ConvertUp implements apis.Convertible
 func (a *Addressable) ConvertUp(ctx context.Context, to apis.Convertible) error {
-	url := a.GetURL()
+	url := a.URL
 	switch sink := to.(type) {
 	case *v1.Addressable:
 		sink.URL = url.DeepCopy()

--- a/apis/duck/v1alpha1/addressable_types_test.go
+++ b/apis/duck/v1alpha1/addressable_types_test.go
@@ -128,6 +128,12 @@ func TestConversion(t *testing.T) {
 		conv:        &Addressable{},
 		wantErrUp:   true,
 		wantErrDown: true,
+	}, {
+		name:        "v1alpha1 - empty",
+		addr:        &Addressable{},
+		conv:        &Addressable{},
+		wantErrUp:   true,
+		wantErrDown: true,
 	}}
 
 	for _, test := range tests {

--- a/apis/duck/v1beta1/addressable_types_test.go
+++ b/apis/duck/v1beta1/addressable_types_test.go
@@ -45,6 +45,12 @@ func TestConversion(t *testing.T) {
 		wantErrUp:   false,
 		wantErrDown: false,
 	}, {
+		name:        "v1 - empty",
+		addr:        &Addressable{},
+		conv:        &v1.Addressable{},
+		wantErrUp:   false,
+		wantErrDown: false,
+	}, {
 		name: "v1beta1",
 		addr: &Addressable{
 			URL: &apis.URL{
@@ -52,6 +58,12 @@ func TestConversion(t *testing.T) {
 				Host:   "bar.com",
 			},
 		},
+		conv:        &Addressable{},
+		wantErrUp:   true,
+		wantErrDown: true,
+	}, {
+		name:        "v1beta1 - empty",
+		addr:        &Addressable{},
 		conv:        &Addressable{},
 		wantErrUp:   true,
 		wantErrDown: true,


### PR DESCRIPTION
attempting to use the addressable converters in another test, I ran into the issue with an empty addressable object:

```
            - 			Addressable: v1beta1.Addressable{},
            + 			Addressable: v1beta1.Addressable{URL: s"http:"},
```

Which means something was adding a non-nil url in the addressable. It was the usage of `GetURL`. So that is removed.

