### PR TITLE
Document genreconciler.

### DIFF
--- a/injection/README.md
+++ b/injection/README.md
@@ -349,7 +349,7 @@ The responsibility and consequences of using the generated
 - If additional events are required to be produced, an implementation can pull a
   recorder from the context: `recorder := controller.GetEventRecorder(ctx)`.
 
-Future features to be concidered:
+Future features to be considered:
 
 - Leverage `configStore` and specifically `ctx = r.configStore.ToContext(ctx)`
   inside `Reconcile`.


### PR DESCRIPTION
Adding documentation on how to use and what to expect from the generated reconciler code added to client injection gen.

/assign @mattmoor 