### PR TITLE
Add helper function to read webhook port number from env var

### DIFF
--- a/webhook/env.go
+++ b/webhook/env.go
@@ -17,17 +17,23 @@ limitations under the License.
 package webhook
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 )
 
 const portEnvKey = "WEBHOOK_PORT"
 
-// Port returns the webhook port set by portEnvKey, or default port if env var is invalid.
+// Port returns the webhook port set by portEnvKey, or default port if env var is not set.
 func Port(defaultPort int) int {
-	port, err := strconv.Atoi(os.Getenv(portEnvKey))
-	if err != nil || port == 0 {
+	if os.Getenv(portEnvKey) == "" {
 		return defaultPort
+	}
+	port, err := strconv.Atoi(os.Getenv(portEnvKey))
+	if err != nil {
+		panic(fmt.Sprintf("failed to convert the environment variable %q : %v", portEnvKey, err))
+	} else if port == 0 {
+		panic(fmt.Sprintf("the environment variable %q can't be zero", portEnvKey))
 	}
 	return port
 }

--- a/webhook/env.go
+++ b/webhook/env.go
@@ -26,7 +26,7 @@ const portEnvKey = "WEBHOOK_PORT"
 // Port returns the webhook port set by portEnvKey, or default port if env var is invalid.
 func Port(defaultPort int) int {
 	port, err := strconv.Atoi(os.Getenv(portEnvKey))
-	if err != nil {
+	if err != nil || port == 0 {
 		return defaultPort
 	}
 	return port

--- a/webhook/env.go
+++ b/webhook/env.go
@@ -24,8 +24,8 @@ import (
 
 const portEnvKey = "WEBHOOK_PORT"
 
-// Port returns the webhook port set by portEnvKey, or default port if env var is not set.
-func Port(defaultPort int) int {
+// PortFromEnv returns the webhook port set by portEnvKey, or default port if env var is not set.
+func PortFromEnv(defaultPort int) int {
 	if os.Getenv(portEnvKey) == "" {
 		return defaultPort
 	}

--- a/webhook/env.go
+++ b/webhook/env.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"os"
+	"strconv"
+)
+
+const portEnvKey = "WEBHOOK_PORT"
+
+// Port returns the webhook port set by portEnvKey, or default port if env var is invalid.
+func Port(defaultPort int) int {
+	port, err := strconv.Atoi(os.Getenv(portEnvKey))
+	if err != nil {
+		return defaultPort
+	}
+	return port
+}

--- a/webhook/env_test.go
+++ b/webhook/env_test.go
@@ -69,14 +69,14 @@ func TestPort(t *testing.T) {
 
 			defer func() {
 				if r := recover(); r == nil && tc.wantPanic {
-					t.Errorf("did not panic")
+					t.Error("Did not panic")
 				} else if r != nil && !tc.wantPanic {
-					t.Errorf("got unexpected panic")
+					t.Error("Got unexpected panic")
 				}
 			}()
 
 			if got := PortFromEnv(testDefaultPort); got != tc.want {
-				t.Errorf("got %d, want %d", got, tc.want)
+				t.Errorf("PortFromEnv = %d, want: %d", got, tc.want)
 			}
 		})
 	}

--- a/webhook/env_test.go
+++ b/webhook/env_test.go
@@ -75,7 +75,7 @@ func TestPort(t *testing.T) {
 				}
 			}()
 
-			if got := Port(testDefaultPort); got != tc.want {
+			if got := PortFromEnv(testDefaultPort); got != tc.want {
 				t.Errorf("got %d, want %d", got, tc.want)
 			}
 		})

--- a/webhook/env_test.go
+++ b/webhook/env_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"os"
+	"testing"
+)
+
+const (
+	testDefaultPort      = 8888
+	testMissingInputName = "MissingInput" // portEnvKey is not found.
+)
+
+type portTest struct {
+	name string
+	in   string
+	want int
+}
+
+func TestPort(t *testing.T) {
+	tests := []portTest{{
+		name: testMissingInputName,
+		want: testDefaultPort,
+	}, {
+		name: "EmptyInput",
+		in:   "",
+		want: testDefaultPort,
+	}, {
+		name: "InvalidInputNonNumeric",
+		in:   "invalid",
+		want: testDefaultPort,
+	}, {
+		name: "InvalidInputZero",
+		in:   "0",
+		want: testDefaultPort,
+	}, {
+		name: "ValidInput",
+		in:   "443",
+		want: 443,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// portEnvKey is unset when testing missing input.
+			if tc.name != testMissingInputName {
+				os.Setenv(portEnvKey, tc.in)
+			}
+			defer os.Unsetenv(portEnvKey)
+
+			if got := Port(testDefaultPort); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/webhook/env_test.go
+++ b/webhook/env_test.go
@@ -65,7 +65,6 @@ func TestPort(t *testing.T) {
 			if tc.name != testMissingInputName {
 				os.Setenv(portEnvKey, tc.in)
 			}
-			defer os.Unsetenv(portEnvKey)
 
 			defer func() {
 				if r := recover(); r == nil && tc.wantPanic {
@@ -73,6 +72,7 @@ func TestPort(t *testing.T) {
 				} else if r != nil && !tc.wantPanic {
 					t.Error("Got unexpected panic")
 				}
+				os.Unsetenv(portEnvKey)
 			}()
 
 			if got := PortFromEnv(testDefaultPort); got != tc.want {


### PR DESCRIPTION
Users can use WEBHOOK_PORT env var to configure the port that webhook uses.
To read the env var, replace `Port: 8443` with `Port: webhook.Port(8443)` in [main.go](https://github.com/knative/serving/blob/0f1c5af53e0cb5172135d0e9d2d4b7e59e276187/cmd/webhook/main.go#L220).