### PR TITLE
Generate Managed Finalizers for Reconcilers

### DIFF
--- a/codegen/cmd/injection-gen/generators/packages.go
+++ b/codegen/cmd/injection-gen/generators/packages.go
@@ -407,6 +407,7 @@ func reconcilerPackages(basePackage string, groupPkgName string, gv clientgentyp
 					},
 					outputPackage:       packagePath,
 					imports:             generator.NewImportTracker(),
+					groupName:           gv.Group.String(),
 					clientPkg:           clientPackagePath,
 					informerPackagePath: informerPackagePath,
 					schemePkg:           filepath.Join(customArgs.VersionedClientSetPackage, "scheme"),

--- a/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -144,31 +144,9 @@ const (
 
 // NewImpl returns a {{.controllerImpl|raw}} that handles queuing and feeding work from
 // the queue through an implementation of {{.controllerReconciler|raw}}, delegating to
-// the provided Interface.
+// the provided Interface and optional Finalizer methods.
 func NewImpl(ctx context.Context, r Interface) *{{.controllerImpl|raw}} {
 	logger := {{.loggingFromContext|raw}}(ctx)
-	rec := newRecordedReconcilerImpl(ctx, r)
-	return {{.controllerNewImpl|raw}}(rec, logger, defaultQueueName)
-}
-
-// NewFinalizingImpl returns a {{.controllerImpl|raw}} that handles queuing and feeding work from
-// the queue through an implementation of {{.controllerReconciler|raw}}, delegating to
-// the provided Interface with automatic addition and removal of the provided
-// finalizer name.
-func NewFinalizingImpl(ctx context.Context, r Interface, finalizer string) *{{.controllerImpl|raw}} {
-	logger := {{.loggingFromContext|raw}}(ctx)
-	rec := newRecordedReconcilerImpl(ctx, r)
-	finalizer = strings.TrimSpace(finalizer)
-	if finalizer == "" {
-		finalizer = defaultFinalizerName
-	}
-	rec.finalizerName = {{.ptrString|raw}}(finalizer)
-	return {{.controllerNewImpl|raw}}(rec, logger, defaultQueueName)
-}
-
-func newRecordedReconcilerImpl(ctx context.Context, r Interface) *reconcilerImpl {
-	logger := {{.loggingFromContext|raw}}(ctx)
-
 	{{.type|lowercaseSingular}}Informer := {{.informerGet|raw}}(ctx)
 
 	recorder := {{.controllerGetEventRecorder|raw}}(ctx)
@@ -190,12 +168,13 @@ func newRecordedReconcilerImpl(ctx context.Context, r Interface) *reconcilerImpl
 		}()
 	}
 
