### PR TITLE
Retry cluster creation if there's an error

### DIFF
--- a/testutils/clustermanager/e2e-tests/config.go
+++ b/testutils/clustermanager/e2e-tests/config.go
@@ -17,37 +17,37 @@ limitations under the License.
 package clustermanager
 
 import (
-    "regexp"
+	"regexp"
 
-    "knative.dev/pkg/testutils/clustermanager/e2e-tests/boskos"
+	"knative.dev/pkg/testutils/clustermanager/e2e-tests/boskos"
 )
 
 const (
-    DefaultGKEMinNodes  = 1
-    DefaultGKEMaxNodes  = 3
-    DefaultGKENodeType  = "e2-standard-4"
-    DefaultGKERegion    = "us-central1"
-    DefaultGKEZone      = ""
-    regionEnv           = "E2E_CLUSTER_REGION"
-    backupRegionEnv     = "E2E_CLUSTER_BACKUP_REGIONS"
-    DefaultResourceType = boskos.GKEProjectResource
+	DefaultGKEMinNodes  = 1
+	DefaultGKEMaxNodes  = 3
+	DefaultGKENodeType  = "e2-standard-4"
+	DefaultGKERegion    = "us-central1"
+	DefaultGKEZone      = ""
+	regionEnv           = "E2E_CLUSTER_REGION"
+	backupRegionEnv     = "E2E_CLUSTER_BACKUP_REGIONS"
+	DefaultResourceType = boskos.GKEProjectResource
 
-    ClusterRunning = "RUNNING"
+	ClusterRunning = "RUNNING"
 )
 
 var (
-    protectedProjects       = []string{"knative-tests"}
-    protectedClusters       = []string{"knative-prow"}
-    DefaultGKEBackupRegions = []string{"us-west1", "us-east1"}
+	protectedProjects       = []string{"knative-tests"}
+	protectedClusters       = []string{"knative-prow"}
+	DefaultGKEBackupRegions = []string{"us-west1", "us-east1"}
 
-    // If one of the error patterns below is matched, it would be recommended to
-    // retry creating the cluster in a different region/zone.
-    // - stockout (https://github.com/knative/test-infra/issues/592)
-    // - latest GKE not available in this region/zone yet (https://github.com/knative/test-infra/issues/694)
-    retryableCreationErrors = []*regexp.Regexp{
-        regexp.MustCompile(".*Master version \"[0-9a-z\\-.]+\" is unsupported.*"),
-        regexp.MustCompile(".*No valid versions with the prefix \"[0-9.]+\" found.*"),
-        regexp.MustCompile(".*does not have enough resources available to fulfill.*"),
-        regexp.MustCompile(".*only \\d+ nodes out of \\d+ have registered; this is likely due to Nodes failing to start correctly.*"),
-    }
+	// If one of the error patterns below is matched, it would be recommended to
+	// retry creating the cluster in a different region/zone.
+	// - stockout (https://github.com/knative/test-infra/issues/592)
+	// - latest GKE not available in this region/zone yet (https://github.com/knative/test-infra/issues/694)
+	retryableCreationErrors = []*regexp.Regexp{
+		regexp.MustCompile(".*Master version \"[0-9a-z\\-.]+\" is unsupported.*"),
+		regexp.MustCompile(".*No valid versions with the prefix \"[0-9.]+\" found.*"),
+		regexp.MustCompile(".*does not have enough resources available to fulfill.*"),
+		regexp.MustCompile(".*only \\d+ nodes out of \\d+ have registered; this is likely due to Nodes failing to start correctly.*"),
+	}
 )

--- a/testutils/clustermanager/e2e-tests/config.go
+++ b/testutils/clustermanager/e2e-tests/config.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustermanager
+
+import (
+    "regexp"
+
+    "knative.dev/pkg/testutils/clustermanager/e2e-tests/boskos"
+)
+
+const (
+    DefaultGKEMinNodes  = 1
+    DefaultGKEMaxNodes  = 3
+    DefaultGKENodeType  = "e2-standard-4"
+    DefaultGKERegion    = "us-central1"
+    DefaultGKEZone      = ""
+    regionEnv           = "E2E_CLUSTER_REGION"
+    backupRegionEnv     = "E2E_CLUSTER_BACKUP_REGIONS"
+    DefaultResourceType = boskos.GKEProjectResource
+
+    ClusterRunning = "RUNNING"
+)
+
+var (
+    protectedProjects       = []string{"knative-tests"}
+    protectedClusters       = []string{"knative-prow"}
+    DefaultGKEBackupRegions = []string{"us-west1", "us-east1"}
+
+    // If one of the error patterns below is matched, it would be recommended to
+    // retry creating the cluster in a different region/zone.
+    // - stockout (https://github.com/knative/test-infra/issues/592)
+    // - latest GKE not available in this region/zone yet (https://github.com/knative/test-infra/issues/694)
+    retryableCreationErrors = []*regexp.Regexp{
+        regexp.MustCompile(".*Master version \"[0-9a-z\\-.]+\" is unsupported.*"),
+        regexp.MustCompile(".*No valid versions with the prefix \"[0-9.]+\" found.*"),
+        regexp.MustCompile(".*does not have enough resources available to fulfill.*"),
+        regexp.MustCompile(".*only \\d+ nodes out of \\d+ have registered; this is likely due to Nodes failing to start correctly.*"),
+    }
+)

