### PR TITLE
change metric pod_name and container_name to pod and container

### DIFF
--- a/metrics/metricskey/constants.go
+++ b/metrics/metricskey/constants.go
@@ -30,10 +30,10 @@ const (
 	LabelNamespaceName = "namespace_name"
 
 	// ContainerName is the container for which the metric is reported.
-	ContainerName = "container_name"
+	ContainerName = "container"
 
 	// PodName is the name of the pod for which the metric is reported.
-	PodName = "pod_name"
+	PodName = "pod"
 
 	// LabelResponseCode is the label for the HTTP response status code.
 	LabelResponseCode = "response_code"


### PR DESCRIPTION
This PR is to fix the serving issue [6625](https://github.com/knative/serving/issues/6625).

From kubernetes 1.6 pod_name and container_name  becoming pod and container. Making the same change in knative.

Corresponding dashboard changes are made in the serving repo 