### PR TITLE
fix filtering for reconcilers gen.

### DIFF
--- a/codegen/cmd/injection-gen/generators/packages.go
+++ b/codegen/cmd/injection-gen/generators/packages.go
@@ -405,6 +405,7 @@ func reconcilerPackages(basePackage string, groupPkgName string, gv clientgentyp
 					DefaultGen: generator.DefaultGen{
 						OptionalName: "controller",
 					},
+					typeToGenerate:      t,
 					outputPackage:       packagePath,
 					imports:             generator.NewImportTracker(),
 					groupName:           gv.Group.String(),
@@ -432,6 +433,7 @@ func reconcilerPackages(basePackage string, groupPkgName string, gv clientgentyp
 					DefaultGen: generator.DefaultGen{
 						OptionalName: "controller",
 					},
+					typeToGenerate:      t,
 					reconcilerPkg:       packagePath,
 					outputPackage:       filepath.Join(packagePath, "stub"),
 					imports:             generator.NewImportTracker(),
@@ -457,11 +459,12 @@ func reconcilerPackages(basePackage string, groupPkgName string, gv clientgentyp
 					DefaultGen: generator.DefaultGen{
 						OptionalName: "reconciler",
 					},
-					outputPackage: packagePath,
-					imports:       generator.NewImportTracker(),
-					clientsetPkg:  customArgs.VersionedClientSetPackage,
-					listerName:    t.Name.Name + "Lister",
-					listerPkg:     listerPackagePath,
+					typeToGenerate: t,
+					outputPackage:  packagePath,
+					imports:        generator.NewImportTracker(),
+					clientsetPkg:   customArgs.VersionedClientSetPackage,
+					listerName:     t.Name.Name + "Lister",
+					listerPkg:      listerPackagePath,
 				})
 
 				return generators
@@ -483,9 +486,10 @@ func reconcilerPackages(basePackage string, groupPkgName string, gv clientgentyp
 					DefaultGen: generator.DefaultGen{
 						OptionalName: "reconciler",
 					},
-					reconcilerPkg: packagePath,
-					outputPackage: filepath.Join(packagePath, "stub"),
-					imports:       generator.NewImportTracker(),
+					typeToGenerate: t,
+					reconcilerPkg:  packagePath,
+					outputPackage:  filepath.Join(packagePath, "stub"),
+					imports:        generator.NewImportTracker(),
 				})
 
 				return generators

--- a/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -28,9 +28,9 @@ import (
 // with injection.
 type reconcilerControllerGenerator struct {
 	generator.DefaultGen
-	outputPackage string
-	imports       namer.ImportTracker
-	filtered      bool
+	outputPackage  string
+	imports        namer.ImportTracker
+	typeToGenerate *types.Type
 
 	groupName           string
 	clientPkg           string
@@ -41,12 +41,8 @@ type reconcilerControllerGenerator struct {
 var _ generator.Generator = (*reconcilerControllerGenerator)(nil)
 
 func (g *reconcilerControllerGenerator) Filter(c *generator.Context, t *types.Type) bool {
-	// We generate a single client, so return true once.
-	if !g.filtered {
-		g.filtered = true
-		return true
-	}
-	return false
+	// Only process the type for this generator.
+	return t == g.typeToGenerate
 }
 
 func (g *reconcilerControllerGenerator) Namers(c *generator.Context) namer.NameSystems {

--- a/codegen/cmd/injection-gen/generators/reconciler_controller_stub.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller_stub.go
@@ -29,9 +29,9 @@ import (
 // controller for a custom impl with injection.
 type reconcilerControllerStubGenerator struct {
 	generator.DefaultGen
-	outputPackage string
-	imports       namer.ImportTracker
-	filtered      bool
+	outputPackage  string
+	imports        namer.ImportTracker
+	typeToGenerate *types.Type
 
 	reconcilerPkg       string
 	informerPackagePath string
@@ -40,12 +40,8 @@ type reconcilerControllerStubGenerator struct {
 var _ generator.Generator = (*reconcilerControllerStubGenerator)(nil)
 
 func (g *reconcilerControllerStubGenerator) Filter(c *generator.Context, t *types.Type) bool {
-	// We generate a single client, so return true once.
-	if !g.filtered {
-		g.filtered = true
-		return true
-	}
-	return false
+	// Only process the type for this generator.
+	return t == g.typeToGenerate
 }
 
 func (g *reconcilerControllerStubGenerator) Namers(c *generator.Context) namer.NameSystems {

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -28,23 +28,19 @@ import (
 // reconcilerReconcilerGenerator produces a reconciler struct for the given type.
 type reconcilerReconcilerGenerator struct {
 	generator.DefaultGen
-	outputPackage string
-	imports       namer.ImportTracker
-	filtered      bool
-	clientsetPkg  string
-	listerName    string
-	listerPkg     string
+	outputPackage  string
+	imports        namer.ImportTracker
+	typeToGenerate *types.Type
+	clientsetPkg   string
+	listerName     string
+	listerPkg      string
 }
 
 var _ generator.Generator = (*reconcilerReconcilerGenerator)(nil)
 
 func (g *reconcilerReconcilerGenerator) Filter(c *generator.Context, t *types.Type) bool {
-	// We generate a single client, so return true once.
-	if !g.filtered {
-		g.filtered = true
-		return true
-	}
-	return false
+	// Only process the type for this generator.
+	return t == g.typeToGenerate
 }
 
 func (g *reconcilerReconcilerGenerator) Namers(c *generator.Context) namer.NameSystems {

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
@@ -29,9 +29,9 @@ import (
 // implement the reconciler.
 type reconcilerReconcilerStubGenerator struct {
 	generator.DefaultGen
-	outputPackage string
-	imports       namer.ImportTracker
-	filtered      bool
+	outputPackage  string
+	imports        namer.ImportTracker
+	typeToGenerate *types.Type
 
 	reconcilerPkg string
 }
@@ -39,12 +39,8 @@ type reconcilerReconcilerStubGenerator struct {
 var _ generator.Generator = (*reconcilerReconcilerStubGenerator)(nil)
 
 func (g *reconcilerReconcilerStubGenerator) Filter(c *generator.Context, t *types.Type) bool {
-	// We generate a single client, so return true once.
-	if !g.filtered {
-		g.filtered = true
-		return true
-	}
-	return false
+	// Only process the type for this generator.
+	return t == g.typeToGenerate
 }
 
 func (g *reconcilerReconcilerStubGenerator) Namers(c *generator.Context) namer.NameSystems {


### PR DESCRIPTION
I never saw the filter for generators work because I have only been doing one at a time integrations. With two, the filter for type was wrong and would always pick the first one. 

this fixes that filter issue.