--- a/testutils/clustermanager/e2e-tests/config.go
+++ b/testutils/clustermanager/e2e-tests/config.go
@@ -23,22 +23,22 @@ import (
 )
 
 const (
-	DefaultGKEMinNodes  = 1
-	DefaultGKEMaxNodes  = 3
-	DefaultGKENodeType  = "e2-standard-4"
-	DefaultGKERegion    = "us-central1"
-	DefaultGKEZone      = ""
+	defaultGKEMinNodes  = 1
+	defaultGKEMaxNodes  = 3
+	defaultGKENodeType  = "e2-standard-4"
+	defaultGKERegion    = "us-central1"
+	defaultGKEZone      = ""
 	regionEnv           = "E2E_CLUSTER_REGION"
 	backupRegionEnv     = "E2E_CLUSTER_BACKUP_REGIONS"
-	DefaultResourceType = boskos.GKEProjectResource
+	defaultResourceType = boskos.GKEProjectResource
 
-	ClusterRunning = "RUNNING"
+	clusterRunning = "RUNNING"
 )
 
 var (
 	protectedProjects       = []string{"knative-tests"}
 	protectedClusters       = []string{"knative-prow"}
-	DefaultGKEBackupRegions = []string{"us-west1", "us-east1"}
+	defaultGKEBackupRegions = []string{"us-west1", "us-east1"}
 
 	// If one of the error patterns below is matched, it would be recommended to
 	// retry creating the cluster in a different region/zone.

--- a/testutils/clustermanager/e2e-tests/gke.go
+++ b/testutils/clustermanager/e2e-tests/gke.go
@@ -219,7 +219,7 @@ func (gc *GKECluster) Acquire() error {
 		}
 		if err != nil {
 			errMsg := fmt.Sprintf("Error during cluster creation: '%v'. ", err)
-			if gc.AsyncCleanup { // Delete half created cluster if it's user created
+			if !common.IsProw() { // Delete half created cluster if it's user created
 				errMsg = fmt.Sprintf("%sDeleting cluster %q in region %q zone %q in background...\n", errMsg, clusterName, region, request.Zone)
 				gc.operations.DeleteClusterAsync(gc.Project, region, request.Zone, clusterName)
 			}
@@ -248,8 +248,8 @@ func needsRetryCreation(errMsg string) bool {
 	return false
 }
 
-// Delete takes care of GKE cluster resource cleanup. It only release Boskos resource if running in
-// Prow, otherwise deletes the cluster if marked AsyncCleanup
+// Delete takes care of GKE cluster resource cleanup.
+// It also releases Boskos resource if running in Prow.
 func (gc *GKECluster) Delete() error {
 	if err := gc.checkEnvironment(); err != nil {
 		return fmt.Errorf("failed checking project/cluster from environment: '%v'", err)

--- a/testutils/clustermanager/e2e-tests/gke.go
+++ b/testutils/clustermanager/e2e-tests/gke.go
@@ -278,7 +278,7 @@ func (gc *GKECluster) Delete() error {
 	}
 	log.Printf("Deleting cluster %q in %q", gc.Cluster.Name, gc.Cluster.Location)
 	region, zone := gke.RegionZoneFromLoc(gc.Cluster.Location)
-	if err := gc.operations.DeleteCluster(gc.Project, region, zone, gc.Cluster.Name); err != nil {
+	if _, err := gc.operations.DeleteClusterAsync(gc.Project, region, zone, gc.Cluster.Name); err != nil {
 		return fmt.Errorf("failed deleting cluster: '%v'", err)
 	}
 	return nil

--- a/testutils/clustermanager/e2e-tests/gke.go
+++ b/testutils/clustermanager/e2e-tests/gke.go
@@ -157,12 +157,11 @@ func (gc *GKECluster) Acquire() error {
 	// If comes here we are very likely going to create a cluster, unless
 	// the cluster already exists
 
-	// Get project name from boskos if running in Prow, otherwise it should fail
-	// since we don't know which project to use
-	if gc.IsBoskos {
+	// If running on Prow and project name is not provided, get project name from boskos.
+	if gc.Project == "" && gc.IsBoskos {
 		project, err := gc.boskosOps.AcquireGKEProject(gc.Request.ResourceType)
 		if err != nil {
-			return fmt.Errorf("failed acquiring boskos project: '%v'", err)
+			return fmt.Errorf("failed acquiring boskos project: '%w'", err)
 		}
 		gc.Project = project.Name
 	}

--- a/testutils/clustermanager/e2e-tests/gke_test.go
+++ b/testutils/clustermanager/e2e-tests/gke_test.go
@@ -28,6 +28,7 @@ import (
 
 	container "google.golang.org/api/container/v1beta1"
 	boskoscommon "k8s.io/test-infra/boskos/common"
+
 	"knative.dev/pkg/test/gke"
 	gkeFake "knative.dev/pkg/test/gke/fake"
 	boskosFake "knative.dev/pkg/testutils/clustermanager/e2e-tests/boskos/fake"
@@ -85,7 +86,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{"us-west1", "us-east1"},
-					ResourceType:  DefaultResourceType,
+					ResourceType:  defaultResourceType,
 				},
 			},
 		}, {
@@ -104,7 +105,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{"us-west1", "us-east1"},
-					ResourceType:  DefaultResourceType,
+					ResourceType:  defaultResourceType,
 				},
 			},
 		}, {
@@ -147,7 +148,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{"us-west1", "us-east1"},
-					ResourceType:  DefaultResourceType,
+					ResourceType:  defaultResourceType,
 				},
 				Project:      fakeProj,
 				AsyncCleanup: true,
@@ -173,7 +174,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{"us-west1", "us-east1"},
-					ResourceType:  DefaultResourceType,
+					ResourceType:  defaultResourceType,
 				},
 				Project:      fakeProj,
 				AsyncCleanup: true,
@@ -198,7 +199,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{"us-west1", "us-east1"},
-					ResourceType:  DefaultResourceType,
+					ResourceType:  defaultResourceType,
 				},
 			},
 		}, {
@@ -221,7 +222,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{"us-west1", "us-east1"},
-					ResourceType:  DefaultResourceType,
+					ResourceType:  defaultResourceType,
 				},
 			},
 		}, {
@@ -248,7 +249,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{},
-					ResourceType:  DefaultResourceType,
+					ResourceType:  defaultResourceType,
 				},
 			},
 		}, {
@@ -274,7 +275,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: nil,
-					ResourceType:  DefaultResourceType,
+					ResourceType:  defaultResourceType,
 				},
 			},
 		}, {
@@ -299,7 +300,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: nil,
-					ResourceType:  DefaultResourceType,
+					ResourceType:  defaultResourceType,
 				},
 			},
 		}, {
@@ -318,7 +319,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{"us-west1", "us-east1"},
-					ResourceType:  DefaultResourceType,
+					ResourceType:  defaultResourceType,
 				},
 			},
 		}, {
@@ -337,7 +338,7 @@ func TestSetup(t *testing.T) {
 						Addons:      nil,
 					},
 					BackupRegions: []string{"backupregion1", "backupregion2"},
-					ResourceType:  DefaultResourceType,
+					ResourceType:  defaultResourceType,
 				},
 			},
 		}, {
@@ -360,7 +361,7 @@ func TestSetup(t *testing.T) {
 						Addons:      []string{fakeAddons},
 					},
 					BackupRegions: []string{"us-west1", "us-east1"},
-					ResourceType:  DefaultResourceType,
+					ResourceType:  defaultResourceType,
 				},
 			},
 		},
