### PR TITLE
Handle wrong apiVersion/kind in SinkBinding subject  

### DIFF
--- a/webhook/psbinding/reconciler.go
+++ b/webhook/psbinding/reconciler.go
@@ -162,7 +162,7 @@ func (r *BaseReconciler) ReconcileDeletion(ctx context.Context, fb Bindable) err
 	// If it is our turn to finalize the Binding, then first undo the effect
 	// of our Binding on the resource.
 	logging.FromContext(ctx).Infof("Removing the binding for %s", fb.GetName())
-	if err := r.ReconcileSubject(ctx, fb, fb.Undo); apierrs.IsNotFound(err) {
+	if err := r.ReconcileSubject(ctx, fb, fb.Undo); apierrs.IsNotFound(err) || apierrs.IsForbidden(err) {
 		// If the subject has been deleted, then there is nothing to undo.
 	} else if err != nil {
 		return err
@@ -252,7 +252,9 @@ func (r *BaseReconciler) ReconcileSubject(ctx context.Context, fb Bindable, muta
 	// use to fetch our PodSpecable resources.
 	_, lister, err := r.Factory.Get(gvr)
 	if err != nil {
-		return fmt.Errorf("error getting a lister for resource '%+v': %v", gvr, err)
+		logging.FromContext(ctx).Errorf("Error getting a lister for resource '%+v': %v", gvr, err)
+		fb.GetBindingStatus().MarkBindingUnavailable("SubjectUnavailable", err.Error())
+		return err
 	}
 
 	// Based on the type of subject reference, build up a list of referents.

--- a/webhook/psbinding/table_test.go
+++ b/webhook/psbinding/table_test.go
@@ -19,6 +19,7 @@ package psbinding
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -40,6 +41,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -1393,6 +1395,83 @@ func TestBaseReconcile(t *testing.T) {
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchRemoveFinalizer("foo", "bar", "" /* resource version */),
 		},
+	}, {
+		Name: "finalizing forbidden subject",
+		Key:  "foo/bar",
+		WithReactors: []clientgotesting.ReactionFunc{
+			// This will cause the duck informer factory to return a Forbidden error on Get(gvr)
+			// The informer calls list to ensure the type exists - this will
+			func(a clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+				if a.Matches("list", "deployments") {
+					return true, nil, apierrs.NewForbidden(schema.GroupResource{}, "", errors.New("some-error"))
+				}
+				return false, nil, nil
+			},
+		},
+		Objects: []runtime.Object{
+			&TestBindable{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "foo",
+					Name:              "bar",
+					DeletionTimestamp: &metav1.Time{time.Now()},
+					Finalizers:        []string{"testbindables.duck.knative.dev"},
+				},
+				Spec: TestBindableSpec{
+					BindingSpec: duckv1alpha1.BindingSpec{
+						Subject: tracker.Reference{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+							Namespace:  "foo",
+							Name:       "on-it",
+						},
+					},
+					Foo: "new value",
+				},
+				Status: TestBindableStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{{
+							Type:   "Ready",
+							Status: "True",
+						}},
+					},
+				},
+			},
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchRemoveFinalizer("foo", "bar", "" /* resource version */),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: mustTU(t, &TestBindable{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "foo",
+					Name:              "bar",
+					DeletionTimestamp: &metav1.Time{time.Now()},
+					Finalizers:        []string{"testbindables.duck.knative.dev"},
+				},
+				Spec: TestBindableSpec{
+					BindingSpec: duckv1alpha1.BindingSpec{
+						Subject: tracker.Reference{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+							Namespace:  "foo",
+							Name:       "on-it",
+						},
+					},
+					Foo: "new value",
+				},
+				Status: TestBindableStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{{
+							Type:   "Ready",
+							Status: "False",
+							Reason: "SubjectUnavailable",
+							// prefix comes from apiserrs.NewForbidden
+							Message: "forbidden: some-error",
+						}},
+					},
+				},
+			}),
+		}},
 	}, {
 		Name: "finalizing (unbind, and remove the finalizer)",
 		Key:  "foo/bar",


### PR DESCRIPTION
If [r.Factory.Get(gvr)](https://github.com/knative/pkg/blob/76b1a0d8134f5a5d4172a8b95b0e6ce47b92c0f7/webhook/psbinding/reconciler.go#L253) fails, set SinkBinding `Ready` condition to False with `SubjectUnavailable` Reason and underlying error in Message field. 
On SinkBinding deletion request, If underlying error is of `IsForbidden` type (which may be caused by GVR misspell), consider Subject as non-existing and remove SinkBinding 

knative/eventing#2464 