### PR TITLE
Allow a 'None' metrics backend, to basically do nothing.

### DIFF
--- a/metrics/config.go
+++ b/metrics/config.go
@@ -60,6 +60,8 @@ const (
 	// OpenCensus is used to export to the OpenCensus Agent / Collector,
 	// which can send to many other services.
 	OpenCensus metricsBackend = "opencensus"
+	// None is used to export, well, nothing.
+	None metricsBackend = "none"
 
 	defaultBackendEnvName = "DEFAULT_METRICS_BACKEND"
 

--- a/metrics/config_observability.go
+++ b/metrics/config_observability.go
@@ -53,7 +53,7 @@ type ObservabilityConfig struct {
 	EnableProbeRequestLog bool
 
 	// RequestMetricsBackend specifies the request metrics destination, e.g. Prometheus,
-	// Stackdriver.
+	// Stackdriver. "None" disables all backends.
 	RequestMetricsBackend string
 
 	// EnableProfiling indicates whether it is allowed to retrieve runtime profiling data from

--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -195,6 +195,8 @@ func newMetricsExporter(config *metricsConfig, logger *zap.SugaredLogger) (view.
 		e, err = newStackdriverExporter(config, logger)
 	case Prometheus:
 		e, err = newPrometheusExporter(config, logger)
+	case None:
+		e, err = nil, nil
 	default:
 		err = fmt.Errorf("unsupported metrics backend %v", config.backendDestination)
 	}

--- a/metrics/exporter_test.go
+++ b/metrics/exporter_test.go
@@ -68,11 +68,16 @@ func TestMetricsExporter(t *testing.T) {
 			domain:             servingDomain,
 			component:          testComponent,
 			backendDestination: "unsupported",
-			stackdriverClientConfig: StackdriverClientConfig{
-				ProjectID: "",
-			},
 		},
 		expectSuccess: false,
+	}, {
+		name: "noneBackend",
+		config: &metricsConfig{
+			domain:             servingDomain,
+			component:          testComponent,
+			backendDestination: None,
+		},
+		expectSuccess: true,
 	}, {
 		name: "validConfig",
 		config: &metricsConfig{
@@ -198,9 +203,9 @@ func TestMetricsExporter(t *testing.T) {
 	// getStackdriverSecretFunc = fakeGetStackdriverSecret
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			e, err := newMetricsExporter(test.config, TestLogger(t))
+			_, err := newMetricsExporter(test.config, TestLogger(t))
 
-			succeeded := e != nil && err == nil
+			succeeded := err == nil
 			if test.expectSuccess != succeeded {
 				t.Errorf("Unexpected test result. Expected success? [%v]. Error: [%v]", test.expectSuccess, err)
 			}


### PR DESCRIPTION
This is useful if you want to disable any surfacing of metrics whatsoever.