### PR TITLE
bump the minimum version to 1.15.1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -30,7 +30,7 @@ const (
 	// the Kubernetes minimum version required by Knative.
 	KubernetesMinVersionKey = "KUBERNETES_MIN_VERSION"
 
-	defaultMinimumVersion = "v1.15.0"
+	defaultMinimumVersion = "v1.15.1"
 )
 
 func getMinimumVersion() string {

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -41,16 +41,16 @@ func TestVersionCheck(t *testing.T) {
 		wantError       bool
 	}{{
 		name:          "greater version (patch)",
-		actualVersion: &testVersioner{version: "v1.15.1"},
+		actualVersion: &testVersioner{version: "v1.15.2"},
 	}, {
 		name:          "greater version (minor)",
 		actualVersion: &testVersioner{version: "v1.16.0"},
 	}, {
 		name:          "same version",
-		actualVersion: &testVersioner{version: "v1.15.0"},
+		actualVersion: &testVersioner{version: "v1.15.1"},
 	}, {
 		name:          "same version with build",
-		actualVersion: &testVersioner{version: "v1.15.0+k3s.1"},
+		actualVersion: &testVersioner{version: "v1.15.1+k3s.1"},
 	}, {
 		name:          "smaller version",
 		actualVersion: &testVersioner{version: "v1.14.3"},


### PR DESCRIPTION
Kubernetes 1.15.0 has a bug in openapi and conversion webhook does not
allow to deploy Knative resources by kubectl at all.
To avoid hit the issue, this patch bumps the minimum version to
1.15.1.

Please refer to https://github.com/knative/serving/issues/6787 for more detail.