### PR TITLE
Actually use the subtest names in recorder test.

### DIFF
--- a/metrics/record_test.go
+++ b/metrics/record_test.go
@@ -127,16 +127,14 @@ func testRecord(t *testing.T, measure *stats.Int64Measure, shouldReportCases []c
 	defer view.Unregister(v)
 
 	for _, test := range shouldReportCases {
-		setCurMetricsConfig(test.metricsConfig)
-		Record(ctx, test.measurement)
-		metricstest.CheckLastValueData(t, test.measurement.Measure().Name(), map[string]string{}, test.measurement.Value())
+		t.Run(test.name, func(t *testing.T) {
+			setCurMetricsConfig(test.metricsConfig)
+			Record(ctx, test.measurement)
+			metricstest.CheckLastValueData(t, test.measurement.Measure().Name(), map[string]string{}, test.measurement.Value())
+		})
 	}
 
-	shouldNotReportCases := []struct {
-		name          string
-		metricsConfig *metricsConfig
-		measurement   stats.Measurement
-	}{{ // Use a different value for the measurement other than the last one of shouldReportCases
+	shouldNotReportCases := []cases{{ // Use a different value for the measurement other than the last one of shouldReportCases
 		name: "stackdriver backend with unsupported metric but not allow custom metric",
 		metricsConfig: &metricsConfig{
 			isStackdriverBackend:        true,
@@ -154,10 +152,12 @@ func testRecord(t *testing.T, measure *stats.Int64Measure, shouldReportCases []c
 	}}
 
 	for _, test := range shouldNotReportCases {
-		setCurMetricsConfig(test.metricsConfig)
-		Record(ctx, test.measurement)
-		metricstest.CheckLastValueData(t, test.measurement.Measure().Name(), map[string]string{},
-			float64(len(shouldReportCases))) // The value is still the last one of shouldReportCases
+		t.Run(test.name, func(t *testing.T) {
+			setCurMetricsConfig(test.metricsConfig)
+			Record(ctx, test.measurement)
+			metricstest.CheckLastValueData(t, test.measurement.Measure().Name(), map[string]string{},
+				float64(len(shouldReportCases))) // The value is still the last one of shouldReportCases
+		})
 	}
 }
 


### PR DESCRIPTION
The test names have been unused before. We can also reuse the `cases` type instead of redefining it inline.