### PR TITLE
Include utility to migrate a CRD's storage version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1516,6 +1516,7 @@
     "k8s.io/client-go/tools/leaderelection",
     "k8s.io/client-go/tools/leaderelection/resourcelock",
     "k8s.io/client-go/tools/metrics",
+    "k8s.io/client-go/tools/pager",
     "k8s.io/client-go/tools/record",
     "k8s.io/client-go/util/retry",
     "k8s.io/client-go/util/workqueue",

--- a/apiextensions/OWNERS
+++ b/apiextensions/OWNERS
@@ -1,0 +1,5 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+# TODO - make a group
+approvers:
+- dprotaso

--- a/apiextensions/storageversion/cmd/migrate/config.go
+++ b/apiextensions/storageversion/cmd/migrate/config.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// TODO - make a package that's reusable here and by sharedmain
+
+func configOrDie() *rest.Config {
+	var (
+		masterURL = flag.String("master", "",
+			"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+		kubeconfig = flag.String("kubeconfig", "",
+			"Path to a kubeconfig. Only required if out-of-cluster.")
+	)
+
+	flag.Parse()
+
+	cfg, err := getConfig(*masterURL, *kubeconfig)
+	if err != nil {
+		panic(fmt.Sprintf("Error building kubeconfig: %v", err))
+	}
+
+	return cfg
+}
+
+// GetConfig returns a rest.Config to be used for kubernetes client creation.
+// It does so in the following order:
+//   1. Use the passed kubeconfig/masterURL.
+//   2. Fallback to the KUBECONFIG environment variable.
+//   3. Fallback to in-cluster config.
+//   4. Fallback to the ~/.kube/config.
+func getConfig(masterURL, kubeconfig string) (*rest.Config, error) {
+	if kubeconfig == "" {
+		kubeconfig = os.Getenv("KUBECONFIG")
+	}
+	// If we have an explicit indication of where the kubernetes config lives, read that.
+	if kubeconfig != "" {
+		return clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
+	}
+	// If not, try the in-cluster config.
+	if c, err := rest.InClusterConfig(); err == nil {
+		return c, nil
+	}
+	// If no in-cluster config, try the default location in the user's home directory.
+	if usr, err := user.Current(); err == nil {
+		if c, err := clientcmd.BuildConfigFromFlags("", filepath.Join(usr.HomeDir, ".kube", "config")); err == nil {
+			return c, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not create a valid kubeconfig")
+}

--- a/apiextensions/storageversion/cmd/migrate/config.go
+++ b/apiextensions/storageversion/cmd/migrate/config.go
@@ -47,7 +47,7 @@ func configOrDie() *rest.Config {
 	return cfg
 }
 
-// GetConfig returns a rest.Config to be used for kubernetes client creation.
+// getConfig returns a rest.Config to be used for kubernetes client creation.
 // It does so in the following order:
 //   1. Use the passed kubeconfig/masterURL.
 //   2. Fallback to the KUBECONFIG environment variable.

--- a/apiextensions/storageversion/cmd/migrate/main.go
+++ b/apiextensions/storageversion/cmd/migrate/main.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"go.uber.org/zap"
+	apixclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"knative.dev/pkg/apiextensions/storageversion"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/signals"
+)
+
+func main() {
+	logger := setupLogger()
+	defer logger.Sync()
+
+	config := configOrDie()
+	grs, err := parseResources(flag.Args())
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	migrator := storageversion.NewMigrator(
+		dynamic.NewForConfigOrDie(config),
+		apixclient.NewForConfigOrDie(config),
+	)
+
+	ctx := signals.NewContext()
+
+	logger.Infof("Migrating %d group resources", len(grs))
+
+	for _, gr := range grs {
+		logger.Infof("Migrating group resource %s", gr)
+		if err := migrator.Migrate(ctx, gr); err != nil {
+			logger.Fatalf("Failed to migrate: %s", err)
+		}
+	}
+
+	logger.Infof("Migration complete")
+}
+
+func parseResources(args []string) ([]schema.GroupResource, error) {
+	grs := make([]schema.GroupResource, 0, len(args))
+	for _, arg := range args {
+		gr := schema.ParseGroupResource(arg)
+		if gr.Empty() {
+			return nil, fmt.Errorf("unable to parse group version: %s", arg)
+		}
+		grs = append(grs, gr)
+	}
+	return grs, nil
+}
+
+func setupLogger() *zap.SugaredLogger {
+	const component = "storage-migrator"
+
+	config, err := logging.NewConfigFromMap(nil)
+	if err != nil {
+		log.Fatalf("Failed to create logging config: %s", err)
+	}
+
+	logger, _ := logging.NewLoggerFromConfig(config, component)
+	return logger
+}

--- a/apiextensions/storageversion/cmd/migrate/main.go
+++ b/apiextensions/storageversion/cmd/migrate/main.go
@@ -56,7 +56,7 @@ func main() {
 		}
 	}
 
