### PR TITLE
Sinkbinding Webhook should label namespace for inclusion

### DIFF
--- a/reconciler/testing/table.go
+++ b/reconciler/testing/table.go
@@ -321,7 +321,9 @@ func (r *TableRow) Test(t *testing.T, factory Factory) {
 		if got.GetName() != want.GetName() {
 			t.Errorf("Unexpected patch[%d]: %#v", i, got)
 		}
-		if !r.SkipNamespaceValidation && got.GetNamespace() != expectedNamespace {
+		if (!r.SkipNamespaceValidation && got.GetNamespace() != expectedNamespace) &&
+			(!r.SkipNamespaceValidation && got.GetResource().GroupResource().Resource != "namespaces" &&
+				got.GetName() != expectedNamespace) {
 			t.Errorf("Unexpected patch[%d]: %#v", i, got)
 		}
 		if diff := cmp.Diff(string(want.GetPatch()), string(got.GetPatch())); diff != "" {

--- a/webhook/psbinding/reconciler.go
+++ b/webhook/psbinding/reconciler.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"knative.dev/pkg/apis"
@@ -45,7 +46,7 @@ import (
 
 var jsonLabelPatch = map[string]interface{}{
 	"metadata": map[string]interface{}{
-		"labels": map[string]string{"bindings.knative.dev/include": "true"},
+		"labels": map[string]string{duck.BindingIncludeLabel: "true"},
 	},
 }
 
@@ -81,6 +82,9 @@ type BaseReconciler struct {
 	// Recorder is an event recorder for recording Event resources to the
 	// Kubernetes API.
 	Recorder record.EventRecorder
+
+	// Namespace Lister
+	NamespaceLister corev1listers.NamespaceLister
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -237,6 +241,25 @@ func (r *BaseReconciler) RemoveFinalizer(ctx context.Context, fb kmeta.Accessor)
 
 func (r *BaseReconciler) labelNamespace(ctx context.Context, subject tracker.Reference) error {
 
+	namespaceObject, err := r.NamespaceLister.Get(subject.Namespace)
+	if apierrs.IsNotFound(err) {
+		logging.FromContext(ctx).Infof("Error getting namespace listener (not found): %v", err)
+		return err
+	} else if err != nil {
+		return err
+	}
+
+	labels := namespaceObject.GetLabels()
+	if labels[duck.BindingIncludeLabel] != "" || labels[duck.BindingExcludeLabel] != "" {
+		return nil
+	}
+
+	patch, err := json.Marshal(jsonLabelPatch)
+	if err != nil {
+		logging.FromContext(ctx).Infof("Error generating json patch: %v, to namespace: %s", err, subject.Namespace)
+		return nil
+	}
+
 	// Determine the GroupVersionResource of the subject reference
 	gvr := schema.GroupVersionResource{
 		Group:    "",
@@ -244,28 +267,6 @@ func (r *BaseReconciler) labelNamespace(ctx context.Context, subject tracker.Ref
 		Resource: "namespaces",
 	}
 
-	// Don't remove any existing labels or add ours more than once
-	_, namespaceLister, err := r.Factory.Get(gvr)
-	if err != nil {
-		logging.FromContext(ctx).Infof("Error getting lister for namespaces: '%v': %v", gvr, err)
-		return err
-	}
-	namespaceObject, err := namespaceLister.Get(subject.Namespace)
-	if apierrs.IsNotFound(err) {
-		logging.FromContext(ctx).Infof("")
-		return err
-	} else if err != nil {
-		return err
-	}
-	labels := (namespaceObject.(*duckv1.WithPod)).GetLabels()
-	if labels["bindings.knative.dev/exclude"] != "" || labels["bindings.knative.dev/include"] != "" {
-		return nil
-	}
-	patch, err := json.Marshal(jsonLabelPatch)
-	if err != nil {
-		logging.FromContext(ctx).Infof("Error generating json patch: %v, to namespace: %s", err, subject.Namespace)
-		return nil
-	}
 	_, err = r.DynamicClient.Resource(gvr).Patch(subject.Namespace, types.MergePatchType, patch, metav1.PatchOptions{})
 	if err != nil {
 		logging.FromContext(ctx).Infof("Error applying patch to namespace: %s: %v", subject.Namespace, err)

--- a/webhook/psbinding/reconciler.go
+++ b/webhook/psbinding/reconciler.go
@@ -243,9 +243,10 @@ func (r *BaseReconciler) labelNamespace(ctx context.Context, subject tracker.Ref
 
 	namespaceObject, err := r.NamespaceLister.Get(subject.Namespace)
 	if apierrs.IsNotFound(err) {
-		logging.FromContext(ctx).Infof("Error getting namespace listener (not found): %v", err)
+		logging.FromContext(ctx).Infof("Error getting namespace (not found): %v", err)
 		return err
 	} else if err != nil {
+		logging.FromContext(ctx).Infof("Error getting namespace: %v", err)
 		return err
 	}
 

--- a/webhook/psbinding/table_test.go
+++ b/webhook/psbinding/table_test.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -1126,6 +1127,11 @@ func TestBaseReconcile(t *testing.T) {
 					},
 				},
 			},
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			},
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: mustTU(t, &TestBindable{
@@ -1156,6 +1162,7 @@ func TestBaseReconcile(t *testing.T) {
 		}},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizer("foo", "bar", "" /* resource version */),
+			patchAddLabel("foo"),
 			patchAddEnv("foo", "on-it", "asdfasdfasdfasdf"),
 		},
 	}, {
@@ -1227,6 +1234,12 @@ func TestBaseReconcile(t *testing.T) {
 							Status: "True",
 						}},
 					},
+				},
+			},
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "foo",
+					Labels: map[string]string{"bindings.knative.dev/include": "true"},
 				},
 			},
 			&appsv1.Deployment{
@@ -1329,6 +1342,14 @@ func TestBaseReconcile(t *testing.T) {
 					},
 				},
 			},
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			},
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddLabel("foo"),
 		},
 	}, {
 		Name: "finalizing, but not our turn.",
@@ -1534,8 +1555,14 @@ func TestBaseReconcile(t *testing.T) {
 					},
 				},
 			},
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			},
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddLabel("foo"),
 			patchRemoveEnv("foo", "on-it"),
 			patchRemoveFinalizer("foo", "bar", "" /* resource version */),
 		},
