### PR TITLE
Drop the logic to create missing secrets.

### DIFF
--- a/webhook/certificates/certificates.go
+++ b/webhook/certificates/certificates.go
@@ -55,14 +55,10 @@ func (r *reconciler) reconcileCertificate(ctx context.Context) error {
 
 	secret, err := r.secretlister.Secrets(system.Namespace()).Get(r.secretName)
 	if apierrors.IsNotFound(err) {
-		secret, err = certresources.MakeSecret(ctx, r.secretName, system.Namespace(), r.serviceName)
-		if err != nil {
-			return err
-		}
-		secret, err = r.client.CoreV1().Secrets(secret.Namespace).Create(secret)
-		if err != nil {
-			return err
-		}
+		// The secret should be created explicitly by a higher-level system
+		// that's responsible for install/updates.  We simply populate the
+		// secret information.
+		return nil
 	} else if err != nil {
 		logger.Errorf("Error accessing certificate secret %q: %v", r.secretName, err)
 		return err

--- a/webhook/certificates/certificates_test.go
+++ b/webhook/certificates/certificates_test.go
@@ -64,17 +64,8 @@ func TestReconcile(t *testing.T) {
 		Key:     key,
 		Objects: []runtime.Object{secret},
 	}, {
-		Name:        "secret does not exist",
-		Key:         key,
-		WantCreates: []runtime.Object{secret},
-	}, {
-		Name:    "secret does not exist, create error",
-		Key:     key,
-		WantErr: true,
-		WithReactors: []clientgotesting.ReactionFunc{
-			InduceFailure("create", "secrets"),
-		},
-		WantCreates: []runtime.Object{secret},
+		Name: "secret does not exist",
+		Key:  key,
 	}, {
 		Name: "missing server key",
 		Key:  key,
@@ -176,9 +167,20 @@ func TestReconcileMakeSecretFailure(t *testing.T) {
 		Key:     key,
 		Objects: []runtime.Object{secret},
 	}, {
-		Name:    "secret does not exist",
+		Name:    "malformed secret",
 		Key:     key,
 		WantErr: true,
+		Objects: []runtime.Object{&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: system.Namespace(),
+			},
+			Data: map[string][]byte{
+				// certresources.ServerKey:  []byte("missing"),
+				certresources.ServerCert: []byte("present"),
+				certresources.CACert:     []byte("present"),
+			},
+		}},
 	}, {
 		Name: "missing server key",
 		Key:  key,


### PR DESCRIPTION
This is a carry-over from when this was originally written and we had webhooks and secrets being GC'd due to a bad owner reference.