-	logger.Infof("Migration complete")
+	logger.Info("Migration complete")
 }
 
 func parseResources(args []string) ([]schema.GroupResource, error) {

--- a/apiextensions/storageversion/migrator.go
+++ b/apiextensions/storageversion/migrator.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageversion
+
+import (
+	"context"
+	"fmt"
+
+	apix "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apixclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/pager"
+)
+
+type Migrator struct {
+	dynamicClient dynamic.Interface
+	apixClient    apixclient.Interface
+}
+
+func NewMigrator(d dynamic.Interface, a apixclient.Interface) *Migrator {
+	return &Migrator{
+		dynamicClient: d,
+		apixClient:    a,
+	}
+}
+
+func (m *Migrator) Migrate(ctx context.Context, gr schema.GroupResource) error {
+	crdClient := m.apixClient.ApiextensionsV1beta1().CustomResourceDefinitions()
+
+	crd, err := crdClient.Get(gr.String(), metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to fetch crd %s - %w", gr, err)
+	}
+
+	version := storageVersion(crd)
+
+	if err := m.migrateResources(ctx, gr.WithVersion(version)); err != nil {
+		return err
+	}
+
+	patch := fmt.Sprintf(`{"status":{"storedVersions":["` + version + `"]}}`)
+	_, err = crdClient.Patch(crd.Name, types.StrategicMergePatchType, []byte(patch), "status")
+	if err != nil {
+		return fmt.Errorf("unable to drop storage version definition %s - %w", gr, err)
+	}
+
+	return nil
+}
+
+func (m *Migrator) migrateResources(ctx context.Context, gvr schema.GroupVersionResource) error {
+	client := m.dynamicClient.Resource(gvr)
+
+	listFunc := func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.Namespace(metav1.NamespaceAll).List(opts)
+	}
+
+	onEach := func(obj runtime.Object) error {
+		item := obj.(metav1.Object)
+
+		_, err := client.Namespace(item.GetNamespace()).
+			Patch(item.GetName(), types.MergePatchType, []byte("{}"), metav1.PatchOptions{})
+
+		if err != nil {
+			return fmt.Errorf("unable to patch resource %s/%s (gvr: %s) - %w",
+				item.GetNamespace(), item.GetName(),
+				gvr, err)
+		}
+
+		return nil
+	}
+
+	pager := pager.New(listFunc)
+	return pager.EachListItem(ctx, metav1.ListOptions{}, onEach)
+}
+
+func storageVersion(crd *apix.CustomResourceDefinition) string {
+	var version string
+
+	for _, v := range crd.Spec.Versions {
+		if v.Storage {
+			version = v.Name
+			break
+		}
+	}
+
+	if version == "" {
+		version = crd.Spec.Version
+	}
+
+	return version
+}

--- a/apiextensions/storageversion/migrator.go
+++ b/apiextensions/storageversion/migrator.go
@@ -30,11 +30,14 @@ import (
 	"k8s.io/client-go/tools/pager"
 )
 
+// Migrator will read custom resource definitions and upgrade
+// the associated resources to the latest storage version
 type Migrator struct {
 	dynamicClient dynamic.Interface
 	apixClient    apixclient.Interface
 }
 
