### PR TITLE
Remove named returns, since they look icky :)

### DIFF
--- a/webhook/certificates/certificates.go
+++ b/webhook/certificates/certificates.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	// Time used for updating a certificate before it expires. Default 1 week.
+	// Time used for updating a certificate before it expires.
 	oneWeek = 7 * 24 * time.Hour
 )
 
@@ -64,7 +64,7 @@ func (r *reconciler) reconcileCertificate(ctx context.Context) error {
 			return err
 		}
 	} else if err != nil {
-		logger.Errorf("error accessing certificate secret %q: %v", r.secretName, err)
+		logger.Errorf("Error accessing certificate secret %q: %v", r.secretName, err)
 		return err
 	}
 

--- a/webhook/resourcesemantics/conversion/conversion.go
+++ b/webhook/resourcesemantics/conversion/conversion.go
@@ -52,6 +52,7 @@ func (r *reconciler) Convert(
 	for _, obj := range req.Objects {
 		converted, err := r.convert(ctx, obj, req.DesiredAPIVersion)
 		if err != nil {
+			logging.FromContext(ctx).Errorf("Conversion failed: %v", err)
 			res.Result.Status = metav1.StatusFailure
 			res.Result.Message = err.Error()
 			break
@@ -68,19 +69,13 @@ func (r *reconciler) convert(
 	ctx context.Context,
 	inRaw runtime.RawExtension,
 	targetVersion string,
-) (outRaw runtime.RawExtension, err error) {
-
+) (runtime.RawExtension, error) {
 	logger := logging.FromContext(ctx)
-
-	defer func() {
-		if err != nil {
-			logger.Errorf("Conversion failed: %s", err)
-		}
-	}()
+	var ret runtime.RawExtension
 
 	inGVK, err := parseGVK(inRaw)
 	if err != nil {
-		return
+		return ret, err
 	}
 
 	logger.Infof("Converting %s to version %s", formatGVK(inGVK), targetVersion)
@@ -88,30 +83,25 @@ func (r *reconciler) convert(
 	inGK := inGVK.GroupKind()
 	conv, ok := r.kinds[inGK]
 	if !ok {
-		err = fmt.Errorf("no conversion support for type %s", formatGK(inGVK.GroupKind()))
-		return
+		return ret, fmt.Errorf("no conversion support for type %s", formatGK(inGVK.GroupKind()))
 	}
 
 	outGVK, err := parseAPIVersion(targetVersion, inGK.Kind)
 	if err != nil {
-		return
+		return ret, err
 	}
 
 	inZygote, ok := conv.Zygotes[inGVK.Version]
 	if !ok {
-		err = fmt.Errorf("conversion not supported for type %s", formatGVK(inGVK))
-		return
+		return ret, fmt.Errorf("conversion not supported for type %s", formatGVK(inGVK))
 	}
 	outZygote, ok := conv.Zygotes[outGVK.Version]
 	if !ok {
-		err = fmt.Errorf("conversion not supported for type %s", formatGVK(outGVK))
-		return
+		return ret, fmt.Errorf("conversion not supported for type %s", formatGVK(outGVK))
 	}
 	hubZygote, ok := conv.Zygotes[conv.HubVersion]
 	if !ok {
-		inGK := inGVK.GroupKind()
-		err = fmt.Errorf("conversion not supported for type %s", formatGK(inGK))
-		return
+		return ret, fmt.Errorf("conversion not supported for type %s", formatGK(inGVK.GroupKind()))
 	}
 
 	in := inZygote.DeepCopyObject().(ConvertibleObject)
@@ -127,22 +117,19 @@ func (r *reconciler) convert(
 
 	// TODO(dprotaso) - potentially error on unknown fields
 	if err = json.Unmarshal(inRaw.Raw, &in); err != nil {
-		err = fmt.Errorf("unable to unmarshal input: %w", err)
-		return
+		return ret, fmt.Errorf("unable to unmarshal input: %w", err)
 	}
 
 	if inGVK.Version == conv.HubVersion {
 		hub = in
 	} else if err = hub.ConvertFrom(ctx, in); err != nil {
-		err = fmt.Errorf("conversion failed to version %s for type %s -  %w", outGVK.Version, formatGVK(inGVK), err)
-		return
+		return ret, fmt.Errorf("conversion failed to version %s for type %s -  %w", outGVK.Version, formatGVK(inGVK), err)
 	}
 
 	if outGVK.Version == conv.HubVersion {
 		out = hub
 	} else if err = hub.ConvertTo(ctx, out); err != nil {
-		err = fmt.Errorf("conversion failed to version %s for type %s -  %w", outGVK.Version, formatGVK(inGVK), err)
-		return
+		return ret, fmt.Errorf("conversion failed to version %s for type %s -  %w", outGVK.Version, formatGVK(inGVK), err)
 	}
 
 	out.GetObjectKind().SetGroupVersionKind(outGVK)
@@ -151,31 +138,33 @@ func (r *reconciler) convert(
 		defaultable.SetDefaults(ctx)
 	}
 
-	if outRaw.Raw, err = json.Marshal(out); err != nil {
-		err = fmt.Errorf("unable to marshal output: %w", err)
-		return
+	if ret.Raw, err = json.Marshal(out); err != nil {
+		return ret, fmt.Errorf("unable to marshal output: %w", err)
 	}
-
-	return
+	return ret, nil
 }
 
-func parseGVK(in runtime.RawExtension) (gvk schema.GroupVersionKind, err error) {
-	var typeMeta metav1.TypeMeta
+func parseGVK(in runtime.RawExtension) (schema.GroupVersionKind, error) {
+	var (
+		typeMeta metav1.TypeMeta
+		gvk      schema.GroupVersionKind
+	)
 
-	if err = json.Unmarshal(in.Raw, &typeMeta); err != nil {
-		err = fmt.Errorf("error parsing type meta %q - %w", string(in.Raw), err)
-		return
+	if err := json.Unmarshal(in.Raw, &typeMeta); err != nil {
+		return gvk, fmt.Errorf("error parsing type meta %q - %w", string(in.Raw), err)
 	}
 
 	gv, err := schema.ParseGroupVersion(typeMeta.APIVersion)
+	if err != nil {
+		return gvk, fmt.Errorf("error parsing GV %q: %w", typeMeta.APIVersion, err)
+	}
 	gvk = gv.WithKind(typeMeta.Kind)
 
 	if gvk.Group == "" || gvk.Version == "" || gvk.Kind == "" {
-		err = fmt.Errorf("invalid GroupVersionKind %v", gvk)
-		return
+		return gvk, fmt.Errorf("invalid GroupVersionKind %v", gvk)
 	}
 
-	return
+	return gvk, nil
 }
 
 func parseAPIVersion(apiVersion string, kind string) (schema.GroupVersionKind, error) {


### PR DESCRIPTION
In general, imo, it's prettier to return things as is, rather than the pattern that was
there. Also net negative code :). But, this is debatable, I guess 🤷‍♂ 
Also handle one more error case, which was kind of ignored before (probably in practice
impossible, but idk)

/assign @dprotaso mattmoor