### PR TITLE
Normalize CM owners across CM directories

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -21,6 +21,7 @@ aliases:
   - mattmoor
   - mdemirhan
   - dprotaso
+  - vagababov
 
   controller-approvers:
   - dgerd

--- a/logging/config
+++ b/logging/config
@@ -1,0 +1,4 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- configmap-approvers

--- a/tracing/config/OWNERS
+++ b/tracing/config/OWNERS
@@ -1,0 +1,4 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- configmap-approvers


### PR DESCRIPTION
Make sure they're uniform more or less.
Also add myself for CM approvers, given I've rewrote most of them recently.

/assign mattmoor