### PR TITLE
t.Fatal must not be called in a goroutine.

### DIFF
--- a/webhook/admission_integration_test.go
+++ b/webhook/admission_integration_test.go
@@ -132,7 +132,7 @@ func TestAdmissionValidResponseForResource(t *testing.T) {
 		defer close(doneCh)
 		response, err := tlsClient.Do(req)
 		if err != nil {
-			t.Fatalf("Failed to get response %v", err)
+			t.Errorf("Failed to get response %v", err)
 		}
 
 		if got, want := response.StatusCode, http.StatusOK; got != want {
@@ -142,14 +142,14 @@ func TestAdmissionValidResponseForResource(t *testing.T) {
 		defer response.Body.Close()
 		responseBody, err := ioutil.ReadAll(response.Body)
 		if err != nil {
-			t.Fatalf("Failed to read response body %v", err)
+			t.Errorf("Failed to read response body %v", err)
 		}
 
 		reviewResponse := admissionv1beta1.AdmissionReview{}
 
 		err = json.NewDecoder(bytes.NewReader(responseBody)).Decode(&reviewResponse)
 		if err != nil {
-			t.Fatalf("Failed to decode response: %v", err)
+			t.Errorf("Failed to decode response: %v", err)
 		}
 	}()
 

--- a/webhook/admission_integration_test.go
+++ b/webhook/admission_integration_test.go
@@ -133,16 +133,19 @@ func TestAdmissionValidResponseForResource(t *testing.T) {
 		response, err := tlsClient.Do(req)
 		if err != nil {
 			t.Errorf("Failed to get response %v", err)
+			return
 		}
 
 		if got, want := response.StatusCode, http.StatusOK; got != want {
 			t.Errorf("Response status code = %v, wanted %v", got, want)
+			return
 		}
 
 		defer response.Body.Close()
 		responseBody, err := ioutil.ReadAll(response.Body)
 		if err != nil {
 			t.Errorf("Failed to read response body %v", err)
+			return
 		}
 
 		reviewResponse := admissionv1beta1.AdmissionReview{}
@@ -150,6 +153,7 @@ func TestAdmissionValidResponseForResource(t *testing.T) {
 		err = json.NewDecoder(bytes.NewReader(responseBody)).Decode(&reviewResponse)
 		if err != nil {
 			t.Errorf("Failed to decode response: %v", err)
+			return
 		}
 	}()
 


### PR DESCRIPTION
> A test ends when its Test function returns or calls any of the methods FailNow, Fatal, Fatalf, SkipNow, Skip, or Skipf. Those methods, as well as the Parallel method, must be called only from the goroutine running the Test function.

/assign @vagababov 