### PR TITLE
Fix a few simple linter warnings: unused code, govet warnings etc.

### DIFF
--- a/codegen/cmd/injection-gen/generators/packages.go
+++ b/codegen/cmd/injection-gen/generators/packages.go
@@ -206,11 +206,6 @@ func isNonNamespaced(t *types.Type) bool {
 	return nonNamespaced
 }
 
-// isInternal returns true if the tags for a member do not contain a json tag
-func isInternal(m types.Member) bool {
-	return !strings.Contains(m.Tags, "json")
-}
-
 func vendorless(p string) string {
 	if pos := strings.LastIndex(p, "/vendor/"); pos != -1 {
 		return p[pos+len("/vendor/"):]

--- a/leaderelection/config.go
+++ b/leaderelection/config.go
@@ -17,7 +17,6 @@ limitations under the License.
 package leaderelection
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -30,10 +29,7 @@ import (
 
 const ConfigMapNameEnv = "CONFIG_LEADERELECTION_NAME"
 
-var (
-	errEmptyLeaderElectionConfig = errors.New("empty leader election configuration")
-	validResourceLocks           = sets.NewString("leases", "configmaps", "endpoints")
-)
+var validResourceLocks = sets.NewString("leases", "configmaps", "endpoints")
 
 // NewConfigFromMap returns a Config for the given map, or an error.
 func NewConfigFromMap(data map[string]string) (*Config, error) {

--- a/metrics/exporter_test.go
+++ b/metrics/exporter_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"go.opencensus.io/tag"
 	. "knative.dev/pkg/logging/testing"
 )
 
@@ -26,11 +25,10 @@ import (
 // 	See https://github.com/knative/pkg/issues/608
 
 const (
-	testNS            = "test"
-	testService       = "test-service"
-	testRoute         = "test-route"
-	testConfiguration = "test-configuration"
-	testRevision      = "test-revision"
+	testNS       = "test"
+	testService  = "test-service"
+	testRoute    = "test-route"
+	testRevision = "test-revision"
 
 	testBroker              = "test-broker"
 	testEventType           = "test-eventtype"
@@ -40,14 +38,6 @@ const (
 	testSource              = "test-source"
 	testSourceResourceGroup = "test-source-rg"
 )
-
-func mustNewTagKey(s string) tag.Key {
-	tagKey, err := tag.NewKey(s)
-	if err != nil {
-		panic(err)
-	}
-	return tagKey
-}
 
 func TestMain(m *testing.M) {
 	resetCurPromSrv()

--- a/metrics/monitored_resources.go
+++ b/metrics/monitored_resources.go
@@ -17,7 +17,6 @@ limitations under the License.
 package metrics
 
 import (
-	"go.opencensus.io/tag"
 	"knative.dev/pkg/metrics/metricskey"
 )
 
@@ -25,14 +24,6 @@ type Global struct{}
 
 func (g *Global) MonitoredResource() (resType string, labels map[string]string) {
 	return "global", nil
-}
-
-func getTagsMap(tags []tag.Tag) map[string]string {
-	tagsMap := map[string]string{}
-	for _, t := range tags {
-		tagsMap[t.Key.Name()] = t.Value
-	}
-	return tagsMap
 }
 
 func valueOrUnknown(key string, tagsMap map[string]string) string {

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -25,21 +25,14 @@ import (
 	"os"
 	"os/user"
 	"path"
-	"sync"
 	"text/template"
 	"time"
 
 	"knative.dev/pkg/test/logging"
 )
 
-const (
-	// The recommended default log level https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
-	klogDefaultLogLevel = "2"
-)
-
 var (
-	flagsSetupOnce = &sync.Once{}
-	klogFlags      = flag.NewFlagSet("klog", flag.ExitOnError)
+	klogFlags = flag.NewFlagSet("klog", flag.ExitOnError)
 	// Flags holds the command line flags or defaults for settings in the user's environment.
 	// See EnvironmentFlags for a list of supported fields.
 	Flags = initializeFlags()

--- a/test/logging/logging_test.go
+++ b/test/logging/logging_test.go
@@ -54,8 +54,7 @@ func TestTLogger(legacy *testing.T) {
 	t, cancel := NewTLogger(legacy)
 	defer cancel()
 
-	var blank interface{}
-	blank = &someStruct
+	var blank interface{} = &someStruct
 
 	t.V(6).Info("Should not be printed")
 	t.V(4).Info("Should be printed!")

--- a/test/logging/sugar.go
+++ b/test/logging/sugar.go
@@ -32,9 +32,6 @@ import (
 const (
 	_oddNumberErrMsg    = "Ignored key without a value."
 	_nonStringKeyErrMsg = "Ignored key-value pairs with non-string keys."
-	spewLevel1          = 2
-	spewLevel2          = 4
-	spewLevel3          = 6
 )
 
 var spewConfig *spew.ConfigState

--- a/test/logging/tlogger.go
+++ b/test/logging/tlogger.go
@@ -315,7 +315,7 @@ func newTLogger(t *testing.T, verbosity int, dontFail bool) (*TLogger, func()) {
 		l:        log,
 		level:    verbosity,
 		t:        t,
-		errs:     make(map[string][]interface{}, 0),
+		errs:     make(map[string][]interface{}),
 		dontFail: dontFail,
 	}
 	return &tlogger, func() {

--- a/test/testgrid/testgrid.go
+++ b/test/testgrid/testgrid.go
@@ -51,10 +51,10 @@ func CreateXMLOutput(tc []junit.TestCase, testName string) error {
 	outputFile := path.Join(artifactsDir, filePrefix+testName+extension)
 	log.Printf("Storing output in %s", outputFile)
 	f, err := os.OpenFile(outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	defer f.Close()
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 	if _, err := f.WriteString(string(op) + "\n"); err != nil {
 		return err
 	}

--- a/webhook/psbinding/table_test.go
+++ b/webhook/psbinding/table_test.go
@@ -768,7 +768,7 @@ func TestWebhookReconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:         "foo",
 					Name:              "bar2",
-					DeletionTimestamp: &metav1.Time{time.Now()},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
 				},
 				Spec: TestBindableSpec{
 					BindingSpec: duckv1alpha1.BindingSpec{
@@ -1338,7 +1338,7 @@ func TestBaseReconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:         "foo",
 					Name:              "bar",
-					DeletionTimestamp: &metav1.Time{time.Now()},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
 					Finalizers: []string{
 						"slow.your.role",
 						"testbindables.duck.knative.dev",
@@ -1373,7 +1373,7 @@ func TestBaseReconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:         "foo",
 					Name:              "bar",
-					DeletionTimestamp: &metav1.Time{time.Now()},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
 					Finalizers: []string{
 						"testbindables.duck.knative.dev",
 					},
@@ -1422,7 +1422,7 @@ func TestBaseReconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:         "foo",
 					Name:              "bar",
-					DeletionTimestamp: &metav1.Time{time.Now()},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
 					Finalizers:        []string{"testbindables.duck.knative.dev"},
 				},
 				Spec: TestBindableSpec{
@@ -1454,7 +1454,7 @@ func TestBaseReconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:         "foo",
 					Name:              "bar",
-					DeletionTimestamp: &metav1.Time{time.Now()},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
 					Finalizers:        []string{"testbindables.duck.knative.dev"},
 				},
 				Spec: TestBindableSpec{
@@ -1489,7 +1489,7 @@ func TestBaseReconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:         "foo",
 					Name:              "bar",
-					DeletionTimestamp: &metav1.Time{time.Now()},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
 					Finalizers: []string{
 						"testbindables.duck.knative.dev",
 					},
@@ -1652,7 +1652,7 @@ func TestBaseReconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:         "foo",
 					Name:              "bar",
-					DeletionTimestamp: &metav1.Time{time.Now()},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
 					Finalizers: []string{
 						"testbindables.duck.knative.dev",
 					},
@@ -1691,7 +1691,7 @@ func TestBaseReconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:         "foo",
 					Name:              "bar",
-					DeletionTimestamp: &metav1.Time{time.Now()},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
 					Finalizers: []string{
 						"testbindables.duck.knative.dev",
 					},
@@ -1830,7 +1830,7 @@ func TestBaseReconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:         "foo",
 					Name:              "bar",
-					DeletionTimestamp: &metav1.Time{time.Now()},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
 					Finalizers: []string{
 						"testbindables.duck.knative.dev",
 					},
@@ -1954,17 +1954,6 @@ func patchAddEnv(namespace, name, value string) clientgotesting.PatchActionImpl 
 	action.Namespace = namespace
 
 	patch := fmt.Sprintf(`[{"op":"add","path":"/spec/template/spec/containers/0/env","value":[{"name":"FOO","value":%q}]}]`, value)
-
-	action.Patch = []byte(patch)
-	return action
-}
-
-func patchReplaceEnv(namespace, name, value string) clientgotesting.PatchActionImpl {
-	action := clientgotesting.PatchActionImpl{}
-	action.Name = name
-	action.Namespace = namespace
-
-	patch := fmt.Sprintf(`[{"op":"replace","path":"/spec/template/spec/containers/0/env/0/value","value":%q}]`, value)
 
 	action.Patch = []byte(patch)
 	return action

--- a/webhook/resourcesemantics/defaulting/defaulting_test.go
+++ b/webhook/resourcesemantics/defaulting/defaulting_test.go
@@ -505,28 +505,6 @@ func createInnerDefaultResourceWithoutSpec(t *testing.T) []byte {
 	return b
 }
 
-func createInnerDefaultResourceWithSpecAndStatus(t *testing.T, spec *InnerDefaultSpec, status *InnerDefaultStatus) []byte {
-	t.Helper()
-	r := InnerDefaultResource{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: system.Namespace(),
-			Name:      "a name",
-		},
-	}
-	if spec != nil {
-		r.Spec = *spec
-	}
-	if status != nil {
-		r.Status = *status
-	}
-
-	b, err := json.Marshal(r)
-	if err != nil {
-		t.Fatalf("Error marshaling bytes: %v", err)
-	}
-	return b
-}
-
 func NewTestResourceAdmissionController(t *testing.T) *reconciler {
 	ctx, _ := SetupFakeContext(t)
 	ctx = webhook.WithOptions(ctx, webhook.Options{

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -40,10 +40,8 @@ func newDefaultOptions() Options {
 }
 
 const (
-	testNamespace    = "test-namespace"
 	testResourceName = "test-resource"
 	user1            = "brutto@knative.dev"
-	user2            = "arrabbiato@knative.dev"
 )
 
 func newNonRunningTestWebhook(t *testing.T, options Options, acs ...interface{}) (


### PR DESCRIPTION
Because deadcode is bad code!