### PR TITLE
Mutate `-` to `_` in component names for metrics

### DIFF
--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -16,6 +16,7 @@ package metrics
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"go.opencensus.io/stats/view"
@@ -89,7 +90,7 @@ func ConfigMapWatcher(component string, secrets SecretFetcher, logger *zap.Sugar
 	return func(configMap *corev1.ConfigMap) {
 		UpdateExporter(ExporterOptions{
 			Domain:    domain,
-			Component: component,
+			Component: strings.ReplaceAll(component, "-", "_"),
 			ConfigMap: configMap.Data,
 			Secrets:   secrets,
 		}, logger)

--- a/metrics/exporter_test.go
+++ b/metrics/exporter_test.go
@@ -85,6 +85,17 @@ func TestMetricsExporter(t *testing.T) {
 		},
 		expectSuccess: true,
 	}, {
+		name: "validConfigWithDashInName",
+		config: &metricsConfig{
+			domain:             servingDomain,
+			component:          "test-component",
+			backendDestination: Stackdriver,
+			stackdriverClientConfig: StackdriverClientConfig{
+				ProjectID: "testProj",
+			},
+		},
+		expectSuccess: true,
+	}, {
 		name: "stackdriverConfigOnly",
 		config: &metricsConfig{
 			backendDestination: Stackdriver,


### PR DESCRIPTION
Passing `-` in will create invalid metric names for prometheus (at least); mutate it on the way in.

As a follow-up, we need to add validation for the component name on the way into metrics.