### PR TITLE
Do not set to unknown status when all dependents passed happy check

### DIFF
--- a/apis/condition_set.go
+++ b/apis/condition_set.go
@@ -334,7 +334,7 @@ func (r conditionsImpl) findUnhappyDependent() *Condition {
 	}
 
 	// If something was not initialized.
-	if len(r.dependents) != len(conditions) {
+	if len(r.dependents) > len(conditions) {
 		return &Condition{
 			Status: corev1.ConditionUnknown,
 		}

--- a/apis/condition_set_impl_test.go
+++ b/apis/condition_set_impl_test.go
@@ -768,6 +768,45 @@ func TestMarkTrue(t *testing.T) {
 			Type:   ConditionReady,
 			Status: corev1.ConditionTrue,
 		},
+	}, {
+		name: "all happy but not cover all dependents",
+		conditions: Conditions{{
+			Type:    ConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  "LongStory",
+			Message: "Set manually",
+		}, {
+			Type:   "Foo",
+			Status: corev1.ConditionTrue,
+		}},
+		mark:           "Foo",
+		conditionTypes: []ConditionType{"Foo", "Bar"}, // dependents is more than conditions.
+		happy:          false,
+		happyWant: &Condition{
+			Type:   ConditionReady,
+			Status: corev1.ConditionUnknown,
+		},
+	}, {
+		name: "all happy and cover all dependents",
+		conditions: Conditions{{
+			Type:    ConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  "LongStory",
+			Message: "Set manually",
+		}, {
+			Type:   "Foo",
+			Status: corev1.ConditionTrue,
+		}, {
+			Type:   "NewCondition",
+			Status: corev1.ConditionTrue,
+		}},
+		mark:           "Foo",
+		conditionTypes: []ConditionType{"Foo"}, // dependents is less than conditions.
+		happy:          true,
+		happyWant: &Condition{
+			Type:   ConditionReady,
+			Status: corev1.ConditionTrue,
+		},
 	}}
 	doTestMarkTrueAccessor(t, cases)
 }


### PR DESCRIPTION
`accessor.GetConditions()` in `findUnhappyDependent()` gets status
filed from runtime. So, if an object has following status:

```
  status:
    address:
      url: http://hello-example.default.svc.cluster.local
    conditions:
    - lastTransitionTime: "2020-04-02T09:49:03Z"
      status: "True"
      type: AllTrafficAssigned
    - lastTransitionTime: "2020-04-02T09:49:03Z"
      message: autoTLS is not enabled
      reason: AutoTLSNotEnabled
      severity: Info
      status: "True"
      type: CertificateProvisioned
    - lastTransitionTime: "2020-04-02T09:49:05Z"
      status: "True"
      type: IngressReady
    - lastTransitionTime: "2020-04-02T09:49:05Z"
      status: "True"
      type: Ready
```

`accessor.GetConditions()` returns `AllTrafficAssigned`,
`CertificateProvisioned`, `IngressReady` (and `Ready`).

Now, current code (`len(r.dependents) != len(conditions)`) sets to
`Unknown` if all conditions are not unhappy. However, it does not work
if we added a new dependent and downgraded the cluster because
the number of dependents is less than current status conditions.

This patch changes to the condition check because if all dependents
are verified, it should not set to unknown status. 