### PR TITLE
Updating comment on Destination

### DIFF
--- a/apis/duck/v1/source_types.go
+++ b/apis/duck/v1/source_types.go
@@ -48,8 +48,7 @@ type Source struct {
 }
 
 type SourceSpec struct {
-	// Sink is a reference to an object that will resolve to a domain name or a
-	// URI directly to use as the sink.
+	// Sink is a reference to an object that will resolve to a uri to use as the sink.
 	Sink Destination `json:"sink,omitempty"`
 
 	// CloudEventOverrides defines overrides to control the output format and


### PR DESCRIPTION
Update was discussed in eventing [PR 2564](https://github.com/knative/eventing/pull/2564), because it's no longer a domain name, but merely a URI.

/assign @vaikas
/assign @n3wscott  

Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>