@@ -583,7 +584,7 @@ func TestAcquire(t *testing.T) {
 			name: "cluster not exist, running in Prow and boskos not available",
 			td: testdata{
 				request: request{clusterName: predefinedClusterName, addons: []string{}},
-				isProw:  true, project: fakeProj, nextOpStatus: []string{}, boskosProjs: []string{}, skipCreation: false},
+				isProw:  true, nextOpStatus: []string{}, boskosProjs: []string{}, skipCreation: false},
 			want: wantResult{expCluster: nil, expErr: fmt.Errorf("failed acquiring boskos project: 'no GKE project available'"), expPanic: false},
 		}, {
 			name: "cluster not exist, running in Prow and boskos available",
@@ -599,7 +600,7 @@ func TestAcquire(t *testing.T) {
 				NodePools: []*container.NodePool{
 					{
 						Name:             "default-pool",
-						InitialNodeCount: DefaultGKEMinNodes,
+						InitialNodeCount: defaultGKEMinNodes,
 						Config:           &container.NodeConfig{MachineType: "e2-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 						Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 					},
@@ -629,7 +630,7 @@ func TestAcquire(t *testing.T) {
 					NodePools: []*container.NodePool{
 						{
 							Name:             "default-pool",
-							InitialNodeCount: DefaultGKEMinNodes,
+							InitialNodeCount: defaultGKEMinNodes,
 							Config:           &container.NodeConfig{MachineType: "e2-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
@@ -656,7 +657,7 @@ func TestAcquire(t *testing.T) {
 					NodePools: []*container.NodePool{
 						{
 							Name:             "default-pool",
-							InitialNodeCount: DefaultGKEMinNodes,
+							InitialNodeCount: defaultGKEMinNodes,
 							Config:           &container.NodeConfig{MachineType: "e2-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
@@ -697,7 +698,7 @@ func TestAcquire(t *testing.T) {
 					NodePools: []*container.NodePool{
 						{
 							Name:             "default-pool",
-							InitialNodeCount: DefaultGKEMinNodes,
+							InitialNodeCount: defaultGKEMinNodes,
 							Config:           &container.NodeConfig{MachineType: "e2-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
@@ -723,7 +724,7 @@ func TestAcquire(t *testing.T) {
 					NodePools: []*container.NodePool{
 						{
 							Name:             "default-pool",
-							InitialNodeCount: DefaultGKEMinNodes,
+							InitialNodeCount: defaultGKEMinNodes,
 							Config:           &container.NodeConfig{MachineType: "e2-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
@@ -751,7 +752,7 @@ func TestAcquire(t *testing.T) {
 					NodePools: []*container.NodePool{
 						{
 							Name:             "default-pool",
-							InitialNodeCount: DefaultGKEMinNodes,
+							InitialNodeCount: defaultGKEMinNodes,
 							Config:           &container.NodeConfig{MachineType: "e2-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
@@ -778,7 +779,7 @@ func TestAcquire(t *testing.T) {
 					NodePools: []*container.NodePool{
 						{
 							Name:             "default-pool",
-							InitialNodeCount: DefaultGKEMinNodes,
+							InitialNodeCount: defaultGKEMinNodes,
 							Config:           &container.NodeConfig{MachineType: "e2-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
@@ -817,7 +818,7 @@ func TestAcquire(t *testing.T) {
 					NodePools: []*container.NodePool{
 						{
 							Name:             "default-pool",
-							InitialNodeCount: DefaultGKEMinNodes,
+							InitialNodeCount: defaultGKEMinNodes,
 							Config:           &container.NodeConfig{MachineType: "e2-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
@@ -845,7 +846,7 @@ func TestAcquire(t *testing.T) {
 					NodePools: []*container.NodePool{
 						{
 							Name:             "default-pool",
-							InitialNodeCount: DefaultGKEMinNodes,
+							InitialNodeCount: defaultGKEMinNodes,
 							Config:           &container.NodeConfig{MachineType: "e2-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
@@ -871,7 +872,7 @@ func TestAcquire(t *testing.T) {
 					NodePools: []*container.NodePool{
 						{
 							Name:             "default-pool",
-							InitialNodeCount: DefaultGKEMinNodes,
+							InitialNodeCount: defaultGKEMinNodes,
 							Config:           &container.NodeConfig{MachineType: "e2-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
@@ -896,7 +897,7 @@ func TestAcquire(t *testing.T) {
 					NodePools: []*container.NodePool{
 						{
 							Name:             "default-pool",
-							InitialNodeCount: DefaultGKEMinNodes,
+							InitialNodeCount: defaultGKEMinNodes,
 							Config:           &container.NodeConfig{MachineType: "e2-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
 							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
 						},
@@ -995,15 +996,15 @@ func TestAcquire(t *testing.T) {
 			fgc.Request = &GKERequest{
 				Request: gke.Request{
 					ClusterName: tt.td.request.clusterName,
-					MinNodes:    DefaultGKEMinNodes,
-					MaxNodes:    DefaultGKEMaxNodes,
-					NodeType:    DefaultGKENodeType,
-					Region:      DefaultGKERegion,
+					MinNodes:    defaultGKEMinNodes,
+					MaxNodes:    defaultGKEMaxNodes,
+					NodeType:    defaultGKENodeType,
+					Region:      defaultGKERegion,
 					Zone:        "",
 					Addons:      tt.td.request.addons,
 				},
-				BackupRegions: DefaultGKEBackupRegions,
-				ResourceType:  DefaultResourceType,
+				BackupRegions: defaultGKEBackupRegions,
+				ResourceType:  defaultResourceType,
 			}
 			opCount := 0
 			if data.existCluster != nil {
@@ -1019,6 +1020,9 @@ func TestAcquire(t *testing.T) {
 				fgc.operations.(*gkeFake.GKESDKClient).OpStatus[strconv.Itoa(opCount+i)] = status
 			}
 
+			if data.isProw && data.project == "" {
+				fgc.IsBoskos = true
+			}
 			if data.skipCreation {
 				fgc.Request.SkipCreation = true
 			}
@@ -1043,8 +1047,6 @@ func TestDelete(t *testing.T) {
 	type testdata struct {
 		isProw         bool
 		isBoskos       bool
-		NeedsCleanup   bool
-		requestCleanup bool
 		boskosState    []*boskoscommon.Resource
 		cluster        *container.Cluster
 	}
@@ -1059,45 +1061,9 @@ func TestDelete(t *testing.T) {
 		want wantResult
 	}{
 		{
-			name: "Not in prow, AsyncCleanup is false",
+			name: "Not in prow",
 			td: testdata{
 				isProw:         false,
-				NeedsCleanup:   false,
-				requestCleanup: false,
-				boskosState:    []*boskoscommon.Resource{},
-				cluster: &container.Cluster{
-					Name:     "customcluster",
-					Location: "us-central1",
-				},
-			},
-			want: wantResult{
-				nil,
-				&container.Cluster{
-					Name:         "customcluster",
-					Location:     "us-central1",
-					Status:       "RUNNING",
-					AddonsConfig: &container.AddonsConfig{},
-					NodePools: []*container.NodePool{
-						{
-							Name:             "default-pool",
-							InitialNodeCount: DefaultGKEMinNodes,
-							Config:           &container.NodeConfig{MachineType: "e2-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
-							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
-						},
-					},
-					MasterAuth: &container.MasterAuth{
-						Username: "admin",
-					},
-				},
-				nil,
-			},
-		},
-		{
-			name: "Not in prow, AsyncCleanup is true",
-			td: testdata{
-				isProw:         false,
-				NeedsCleanup:   true,
-				requestCleanup: false,
 				boskosState:    []*boskoscommon.Resource{},
 				cluster: &container.Cluster{
 					Name:     "customcluster",
@@ -1111,29 +1077,9 @@ func TestDelete(t *testing.T) {
 			},
 		},
 		{
-			name: "Not in prow, AsyncCleanup is false, requestCleanup is true",
+			name: "Not in prow, but cluster doesn't exist",
 			td: testdata{
 				isProw:         false,
-				NeedsCleanup:   false,
-				requestCleanup: true,
-				boskosState:    []*boskoscommon.Resource{},
-				cluster: &container.Cluster{
-					Name:     "customcluster",
-					Location: "us-central1",
-				},
-			},
-			want: wantResult{
-				nil,
-				nil,
-				nil,
-			},
-		},
-		{
-			name: "Not in prow, AsyncCleanup is true, but cluster doesn't exist",
-			td: testdata{
-				isProw:         false,
-				NeedsCleanup:   true,
-				requestCleanup: false,
 				boskosState:    []*boskoscommon.Resource{},
 				cluster:        nil,
 			},
@@ -1144,12 +1090,10 @@ func TestDelete(t *testing.T) {
 			},
 		},
 		{
-			name: "In prow, only need to release boskos",
+			name: "In prow",
 			td: testdata{
 				isProw:         true,
 				isBoskos:       true,
-				NeedsCleanup:   true,
-				requestCleanup: false,
 				boskosState: []*boskoscommon.Resource{{
 					Name: fakeProj,
 				}},
@@ -1164,23 +1108,7 @@ func TestDelete(t *testing.T) {
 					Name:  fakeProj,
 					State: boskoscommon.Free,
 				}},
-				&container.Cluster{
-					Name:         "customcluster",
-					Location:     "us-central1",
-					Status:       "RUNNING",
-					AddonsConfig: &container.AddonsConfig{},
-					NodePools: []*container.NodePool{
-						{
-							Name:             "default-pool",
-							InitialNodeCount: DefaultGKEMinNodes,
-							Config:           &container.NodeConfig{MachineType: "e2-standard-4", OauthScopes: []string{container.CloudPlatformScope}},
-							Autoscaling:      &container.NodePoolAutoscaling{Enabled: true, MaxNodeCount: 3, MinNodeCount: 1},
-						},
-					},
-					MasterAuth: &container.MasterAuth{
-						Username: "admin",
-					},
-				},
+				nil,
 				nil,
 			},
 		},
@@ -1229,13 +1157,12 @@ func TestDelete(t *testing.T) {
 			fgc := setupFakeGKECluster()
 			fgc.Project = fakeProj
 			fgc.IsBoskos = data.isBoskos
-			fgc.AsyncCleanup = data.NeedsCleanup
 			fgc.Request = &GKERequest{
 				Request: gke.Request{
-					MinNodes: DefaultGKEMinNodes,
-					MaxNodes: DefaultGKEMaxNodes,
-					NodeType: DefaultGKENodeType,
-					Region:   DefaultGKERegion,
+					MinNodes: defaultGKEMinNodes,
+					MaxNodes: defaultGKEMaxNodes,
+					NodeType: defaultGKENodeType,
+					Region:   defaultGKERegion,
 					Zone:     "",
 				},
 			}
@@ -1249,7 +1176,7 @@ func TestDelete(t *testing.T) {
 			for _, bos := range data.boskosState {
 				fgc.boskosOps.(*boskosFake.FakeBoskosClient).NewGKEProject(bos.Name)
 				// Acquire with default user
-				fgc.boskosOps.(*boskosFake.FakeBoskosClient).AcquireGKEProject(DefaultResourceType)
+				fgc.boskosOps.(*boskosFake.FakeBoskosClient).AcquireGKEProject(defaultResourceType)
 			}
 
 			err := fgc.Delete()
@@ -1258,9 +1185,9 @@ func TestDelete(t *testing.T) {
 				gotCluster, _ = fgc.operations.GetCluster(fakeProj, data.cluster.Location, "", data.cluster.Name)
 			}
 			gotBoskos := fgc.boskosOps.(*boskosFake.FakeBoskosClient).GetResources()
-			errMsg := fmt.Sprintf("testing deleting cluster, with:\n\tIs Prow: '%v'\n\tIs Boskos: '%v'\n\tNeed cleanup: '%v'\n\t"+
-				"Request cleanup: '%v'\n\texisting cluster: '%v'\n\tboskos state: '%v'",
-				data.isProw, data.isBoskos, data.NeedsCleanup, data.requestCleanup, data.cluster, data.boskosState)
+			errMsg := fmt.Sprintf("testing deleting cluster, with:\n\tIs Prow: '%v'\n\tIs Boskos: '%v'\n\t"+
+				"existing cluster: '%v'\n\tboskos state: '%v'",
+				data.isProw, data.isBoskos, data.cluster, data.boskosState)
 			if !reflect.DeepEqual(err, tt.want.Err) {
 				t.Errorf("%s\nerror got: '%v'\nerror want: '%v'", errMsg, err, tt.want.Err)
 			}

--- a/testutils/clustermanager/e2e-tests/gke_test.go
+++ b/testutils/clustermanager/e2e-tests/gke_test.go
@@ -1045,10 +1045,10 @@ func TestAcquire(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	type testdata struct {
-		isProw         bool
-		isBoskos       bool
-		boskosState    []*boskoscommon.Resource
-		cluster        *container.Cluster
+		isProw      bool
+		isBoskos    bool
+		boskosState []*boskoscommon.Resource
+		cluster     *container.Cluster
 	}
 	type wantResult struct {
 		Boskos  []*boskoscommon.Resource
@@ -1063,8 +1063,8 @@ func TestDelete(t *testing.T) {
 		{
 			name: "Not in prow",
 			td: testdata{
-				isProw:         false,
-				boskosState:    []*boskoscommon.Resource{},
+				isProw:      false,
+				boskosState: []*boskoscommon.Resource{},
 				cluster: &container.Cluster{
 					Name:     "customcluster",
 					Location: "us-central1",
@@ -1079,9 +1079,9 @@ func TestDelete(t *testing.T) {
 		{
 			name: "Not in prow, but cluster doesn't exist",
 			td: testdata{
-				isProw:         false,
-				boskosState:    []*boskoscommon.Resource{},
-				cluster:        nil,
+				isProw:      false,
+				boskosState: []*boskoscommon.Resource{},
+				cluster:     nil,
 			},
 			want: wantResult{
 				nil,
@@ -1092,8 +1092,8 @@ func TestDelete(t *testing.T) {
 		{
 			name: "In prow",
 			td: testdata{
-				isProw:         true,
-				isBoskos:       true,
+				isProw:   true,
+				isBoskos: true,
 				boskosState: []*boskoscommon.Resource{{
 					Name: fakeProj,
 				}},

--- a/testutils/clustermanager/e2e-tests/gke_test.go
+++ b/testutils/clustermanager/e2e-tests/gke_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package clustermanager
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -585,7 +586,7 @@ func TestAcquire(t *testing.T) {
 			td: testdata{
 				request: request{clusterName: predefinedClusterName, addons: []string{}},
 				isProw:  true, nextOpStatus: []string{}, boskosProjs: []string{}, skipCreation: false},
-			want: wantResult{expCluster: nil, expErr: fmt.Errorf("failed acquiring boskos project: 'no GKE project available'"), expPanic: false},
+			want: wantResult{expCluster: nil, expErr: fmt.Errorf("failed acquiring boskos project: '%w'", errors.New("no GKE project available")), expPanic: false},
 		}, {
 			name: "cluster not exist, running in Prow and boskos available",
 			td: testdata{
@@ -614,7 +615,7 @@ func TestAcquire(t *testing.T) {
 			td: testdata{
 				request: request{clusterName: predefinedClusterName, addons: []string{}},
 				isProw:  true, nextOpStatus: []string{}, boskosProjs: []string{}, skipCreation: false},
-			want: wantResult{expCluster: nil, expErr: fmt.Errorf("failed acquiring boskos project: 'no GKE project available'"), expPanic: false},
+			want: wantResult{expCluster: nil, expErr: fmt.Errorf("failed acquiring boskos project: '%w'", errors.New("no GKE project available")), expPanic: false},
 		},
 		{
 			name: "cluster not exist, project not set, running in Prow and boskos available",

--- a/testutils/clustermanager/e2e-tests/gke_test.go
+++ b/testutils/clustermanager/e2e-tests/gke_test.go
@@ -150,7 +150,7 @@ func TestSetup(t *testing.T) {
 					ResourceType:  DefaultResourceType,
 				},
 				Project:      fakeProj,
-				NeedsCleanup: true,
+				AsyncCleanup: true,
 			},
 		}, {
 			name: "Project provided, running in Prow",
@@ -176,7 +176,7 @@ func TestSetup(t *testing.T) {
 					ResourceType:  DefaultResourceType,
 				},
 				Project:      fakeProj,
-				NeedsCleanup: true,
+				AsyncCleanup: true,
 			},
 		}, {
 			name: "Cluster name provided, not running in Prow",
@@ -1022,9 +1022,9 @@ func TestAcquire(t *testing.T) {
 			if data.skipCreation {
 				fgc.Request.SkipCreation = true
 			}
-			// Set NeedsCleanup to false for easier testing, as it launches a
+			// Set AsyncCleanup to false for easier testing, as it launches a
 			// goroutine
-			fgc.NeedsCleanup = false
+			fgc.AsyncCleanup = false
 			err := fgc.Acquire()
 			errMsg := fmt.Sprintf("testing acquiring cluster, with:\n\tisProw: '%v'\n\tproject: '%v'\n\texisting cluster: '%+v'\n\tSkip creation: '%+v'\n\t"+
 				"next operations outcomes: '%v'\n\taddons: '%v'\n\tboskos projects: '%v'",
@@ -1059,7 +1059,7 @@ func TestDelete(t *testing.T) {
 		want wantResult
 	}{
 		{
-			name: "Not in prow, NeedsCleanup is false",
+			name: "Not in prow, AsyncCleanup is false",
 			td: testdata{
 				isProw:         false,
 				NeedsCleanup:   false,
@@ -1093,7 +1093,7 @@ func TestDelete(t *testing.T) {
 			},
 		},
 		{
-			name: "Not in prow, NeedsCleanup is true",
+			name: "Not in prow, AsyncCleanup is true",
 			td: testdata{
 				isProw:         false,
 				NeedsCleanup:   true,
@@ -1111,7 +1111,7 @@ func TestDelete(t *testing.T) {
 			},
 		},
 		{
-			name: "Not in prow, NeedsCleanup is false, requestCleanup is true",
+			name: "Not in prow, AsyncCleanup is false, requestCleanup is true",
 			td: testdata{
 				isProw:         false,
 				NeedsCleanup:   false,
@@ -1129,7 +1129,7 @@ func TestDelete(t *testing.T) {
 			},
 		},
 		{
-			name: "Not in prow, NeedsCleanup is true, but cluster doesn't exist",
+			name: "Not in prow, AsyncCleanup is true, but cluster doesn't exist",
 			td: testdata{
 				isProw:         false,
 				NeedsCleanup:   true,
@@ -1229,7 +1229,7 @@ func TestDelete(t *testing.T) {
 			fgc := setupFakeGKECluster()
 			fgc.Project = fakeProj
 			fgc.IsBoskos = data.isBoskos
-			fgc.NeedsCleanup = data.NeedsCleanup
+			fgc.AsyncCleanup = data.NeedsCleanup
 			fgc.Request = &GKERequest{
 				Request: gke.Request{
 					MinNodes: DefaultGKEMinNodes,
@@ -1250,11 +1250,6 @@ func TestDelete(t *testing.T) {
 				fgc.boskosOps.(*boskosFake.FakeBoskosClient).NewGKEProject(bos.Name)
 				// Acquire with default user
 				fgc.boskosOps.(*boskosFake.FakeBoskosClient).AcquireGKEProject(DefaultResourceType)
-			}
-			if data.requestCleanup {
-				fgc.Request = &GKERequest{
-					NeedsCleanup: true,
-				}
 			}
 
 			err := fgc.Delete()

--- a/testutils/clustermanager/e2e-tests/util.go
+++ b/testutils/clustermanager/e2e-tests/util.go
@@ -45,7 +45,7 @@ func getResourceName(rt ResourceType) (string, error) {
 			return "", fmt.Errorf("failed getting BUILD_NUMBER env var")
 		}
 		if len(buildNumStr) > 20 {
-			buildNumStr = string(buildNumStr[:20])
+			buildNumStr = buildNumStr[:20]
 		}
 		resName = fmt.Sprintf("%s-%s", resName, buildNumStr)
 	}

--- a/testutils/clustermanager/prow-cluster-operation/actions/create.go
+++ b/testutils/clustermanager/prow-cluster-operation/actions/create.go
@@ -44,7 +44,7 @@ const (
 // after the cluster operation is finished
 func writeMetaData(cluster *container.Cluster, project string) {
 	// Set up metadata client for saving metadata
-	c, err := client.NewClient("")
+	c, err := client.New("")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/testutils/clustermanager/prow-cluster-operation/actions/delete.go
+++ b/testutils/clustermanager/prow-cluster-operation/actions/delete.go
@@ -21,6 +21,7 @@ import (
 	"log"
 
 	clm "knative.dev/pkg/testutils/clustermanager/e2e-tests"
+	"knative.dev/pkg/testutils/clustermanager/e2e-tests/common"
 	"knative.dev/pkg/testutils/clustermanager/prow-cluster-operation/options"
 )
 
@@ -40,15 +41,13 @@ func Delete(o *options.RequestWrapper) error {
 	if err = gkeOps.Delete(); err != nil {
 		return fmt.Errorf("failed deleting cluster: '%v'", err)
 	}
-	// TODO: uncomment the lines below when previous Delete command becomes
-	// async operation
-	// // Unset context with best effort. The first command only unsets current
-	// // context, but doesn't delete the entry from kubeconfig, and should return it's
-	// // context if succeeded, which can be used by the second command to
-	// // delete it from kubeconfig
-	// if out, err := common.StandardExec("kubectl", "config", "unset", "current-context"); err != nil {
-	// 	common.StandardExec("kubectl", "config", "unset", "contexts."+string(out))
-	// }
+	// Unset context with best effort. The first command only unsets current
+	// context, but doesn't delete the entry from kubeconfig, and should return it's
+	// context if succeeded, which can be used by the second command to
+	// delete it from kubeconfig
+	if out, err := common.StandardExec("kubectl", "config", "unset", "current-context"); err != nil {
+		common.StandardExec("kubectl", "config", "unset", "contexts."+string(out))
+	}
 
 	return nil
 }

--- a/testutils/clustermanager/prow-cluster-operation/actions/delete.go
+++ b/testutils/clustermanager/prow-cluster-operation/actions/delete.go
@@ -27,7 +27,6 @@ import (
 
 // Delete deletes a GKE cluster
 func Delete(o *options.RequestWrapper) error {
-	o.Request.NeedsCleanup = true
 	o.Request.SkipCreation = true
 
 	gkeClient := clm.GKEClient{}

--- a/testutils/metahelper/client/client.go
+++ b/testutils/metahelper/client/client.go
@@ -53,7 +53,7 @@ func New(dir string) (*client, error) {
 	c.Path = path.Join(dir, filename)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		if err = os.MkdirAll(dir, 0777); err != nil {
-			return nil, fmt.Errorf("failed creating directory: %v", err)
+			return nil, fmt.Errorf("failed creating directory: %w", err)
 		}
 	}
 	return c, nil

--- a/testutils/metahelper/client/client.go
+++ b/testutils/metahelper/client/client.go
@@ -39,10 +39,10 @@ type client struct {
 	Path     string
 }
 
-// NewClient creates a client, takes custom directory for storing `metadata.json`.
+// New creates a client, takes custom directory for storing `metadata.json`.
 // It reads existing `metadata.json` file if it exists, otherwise creates it.
 // Errors out if there is any file i/o problem other than file not exist error.
-func NewClient(dir string) (*client, error) {
+func New(dir string) (*client, error) {
 	c := &client{
 		MetaData: make(map[string]string),
 	}
@@ -53,7 +53,7 @@ func NewClient(dir string) (*client, error) {
 	c.Path = path.Join(dir, filename)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		if err = os.MkdirAll(dir, 0777); err != nil {
-			return nil, fmt.Errorf("Failed to create directory: %v", err)
+			return nil, fmt.Errorf("failed creating directory: %v", err)
 		}
 	}
 	return c, nil

--- a/testutils/metahelper/client/client_test.go
+++ b/testutils/metahelper/client/client_test.go
@@ -54,7 +54,7 @@ func TestNewClient(t *testing.T) {
 		}
 		os.RemoveAll(dir)
 		defer os.RemoveAll(dir)
-		c, err := NewClient(data.customDir)
+		c, err := New(data.customDir)
 		errMsg := fmt.Sprintf("Testing new client with dir: %q", data.customDir)
 		if (err == nil && data.expErr) || (err != nil && !data.expErr) {
 			log.Fatalf("%s\ngot: '%v', want: '%v'", errMsg, err, data.expErr)
@@ -88,7 +88,7 @@ func TestSync(t *testing.T) {
 	}
 
 	for _, data := range datas {
-		c, _ := NewClient(fakeArtifactDir)
+		c, _ := New(fakeArtifactDir)
 		os.Remove(c.Path)
 		if data.fileExist {
 			defer os.Remove(c.Path)
@@ -126,7 +126,7 @@ func TestSet(t *testing.T) {
 	}
 
 	for _, data := range datas {
-		c, _ := NewClient(fakeArtifactDir)
+		c, _ := New(fakeArtifactDir)
 		defer os.Remove(c.Path)
 		ioutil.WriteFile(c.Path, []byte(data.content), 0644)
 
@@ -163,7 +163,7 @@ func TestGet(t *testing.T) {
 	}
 
 	for _, data := range datas {
-		c, _ := NewClient(fakeArtifactDir)
+		c, _ := New(fakeArtifactDir)
 		defer os.Remove(c.Path)
 		ioutil.WriteFile(c.Path, []byte(data.content), 0644)
 

--- a/testutils/metahelper/main.go
+++ b/testutils/metahelper/main.go
@@ -38,7 +38,7 @@ func main() {
 	// Create with default path of metahelper/client, so that the path is
 	// consistent with all other consumers of metahelper/client that run within
 	// the same context of this tool
-	c, err := client.NewClient("")
+	c, err := client.New("")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
1. Add cluster retry logic, and the error patterns are copied from https://github.com/knative/test-infra/blob/master/scripts/e2e-tests.sh#L312-L315 (I think it shares the same error pattern as `gcloud`, at least I tried the `unsupported GKE version` error, and the error message is the same)
2. If it's on boskos, delete cluster asynchronously. If it's on local, make it a blocking operation (Not sure if it's the desired logic, I'll need to fix the unit tests if so)