### PR TITLE
Limit listers to the system names for secrets.

### DIFF
--- a/webhook/certificates/controller.go
+++ b/webhook/certificates/controller.go
@@ -22,6 +22,7 @@ import (
 	// Injection stuff
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
+	"knative.dev/pkg/injection"
 
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
@@ -41,6 +42,7 @@ func NewController(
 ) *controller.Impl {
 
 	client := kubeclient.Get(ctx)
+	ctx = injection.WithNamespaceScope(ctx, system.Namespace())
 	secretInformer := secretinformer.Get(ctx)
 	options := webhook.GetOptions(ctx)
 

--- a/webhook/configmaps/controller.go
+++ b/webhook/configmaps/controller.go
@@ -24,6 +24,7 @@ import (
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	vwhinformer "knative.dev/pkg/client/injection/kube/informers/admissionregistration/v1beta1/validatingwebhookconfiguration"
 	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
+	"knative.dev/pkg/injection"
 
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
@@ -41,9 +42,12 @@ func NewAdmissionController(
 ) *controller.Impl {
 
 	client := kubeclient.Get(ctx)
+	// Those are global.
 	vwhInformer := vwhinformer.Get(ctx)
-	secretInformer := secretinformer.Get(ctx)
 	options := webhook.GetOptions(ctx)
+
+	ctx = injection.WithNamespaceScope(ctx, system.Namespace())
+	secretInformer := secretinformer.Get(ctx)
 
 	wh := &reconciler{
 		name: name,

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -26,6 +26,7 @@ import (
 	// Injection stuff
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	kubeinformerfactory "knative.dev/pkg/client/injection/kube/informers/factory"
+	"knative.dev/pkg/injection"
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -89,7 +90,8 @@ func New(
 	// of the admission controllers' informers *also* require the secret
 	// informer, then we can fetch the shared informer factory here and produce
 	// a new secret informer from it.
-	secretInformer := kubeinformerfactory.Get(ctx).Core().V1().Secrets()
+	ctxN := injection.WithNamespaceScope(ctx, system.Namespace())
+	secretInformer := kubeinformerfactory.Get(ctxN).Core().V1().Secrets()
 
 	opts := GetOptions(ctx)
 	if opts == nil {

--- a/webhook/webhook_integration_test.go
+++ b/webhook/webhook_integration_test.go
@@ -25,14 +25,15 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	kubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
-	"knative.dev/pkg/system"
-
-	"golang.org/x/sync/errgroup"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/metrics/metricstest"
+	"knative.dev/pkg/system"
 	pkgtest "knative.dev/pkg/testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // createResource creates a testing.Resource with the given name in the system namespace.


### PR DESCRIPTION
This is to restrict somewhat the memory consumption
of the webhook, which is now linear with number of namespaces
in the system.

For #1152 
/assign @dprotaso mattmoor