+// NewMigrator will return a new Migrator
 func NewMigrator(d dynamic.Interface, a apixclient.Interface) *Migrator {
 	return &Migrator{
 		dynamicClient: d,
@@ -42,6 +45,14 @@ func NewMigrator(d dynamic.Interface, a apixclient.Interface) *Migrator {
 	}
 }
 
+// Migrate takes a group resource (ie. resource.some.group.dev) and
+// updates instances of the resource to the latest storage version
+//
+// This is done by listing all the resources and performing an empty patch
+// which triggers a migration on the K8s API server
+//
+// Finally the migrator will update the CRD's status and drop older storage
+// versions
 func (m *Migrator) Migrate(ctx context.Context, gr schema.GroupResource) error {
 	crdClient := m.apixClient.ApiextensionsV1beta1().CustomResourceDefinitions()
 

--- a/apiextensions/storageversion/migrator.go
+++ b/apiextensions/storageversion/migrator.go
@@ -67,7 +67,7 @@ func (m *Migrator) Migrate(ctx context.Context, gr schema.GroupResource) error {
 		return err
 	}
 
-	patch := fmt.Sprintf(`{"status":{"storedVersions":["` + version + `"]}}`)
+	patch := `{"status":{"storedVersions":["` + version + `"]}}`
 	_, err = crdClient.Patch(crd.Name, types.StrategicMergePatchType, []byte(patch), "status")
 	if err != nil {
 		return fmt.Errorf("unable to drop storage version definition %s - %w", gr, err)

--- a/apiextensions/storageversion/migrator_test.go
+++ b/apiextensions/storageversion/migrator_test.go
@@ -102,44 +102,40 @@ func TestMigrate_Errors(t *testing.T) {
 		name string
 		crd  func(*k8stesting.Fake)
 		dyn  func(*k8stesting.Fake)
-	}{
-		{
-			name: "failed to fetch CRD",
-			crd: func(fake *k8stesting.Fake) {
-				fake.PrependReactor("get", "*",
-					func(k8stesting.Action) (bool, runtime.Object, error) {
-						return true, nil, fmt.Errorf("failed to get crd")
-					})
-			},
+	}{{
+		name: "failed to fetch CRD",
+		crd: func(fake *k8stesting.Fake) {
+			fake.PrependReactor("get", "*",
+				func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, fmt.Errorf("failed to get crd")
+				})
 		},
-		{
-			name: "listing fails",
-			dyn: func(fake *k8stesting.Fake) {
-				fake.PrependReactor("list", "*",
-					func(k8stesting.Action) (bool, runtime.Object, error) {
-						return true, nil, fmt.Errorf("failed to list resources")
-					})
-			},
+	}, {
+		name: "listing fails",
+		dyn: func(fake *k8stesting.Fake) {
+			fake.PrependReactor("list", "*",
+				func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, fmt.Errorf("failed to list resources")
+				})
 		},
-		{
-			name: "patching resource fails",
-			dyn: func(fake *k8stesting.Fake) {
-				fake.PrependReactor("patch", "*",
-					func(k8stesting.Action) (bool, runtime.Object, error) {
-						return true, nil, fmt.Errorf("failed to patch resources")
-					})
-			},
+	}, {
+		name: "patching resource fails",
+		dyn: func(fake *k8stesting.Fake) {
+			fake.PrependReactor("patch", "*",
+				func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, fmt.Errorf("failed to patch resources")
+				})
 		},
-		{
-			name: "patching definition fails",
-			crd: func(fake *k8stesting.Fake) {
-				fake.PrependReactor("patch", "*",
-					func(k8stesting.Action) (bool, runtime.Object, error) {
-						return true, nil, fmt.Errorf("failed to patch definition")
-					})
-			},
+	}, {
+		name: "patching definition fails",
+		crd: func(fake *k8stesting.Fake) {
+			fake.PrependReactor("patch", "*",
+				func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, fmt.Errorf("failed to patch definition")
+				})
 		},
-		// todo paging fails
+	},
+	// todo paging fails
 	}
 
 	for _, test := range tests {

--- a/apiextensions/storageversion/migrator_test.go
+++ b/apiextensions/storageversion/migrator_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageversion
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	apix "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apixFake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicFake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+var (
+	fakeGK = schema.GroupKind{
+		Kind:  "Fake",
+		Group: "group.dev",
+	}
+
+	fakeListGK = schema.GroupKind{
+		Kind:  "FakeList",
+		Group: "group.dev",
+	}
+
+	fakeGR = schema.GroupResource{
+		Resource: "fakes",
+		Group:    "group.dev",
+	}
+
+	fakeCRD = &apix.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fakeGR.String(),
+		},
+		Spec: apix.CustomResourceDefinitionSpec{
+			Group: fakeGK.Group,
+			Versions: []apix.CustomResourceDefinitionVersion{
+				{Name: "v1alpha1", Served: true, Storage: false},
+				{Name: "v1", Served: true, Storage: true},
+			},
+		},
+		Status: apix.CustomResourceDefinitionStatus{
+			StoredVersions: []string{
+				"v1alpha1",
+				"v1",
+			},
+		},
+	}
+)
+
+func TestMigrate(t *testing.T) {
+	// setup
+	resources := []runtime.Object{fake("first"), fake("second")}
+	dclient := dynamicFake.NewSimpleDynamicClient(runtime.NewScheme(), resources...)
+	cclient := apixFake.NewSimpleClientset(fakeCRD)
+	m := NewMigrator(dclient, cclient)
+
+	if err := m.Migrate(context.TODO(), fakeGR); err != nil {
+		t.Fatalf("Migrate() = %s", err)
+	}
+
+	assertPatches(t, dclient.Actions(),
+		// patch resource definition dropping non-storage version
+		emptyResourcePatch("first", "v1"),
+		emptyResourcePatch("second", "v1"),
+	)
+
+	assertPatches(t, cclient.Actions(),
+		// patch resource definition dropping non-storage version
+		crdStorageVersionPatch(fakeCRD.Name, "v1"),
+	)
+}
+
+// func TestMigrate_Paging(t *testing.T) {
+// 	t.Skip("client-go lacks testing pagination " +
+// 		"since list options aren't captured in actions")
+// }
+
+func TestMigrate_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		crd  func(*k8stesting.Fake)
+		dyn  func(*k8stesting.Fake)
+	}{
+		{
+			name: "failed to fetch CRD",
+			crd: func(fake *k8stesting.Fake) {
+				fake.PrependReactor("get", "*",
+					func(k8stesting.Action) (bool, runtime.Object, error) {
+						return true, nil, fmt.Errorf("failed to get crd")
+					})
+			},
+		},
+		{
+			name: "listing fails",
+			dyn: func(fake *k8stesting.Fake) {
+				fake.PrependReactor("list", "*",
+					func(k8stesting.Action) (bool, runtime.Object, error) {
+						return true, nil, fmt.Errorf("failed to list resources")
+					})
+			},
+		},
+		{
+			name: "patching resource fails",
+			dyn: func(fake *k8stesting.Fake) {
+				fake.PrependReactor("patch", "*",
+					func(k8stesting.Action) (bool, runtime.Object, error) {
+						return true, nil, fmt.Errorf("failed to patch resources")
+					})
+			},
+		},
+		{
+			name: "patching definition fails",
+			crd: func(fake *k8stesting.Fake) {
+				fake.PrependReactor("patch", "*",
+					func(k8stesting.Action) (bool, runtime.Object, error) {
+						return true, nil, fmt.Errorf("failed to patch definition")
+					})
+			},
+		},
+		// todo paging fails
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			resources := []runtime.Object{fake("first"), fake("second")}
+			dclient := dynamicFake.NewSimpleDynamicClient(runtime.NewScheme(), resources...)
+			cclient := apixFake.NewSimpleClientset(fakeCRD)
+
+			if test.crd != nil {
+				test.crd(&cclient.Fake)
+			}
+
+			if test.dyn != nil {
+				test.dyn(&dclient.Fake)
+			}
+
+			m := NewMigrator(dclient, cclient)
+			if err := m.Migrate(context.TODO(), fakeGR); err == nil {
+				t.Errorf("Migrate should have returned an error")
+			}
+		})
+	}
+}
+
+func assertPatches(t *testing.T, actions []k8stesting.Action, want ...k8stesting.PatchAction) {
+	t.Helper()
+
+	got := getPatchActions(actions)
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("unexpected patches: %s", diff)
+	}
+}
+
+func emptyResourcePatch(name, version string) k8stesting.PatchAction {
+	return k8stesting.NewPatchAction(
+		fakeGR.WithVersion(version),
+		"default",
+		name,
+		types.MergePatchType,
+		[]byte("{}"))
+}
+
+func crdStorageVersionPatch(name, version string) k8stesting.PatchAction {
+	return k8stesting.NewRootPatchSubresourceAction(
+		apix.SchemeGroupVersion.WithResource("customresourcedefinitions"),
+		name,
+		types.StrategicMergePatchType,
+		[]byte(`{"status":{"storedVersions":["`+version+`"]}}`),
+		"status",
+	)
+}
+
+func getPatchActions(actions []k8stesting.Action) []k8stesting.PatchAction {
+	var patches []k8stesting.PatchAction
+
+	for _, action := range actions {
+		if pa, ok := action.(k8stesting.PatchAction); ok {
+			patches = append(patches, pa)
+		}
+	}
+
+	return patches
+}
+
+func fake(name string) runtime.Object {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "group.dev/v1",
+			"kind":       "Fake",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": "default",
+			},
+		},
+	}
+}

--- a/apiextensions/storageversion/migrator_test.go
+++ b/apiextensions/storageversion/migrator_test.go
@@ -158,7 +158,7 @@ func TestMigrate_Errors(t *testing.T) {
 
 			m := NewMigrator(dclient, cclient)
 			if err := m.Migrate(context.TODO(), fakeGR); err == nil {
-				t.Errorf("Migrate should have returned an error")
+				t.Error("Migrate should have returned an error")
 			}
 		})
 	}

--- a/apiextensions/storageversion/migrator_test.go
+++ b/apiextensions/storageversion/migrator_test.go
@@ -144,7 +144,6 @@ func TestMigrate_Errors(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			resources := []runtime.Object{fake("first"), fake("second")}
 			dclient := dynamicFake.NewSimpleDynamicClient(runtime.NewScheme(), resources...)
 			cclient := apixFake.NewSimpleClientset(fakeCRD)


### PR DESCRIPTION
See https://github.com/knative/serving/pull/7499 for context

Essentially, the tool is generic enough it's possible to use on any CRD