### PR TITLE
Allow Delete verb on validation callbacks

### DIFF
--- a/apis/contexts.go
+++ b/apis/contexts.go
@@ -39,6 +39,21 @@ func IsInCreate(ctx context.Context) bool {
 }
 
 // This is attached to contexts passed to webhook interfaces when
+// the receiver being validated is being deleted.
+type inDeleteKey struct{}
+
+// WithinDelete is used to note that the webhook is calling within
+// the context of a Delete operation.
+func WithinDelete(ctx context.Context) context.Context {
+	return context.WithValue(ctx, inDeleteKey{}, struct{}{})
+}
+
+// IsInDelete checks whether the context is a Delete.
+func IsInDelete(ctx context.Context) bool {
+	return ctx.Value(inDeleteKey{}) != nil
+}
+
+// This is attached to contexts passed to webhook interfaces when
 // the receiver being validated is being updated.
 type inUpdateKey struct{}
 

--- a/apis/contexts_test.go
+++ b/apis/contexts_test.go
@@ -49,6 +49,21 @@ func TestContexts(t *testing.T) {
 		check: IsInCreate,
 		want:  false,
 	}, {
+		name:  "is in delete",
+		ctx:   WithinDelete(ctx),
+		check: IsInDelete,
+		want:  true,
+	}, {
+		name:  "not in delete (bare)",
+		ctx:   ctx,
+		check: IsInDelete,
+		want:  false,
+	}, {
+		name:  "not in delete (create)",
+		ctx:   WithinCreate(ctx),
+		check: IsInDelete,
+		want:  false,
+	}, {
 		name:  "is in update",
 		ctx:   WithinUpdate(ctx, struct{}{}),
 		check: IsInUpdate,
@@ -144,7 +159,7 @@ func TestContexts(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := tc.check(tc.ctx)
 			if tc.want != got {
-				t.Errorf("check() = %v, wanted %v", tc.want, got)
+				t.Errorf("check() = %v, wanted %v", got, tc.want)
 			}
 		})
 	}

