### PR TITLE
Realized a corner case on ordering and False > Unknown states.

### DIFF
--- a/apis/condition_set.go
+++ b/apis/condition_set.go
@@ -276,7 +276,7 @@ func (r conditionsImpl) MarkTrue(t ConditionType) {
 }
 
 func (r conditionsImpl) propagateFailure(org, orgTL *Condition) {
-	// First check the dependents for errors at the Error level.
+	// First check the dependents with Status == False.
 	for _, cond := range r.dependents {
 		c := r.GetCondition(cond)
 		// False conditions trump Unknown.
@@ -291,7 +291,7 @@ func (r conditionsImpl) propagateFailure(org, orgTL *Condition) {
 			return
 		}
 	}
-	// Second check for Unknown status.
+	// Second check for dependents with Status == Unknown.
 	for _, cond := range r.dependents {
 		c := r.GetCondition(cond)
 		if c.IsUnknown() {

--- a/apis/condition_set.go
+++ b/apis/condition_set.go
@@ -261,13 +261,7 @@ func (r conditionsImpl) MarkTrue(t ConditionType) {
 			// Update the happy condition if the current ready condition is
 			// marked not ready because of this condition.
 			if org.Reason == orgTL.Reason && org.Message == orgTL.Message {
-				r.SetCondition(Condition{
-					Type:     r.happy,
-					Status:   c.Status,
-					Reason:   c.Reason,
-					Message:  c.Message,
-					Severity: r.severity(r.happy),
-				})
+				r.propagateFailure(org, orgTL)
 			}
 			return
 		}
@@ -279,6 +273,38 @@ func (r conditionsImpl) MarkTrue(t ConditionType) {
 		Status:   corev1.ConditionTrue,
 		Severity: r.severity(r.happy),
 	})
+}
+
+func (r conditionsImpl) propagateFailure(org, orgTL *Condition) {
+	// First check the dependents for errors at the Error level.
+	for _, cond := range r.dependents {
+		c := r.GetCondition(cond)
+		// False conditions trump Unknown.
+		if c.IsFalse() {
+			r.SetCondition(Condition{
+				Type:     r.happy,
+				Status:   c.Status,
+				Reason:   c.Reason,
+				Message:  c.Message,
+				Severity: r.severity(r.happy),
+			})
+			return
+		}
+	}
+	// Second check for Unknown status.
+	for _, cond := range r.dependents {
+		c := r.GetCondition(cond)
+		if c.IsUnknown() {
+			r.SetCondition(Condition{
+				Type:     r.happy,
+				Status:   c.Status,
+				Reason:   c.Reason,
+				Message:  c.Message,
+				Severity: r.severity(r.happy),
+			})
+			return
+		}
+	}
 }
 
 // MarkUnknown sets the status of t to Unknown and also sets the happy condition

--- a/apis/condition_set_impl_test.go
+++ b/apis/condition_set_impl_test.go
@@ -548,6 +548,37 @@ func TestMarkTrue(t *testing.T) {
 			Reason:  "BarReason",
 			Message: "BarMsg",
 		},
+	}, {
+		name: "update dep 1/3, mixed status, still not happy",
+		conditions: Conditions{{
+			Type:    ConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  "FooReason",
+			Message: "FooMsg",
+		}, {
+			Type:    "Foo",
+			Status:  corev1.ConditionFalse,
+			Reason:  "FooReason",
+			Message: "FooMsg",
+		}, {
+			Type:    "Bar",
+			Status:  corev1.ConditionUnknown,
+			Reason:  "BarReason",
+			Message: "BarMsg",
+		}, {
+			Type:    "Baz",
+			Status:  corev1.ConditionFalse,
+			Reason:  "BazReason",
+			Message: "BazMsg",
+		}},
+		mark:  "Foo",
+		happy: false,
+		happyWant: &Condition{
+			Type:    ConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  "BazReason",
+			Message: "BazMsg",
+		},
 	}}
 	doTestMarkTrueAccessor(t, cases)
 }

--- a/apis/condition_set_impl_test.go
+++ b/apis/condition_set_impl_test.go
@@ -579,6 +579,37 @@ func TestMarkTrue(t *testing.T) {
 			Reason:  "BazReason",
 			Message: "BazMsg",
 		},
+	}, {
+		name: "update dep 1/3, unknown status, still not happy",
+		conditions: Conditions{{
+			Type:    ConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  "FooReason",
+			Message: "FooMsg",
+		}, {
+			Type:    "Foo",
+			Status:  corev1.ConditionFalse,
+			Reason:  "FooReason",
+			Message: "FooMsg",
+		}, {
+			Type:    "Bar",
+			Status:  corev1.ConditionUnknown,
+			Reason:  "BarReason",
+			Message: "BarMsg",
+		}, {
+			Type:    "Baz",
+			Status:  corev1.ConditionUnknown,
+			Reason:  "BazReason",
+			Message: "BazMsg",
+		}},
+		mark:  "Foo",
+		happy: false,
+		happyWant: &Condition{
+			Type:    ConditionReady,
+			Status:  corev1.ConditionUnknown,
+			Reason:  "BarReason",
+			Message: "BarMsg",
+		},
 	}}
 	doTestMarkTrueAccessor(t, cases)
 }


### PR DESCRIPTION
If you have the case:

Foo False
Bar Unknown
Baz False

And Foo was the last to be set, Ready will be set as Foo (message and reason)

If Foo is cleared, Baz should propagate to Ready reason and message.

This PR does that ^