### PR TITLE
Add an `--upgrade` flag to `./hack/update-deps.sh`

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -23,8 +23,26 @@ set -o pipefail
 
 cd ${ROOT_DIR}
 
+# The list of dependencies that we track at HEAD and periodically
+# float forward in this repository.
+FLOATING_DEPS=(
+  "knative.dev/test-infra"
+)
+
+# Parse flags to determine any we should pass to dep.
+DEP_FLAGS=()
+while [[ $# -ne 0 ]]; do
+  parameter=$1
+  case ${parameter} in
+    --upgrade) DEP_FLAGS=( -update ${FLOATING_DEPS[@]} ) ;;
+    *) abort "unknown option ${parameter}" ;;
+  esac
+  shift
+done
+readonly DEP_FLAGS
+
 # Ensure we have everything we need under vendor/
-dep ensure $@
+dep ensure ${DEP_FLAGS[@]}
 
 rm -rf $(find vendor/ -name 'OWNERS')
 rm -rf $(find vendor/ -name '*_test.go')


### PR DESCRIPTION
This flag upgrades the list of dependencies that we choose to track at HEAD.

cc @n3wscott @coryrc @chaodaiG @vdemeester 