### PR TITLE
Add MarkTrueWithReason function to ConditionManager

### DIFF
--- a/apis/condition_set.go
+++ b/apis/condition_set.go
@@ -75,6 +75,10 @@ type ConditionManager interface {
 	// true if all dependents are true.
 	MarkTrue(t ConditionType)
 
+	// MarkTrueWithReason sets the status of t to true with the reason, and then marks the happy
+	// condition to true if all dependents are true.
+	MarkTrueWithReason(t ConditionType, reason, messageFormat string, messageA ...interface{})
+
 	// MarkUnknown sets the status of t to Unknown and also sets the happy condition
 	// to Unknown if no other dependent condition is in an error state.
 	MarkUnknown(t ConditionType, reason, messageFormat string, messageA ...interface{})
@@ -253,7 +257,25 @@ func (r conditionsImpl) MarkTrue(t ConditionType) {
 		Status:   corev1.ConditionTrue,
 		Severity: r.severity(t),
 	})
+	r.markHappy(t)
+}
 
+// MarkTrueWithReason sets the status of t to true with the reason, and then marks the happy condition to
+// true if all other dependents are also true.
+func (r conditionsImpl) MarkTrueWithReason(t ConditionType, reason, messageFormat string, messageA ...interface{}) {
+	// set the specified condition
+	r.SetCondition(Condition{
+		Type:     t,
+		Status:   corev1.ConditionTrue,
+		Reason:   reason,
+		Message:  fmt.Sprintf(messageFormat, messageA...),
+		Severity: r.severity(t),
+	})
+	r.markHappy(t)
+}
+
+// markHappy marks the happy condition to true if all other dependents are also true.
+func (r conditionsImpl) markHappy(t ConditionType) {
 	if c := r.findUnhappyDependent(); c != nil {
 		// Propagate unhappy dependent to happy condition.
 		r.SetCondition(Condition{

--- a/apis/condition_set.go
+++ b/apis/condition_set.go
@@ -257,7 +257,7 @@ func (r conditionsImpl) MarkTrue(t ConditionType) {
 		Status:   corev1.ConditionTrue,
 		Severity: r.severity(t),
 	})
-	r.markHappy(t)
+	r.recomputeHappiness(t)
 }
 
 // MarkTrueWithReason sets the status of t to true with the reason, and then marks the happy condition to
@@ -271,11 +271,11 @@ func (r conditionsImpl) MarkTrueWithReason(t ConditionType, reason, messageForma
 		Message:  fmt.Sprintf(messageFormat, messageA...),
 		Severity: r.severity(t),
 	})
-	r.markHappy(t)
+	r.recomputeHappiness(t)
 }
 
-// markHappy marks the happy condition to true if all other dependents are also true.
-func (r conditionsImpl) markHappy(t ConditionType) {
+// recomputeHappiness marks the happy condition to true if all other dependents are also true.
+func (r conditionsImpl) recomputeHappiness(t ConditionType) {
 	if c := r.findUnhappyDependent(); c != nil {
 		// Propagate unhappy dependent to happy condition.
 		r.SetCondition(Condition{

--- a/apis/condition_set_test.go
+++ b/apis/condition_set_test.go
@@ -108,18 +108,24 @@ func TestNonTerminalCondition(t *testing.T) {
 	// Setting a "non-terminal" condition, doesn't change Ready.
 	manager.MarkUnknown("Bar", "", "")
 	if got, want := manager.GetCondition("Ready").Status, corev1.ConditionTrue; got != want {
+		t.Errorf("MarkUnknown(Bar) = %v, wanted %v", got, want)
+	}
+
+	// Setting the other "terminal" condition by Unknown makes Ready false
+	manager.MarkUnknown("Foo", "", "")
+	if got, want := manager.GetCondition("Ready").Status, corev1.ConditionUnknown; got != want {
 		t.Errorf("MarkUnknown(Foo) = %v, wanted %v", got, want)
 	}
 
-	// Setting the other "terminal" condition makes Ready true.
+	// Setting the other "terminal" condition by True makes Ready true
 	manager.MarkTrueWithReason("Foo", "", "")
 	if got, want := manager.GetCondition("Ready").Status, corev1.ConditionTrue; got != want {
-		t.Errorf("MarkTrue(Foo) = %v, wanted %v", got, want)
+		t.Errorf("MarkUnknown(Foo) = %v, wanted %v", got, want)
 	}
 
 	// Setting a "non-terminal" condition, doesn't change Ready.
 	manager.MarkFalse("Bar", "", "")
 	if got, want := manager.GetCondition("Ready").Status, corev1.ConditionTrue; got != want {
-		t.Errorf("MarkFalse(Foo) = %v, wanted %v", got, want)
+		t.Errorf("MarkFalse(Bar) = %v, wanted %v", got, want)
 	}
 }

--- a/apis/condition_set_test.go
+++ b/apis/condition_set_test.go
@@ -111,6 +111,12 @@ func TestNonTerminalCondition(t *testing.T) {
 		t.Errorf("MarkUnknown(Foo) = %v, wanted %v", got, want)
 	}
 
+	// Setting the other "terminal" condition makes Ready true.
+	manager.MarkTrueWithReason("Foo", "", "")
+	if got, want := manager.GetCondition("Ready").Status, corev1.ConditionTrue; got != want {
+		t.Errorf("MarkTrue(Foo) = %v, wanted %v", got, want)
+	}
+
 	// Setting a "non-terminal" condition, doesn't change Ready.
 	manager.MarkFalse("Bar", "", "")
 	if got, want := manager.GetCondition("Ready").Status, corev1.ConditionTrue; got != want {


### PR DESCRIPTION
Currently we cannot set a condition to true with the reason.

When using `MarkTrue()` function, it does not allow us to add the reason and message.
Also, if we use `SetCondition()` instead, it does not update the happy condition.

So, this PR adds new `MarkTrueWithReason(reason, message)` function to solve it.

For example in the Serving project, we want to manage KCert's condition, like below:

#### After using this path for https://github.com/knative/serving/pull/7163:

```
$ kubectl get rt hello-example -o yaml
    ...
    conditions:
    - lastTransitionTime: "2020-03-07T08:30:11Z"
      message: autoTLS is not enabled
      reason: AutoTLSNotEnabled
      status: "True"
      type: CertificateProvisioned

$ kubectl get rt
NAME            URL                                        READY   REASON
hello-example   http://hello-example.default.example.com   True
```
