### PR TITLE
[Reconciler Generators] Adding support for configStore.ToContext

### DIFF
--- a/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -133,6 +133,10 @@ func (g *reconcilerControllerGenerator) GenerateType(c *generator.Context, t *ty
 			Package: "knative.dev/pkg/controller",
 			Name:    "OptionsFn",
 		}),
+		"contextContext": c.Universe.Type(types.Name{
+			Package: "context",
+			Name:    "Context",
+		}),
 	}
 
 	sw.Do(reconcilerControllerNewImpl, m)
@@ -151,7 +155,7 @@ const (
 // the queue through an implementation of {{.controllerReconciler|raw}}, delegating to
 // the provided Interface and optional Finalizer methods. OptionsFn is used to return
 // {{.controllerOptions|raw}} to be used but the internal reconciler.
-func NewImpl(ctx context.Context, r Interface, optionsFns ...{{.controllerOptionsFn|raw}}) *{{.controllerImpl|raw}} {
+func NewImpl(ctx {{.contextContext|raw}}, r Interface, optionsFns ...{{.controllerOptionsFn|raw}}) *{{.controllerImpl|raw}} {
 	logger := {{.loggingFromContext|raw}}(ctx)
 
 	// Check the options function input. It should be 0 or 1.

--- a/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -187,7 +187,7 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...OptionsFn) *{{.cont
 	impl := {{.controllerNewImpl|raw}}(rec, logger, defaultQueueName)
 
 	// Pass impl to the options. Save any optional results.
-	for _, fn := range optionFns {
+	for _, fn := range optionsFns {
 		opts := fn(impl)
 		if opts.ConfigStore != nil {
 			rec.configStore = opts.ConfigStore

--- a/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -193,7 +193,7 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...OptionsFn) *{{.cont
 			rec.configStore = opts.ConfigStore
 		}
 	}
-	
+
 	return impl
 }
 

--- a/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -129,6 +129,10 @@ func (g *reconcilerControllerGenerator) GenerateType(c *generator.Context, t *ty
 			Package: "knative.dev/pkg/controller",
 			Name:    "Options",
 		}),
+		"controllerOptionsFn": c.Universe.Type(types.Name{
+			Package: "knative.dev/pkg/controller",
+			Name:    "OptionsFn",
+		}),
 	}
 
 	sw.Do(reconcilerControllerNewImpl, m)
@@ -143,13 +147,11 @@ const (
 	defaultQueueName           = "{{.type|allLowercasePlural}}"
 )
 
-type OptionsFn func (impl *{{.controllerImpl|raw}}) {{.controllerOptions|raw}}
-
 // NewImpl returns a {{.controllerImpl|raw}} that handles queuing and feeding work from
 // the queue through an implementation of {{.controllerReconciler|raw}}, delegating to
 // the provided Interface and optional Finalizer methods. OptionsFn is used to return
 // {{.controllerOptions|raw}} to be used but the internal reconciler.
-func NewImpl(ctx context.Context, r Interface, optionsFns ...OptionsFn) *{{.controllerImpl|raw}} {
+func NewImpl(ctx context.Context, r Interface, optionsFns ...{{.controllerOptionsFn|raw}}) *{{.controllerImpl|raw}} {
 	logger := {{.loggingFromContext|raw}}(ctx)
 
 	// Check the options function input. It should be 0 or 1.

--- a/codegen/cmd/injection-gen/generators/reconciler_controller_stub.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller_stub.go
@@ -18,7 +18,6 @@ package generators
 
 import (
 	"io"
-
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
@@ -75,6 +74,14 @@ func (g *reconcilerControllerStubGenerator) GenerateType(c *generator.Context, t
 			Package: "knative.dev/pkg/logging",
 			Name:    "FromContext",
 		}),
+		"contextContext": c.Universe.Type(types.Name{
+			Package: "context",
+			Name:    "Context",
+		}),
+		"configmapWatcher": c.Universe.Type(types.Name{
+			Package: "knative.dev/pkg/configmap",
+			Name:    "Watcher",
+		}),
 	}
 
 	sw.Do(reconcilerControllerStub, m)
@@ -87,8 +94,8 @@ var reconcilerControllerStub = `
 
 // NewController creates a Reconciler for {{.type|public}} and returns the result of NewImpl.
 func NewController(
-	ctx context.Context,
-	cmw configmap.Watcher,
+	ctx {{.contextContext|raw}},
+	cmw {{.configmapWatcher|raw}},
 ) *{{.controllerImpl|raw}} {
 	logger := {{.loggingFromContext|raw}}(ctx)
 

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -197,7 +197,7 @@ func NewReconciler(ctx context.Context, logger *{{.zapSugaredLogger|raw}}, clien
 		Recorder: recorder,
 		reconciler:    r,
 	}
-	
+
 	for _, opts := range options {
 		if opts.ConfigStore != nil {
 			rec.configStore = opts.ConfigStore

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -214,7 +214,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	logger := {{.loggingFromContext|raw}}(ctx)
 
 	// If configStore is set, attach the frozen configuration to the context.
-	if r.configStore {
+	if r.configStore != nil {
 		ctx = r.configStore.ToContext(ctx)
 	}
 

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -124,6 +124,10 @@ func (g *reconcilerReconcilerGenerator) GenerateType(c *generator.Context, t *ty
 			Package: "knative.dev/pkg/controller",
 			Name:    "Options",
 		}),
+		"contextContext": c.Universe.Type(types.Name{
+			Package: "context",
+			Name:    "Context",
+		}),
 	}
 
 	sw.Do(reconcilerInterfaceFactory, m)
@@ -145,7 +149,7 @@ type Interface interface {
 	// for the Kind inside of ReconcileKind, it is the responsibility of the calling
 	// controller to propagate those properties. The resource passed to ReconcileKind
  	// will always have an empty deletion timestamp.
-	ReconcileKind(ctx context.Context, o *{{.type|raw}}) {{.reconcilerEvent|raw}}
+	ReconcileKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}}
 }
 
 // Finalizer defines the strongly typed interfaces to be implemented by a
@@ -156,7 +160,7 @@ type Finalizer interface {
 	// Normal type {{.reconcilerEvent|raw}} will allow the finalizer to be deleted on
 	// the resource. The resource passed to FinalizeKind will always have a set
 	// deletion timestamp.
-	FinalizeKind(ctx context.Context, o *{{.type|raw}}) {{.reconcilerEvent|raw}}
+	FinalizeKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}}
 }
 
 // reconcilerImpl implements controller.Reconciler for {{.type|raw}} resources.
@@ -185,7 +189,7 @@ var _ controller.Reconciler = (*reconcilerImpl)(nil)
 `
 
 var reconcilerNewReconciler = `
-func NewReconciler(ctx context.Context, logger *{{.zapSugaredLogger|raw}}, client {{.clientsetInterface|raw}}, lister {{.resourceLister|raw}}, recorder {{.recordEventRecorder|raw}}, r Interface, options ...{{.controllerOptions|raw}} ) {{.controllerReconciler|raw}} {
+func NewReconciler(ctx {{.contextContext|raw}}, logger *{{.zapSugaredLogger|raw}}, client {{.clientsetInterface|raw}}, lister {{.resourceLister|raw}}, recorder {{.recordEventRecorder|raw}}, r Interface, options ...{{.controllerOptions|raw}} ) {{.controllerReconciler|raw}} {
 	// Check the options function input. It should be 0 or 1.
 	if len(options) > 1 {
 		logger.Fatalf("up to one options struct is supported, found %d", len(options))
@@ -210,7 +214,7 @@ func NewReconciler(ctx context.Context, logger *{{.zapSugaredLogger|raw}}, clien
 
 var reconcilerImplFactory = `
 // Reconcile implements controller.Reconciler
-func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
+func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) error {
 	logger := {{.loggingFromContext|raw}}(ctx)
 
 	// If configStore is set, attach the frozen configuration to the context.
@@ -321,7 +325,7 @@ var reconcilerFinalizerFactory = `
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *{{.type|raw}}) error {
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx {{.contextContext|raw}}, resource *{{.type|raw}}) error {
 	finalizerName := defaultFinalizerName
 
 	actual, err := r.Lister.{{.type|apiGroup}}(resource.Namespace).Get(resource.Name)
@@ -378,7 +382,7 @@ func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource 
 	return err
 }
 
-func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *{{.type|raw}}) error {
+func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx {{.contextContext|raw}}, resource *{{.type|raw}}) error {
 	if _, ok := r.reconciler.(Finalizer); !ok {
 		return nil
 	}
@@ -396,7 +400,7 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 	return r.updateFinalizersFiltered(ctx, resource)
 }
 
-func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *{{.type|raw}}, reconcileEvent {{.reconcilerEvent|raw}}) error {
+func (r *reconcilerImpl) clearFinalizer(ctx {{.contextContext|raw}}, resource *{{.type|raw}}, reconcileEvent {{.reconcilerEvent|raw}}) error {
 	if _, ok := r.reconciler.(Finalizer); !ok {
 		return nil
 	}
@@ -409,7 +413,7 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *{{.type|r
 	if reconcileEvent != nil {
 		var event *{{.reconcilerReconcilerEvent|raw}}
 		if reconciler.EventAs(reconcileEvent, &event) {
-			if event.EventType == v1.EventTypeNormal {
+			if event.EventType == {{.corev1EventTypeNormal|raw}} {
 				finalizers.Delete(defaultFinalizerName)
 			}
 		}

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -82,10 +82,10 @@ func (g *reconcilerReconcilerGenerator) GenerateType(c *generator.Context, t *ty
 			Package: "k8s.io/api/core/v1",
 			Name:    "EventTypeWarning",
 		}),
-		"reconcilerEvent":           c.Universe.Type(types.Name{Package: "knative.dev/pkg/reconciler", Name: "Event"}),
-		"reconcilerReconcilerEvent": c.Universe.Type(types.Name{Package: "knative.dev/pkg/reconciler", Name: "ReconcilerEvent"}),
-
+		"reconcilerEvent":                c.Universe.Type(types.Name{Package: "knative.dev/pkg/reconciler", Name: "Event"}),
+		"reconcilerReconcilerEvent":      c.Universe.Type(types.Name{Package: "knative.dev/pkg/reconciler", Name: "ReconcilerEvent"}),
 		"reconcilerRetryUpdateConflicts": c.Universe.Function(types.Name{Package: "knative.dev/pkg/reconciler", Name: "RetryUpdateConflicts"}),
+		"reconcilerConfigStore":          c.Universe.Type(types.Name{Name: "ConfigStore", Package: "knative.dev/pkg/reconciler"}),
 		// Deps
 		"clientsetInterface": c.Universe.Type(types.Name{Name: "Interface", Package: g.clientsetPkg}),
 		"resourceLister":     c.Universe.Type(types.Name{Name: g.listerName, Package: g.listerPkg}),
@@ -119,6 +119,10 @@ func (g *reconcilerReconcilerGenerator) GenerateType(c *generator.Context, t *ty
 		"setsNewString": c.Universe.Function(types.Name{
 			Package: "k8s.io/apimachinery/pkg/util/sets",
 			Name:    "NewString",
+		}),
+		"controllerOptions": c.Universe.Type(types.Name{
+			Package: "knative.dev/pkg/controller",
+			Name:    "Options",
 		}),
 	}
 
@@ -167,6 +171,10 @@ type reconcilerImpl struct {
 	// Kubernetes API.
 	Recorder {{.recordEventRecorder|raw}}
 
+	// configStore allows for decorating a context with config maps.
+	// +optional
+	configStore {{.reconcilerConfigStore|raw}}
+
 	// reconciler is the implementation of the business logic of the resource.
 	reconciler Interface
 }
@@ -177,13 +185,26 @@ var _ controller.Reconciler = (*reconcilerImpl)(nil)
 `
 
 var reconcilerNewReconciler = `
-func NewReconciler(ctx context.Context, logger *{{.zapSugaredLogger|raw}}, client {{.clientsetInterface|raw}}, lister {{.resourceLister|raw}}, recorder {{.recordEventRecorder|raw}}, r Interface) {{.controllerReconciler|raw}} {
-	return &reconcilerImpl{
+func NewReconciler(ctx context.Context, logger *{{.zapSugaredLogger|raw}}, client {{.clientsetInterface|raw}}, lister {{.resourceLister|raw}}, recorder {{.recordEventRecorder|raw}}, r Interface, options ...{{.controllerOptions|raw}} ) {{.controllerReconciler|raw}} {
+	// Check the options function input. It should be 0 or 1.
+	if len(options) > 1 {
+		logger.Fatalf("up to one options struct is supported, found %d", len(options))
+	}
+
+	rec := &reconcilerImpl{
 		Client: client,
 		Lister: lister,
 		Recorder: recorder,
 		reconciler:    r,
 	}
+	
+	for _, opts := range options {
+		if opts.ConfigStore != nil {
+			rec.configStore = opts.ConfigStore
+		}
+	}
+
+	return rec
 }
 `
 
@@ -192,17 +213,17 @@ var reconcilerImplFactory = `
 func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	logger := {{.loggingFromContext|raw}}(ctx)
 
+	// If configStore is set, attach the frozen configuration to the context.
+	if r.configStore {
+		ctx = r.configStore.ToContext(ctx)
+	}
+
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := {{.cacheSplitMetaNamespaceKey|raw}}(key)
 	if err != nil {
 		logger.Errorf("invalid resource key: %s", key)
 		return nil
 	}
-
-    // TODO(n3wscott): this is needed for serving.
- 	// If our controller has configuration state, we'd "freeze" it and
-	// attach the frozen configuration to the context.
-	//    ctx = r.configStore.ToContext(ctx)
 
 	// Get the resource with this namespace/name.
 	original, err := r.Lister.{{.type|apiGroup}}(namespace).Get(name)
@@ -218,6 +239,9 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	var reconcileEvent {{.reconcilerEvent|raw}}
 	if resource.GetDeletionTimestamp().IsZero() {
+		// Append the target method to the logger.
+		logger = logger.With(zap.String("targetMethod", "ReconcileKind"))
+
 		// Set and update the finalizer on resource if r.reconciler
 		// implements Finalizer.
 		if err := r.setFinalizerIfFinalizer(ctx, resource); err != nil {
@@ -228,6 +252,9 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		// updates regardless of whether the reconciliation errored out.
 		reconcileEvent = r.reconciler.ReconcileKind(ctx, resource)
 	} else if fin, ok := r.reconciler.(Finalizer); ok {
+		// Append the target method to the logger.
+		logger = logger.With(zap.String("targetMethod", "FinalizeKind"))
+
 		// For finalizing reconcilers, if this resource being marked for deletion
 		// and reconciled cleanly (nil or normal event), remove the finalizer.
 		reconcileEvent = fin.FinalizeKind(ctx, resource)
@@ -253,11 +280,11 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	if reconcileEvent != nil {
 		var event *{{.reconcilerReconcilerEvent|raw}}
 		if reconciler.EventAs(reconcileEvent, &event) {
-			logger.Infow("ReconcileKind returned an event", zap.Any("event", reconcileEvent))
+			logger.Infow("returned an event", zap.Any("event", reconcileEvent))
 			r.Recorder.Eventf(resource, event.EventType, event.Reason, event.Format, event.Args...)
 			return nil
 		} else {
-			logger.Errorw("ReconcileKind returned an error", zap.Error(reconcileEvent))
+			logger.Errorw("returned an error", zap.Error(reconcileEvent))
 			r.Recorder.Event(resource, {{.corev1EventTypeWarning|raw}}, "InternalError", reconcileEvent.Error())
 			return reconcileEvent
 		}

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
@@ -81,6 +81,10 @@ func (g *reconcilerReconcilerStubGenerator) GenerateType(c *generator.Context, t
 			Package: "k8s.io/api/core/v1",
 			Name:    "EventTypeNormal",
 		}),
+		"contextContext": c.Universe.Type(types.Name{
+			Package: "context",
+			Name:    "Context",
+		}),
 	}
 
 	sw.Do(reconcilerReconcilerStub, m)
@@ -110,7 +114,7 @@ var _ {{.reconcilerInterface|raw}} = (*Reconciler)(nil)
 
 
 // ReconcileKind implements Interface.ReconcileKind.
-func (r *Reconciler) ReconcileKind(ctx context.Context, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
+func (r *Reconciler) ReconcileKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
 	o.Status.InitializeConditions()
 
 	// TODO: add custom reconciliation logic here.
@@ -121,7 +125,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *{{.type|raw}}) {{.rec
 
 // Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called
 // when the resource is deleted.
-//func (r *Reconciler) FinalizeKind(ctx context.Context, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
+//func (r *Reconciler) FinalizeKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
 //	// TODO: add custom finalization logic here.
 //	return nil
 //}

--- a/controller/options.go
+++ b/controller/options.go
@@ -24,3 +24,8 @@ type Options struct {
 	// ConfigStore is used to attach the frozen configuration to the context.
 	ConfigStore reconciler.ConfigStore
 }
+
+// OptionsFn is a callback method signature that accepts an Impl and returns
+// Options. Used for controllers that need access to the members of Options but
+// to build Options, integrators need an Impl.
+type OptionsFn func(impl *Impl) Options

--- a/controller/options.go
+++ b/controller/options.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import "knative.dev/pkg/reconciler"
+
+// Options is additional resources a Controller might want to use depending
+// on implementation.
+type Options struct {
+	// ConfigStore is used to attach the frozen configuration to the context.
+	ConfigStore reconciler.ConfigStore
+}

--- a/injection/README.md
+++ b/injection/README.md
@@ -371,21 +371,21 @@ To add this feature to the generated reconciler, it will have to be passed in on
 kindreconciler "knative.dev/<repo>/pkg/client/injection/reconciler/<clientgroup>/<version>/<resource>"
 ...
 impl := kindreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
-	    // Setup options that require access to a controller.Impl.
-		configsToResync := []interface{}{
-			&some.Config{},
-		}
-		resyncOnConfigChange := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
-			impl.FilteredGlobalResync(myFilterFunc, kindInformer.Informer())
-		})
-		configStore := config.NewStore(c.Logger.Named("config-store"), resyncOnConfigChange)
-		configStore.WatchConfigs(cmw)
-
-        // Return the controller options.
-		return controller.Options{
-			ConfigStore: configStore,
-		}
+	// Setup options that require access to a controller.Impl.
+	configsToResync := []interface{}{
+		&some.Config{},
+	}
+	resyncOnConfigChange := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
+		impl.FilteredGlobalResync(myFilterFunc, kindInformer.Informer())
 	})
+	configStore := config.NewStore(c.Logger.Named("config-store"), resyncOnConfigChange)
+	configStore.WatchConfigs(cmw)
+
+	// Return the controller options.
+	return controller.Options{
+		ConfigStore: configStore,
+	}
+})
 ```
 
 ### Artifacts

--- a/injection/README.md
+++ b/injection/README.md
@@ -63,9 +63,9 @@ impl := controller.NewImpl(c, logger, "NameOfController")
 becomes
 
 ```go
-reconciler "knative.dev/<repo>/pkg/client/injection/reconciler/<clientgroup>/<version>/<resource>"
+kindreconciler "knative.dev/<repo>/pkg/client/injection/reconciler/<clientgroup>/<version>/<resource>"
 ...
-impl := reconciler.NewImpl(ctx, c)
+impl := kindreconciler.NewImpl(ctx, c)
 ```
 
 See
@@ -358,6 +358,34 @@ Future features to be considered:
     will synchronize it back to the API Server.
 - Adjust `+genreconciler` to allow for generated reconcilers to be made without
   annotating the type struct.
+
+### ConfigStore
+
+Config store is used to decorate the context with a snapshot of configmaps to be used in a reconciler method.
+
+To add this feature to the generated reconciler, it will have to be passed in on `reconciler<kind>.NewImpl` like so:
+
+```go
+controller "knative.dev/pkg/controller"
+kindreconciler "knative.dev/<repo>/pkg/client/injection/reconciler/<clientgroup>/<version>/<resource>"
+...
+impl := kindreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
+	    // Setup options that require access to a controller.Impl.
+		configsToResync := []interface{}{
+			&some.Config{},
+		}
+		resyncOnConfigChange := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
+			impl.FilteredGlobalResync(myFilterFunc, kindInformer.Informer())
+		})
+		configStore := config.NewStore(c.Logger.Named("config-store"), resyncOnConfigChange)
+		configStore.WatchConfigs(cmw)
+
+        // Return the controller options.
+		return controller.Options{
+			ConfigStore: configStore,
+		}
+	})
+```  
 
 ### Artifacts
 

--- a/injection/README.md
+++ b/injection/README.md
@@ -361,12 +361,13 @@ Future features to be considered:
 
 ### ConfigStore
 
-Config store is used to decorate the context with a snapshot of configmaps to be used in a reconciler method.
+Config store is used to decorate the context with a snapshot of configmaps to be
+used in a reconciler method.
 
-To add this feature to the generated reconciler, it will have to be passed in on `reconciler<kind>.NewImpl` like so:
+To add this feature to the generated reconciler, it will have to be passed in on
+`reconciler<kind>.NewImpl` like so:
 
 ```go
-controller "knative.dev/pkg/controller"
 kindreconciler "knative.dev/<repo>/pkg/client/injection/reconciler/<clientgroup>/<version>/<resource>"
 ...
 impl := kindreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
@@ -385,7 +386,7 @@ impl := kindreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Op
 			ConfigStore: configStore,
 		}
 	})
-```  
+```
 
 ### Artifacts
 

--- a/reconciler/configstore.go
+++ b/reconciler/configstore.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Veroute.on 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import "context"
+
+// ConfigStore is used to attach the frozen configuration to the context.
+type ConfigStore interface {
+	// ConfigStore is used to attach the frozen configuration to the context.
+	ToContext(ctx context.Context) context.Context
+}


### PR DESCRIPTION
Serving uses snapshot config files all over the place, this change allows the context to be modified by a passed on configStore decorator.

/assign @mattmoor 