### PR TITLE
Found missing forced packages in injection gen.

### DIFF
--- a/client/injection/apiextensions/client/client.go
+++ b/client/injection/apiextensions/client/client.go
@@ -19,7 +19,7 @@ limitations under the License.
 package client
 
 import (
-	"context"
+	context "context"
 
 	clientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	rest "k8s.io/client-go/rest"

--- a/client/injection/apiextensions/client/fake/fake.go
+++ b/client/injection/apiextensions/client/fake/fake.go
@@ -19,11 +19,11 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	fake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/rest"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	rest "k8s.io/client-go/rest"
 	client "knative.dev/pkg/client/injection/apiextensions/client"
 	injection "knative.dev/pkg/injection"
 	logging "knative.dev/pkg/logging"

--- a/client/injection/apiextensions/informers/apiextensions/v1beta1/customresourcedefinition/customresourcedefinition.go
+++ b/client/injection/apiextensions/informers/apiextensions/v1beta1/customresourcedefinition/customresourcedefinition.go
@@ -19,7 +19,7 @@ limitations under the License.
 package customresourcedefinition
 
 import (
-	"context"
+	context "context"
 
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1"
 	factory "knative.dev/pkg/client/injection/apiextensions/informers/factory"

--- a/client/injection/apiextensions/informers/apiextensions/v1beta1/customresourcedefinition/fake/fake.go
+++ b/client/injection/apiextensions/informers/apiextensions/v1beta1/customresourcedefinition/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	customresourcedefinition "knative.dev/pkg/client/injection/apiextensions/informers/apiextensions/v1beta1/customresourcedefinition"
 	fake "knative.dev/pkg/client/injection/apiextensions/informers/factory/fake"

--- a/client/injection/apiextensions/informers/factory/factory.go
+++ b/client/injection/apiextensions/informers/factory/factory.go
@@ -19,7 +19,7 @@ limitations under the License.
 package factory
 
 import (
-	"context"
+	context "context"
 
 	externalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	client "knative.dev/pkg/client/injection/apiextensions/client"

--- a/client/injection/apiextensions/informers/factory/fake/fake.go
+++ b/client/injection/apiextensions/informers/factory/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	externalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	fake "knative.dev/pkg/client/injection/apiextensions/client/fake"

--- a/client/injection/ducks/duck/v1/addressable/addressable.go
+++ b/client/injection/ducks/duck/v1/addressable/addressable.go
@@ -19,7 +19,7 @@ limitations under the License.
 package addressable
 
 import (
-	"context"
+	context "context"
 
 	duck "knative.dev/pkg/apis/duck"
 	v1 "knative.dev/pkg/apis/duck/v1"

--- a/client/injection/ducks/duck/v1/conditions/conditions.go
+++ b/client/injection/ducks/duck/v1/conditions/conditions.go
@@ -19,7 +19,7 @@ limitations under the License.
 package conditions
 
 import (
-	"context"
+	context "context"
 
 	duck "knative.dev/pkg/apis/duck"
 	v1 "knative.dev/pkg/apis/duck/v1"

--- a/client/injection/ducks/duck/v1/podspecable/podspecable.go
+++ b/client/injection/ducks/duck/v1/podspecable/podspecable.go
@@ -19,7 +19,7 @@ limitations under the License.
 package podspecable
 
 import (
-	"context"
+	context "context"
 
 	duck "knative.dev/pkg/apis/duck"
 	v1 "knative.dev/pkg/apis/duck/v1"

--- a/client/injection/ducks/duck/v1/source/source.go
+++ b/client/injection/ducks/duck/v1/source/source.go
@@ -19,7 +19,7 @@ limitations under the License.
 package source
 
 import (
-	"context"
+	context "context"
 
 	duck "knative.dev/pkg/apis/duck"
 	v1 "knative.dev/pkg/apis/duck/v1"

--- a/client/injection/ducks/duck/v1alpha1/addressable/addressable.go
+++ b/client/injection/ducks/duck/v1alpha1/addressable/addressable.go
@@ -19,7 +19,7 @@ limitations under the License.
 package addressable
 
 import (
-	"context"
+	context "context"
 
 	duck "knative.dev/pkg/apis/duck"
 	v1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"

--- a/client/injection/ducks/duck/v1alpha1/binding/binding.go
+++ b/client/injection/ducks/duck/v1alpha1/binding/binding.go
@@ -19,7 +19,7 @@ limitations under the License.
 package binding
 
 import (
-	"context"
+	context "context"
 
 	duck "knative.dev/pkg/apis/duck"
 	v1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"

--- a/client/injection/ducks/duck/v1alpha1/legacytargetable/legacytargetable.go
+++ b/client/injection/ducks/duck/v1alpha1/legacytargetable/legacytargetable.go
@@ -19,7 +19,7 @@ limitations under the License.
 package legacytargetable
 
 import (
-	"context"
+	context "context"
 
 	duck "knative.dev/pkg/apis/duck"
 	v1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"

--- a/client/injection/ducks/duck/v1alpha1/targetable/targetable.go
+++ b/client/injection/ducks/duck/v1alpha1/targetable/targetable.go
@@ -19,7 +19,7 @@ limitations under the License.
 package targetable
 
 import (
-	"context"
+	context "context"
 
 	duck "knative.dev/pkg/apis/duck"
 	v1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"

--- a/client/injection/ducks/duck/v1beta1/addressable/addressable.go
+++ b/client/injection/ducks/duck/v1beta1/addressable/addressable.go
@@ -19,7 +19,7 @@ limitations under the License.
 package addressable
 
 import (
-	"context"
+	context "context"
 
 	duck "knative.dev/pkg/apis/duck"
 	v1beta1 "knative.dev/pkg/apis/duck/v1beta1"

--- a/client/injection/ducks/duck/v1beta1/conditions/conditions.go
+++ b/client/injection/ducks/duck/v1beta1/conditions/conditions.go
@@ -19,7 +19,7 @@ limitations under the License.
 package conditions
 
 import (
-	"context"
+	context "context"
 
 	duck "knative.dev/pkg/apis/duck"
 	v1beta1 "knative.dev/pkg/apis/duck/v1beta1"

--- a/client/injection/ducks/duck/v1beta1/source/source.go
+++ b/client/injection/ducks/duck/v1beta1/source/source.go
@@ -19,7 +19,7 @@ limitations under the License.
 package source
 
 import (
-	"context"
+	context "context"
 
 	duck "knative.dev/pkg/apis/duck"
 	v1beta1 "knative.dev/pkg/apis/duck/v1beta1"

--- a/client/injection/kube/client/client.go
+++ b/client/injection/kube/client/client.go
@@ -19,7 +19,7 @@ limitations under the License.
 package client
 
 import (
-	"context"
+	context "context"
 
 	kubernetes "k8s.io/client-go/kubernetes"
 	rest "k8s.io/client-go/rest"

--- a/client/injection/kube/client/fake/fake.go
+++ b/client/injection/kube/client/fake/fake.go
@@ -19,11 +19,11 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
-	"k8s.io/apimachinery/pkg/runtime"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	fake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/rest"
+	rest "k8s.io/client-go/rest"
 	client "knative.dev/pkg/client/injection/kube/client"
 	injection "knative.dev/pkg/injection"
 	logging "knative.dev/pkg/logging"

--- a/client/injection/kube/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration/fake/fake.go
+++ b/client/injection/kube/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	mutatingwebhookconfiguration "knative.dev/pkg/client/injection/kube/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration/mutatingwebhookconfiguration.go
+++ b/client/injection/kube/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration/mutatingwebhookconfiguration.go
@@ -19,7 +19,7 @@ limitations under the License.
 package mutatingwebhookconfiguration
 
 import (
-	"context"
+	context "context"
 
 	v1beta1 "k8s.io/client-go/informers/admissionregistration/v1beta1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/admissionregistration/v1beta1/validatingwebhookconfiguration/fake/fake.go
+++ b/client/injection/kube/informers/admissionregistration/v1beta1/validatingwebhookconfiguration/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	validatingwebhookconfiguration "knative.dev/pkg/client/injection/kube/informers/admissionregistration/v1beta1/validatingwebhookconfiguration"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/admissionregistration/v1beta1/validatingwebhookconfiguration/validatingwebhookconfiguration.go
+++ b/client/injection/kube/informers/admissionregistration/v1beta1/validatingwebhookconfiguration/validatingwebhookconfiguration.go
@@ -19,7 +19,7 @@ limitations under the License.
 package validatingwebhookconfiguration
 
 import (
-	"context"
+	context "context"
 
 	v1beta1 "k8s.io/client-go/informers/admissionregistration/v1beta1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/apps/v1/controllerrevision/controllerrevision.go
+++ b/client/injection/kube/informers/apps/v1/controllerrevision/controllerrevision.go
@@ -19,7 +19,7 @@ limitations under the License.
 package controllerrevision
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/apps/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/apps/v1/controllerrevision/fake/fake.go
+++ b/client/injection/kube/informers/apps/v1/controllerrevision/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	controllerrevision "knative.dev/pkg/client/injection/kube/informers/apps/v1/controllerrevision"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/apps/v1/daemonset/daemonset.go
+++ b/client/injection/kube/informers/apps/v1/daemonset/daemonset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package daemonset
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/apps/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/apps/v1/daemonset/fake/fake.go
+++ b/client/injection/kube/informers/apps/v1/daemonset/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	daemonset "knative.dev/pkg/client/injection/kube/informers/apps/v1/daemonset"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/apps/v1/deployment/deployment.go
+++ b/client/injection/kube/informers/apps/v1/deployment/deployment.go
@@ -19,7 +19,7 @@ limitations under the License.
 package deployment
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/apps/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/apps/v1/deployment/fake/fake.go
+++ b/client/injection/kube/informers/apps/v1/deployment/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	deployment "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/apps/v1/replicaset/fake/fake.go
+++ b/client/injection/kube/informers/apps/v1/replicaset/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	replicaset "knative.dev/pkg/client/injection/kube/informers/apps/v1/replicaset"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/apps/v1/replicaset/replicaset.go
+++ b/client/injection/kube/informers/apps/v1/replicaset/replicaset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package replicaset
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/apps/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/apps/v1/statefulset/fake/fake.go
+++ b/client/injection/kube/informers/apps/v1/statefulset/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	statefulset "knative.dev/pkg/client/injection/kube/informers/apps/v1/statefulset"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/apps/v1/statefulset/statefulset.go
+++ b/client/injection/kube/informers/apps/v1/statefulset/statefulset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package statefulset
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/apps/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/autoscaling/v1/horizontalpodautoscaler/fake/fake.go
+++ b/client/injection/kube/informers/autoscaling/v1/horizontalpodautoscaler/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	horizontalpodautoscaler "knative.dev/pkg/client/injection/kube/informers/autoscaling/v1/horizontalpodautoscaler"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/autoscaling/v1/horizontalpodautoscaler/horizontalpodautoscaler.go
+++ b/client/injection/kube/informers/autoscaling/v1/horizontalpodautoscaler/horizontalpodautoscaler.go
@@ -19,7 +19,7 @@ limitations under the License.
 package horizontalpodautoscaler
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/autoscaling/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/autoscaling/v2beta1/horizontalpodautoscaler/fake/fake.go
+++ b/client/injection/kube/informers/autoscaling/v2beta1/horizontalpodautoscaler/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	horizontalpodautoscaler "knative.dev/pkg/client/injection/kube/informers/autoscaling/v2beta1/horizontalpodautoscaler"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/autoscaling/v2beta1/horizontalpodautoscaler/horizontalpodautoscaler.go
+++ b/client/injection/kube/informers/autoscaling/v2beta1/horizontalpodautoscaler/horizontalpodautoscaler.go
@@ -19,7 +19,7 @@ limitations under the License.
 package horizontalpodautoscaler
 
 import (
-	"context"
+	context "context"
 
 	v2beta1 "k8s.io/client-go/informers/autoscaling/v2beta1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/batch/v1/job/fake/fake.go
+++ b/client/injection/kube/informers/batch/v1/job/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	job "knative.dev/pkg/client/injection/kube/informers/batch/v1/job"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/batch/v1/job/job.go
+++ b/client/injection/kube/informers/batch/v1/job/job.go
@@ -19,7 +19,7 @@ limitations under the License.
 package job
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/batch/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/batch/v1beta1/cronjob/cronjob.go
+++ b/client/injection/kube/informers/batch/v1beta1/cronjob/cronjob.go
@@ -19,7 +19,7 @@ limitations under the License.
 package cronjob
 
 import (
-	"context"
+	context "context"
 
 	v1beta1 "k8s.io/client-go/informers/batch/v1beta1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/batch/v1beta1/cronjob/fake/fake.go
+++ b/client/injection/kube/informers/batch/v1beta1/cronjob/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	cronjob "knative.dev/pkg/client/injection/kube/informers/batch/v1beta1/cronjob"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/componentstatus/componentstatus.go
+++ b/client/injection/kube/informers/core/v1/componentstatus/componentstatus.go
@@ -19,7 +19,7 @@ limitations under the License.
 package componentstatus
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/core/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/core/v1/componentstatus/fake/fake.go
+++ b/client/injection/kube/informers/core/v1/componentstatus/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	componentstatus "knative.dev/pkg/client/injection/kube/informers/core/v1/componentstatus"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/configmap/configmap.go
+++ b/client/injection/kube/informers/core/v1/configmap/configmap.go
@@ -19,7 +19,7 @@ limitations under the License.
 package configmap
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/core/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/core/v1/configmap/fake/fake.go
+++ b/client/injection/kube/informers/core/v1/configmap/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	configmap "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/endpoints/endpoints.go
+++ b/client/injection/kube/informers/core/v1/endpoints/endpoints.go
@@ -19,7 +19,7 @@ limitations under the License.
 package endpoints
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/core/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/core/v1/endpoints/fake/fake.go
+++ b/client/injection/kube/informers/core/v1/endpoints/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	endpoints "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/event/event.go
+++ b/client/injection/kube/informers/core/v1/event/event.go
@@ -19,7 +19,7 @@ limitations under the License.
 package event
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/core/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/core/v1/event/fake/fake.go
+++ b/client/injection/kube/informers/core/v1/event/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	event "knative.dev/pkg/client/injection/kube/informers/core/v1/event"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/limitrange/fake/fake.go
+++ b/client/injection/kube/informers/core/v1/limitrange/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	limitrange "knative.dev/pkg/client/injection/kube/informers/core/v1/limitrange"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/limitrange/limitrange.go
+++ b/client/injection/kube/informers/core/v1/limitrange/limitrange.go
@@ -19,7 +19,7 @@ limitations under the License.
 package limitrange
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/core/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/core/v1/namespace/fake/fake.go
+++ b/client/injection/kube/informers/core/v1/namespace/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	namespace "knative.dev/pkg/client/injection/kube/informers/core/v1/namespace"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/namespace/namespace.go
+++ b/client/injection/kube/informers/core/v1/namespace/namespace.go
@@ -19,7 +19,7 @@ limitations under the License.
 package namespace
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/core/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/core/v1/node/fake/fake.go
+++ b/client/injection/kube/informers/core/v1/node/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	node "knative.dev/pkg/client/injection/kube/informers/core/v1/node"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/node/node.go
+++ b/client/injection/kube/informers/core/v1/node/node.go
@@ -19,7 +19,7 @@ limitations under the License.
 package node
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/core/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/core/v1/persistentvolume/fake/fake.go
+++ b/client/injection/kube/informers/core/v1/persistentvolume/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	persistentvolume "knative.dev/pkg/client/injection/kube/informers/core/v1/persistentvolume"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/persistentvolume/persistentvolume.go
+++ b/client/injection/kube/informers/core/v1/persistentvolume/persistentvolume.go
@@ -19,7 +19,7 @@ limitations under the License.
 package persistentvolume
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/core/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/core/v1/persistentvolumeclaim/fake/fake.go
+++ b/client/injection/kube/informers/core/v1/persistentvolumeclaim/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	persistentvolumeclaim "knative.dev/pkg/client/injection/kube/informers/core/v1/persistentvolumeclaim"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/persistentvolumeclaim/persistentvolumeclaim.go
+++ b/client/injection/kube/informers/core/v1/persistentvolumeclaim/persistentvolumeclaim.go
@@ -19,7 +19,7 @@ limitations under the License.
 package persistentvolumeclaim
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/core/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/core/v1/pod/fake/fake.go
+++ b/client/injection/kube/informers/core/v1/pod/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	pod "knative.dev/pkg/client/injection/kube/informers/core/v1/pod"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/pod/pod.go
+++ b/client/injection/kube/informers/core/v1/pod/pod.go
@@ -19,7 +19,7 @@ limitations under the License.
 package pod
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/core/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/core/v1/podtemplate/fake/fake.go
+++ b/client/injection/kube/informers/core/v1/podtemplate/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	podtemplate "knative.dev/pkg/client/injection/kube/informers/core/v1/podtemplate"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/podtemplate/podtemplate.go
+++ b/client/injection/kube/informers/core/v1/podtemplate/podtemplate.go
@@ -19,7 +19,7 @@ limitations under the License.
 package podtemplate
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/core/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/core/v1/replicationcontroller/fake/fake.go
+++ b/client/injection/kube/informers/core/v1/replicationcontroller/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	replicationcontroller "knative.dev/pkg/client/injection/kube/informers/core/v1/replicationcontroller"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/replicationcontroller/replicationcontroller.go
+++ b/client/injection/kube/informers/core/v1/replicationcontroller/replicationcontroller.go
@@ -19,7 +19,7 @@ limitations under the License.
 package replicationcontroller
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/core/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/core/v1/resourcequota/fake/fake.go
+++ b/client/injection/kube/informers/core/v1/resourcequota/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	resourcequota "knative.dev/pkg/client/injection/kube/informers/core/v1/resourcequota"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/resourcequota/resourcequota.go
+++ b/client/injection/kube/informers/core/v1/resourcequota/resourcequota.go
@@ -19,7 +19,7 @@ limitations under the License.
 package resourcequota
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/core/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/core/v1/secret/fake/fake.go
+++ b/client/injection/kube/informers/core/v1/secret/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	secret "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/secret/secret.go
+++ b/client/injection/kube/informers/core/v1/secret/secret.go
@@ -19,7 +19,7 @@ limitations under the License.
 package secret
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/core/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/core/v1/service/fake/fake.go
+++ b/client/injection/kube/informers/core/v1/service/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	service "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/service/service.go
+++ b/client/injection/kube/informers/core/v1/service/service.go
@@ -19,7 +19,7 @@ limitations under the License.
 package service
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/core/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/core/v1/serviceaccount/fake/fake.go
+++ b/client/injection/kube/informers/core/v1/serviceaccount/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	serviceaccount "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"

--- a/client/injection/kube/informers/core/v1/serviceaccount/serviceaccount.go
+++ b/client/injection/kube/informers/core/v1/serviceaccount/serviceaccount.go
@@ -19,7 +19,7 @@ limitations under the License.
 package serviceaccount
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/core/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/factory/factory.go
+++ b/client/injection/kube/informers/factory/factory.go
@@ -19,7 +19,7 @@ limitations under the License.
 package factory
 
 import (
-	"context"
+	context "context"
 
 	informers "k8s.io/client-go/informers"
 	client "knative.dev/pkg/client/injection/kube/client"

--- a/client/injection/kube/informers/factory/fake/fake.go
+++ b/client/injection/kube/informers/factory/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	informers "k8s.io/client-go/informers"
 	fake "knative.dev/pkg/client/injection/kube/client/fake"

--- a/client/injection/kube/informers/rbac/v1/clusterrole/clusterrole.go
+++ b/client/injection/kube/informers/rbac/v1/clusterrole/clusterrole.go
@@ -19,7 +19,7 @@ limitations under the License.
 package clusterrole
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/rbac/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/rbac/v1/clusterrole/fake/fake.go
+++ b/client/injection/kube/informers/rbac/v1/clusterrole/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"
 	clusterrole "knative.dev/pkg/client/injection/kube/informers/rbac/v1/clusterrole"

--- a/client/injection/kube/informers/rbac/v1/clusterrolebinding/clusterrolebinding.go
+++ b/client/injection/kube/informers/rbac/v1/clusterrolebinding/clusterrolebinding.go
@@ -19,7 +19,7 @@ limitations under the License.
 package clusterrolebinding
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/rbac/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/rbac/v1/clusterrolebinding/fake/fake.go
+++ b/client/injection/kube/informers/rbac/v1/clusterrolebinding/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"
 	clusterrolebinding "knative.dev/pkg/client/injection/kube/informers/rbac/v1/clusterrolebinding"

--- a/client/injection/kube/informers/rbac/v1/role/fake/fake.go
+++ b/client/injection/kube/informers/rbac/v1/role/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"
 	role "knative.dev/pkg/client/injection/kube/informers/rbac/v1/role"

--- a/client/injection/kube/informers/rbac/v1/role/role.go
+++ b/client/injection/kube/informers/rbac/v1/role/role.go
@@ -19,7 +19,7 @@ limitations under the License.
 package role
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/rbac/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/client/injection/kube/informers/rbac/v1/rolebinding/fake/fake.go
+++ b/client/injection/kube/informers/rbac/v1/rolebinding/fake/fake.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	"context"
+	context "context"
 
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"
 	rolebinding "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding"

--- a/client/injection/kube/informers/rbac/v1/rolebinding/rolebinding.go
+++ b/client/injection/kube/informers/rbac/v1/rolebinding/rolebinding.go
@@ -19,7 +19,7 @@ limitations under the License.
 package rolebinding
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/client-go/informers/rbac/v1"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"

--- a/codegen/cmd/injection-gen/generators/client.go
+++ b/codegen/cmd/injection-gen/generators/client.go
@@ -71,6 +71,10 @@ func (g *clientGenerator) GenerateType(c *generator.Context, t *types.Type, w io
 			Package: "knative.dev/pkg/logging",
 			Name:    "FromContext",
 		}),
+		"contextContext": c.Universe.Type(types.Name{
+			Package: "context",
+			Name:    "Context",
+		}),
 	}
 
 	sw.Do(injectionClient, m)
@@ -86,12 +90,12 @@ func init() {
 // Key is used as the key for associating information with a context.Context.
 type Key struct{}
 
-func withClient(ctx context.Context, cfg *{{.restConfig|raw}}) context.Context {
+func withClient(ctx {{.contextContext|raw}}, cfg *{{.restConfig|raw}}) context.Context {
 	return context.WithValue(ctx, Key{}, {{.clientSetNewForConfigOrDie|raw}}(cfg))
 }
 
 // Get extracts the {{.clientSetInterface|raw}} client from the context.
-func Get(ctx context.Context) {{.clientSetInterface|raw}} {
+func Get(ctx {{.contextContext|raw}}) {{.clientSetInterface|raw}} {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
 		{{.loggingFromContext|raw}}(ctx).Panic(

--- a/codegen/cmd/injection-gen/generators/duck.go
+++ b/codegen/cmd/injection-gen/generators/duck.go
@@ -90,6 +90,10 @@ func (g *duckGenerator) GenerateType(c *generator.Context, t *types.Type, w io.W
 			Package: "knative.dev/pkg/logging",
 			Name:    "FromContext",
 		}),
+		"contextContext": c.Universe.Type(types.Name{
+			Package: "context",
+			Name:    "Context",
+		}),
 	}
 
 	sw.Do(duckFactory, m)
@@ -105,7 +109,7 @@ func init() {
 // Key is used for associating the Informer inside the context.Context.
 type Key struct{}
 
-func WithDuck(ctx context.Context) context.Context {
+func WithDuck(ctx {{.contextContext|raw}}) {{.contextContext|raw}} {
 	dc := {{.dynamicGet|raw}}(ctx)
 	dif := &{{.duckCachedInformerFactory|raw}}{
 		Delegate: &{{.duckTypedInformerFactory|raw}}{
@@ -119,7 +123,7 @@ func WithDuck(ctx context.Context) context.Context {
 }
 
 // Get extracts the typed informer from the context.
-func Get(ctx context.Context) {{.duckInformerFactory|raw}} {
+func Get(ctx {{.contextContext|raw}}) {{.duckInformerFactory|raw}} {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
 		{{.loggingFromContext|raw}}(ctx).Panic(

--- a/codegen/cmd/injection-gen/generators/factory.go
+++ b/codegen/cmd/injection-gen/generators/factory.go
@@ -77,6 +77,10 @@ func (g *factoryGenerator) GenerateType(c *generator.Context, t *types.Type, w i
 			Package: "knative.dev/pkg/logging",
 			Name:    "FromContext",
 		}),
+		"contextContext": c.Universe.Type(types.Name{
+			Package: "context",
+			Name:    "Context",
+		}),
 	}
 
 	sw.Do(injectionFactory, m)
@@ -92,7 +96,7 @@ func init() {
 // Key is used as the key for associating information with a context.Context.
 type Key struct{}
 
-func withInformerFactory(ctx context.Context) context.Context {
+func withInformerFactory(ctx {{.contextContext|raw}}) {{.contextContext|raw}} {
 	c := {{.cachingClientGet|raw}}(ctx)
 	opts := make([]{{.informersSharedInformerOption|raw}}, 0, 1)
 	if {{.injectionHasNamespace|raw}}(ctx) {
@@ -103,7 +107,7 @@ func withInformerFactory(ctx context.Context) context.Context {
 }
 
 // Get extracts the InformerFactory from the context.
-func Get(ctx context.Context) {{.informersSharedInformerFactory|raw}} {
+func Get(ctx {{.contextContext|raw}}) {{.informersSharedInformerFactory|raw}} {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
 		{{.loggingFromContext|raw}}(ctx).Panic(

--- a/codegen/cmd/injection-gen/generators/fakeclient.go
+++ b/codegen/cmd/injection-gen/generators/fakeclient.go
@@ -75,6 +75,10 @@ func (g *fakeClientGenerator) GenerateType(c *generator.Context, t *types.Type, 
 			Package: "knative.dev/pkg/logging",
 			Name:    "FromContext",
 		}),
+		"contextContext": c.Universe.Type(types.Name{
+			Package: "context",
+			Name:    "Context",
+		}),
 	}
 
 	sw.Do(injectionFakeClient, m)
@@ -87,18 +91,18 @@ func init() {
 	{{.injectionRegisterClient|raw}}(withClient)
 }
 
-func withClient(ctx context.Context, cfg *rest.Config) context.Context {
+func withClient(ctx {{.contextContext|raw}}, cfg *rest.Config) {{.contextContext|raw}} {
 	ctx, _ = With(ctx)
 	return ctx
 }
 
-func With(ctx context.Context, objects ...runtime.Object) (context.Context, *{{.fakeClient|raw}}) {
+func With(ctx {{.contextContext|raw}}, objects ...runtime.Object) ({{.contextContext|raw}}, *{{.fakeClient|raw}}) {
 	cs := fake.NewSimpleClientset(objects...)
 	return context.WithValue(ctx, {{.clientKey|raw}}{}, cs), cs
 }
 
 // Get extracts the Kubernetes client from the context.
-func Get(ctx context.Context) *{{.fakeClient|raw}} {
+func Get(ctx {{.contextContext|raw}}) *{{.fakeClient|raw}} {
 	untyped := ctx.Value({{.clientKey|raw}}{})
 	if untyped == nil {
 		{{.loggingFromContext|raw}}(ctx).Panic(

--- a/codegen/cmd/injection-gen/generators/fakeclient.go
+++ b/codegen/cmd/injection-gen/generators/fakeclient.go
@@ -79,6 +79,8 @@ func (g *fakeClientGenerator) GenerateType(c *generator.Context, t *types.Type, 
 			Package: "context",
 			Name:    "Context",
 		}),
+		"restConfig":    c.Universe.Type(types.Name{Package: "k8s.io/client-go/rest", Name: "Config"}),
+		"runtimeObject": c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/runtime", Name: "Object"}),
 	}
 
 	sw.Do(injectionFakeClient, m)
@@ -91,12 +93,12 @@ func init() {
 	{{.injectionRegisterClient|raw}}(withClient)
 }
 
-func withClient(ctx {{.contextContext|raw}}, cfg *rest.Config) {{.contextContext|raw}} {
+func withClient(ctx {{.contextContext|raw}}, cfg *{{.restConfig|raw}}) {{.contextContext|raw}} {
 	ctx, _ = With(ctx)
 	return ctx
 }
 
-func With(ctx {{.contextContext|raw}}, objects ...runtime.Object) ({{.contextContext|raw}}, *{{.fakeClient|raw}}) {
+func With(ctx {{.contextContext|raw}}, objects ...{{.runtimeObject|raw}}) ({{.contextContext|raw}}, *{{.fakeClient|raw}}) {
 	cs := fake.NewSimpleClientset(objects...)
 	return context.WithValue(ctx, {{.clientKey|raw}}{}, cs), cs
 }

--- a/codegen/cmd/injection-gen/generators/fakefactory.go
+++ b/codegen/cmd/injection-gen/generators/fakefactory.go
@@ -79,6 +79,10 @@ func (g *fakeFactoryGenerator) GenerateType(c *generator.Context, t *types.Type,
 		"injectionHasNamespace":     c.Universe.Type(types.Name{Package: "knative.dev/pkg/injection", Name: "HasNamespaceScope"}),
 		"injectionGetNamespace":     c.Universe.Type(types.Name{Package: "knative.dev/pkg/injection", Name: "GetNamespaceScope"}),
 		"controllerGetResyncPeriod": c.Universe.Type(types.Name{Package: "knative.dev/pkg/controller", Name: "GetResyncPeriod"}),
+		"contextContext": c.Universe.Type(types.Name{
+			Package: "context",
+			Name:    "Context",
+		}),
 	}
 
 	sw.Do(injectionFakeInformerFactory, m)
@@ -93,7 +97,7 @@ func init() {
 	{{.injectionRegisterInformerFactory|raw}}(withInformerFactory)
 }
 
-func withInformerFactory(ctx context.Context) context.Context {
+func withInformerFactory(ctx {{.contextContext|raw}}) {{.contextContext|raw}} {
 	c := {{.clientGet|raw}}(ctx)
 	opts := make([]{{.informersSharedInformerOption|raw}}, 0, 1)
 	if {{.injectionHasNamespace|raw}}(ctx) {

--- a/codegen/cmd/injection-gen/generators/fakeinformer.go
+++ b/codegen/cmd/injection-gen/generators/fakeinformer.go
@@ -91,6 +91,10 @@ func (g *fakeInformerGenerator) GenerateType(c *generator.Context, t *types.Type
 			Package: "knative.dev/pkg/injection",
 			Name:    "Fake.RegisterInformer",
 		}),
+		"contextContext": c.Universe.Type(types.Name{
+			Package: "context",
+			Name:    "Context",
+		}),
 	}
 
 	sw.Do(injectionFakeInformer, m)
@@ -105,7 +109,7 @@ func init() {
 	{{.injectionRegisterInformer|raw}}(withInformer)
 }
 
-func withInformer(ctx context.Context) (context.Context, {{.controllerInformer|raw}}) {
+func withInformer(ctx {{.contextContext|raw}}) ({{.contextContext|raw}}, {{.controllerInformer|raw}}) {
 	f := {{.factoryGet|raw}}(ctx)
 	inf := f.{{.group}}().{{.version}}().{{.type|publicPlural}}()
 	return context.WithValue(ctx, {{.informerKey|raw}}{}, inf), inf.Informer()

--- a/codegen/cmd/injection-gen/generators/informer.go
+++ b/codegen/cmd/injection-gen/generators/informer.go
@@ -90,6 +90,10 @@ func (g *injectionGenerator) GenerateType(c *generator.Context, t *types.Type, w
 			Package: "knative.dev/pkg/logging",
 			Name:    "FromContext",
 		}),
+		"contextContext": c.Universe.Type(types.Name{
+			Package: "context",
+			Name:    "Context",
+		}),
 	}
 
 	sw.Do(injectionInformer, m)
@@ -105,14 +109,14 @@ func init() {
 // Key is used for associating the Informer inside the context.Context.
 type Key struct{}
 
-func withInformer(ctx context.Context) (context.Context, {{.controllerInformer|raw}}) {
+func withInformer(ctx {{.contextContext|raw}}) ({{.contextContext|raw}}, {{.controllerInformer|raw}}) {
 	f := {{.factoryGet|raw}}(ctx)
 	inf := f.{{.group}}().{{.version}}().{{.type|publicPlural}}()
 	return context.WithValue(ctx, Key{}, inf), inf.Informer()
 }
 
 // Get extracts the typed informer from the context.
-func Get(ctx context.Context) {{.informersTypedInformer|raw}} {
+func Get(ctx {{.contextContext|raw}}) {{.informersTypedInformer|raw}} {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
 		{{.loggingFromContext|raw}}(ctx).Panic(


### PR DESCRIPTION
```
diff --git a/client/injection/apiextensions/client/fake/fake.go b/client/injection/apiextensions/client/fake/fake.go
index 8569828e..dc9e6832 100644
--- a/client/injection/apiextensions/client/fake/fake.go
+++ b/client/injection/apiextensions/client/fake/fake.go
@@ -22,8 +22,8 @@ import (
        "context"
        fake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-       "k8s.io/apimachinery/pkg/runtime"
-       "k8s.io/client-go/rest"
+       "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime"
+       "k8s.io/kubernetes/staging/src/k8s.io/client-go/rest"
```