### PR TITLE
Use metrics.backend-destination for request metrics backend as well

### DIFF
--- a/metrics/config_observability.go
+++ b/metrics/config_observability.go
@@ -86,7 +86,7 @@ func NewObservabilityConfigFromConfigMap(configMap *corev1.ConfigMap) (*Observab
 		oc.EnableProbeRequestLog = strings.EqualFold(eprl, "true")
 	}
 
-	if mb, ok := configMap.Data["metrics.request-metrics-backend-destination"]; ok {
+	if mb, ok := configMap.Data["metrics.backend-destination"]; ok {
 		oc.RequestMetricsBackend = mb
 	} else {
 		oc.RequestMetricsBackend = DefaultRequestMetricsBackend

--- a/metrics/config_observability_test.go
+++ b/metrics/config_observability_test.go
@@ -49,12 +49,12 @@ func TestObservabilityConfiguration(t *testing.T) {
 				Name:      ConfigMapName(),
 			},
 			Data: map[string]string{
-				"logging.enable-var-log-collection":           "true",
-				"logging.revision-url-template":               "https://logging.io",
-				"logging.enable-probe-request-log":            "true",
-				"logging.write-request-logs":                  "true",
-				"logging.request-log-template":                `{"requestMethod": "{{.Request.Method}}"}`,
-				"metrics.request-metrics-backend-destination": "stackdriver",
+				"logging.enable-var-log-collection": "true",
+				"logging.revision-url-template":     "https://logging.io",
+				"logging.enable-probe-request-log":  "true",
+				"logging.write-request-logs":        "true",
+				"logging.request-log-template":      `{"requestMethod": "{{.Request.Method}}"}`,
+				"metrics.backend-destination":       "stackdriver",
 			},
 		},
 	}, {


### PR DESCRIPTION
We allow empty value when we first introduced `metrics.request-metrics-backend-destination` flag to disable request metrics from queue proxy.

We set `Prometheus` as default value in serving 0.12 release, which means we no longer allow disabling request metrics from queue proxy.

It doesn't make sense that we have two flags, i.e. `metrics.backend-destination` and `metrics.request-metrics-backend-destination`, to control what backend to send metrics to. The goal is to keep one, `metrics.backend-destination`.

So switch to use `metrics.backend-destination` instead of `metrics.request-metrics-backend-destination`. Next step is to remove this flag in serving.

