### PR TITLE
Add filtering to class based controller stubs.

### DIFF
--- a/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -154,7 +154,10 @@ const (
 	defaultControllerAgentName = "{{.type|lowercaseSingular}}-controller"
 	defaultFinalizerName       = "{{.type|allLowercasePlural}}.{{.group}}"
 	defaultQueueName           = "{{.type|allLowercasePlural}}"
-	{{if .hasClass}}classAnnotationKey = "{{ .class }}"{{end}}
+	{{if .hasClass}}
+	// ClassAnnotationKey points to the annotation for the class of this resource.
+	ClassAnnotationKey = "{{ .class }}"
+	{{end}}
 )
 
 // NewImpl returns a {{.controllerImpl|raw}} that handles queuing and feeding work from

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -263,9 +263,9 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 		return err
 	}
 	{{if .hasClass}}
-	if classValue, found := original.GetAnnotations()[classAnnotationKey]; !found || classValue != r.classValue {
+	if classValue, found := original.GetAnnotations()[ClassAnnotationKey]; !found || classValue != r.classValue {
 		logger.Debugw("Skip reconciling resource, class annotation value does not match reconciler instance value.",
-			zap.String("classKey", classAnnotationKey),
+			zap.String("classKey", ClassAnnotationKey),
 			zap.String("issue", classValue+"!="+r.classValue))
 		return nil
 	}


### PR DESCRIPTION
Breaking this out from the broader discussion I started on Slack around class-based reconcilers.
Regardless of what the outcome is, I think we should encourage users to add the class filters to their informers to reduce churn.