### PR TITLE
Implement strongly typed class reconcilers

### DIFF
--- a/apis/test/pub/v1alpha1/bar_types.go
+++ b/apis/test/pub/v1alpha1/bar_types.go
@@ -27,7 +27,7 @@ import (
 )
 
 // +genclient
-// +genreconciler
+// +genreconciler:class=example.com/filter.class
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Bar is for testing.

--- a/codegen/cmd/injection-gen/generators/packages.go
+++ b/codegen/cmd/injection-gen/generators/packages.go
@@ -144,7 +144,6 @@ type Tags struct {
 
 	GenerateDuck       bool
 	GenerateReconciler bool
-	ClassFilter        *string
 }
 
 func (t Tags) NeedsInformerInjection() bool {

--- a/codegen/cmd/injection-gen/generators/packages.go
+++ b/codegen/cmd/injection-gen/generators/packages.go
@@ -167,8 +167,13 @@ func MustParseClientGenTags(lines []string) Tags {
 	values := types.ExtractCommentTags("+", lines)
 
 	_, ret.GenerateDuck = values["genduck"]
-	_, ret.GenerateReconciler = values["genreconciler"]
-	_, ret.GenerateReconciler = values["genreconciler:class"]
+
+	_, genRec := values["genreconciler"]
+	_, genRecClass := values["genreconciler:class"]
+	// Generate Reconciler code if genreconciler OR genreconciler:class exist.
+	if genRec || genRecClass {
+		ret.GenerateReconciler = true
+	}
 
 	return ret
 }

--- a/codegen/cmd/injection-gen/generators/reconciler_controller_stub.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller_stub.go
@@ -35,6 +35,8 @@ type reconcilerControllerStubGenerator struct {
 
 	reconcilerPkg       string
 	informerPackagePath string
+	reconcilerClass     string
+	hasReconcilerClass  bool
 }
 
 var _ generator.Generator = (*reconcilerControllerStubGenerator)(nil)
@@ -61,7 +63,9 @@ func (g *reconcilerControllerStubGenerator) GenerateType(c *generator.Context, t
 	klog.V(5).Infof("processing type %v", t)
 
 	m := map[string]interface{}{
-		"type": t,
+		"type":     t,
+		"class":    g.reconcilerClass,
+		"hasClass": g.hasReconcilerClass,
 		"informerGet": c.Universe.Function(types.Name{
 			Package: g.informerPackagePath,
 			Name:    "Get",
@@ -103,9 +107,10 @@ func NewController(
 	{{.type|lowercaseSingular}}Informer := {{.informerGet|raw}}(ctx)
 
 	// TODO: setup additional informers here.
+	{{if .hasClass}}// TODO: pass in the expected value for the class annotation filter.{{end}}
 
 	r := &Reconciler{}
-	impl := {{.reconcilerNewImpl|raw}}(ctx, r)
+	impl := {{.reconcilerNewImpl|raw}}(ctx, r{{if .hasClass}}, "default"{{end}})
 
 	logger.Info("Setting up event handlers.")
 

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -198,7 +198,7 @@ type reconcilerImpl struct {
 	reconciler Interface
 
 	{{if .hasClass}}
-	// classValue is the resource annotation[{{ .class }}] instance value this reconciler instance filters on. 
+	// classValue is the resource annotation[{{ .class }}] instance value this reconciler instance filters on.
 	classValue string
 	{{end}}
 }

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -37,6 +37,9 @@ type reconcilerReconcilerGenerator struct {
 	listerName     string
 	listerPkg      string
 
+	reconcilerClass    string
+	hasReconcilerClass bool
+
 	groupGoName  string
 	groupVersion clientgentypes.GroupVersion
 }
@@ -65,9 +68,11 @@ func (g *reconcilerReconcilerGenerator) GenerateType(c *generator.Context, t *ty
 	klog.V(5).Infof("processing type %v", t)
 
 	m := map[string]interface{}{
-		"type":    t,
-		"group":   namer.IC(g.groupGoName),
-		"version": namer.IC(g.groupVersion.Version.String()),
+		"type":     t,
+		"group":    namer.IC(g.groupGoName),
+		"version":  namer.IC(g.groupVersion.Version.String()),
+		"class":    g.reconcilerClass,
+		"hasClass": g.hasReconcilerClass,
 		"controllerImpl": c.Universe.Type(types.Name{
 			Package: "knative.dev/pkg/controller",
 			Name:    "Impl",
@@ -191,6 +196,11 @@ type reconcilerImpl struct {
 
 	// reconciler is the implementation of the business logic of the resource.
 	reconciler Interface
+
+	{{if .hasClass}}
+	// classValue is the resource annotation[{{ .class }}] instance value this reconciler instance filters on. 
+	classValue string
+	{{end}}
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -199,7 +209,7 @@ var _ controller.Reconciler = (*reconcilerImpl)(nil)
 `
 
 var reconcilerNewReconciler = `
-func NewReconciler(ctx {{.contextContext|raw}}, logger *{{.zapSugaredLogger|raw}}, client {{.clientsetInterface|raw}}, lister {{.resourceLister|raw}}, recorder {{.recordEventRecorder|raw}}, r Interface, options ...{{.controllerOptions|raw}} ) {{.controllerReconciler|raw}} {
+func NewReconciler(ctx {{.contextContext|raw}}, logger *{{.zapSugaredLogger|raw}}, client {{.clientsetInterface|raw}}, lister {{.resourceLister|raw}}, recorder {{.recordEventRecorder|raw}}, r Interface{{if .hasClass}}, classValue string{{end}}, options ...{{.controllerOptions|raw}} ) {{.controllerReconciler|raw}} {
 	// Check the options function input. It should be 0 or 1.
 	if len(options) > 1 {
 		logger.Fatalf("up to one options struct is supported, found %d", len(options))
@@ -210,6 +220,7 @@ func NewReconciler(ctx {{.contextContext|raw}}, logger *{{.zapSugaredLogger|raw}
 		Lister: lister,
 		Recorder: recorder,
 		reconciler:    r,
+		{{if .hasClass}}classValue: classValue,{{end}}
 	}
 
 	for _, opts := range options {
@@ -251,6 +262,15 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 	} else if err != nil {
 		return err
 	}
+	{{if .hasClass}}
+	if classValue, found := original.GetAnnotations()[classAnnotationKey]; !found || classValue != r.classValue {
+		logger.Debugw("Skip reconciling resource, class annotation value does not match reconciler instance value.",
+			zap.String("classKey", classAnnotationKey),
+			zap.String("issue", classValue+"!="+r.classValue))
+		return nil
+	}
+	{{end}}
+
 	// Don't modify the informers copy.
 	resource := original.DeepCopy()
 

--- a/injection/README.md
+++ b/injection/README.md
@@ -423,6 +423,35 @@ var _ addressableservicereconciler.Interface = (*Reconciler)(nil)
 var _ addressableservicereconciler.Finalizer = (*Reconciler)(nil)
 ```
 
+#### Annotation based class filters
+
+Sometimes a reconciler only wants to reconcile a class of resource identified by
+a special annotation on the Custom Resource.
+
+This behavior can be enabled in the generators by adding the annotation class
+key to the type struct:
+
+```go
+// +genreconciler:class=example.com/filter.class
+```
+
+The `genreconciler` generator code will now have the addition of
+`classValue string` to `NewImpl` and `NewReconciler` (for tests):
+
+```go
+NewImpl(ctx context.Context, r Interface, classValue string, optionsFns ...controller.OptionsFn) *controller.Impl
+```
+
+```go
+NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versioned.Interface, lister pubv1alpha1.BarLister, recorder record.EventRecorder, r Interface, classValue string, options ...controller.Options) controller.Reconciler
+```
+
+`ReconcileKind` and `FinalizeKind` will NOT be called for resources that DO NOT
+have the provided `+genreconciler:class=<key>` key annotation. Additionally the
+value of the `<key>` annotation on a resource must match the value provided to
+`NewImpl` (or `NewReconcile`) for `ReconcileKind` or `FinalizeKind` to be called
+for that resource.
+
 #### Stubs
 
 To get started, or to use as reference. It is intended to be copied out of the


### PR DESCRIPTION
Fixes: https://github.com/knative/pkg/issues/1098

Adding a new annotation config to allow us to configure strongly classed reconcilers, such as Eventing's Broker, or Serving's Ingress.

This will be a breaking API change for types that opt into this behavior. The main changes are the addition of ` classValue string` to `NewImpl` and `NewReconciler` (for tests)

```go
NewImpl(ctx context.Context, r Interface, classValue string, optionsFns ...controller.OptionsFn) *controller.Impl
```

```go
NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versioned.Interface, lister pubv1alpha1.BarLister, recorder record.EventRecorder, r Interface, classValue string, options ...controller.Options) controller.Reconciler
```

This feature is enabled with a golang annotation argument:

```go
// +genreconciler:class=example.com/filter.class
```

