### PR TITLE
Auto set observed generation

### DIFF
--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -236,6 +236,10 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		}
 	}
 
+        // Since the Reconciler observed this object, update the Status.ObservedGeneration
+        // to match the objects ObservedGeneration.
+        resource.Status.ObservedGeneration = original.Generation
+
 	// Synchronize the status.
 	if equality.Semantic.DeepEqual(original.Status, resource.Status) {
 		// If we didn't change anything then don't call updateStatus.

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
@@ -115,7 +115,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *{{.type|raw}}) {{.rec
 
 	// TODO: add custom reconciliation logic here.
 
-	o.Status.ObservedGeneration = o.Generation
 	return newReconciledNormal(o.Namespace, o.Name)
 }
 


### PR DESCRIPTION
I can't think of a single case where we wouldn't want to do this for our resources and can think of many cases where it's been a source of bugs.

The one reason why we wouldn't want to do this is that if this is reconciling objects that do not expose the Status.ObservedGeneration field however. Since have that in stub however as well, seemed like the intent is that the resources will have these fields, but I can see the stub breaking is less of an issue than the generated one.

If I had enough template fu, maybe we could look and if the type implements this will we do it.

But in any case, just wanted to throw it out there as a thought.