@@ -1586,9 +1613,15 @@ func TestBaseReconcile(t *testing.T) {
 					},
 				},
 			},
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			},
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizer("foo", "bar", "" /* resource version */),
+			patchAddLabel("foo"),
 			patchAddEnv("foo", "on-it", "asdfasdfasdfasdf"),
 		},
 	}, {
@@ -1643,6 +1676,14 @@ func TestBaseReconcile(t *testing.T) {
 					},
 				},
 			},
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			},
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddLabel("foo"),
 		},
 	}, {
 		Name: "finalizing, missing subject (remove the finalizer, via selector)",
@@ -1679,8 +1720,14 @@ func TestBaseReconcile(t *testing.T) {
 					},
 				},
 			},
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			},
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddLabel("foo"),
 			patchRemoveFinalizer("foo", "bar", "" /* resource version */),
 		},
 	}, {
@@ -1738,8 +1785,14 @@ func TestBaseReconcile(t *testing.T) {
 					},
 				},
 			},
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			},
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddLabel("foo"),
 			patchRemoveEnv("foo", "on-it"),
 			patchRemoveFinalizer("foo", "bar", "" /* resource version */),
 		},
@@ -1789,6 +1842,14 @@ func TestBaseReconcile(t *testing.T) {
 					},
 				},
 			},
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			},
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddLabel("foo"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: mustTU(t, &TestBindable{
@@ -1879,8 +1940,14 @@ func TestBaseReconcile(t *testing.T) {
 					},
 				},
 			},
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			},
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddLabel("foo"),
 			patchRemoveEnv("foo", "on-it"),
 		},
 	}}
@@ -1926,6 +1993,31 @@ func mustTU(t *testing.T, ro duck.OneOfOurs) *unstructured.Unstructured {
 	return u
 }
 
+func patchAddLabel(namespace string) clientgotesting.PatchActionImpl {
+	action := clientgotesting.PatchActionImpl{}
+	resource := schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "namespaces",
+	}
+	actionImpl := clientgotesting.ActionImpl{
+		Namespace:   namespace,
+		Verb:        "patch",
+		Resource:    resource,
+		Subresource: "",
+	}
+	action.ActionImpl = actionImpl
+	action.Name = namespace
+	action.PatchType = types.MergePatchType
+
+	patch, _ := json.Marshal(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"labels": map[string]string{"bindings.knative.dev/include": "true"},
+		},
+	})
+	action.Patch = patch
+	return action
+}
 func patchAddFinalizer(namespace, name, resourceVersion string) clientgotesting.PatchActionImpl {
 	action := clientgotesting.PatchActionImpl{}
 	action.Name = name

--- a/webhook/psbinding/table_test.go
+++ b/webhook/psbinding/table_test.go
@@ -2010,11 +2010,7 @@ func patchAddLabel(namespace string) clientgotesting.PatchActionImpl {
 	action.Name = namespace
 	action.PatchType = types.MergePatchType
 
-	patch, _ := json.Marshal(map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"labels": map[string]string{"bindings.knative.dev/include": "true"},
-		},
-	})
+	patch, _ := json.Marshal(jsonLabelPatch)
 	action.Patch = patch
 	return action
 }

--- a/webhook/psbinding/table_test.go
+++ b/webhook/psbinding/table_test.go
@@ -1239,7 +1239,7 @@ func TestBaseReconcile(t *testing.T) {
 			&corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "foo",
-					Labels: map[string]string{"bindings.knative.dev/include": "true"},
+					Labels: map[string]string{duck.BindingIncludeLabel: "true"},
 				},
 			},
 			&appsv1.Deployment{
@@ -1981,6 +1981,7 @@ func TestBaseReconcile(t *testing.T) {
 				}
 				return nil, apierrs.NewNotFound(gvr.GroupResource(), name)
 			},
+			NamespaceLister: listers.GetNamespaceLister(),
 		}
 	}))
 }


### PR DESCRIPTION
By labelling a target namespace `bindings.knative.dev/inclusion: true` we can then set the psbinding webhook to exlusion and not have the webhook hit every single request to the apiserver (but still allow the psbinding requests we *want* to reconcile).