--- a/webhook/resourcesemantics/validation/reconcile_config.go
+++ b/webhook/resourcesemantics/validation/reconcile_config.go
@@ -97,6 +97,7 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 			Operations: []admissionregistrationv1beta1.OperationType{
 				admissionregistrationv1beta1.Create,
 				admissionregistrationv1beta1.Update,
+				admissionregistrationv1beta1.Delete,
 			},
 			Rule: admissionregistrationv1beta1.Rule{
 				APIGroups:   []string{gvk.Group},

--- a/webhook/resourcesemantics/validation/reconcile_config_test.go
+++ b/webhook/resourcesemantics/validation/reconcile_config_test.go
@@ -59,28 +59,28 @@ func TestReconcile(t *testing.T) {
 
 	// These are the rules we expect given the context of "handlers".
 	expectedRules := []admissionregistrationv1beta1.RuleWithOperations{{
-		Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE"},
+		Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE", "DELETE"},
 		Rule: admissionregistrationv1beta1.Rule{
 			APIGroups:   []string{"pkg.knative.dev"},
 			APIVersions: []string{"v1alpha1"},
 			Resources:   []string{"innerdefaultresources/*"},
 		},
 	}, {
-		Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE"},
+		Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE", "DELETE"},
 		Rule: admissionregistrationv1beta1.Rule{
 			APIGroups:   []string{"pkg.knative.dev"},
 			APIVersions: []string{"v1alpha1"},
 			Resources:   []string{"resources/*"},
 		},
 	}, {
-		Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE"},
+		Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE", "DELETE"},
 		Rule: admissionregistrationv1beta1.Rule{
 			APIGroups:   []string{"pkg.knative.dev"},
 			APIVersions: []string{"v1beta1"},
 			Resources:   []string{"resources/*"},
 		},
 	}, {
-		Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE"},
+		Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE", "DELETE"},
 		Rule: admissionregistrationv1beta1.Rule{
 			APIGroups:   []string{"pkg.knative.io"},
 			APIVersions: []string{"v1alpha1"},

--- a/webhook/resourcesemantics/validation/validation_admit.go
+++ b/webhook/resourcesemantics/validation/validation_admit.go
@@ -161,6 +161,8 @@ func validate(ctx context.Context, resource resourcesemantics.GenericCRD, req *a
 	switch req.Operation {
 	case admissionv1beta1.Create, admissionv1beta1.Update:
 		// Supported verbs
+	case admissionv1beta1.Delete:
+		return nil // Validation handled by optional Callback, but not validatable.
 	default:
 		logger.Infof("Unhandled webhook validation operation, letting it through %v", req.Operation)
 		return nil

--- a/webhook/resourcesemantics/validation/validation_admit.go
+++ b/webhook/resourcesemantics/validation/validation_admit.go
@@ -133,17 +133,15 @@ func (ac *reconciler) decodeRequestAndPrepareContext(
 
 	switch req.Operation {
 	case admissionv1beta1.Update:
-		if oldObj != nil {
-			if req.SubResource == "" {
-				ctx = apis.WithinUpdate(ctx, oldObj)
-			} else {
-				ctx = apis.WithinSubResourceUpdate(ctx, oldObj, req.SubResource)
-			}
-		}
+		ctx = apis.WithinUpdate(ctx, oldObj)
 	case admissionv1beta1.Create:
 		ctx = apis.WithinCreate(ctx)
 	case admissionv1beta1.Delete:
 		ctx = apis.WithinDelete(ctx)
+	}
+
+	if newObj != nil && oldObj != nil && req.SubResource == "" {
+		ctx = apis.WithinSubResourceUpdate(ctx, oldObj, req.SubResource)
 	}
 
 	ctx = apis.WithUserInfo(ctx, &req.UserInfo)

--- a/webhook/resourcesemantics/validation/validation_admit.go
+++ b/webhook/resourcesemantics/validation/validation_admit.go
@@ -131,19 +131,23 @@ func (ac *reconciler) decodeRequestAndPrepareContext(
 		}
 	}
 
-	// Set up the context for validation
-	if oldObj != nil {
-		if req.SubResource == "" {
-			ctx = apis.WithinUpdate(ctx, oldObj)
-		} else {
-			ctx = apis.WithinSubResourceUpdate(ctx, oldObj, req.SubResource)
+	switch req.Operation {
+	case admissionv1beta1.Update:
+		if oldObj != nil {
+			if req.SubResource == "" {
+				ctx = apis.WithinUpdate(ctx, oldObj)
+			} else {
+				ctx = apis.WithinSubResourceUpdate(ctx, oldObj, req.SubResource)
+			}
 		}
-	} else {
+	case admissionv1beta1.Create:
 		ctx = apis.WithinCreate(ctx)
+	case admissionv1beta1.Delete:
+		ctx = apis.WithinDelete(ctx)
 	}
+
 	ctx = apis.WithUserInfo(ctx, &req.UserInfo)
 	ctx = context.WithValue(ctx, kubeclient.Key{}, ac.client)
-
 	if req.DryRun != nil && *req.DryRun {
 		ctx = apis.WithDryRun(ctx)
 	}

--- a/webhook/resourcesemantics/validation/validation_admit.go
+++ b/webhook/resourcesemantics/validation/validation_admit.go
@@ -42,11 +42,11 @@ type Callback struct {
 	function func(ctx context.Context, unstructured *unstructured.Unstructured) error
 
 	// supportedVerbs are the verbs supported for the callback.
-	// The function will only be called on these acitons.
+	// The function will only be called on these actions.
 	supportedVerbs map[webhook.Operation]struct{}
 }
 
-// NewCallback creates a new callback function to be invoked on supported vebs.
+// NewCallback creates a new callback function to be invoked on supported verbs.
 func NewCallback(function func(context.Context, *unstructured.Unstructured) error, supportedVerbs ...webhook.Operation) Callback {
 	m := make(map[webhook.Operation]struct{})
 	for _, op := range supportedVerbs {


### PR DESCRIPTION
Issue #1207
Issue  #1140

**Proposed Changes**

- Allow Delete verb on validation callbacks
- Include IsInDelete on the context
    - Note: I'm not a huge fan of the pattern of IfInVerb on context  rather than just storing the verb. It robs us of the ability to Switch on verb and  allows for the possibility of more than one set. That said, its how it is.
- Test callback on a delete verb