-	return &reconcilerImpl{
+	rec := &reconcilerImpl{
 		Client:  {{.clientGet|raw}}(ctx),
 		Lister:  {{.type|lowercaseSingular}}Informer.Lister(),
 		Recorder: recorder,
 		reconciler:    r,
 	}
+	return {{.controllerNewImpl|raw}}(rec, logger, defaultQueueName)
 }
 
 func init() {

--- a/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -32,6 +32,7 @@ type reconcilerControllerGenerator struct {
 	imports       namer.ImportTracker
 	filtered      bool
 
+	groupName           string
 	clientPkg           string
 	schemePkg           string
 	informerPackagePath string
@@ -65,7 +66,8 @@ func (g *reconcilerControllerGenerator) GenerateType(c *generator.Context, t *ty
 	klog.V(5).Infof("processing type %v", t)
 
 	m := map[string]interface{}{
-		"type": t,
+		"type":  t,
+		"group": g.groupName,
 		"controllerImpl": c.Universe.Type(types.Name{
 			Package: "knative.dev/pkg/controller",
 			Name:    "Impl",
@@ -136,7 +138,7 @@ func (g *reconcilerControllerGenerator) GenerateType(c *generator.Context, t *ty
 var reconcilerControllerNewImpl = `
 const (
 	defaultControllerAgentName = "{{.type|lowercaseSingular}}-controller"
-	defaultFinalizerName       = "{{.type|lowercaseSingular}}.{{.type|apiGroup}}" // TODO: check this. DO NOT SUBMIT
+	defaultFinalizerName       = "{{.type|allLowercasePlural}}.{{.group}}"
 	defaultQueueName           = "{{.type|allLowercasePlural}}"
 )
 

--- a/codegen/cmd/injection-gen/generators/reconciler_controller_stub.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller_stub.go
@@ -75,10 +75,6 @@ func (g *reconcilerControllerStubGenerator) GenerateType(c *generator.Context, t
 			Package: g.reconcilerPkg,
 			Name:    "NewImpl",
 		}),
-		"reconcilerNewFinalizingImpl": c.Universe.Type(types.Name{
-			Package: g.reconcilerPkg,
-			Name:    "NewFinalizingImpl",
-		}),
 		"loggingFromContext": c.Universe.Function(types.Name{
 			Package: "knative.dev/pkg/logging",
 			Name:    "FromContext",
@@ -106,9 +102,6 @@ func NewController(
 
 	r := &Reconciler{}
 	impl := {{.reconcilerNewImpl|raw}}(ctx, r)
-
-	// Alternatively, if {{.type|public}} requires a finalizer:
-	// impl := {{.reconcilerNewFinalizingImpl|raw}}(ctx, r, "")
 
 	logger.Info("Setting up event handlers.")
 

--- a/codegen/cmd/injection-gen/generators/reconciler_controller_stub.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller_stub.go
@@ -75,6 +75,10 @@ func (g *reconcilerControllerStubGenerator) GenerateType(c *generator.Context, t
 			Package: g.reconcilerPkg,
 			Name:    "NewImpl",
 		}),
+		"reconcilerNewFinalizingImpl": c.Universe.Type(types.Name{
+			Package: g.reconcilerPkg,
+			Name:    "NewFinalizingImpl",
+		}),
 		"loggingFromContext": c.Universe.Function(types.Name{
 			Package: "knative.dev/pkg/logging",
 			Name:    "FromContext",
@@ -102,6 +106,9 @@ func NewController(
 
 	r := &Reconciler{}
 	impl := {{.reconcilerNewImpl|raw}}(ctx, r)
+
+	// Alternatively, if {{.type|public}} requires a finalizer:
+	// impl := {{.reconcilerNewFinalizingImpl|raw}}(ctx, r, "")
 
 	logger.Info("Setting up event handlers.")
 

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -218,7 +218,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	var reconcileEvent {{.reconcilerEvent|raw}}
 	if resource.GetDeletionTimestamp().IsZero() {
-		if r.isFinalizing() {
+		if _, ok := r.reconciler.(Finalizer); ok {
 			// For finalizing reconcilers, if this resource is not being deleted, mark the finalizer.
 			r.setFinalizer(resource)
 		}
@@ -360,11 +360,6 @@ func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, desired *
 
 	update, err := r.Client.{{.type|versionedClientset}}().{{.type|apiGroup}}(desired.Namespace).Patch(existing.Name, types.MergePatchType, patch)
 	return update, true, err
-}
-
-func (r *reconcilerImpl) isFinalizing() bool {
-	_, ok := r.reconciler.(Finalizer)
-	return ok
 }
 
 func (r *reconcilerImpl) setFinalizer(a *{{.type|raw}}) {

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
@@ -107,11 +107,6 @@ var _ {{.reconcilerInterface|raw}} = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx context.Context, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
-	if o.GetDeletionTimestamp() != nil {
-		// Check for a DeletionTimestamp.  If present, elide the normal reconcile logic.
-		// When a controller needs finalizer handling, it would go here.
-		return nil
-	}
 	o.Status.InitializeConditions()
 
 	// TODO: add custom reconciliation logic here.
@@ -119,4 +114,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *{{.type|raw}}) {{.rec
 	o.Status.ObservedGeneration = o.Generation
 	return newReconciledNormal(o.Namespace, o.Name)
 }
+
+// Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called
+// when the resource is deleted.
+//func (r *Reconciler) FinalizeKind(ctx context.Context, o *v1alpha1.AddressableService) reconciler.Event {
+//	// TODO: add custom finalization logic here.
+//	return nil
+//}
 `

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
@@ -77,6 +77,10 @@ func (g *reconcilerReconcilerStubGenerator) GenerateType(c *generator.Context, t
 			Package: g.reconcilerPkg,
 			Name:    "Interface",
 		}),
+		"reconcilerFinalizer": c.Universe.Type(types.Name{
+			Package: g.reconcilerPkg,
+			Name:    "Finalizer",
+		}),
 		"corev1EventTypeNormal": c.Universe.Type(types.Name{
 			Package: "k8s.io/api/core/v1",
 			Name:    "EventTypeNormal",
@@ -105,6 +109,10 @@ type Reconciler struct {
 // Check that our Reconciler implements Interface
 var _ {{.reconcilerInterface|raw}} = (*Reconciler)(nil)
 
+// Optionally check that our Reconciler implements Finalizer
+//var _ {{.reconcilerFinalizer|raw}} = (*Reconciler)(nil)
+
+
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx context.Context, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
 	o.Status.InitializeConditions()
@@ -117,7 +125,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *{{.type|raw}}) {{.rec
 
 // Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called
 // when the resource is deleted.
-//func (r *Reconciler) FinalizeKind(ctx context.Context, o *v1alpha1.AddressableService) reconciler.Event {
+//func (r *Reconciler) FinalizeKind(ctx context.Context, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
 //	// TODO: add custom finalization logic here.
 //	return nil
 //}


### PR DESCRIPTION
fixes https://github.com/knative/pkg/issues/1065

Implements option 1. 

Example integration: https://github.com/knative/sample-controller/pull/213/

Integrators have the option to use either managed finalizers by implementing `FinalizeKind`:

```go
func (r *Reconciler) FinalizeKind(ctx context.Context, o *v1alpha1.AddressableService) reconciler.Event {
	// TODO: add custom finalization logic here.
	return nil
}
```

or without finalizers:

```go
// no change
```