### PR TITLE
Renews a webhook cert before it expires

### DIFF
--- a/test/webhook-apicoverage/webhook/webhook.go
+++ b/test/webhook-apicoverage/webhook/webhook.go
@@ -85,7 +85,7 @@ type APICoverageWebhook struct {
 }
 
 func (acw *APICoverageWebhook) generateServerConfig() (*tls.Config, error) {
-	serverKey, serverCert, caCert, err := certresources.CreateCerts(context.Background(), acw.ServiceName, acw.Namespace, time.Now()AddDate(1, 0, 0))
+	serverKey, serverCert, caCert, err := certresources.CreateCerts(context.Background(), acw.ServiceName, acw.Namespace, time.Now().AddDate(1, 0, 0))
 	if err != nil {
 		return nil, fmt.Errorf("Error creating webhook certificates: %v", err)
 	}

--- a/test/webhook-apicoverage/webhook/webhook.go
+++ b/test/webhook-apicoverage/webhook/webhook.go
@@ -85,7 +85,7 @@ type APICoverageWebhook struct {
 }
 
 func (acw *APICoverageWebhook) generateServerConfig() (*tls.Config, error) {
-	serverKey, serverCert, caCert, err := certresources.CreateCerts(context.Background(), acw.ServiceName, acw.Namespace)
+	serverKey, serverCert, caCert, err := certresources.CreateCerts(context.Background(), acw.ServiceName, acw.Namespace, time.Now()AddDate(1, 0, 0))
 	if err != nil {
 		return nil, fmt.Errorf("Error creating webhook certificates: %v", err)
 	}

--- a/webhook/certificates/certificates.go
+++ b/webhook/certificates/certificates.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	// Time used for updating a certificate before it expires. Default 1 week.
-	oneWeek = 168 * time.Hour
+	oneWeek = 7 * 24 * time.Hour
 )
 
 type reconciler struct {
@@ -78,13 +78,12 @@ func (r *reconciler) reconcileCertificate(ctx context.Context) error {
 		// Check the expiration date of the certificate to see if it needs to be updated
 		cert, err := tls.X509KeyPair(secret.Data[certresources.ServerCert], secret.Data[certresources.ServerKey])
 		if err != nil {
-			logger.Errorf("error creating pem from certificate and key: %v", err)
+			logger.Warnf("Error creating pem from certificate and key: %v", err)
 		} else {
 			certData, err := x509.ParseCertificate(cert.Certificate[0])
 			if err != nil {
-				logger.Errorf("error parsing certificate: %v", err)
-			}
-			if certData.NotAfter.Sub(time.Now()) > oneWeek {
+				logger.Errorf("Error parsing certificate: %v", err)
+			} else if time.Now().Add(oneWeek).Before(certData.NotAfter) {
 				return nil
 			}
 		}

--- a/webhook/certificates/certificates_test.go
+++ b/webhook/certificates/certificates_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	kubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
@@ -125,6 +126,19 @@ func TestReconcile(t *testing.T) {
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: secret,
 		}},
+	}, {
+		Name: "certificate expiring soon",
+		Key:  key,
+		// 6 days falls inside of the grace period of 7 days so the secret will be updated
+		Objects: []runtime.Object{secretWithCertData(t, time.Now().Add(6*24*time.Hour))},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: secret,
+		}},
+	}, {
+		Name: "certificate not expiring soon",
+		Key:  key,
+		// 8 days falls outside of the grace period of 7 days so the secret will not be updated
+		Objects: []runtime.Object{secretWithCertData(t, time.Now().Add(8*24*time.Hour))},
 	}}
 
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
@@ -199,5 +213,24 @@ func TestNew(t *testing.T) {
 	c := NewController(ctx, configmap.NewStaticWatcher())
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")
+	}
+}
+
+func secretWithCertData(t *testing.T, expiration time.Time) *corev1.Secret {
+	secretName := "webhook-secret"
+	serverKey, serverCert, caCert, err := certresources.CreateCerts(context.Background(), "webhook-service", system.Namespace(), expiration)
+	if err != nil {
+		t.Fatalf("Failed to create cert: %v", err)
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: system.Namespace(),
+		},
+		Data: map[string][]byte{
+			certresources.ServerKey:  serverKey,
+			certresources.ServerCert: serverCert,
+			certresources.CACert:     caCert,
+		},
 	}
 }

--- a/webhook/certificates/resources/certs_test.go
+++ b/webhook/certificates/resources/certs_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -28,7 +29,7 @@ import (
 )
 
 func TestCreateCerts(t *testing.T) {
-	sKey, serverCertPEM, caCertBytes, err := CreateCerts(TestContextWithLogger(t), "got-the-hook", "knative-webhook")
+	sKey, serverCertPEM, caCertBytes, err := CreateCerts(TestContextWithLogger(t), "got-the-hook", "knative-webhook", time.Now().AddDate(1, 0, 0))
 	if err != nil {
 		t.Fatalf("Failed to create certs %v", err)
 	}

--- a/webhook/certificates/resources/secret.go
+++ b/webhook/certificates/resources/secret.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"context"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,7 +41,7 @@ var MakeSecret = MakeSecretInternal
 
 // MakeSecretInternal is only public so MakeSecret can be restored in testing.  Use MakeSecret.
 func MakeSecretInternal(ctx context.Context, name, namespace, serviceName string) (*corev1.Secret, error) {
-	serverKey, serverCert, caCert, err := CreateCerts(ctx, serviceName, namespace)
+	serverKey, serverCert, caCert, err := CreateCerts(ctx, serviceName, namespace, time.Now().AddDate(1, 0, 0))
 	if err != nil {
 		return nil, err
 	}

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -19,11 +19,9 @@ package webhook
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	// Injection stuff
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -31,7 +29,6 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"knative.dev/pkg/logging"
@@ -166,15 +163,6 @@ func (wh *Webhook) Run(stop <-chan struct{}) error {
 				cert, err := tls.X509KeyPair(serverCert, serverKey)
 				if err != nil {
 					return nil, err
-				}
-				certData, err := x509.ParseCertificate(cert.Certificate[0])
-				if err != nil {
-					logger.Info("failed to parse certificate: " + err.Error())
-				}
-				oneWeek := 168 * time.Hour
-				if certData.NotAfter.Sub(time.Now()) < oneWeek {
-					wh.Client.CoreV1().Secrets(system.Namespace()).Delete(secret.Name, &metav1.DeleteOptions{})
-					logger.Info("Deleting secret so that the certificate will renew.")
 				}
 				return &cert, nil
 			},

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -19,9 +19,11 @@ package webhook
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	// Injection stuff
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -29,6 +31,7 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"knative.dev/pkg/logging"
@@ -163,6 +166,15 @@ func (wh *Webhook) Run(stop <-chan struct{}) error {
 				cert, err := tls.X509KeyPair(serverCert, serverKey)
 				if err != nil {
 					return nil, err
+				}
+				certData, err := x509.ParseCertificate(cert.Certificate[0])
+				if err != nil {
+					logger.Info("failed to parse certificate: " + err.Error())
+				}
+				oneWeek := 168 * time.Hour
+				if certData.NotAfter.Sub(time.Now()) < oneWeek {
+					wh.Client.CoreV1().Secrets(system.Namespace()).Delete(secret.Name, &metav1.DeleteOptions{})
+					logger.Info("Deleting secret so that the certificate will renew.")
 				}
 				return &cert, nil
 			},


### PR DESCRIPTION
This will remove the webhook secret(webhook-certs) so that a new secret is created if the NotAfter/Expiration date is less than a week. 