### PR TITLE
Add standard pod and container name keys

### DIFF
--- a/metrics/metricskey/constants.go
+++ b/metrics/metricskey/constants.go
@@ -29,6 +29,12 @@ const (
 	// LabelNamespaceName is the label for immutable name of the namespace that the service is deployed
 	LabelNamespaceName = "namespace_name"
 
+	// ContainerName is the container for which the metric is reported.
+	ContainerName = "container_name"
+
+	// PodName is the name of the pod for which the metric is reported.
+	PodName = "pod_name"
+
 	// LabelResponseCode is the label for the HTTP response status code.
 	LabelResponseCode = "response_code"
 


### PR DESCRIPTION
Those are used in many places and thus deserve to be named constants.

First class citizenship for pod name! :hammer: 

/assign mattmoor