### PR TITLE
Add callback operations to ValidatingWebhookConfiguration rules

### DIFF
--- a/webhook/resourcesemantics/validation/reconcile_config.go
+++ b/webhook/resourcesemantics/validation/reconcile_config.go
@@ -106,8 +106,7 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 		}
 
 		// Add supported verbs from callbacks to the rule operations
-		callback, ok := ac.callbacks[gvk]
-		if ok {
+		if callback, ok := ac.callbacks[gvk]; ok {
 			for verb := range callback.supportedVerbs {
 				operationType := admissionregistrationv1beta1.OperationType(verb)
 				if operationType != admissionregistrationv1beta1.Create && operationType != admissionregistrationv1beta1.Update {

--- a/webhook/resourcesemantics/validation/validation_admit.go
+++ b/webhook/resourcesemantics/validation/validation_admit.go
@@ -42,11 +42,11 @@ type Callback struct {
 	function func(ctx context.Context, unstructured *unstructured.Unstructured) error
 
 	// supportedVerbs are the verbs supported for the callback.
-	// The function will only be called on these acitons.
+	// The function will only be called on these actions.
 	supportedVerbs map[webhook.Operation]struct{}
 }
 
-// NewCallback creates a new callback function to be invoked on supported vebs.
+// NewCallback creates a new callback function to be invoked on supported verbs.
 func NewCallback(function func(context.Context, *unstructured.Unstructured) error, supportedVerbs ...webhook.Operation) Callback {
 	m := make(map[webhook.Operation]struct{})
 	for _, op := range supportedVerbs {

--- a/webhook/resourcesemantics/validation/validation_admit_test.go
+++ b/webhook/resourcesemantics/validation/validation_admit_test.go
@@ -89,7 +89,7 @@ var (
 			Group:   "pkg.knative.dev",
 			Version: "v1beta1",
 			Kind:    "Resource",
-		}: NewCallback(resourceCallback, webhook.Create, webhook.Update),
+		}: NewCallback(resourceCallback, webhook.Create, webhook.Update, webhook.Delete),
 	}
 	initialResourceWebhook = &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Fixes #1207

Add the supported operations in reconciler callbacks to the webhook configuration. Right now, DELETE requests are intended to be supported by callbacks, but never make it to the `Admit()` method of the admission controller, since the webhook configuration only includes `CREATE` and `UPDATE` operations in its rules.