### PR TITLE
Allow retry of informer cache init upon error

### DIFF
--- a/apis/duck/cached.go
+++ b/apis/duck/cached.go
@@ -29,7 +29,7 @@ type CachedInformerFactory struct {
 	Delegate InformerFactory
 
 	m     sync.Mutex
-	cache map[schema.GroupVersionResource]*result
+	cache map[schema.GroupVersionResource]*informerCache
 }
 
 // Check that CachedInformerFactory implements InformerFactory.
@@ -38,36 +38,39 @@ var _ InformerFactory = (*CachedInformerFactory)(nil)
 // Get implements InformerFactory.
 func (cif *CachedInformerFactory) Get(gvr schema.GroupVersionResource) (cache.SharedIndexInformer, cache.GenericLister, error) {
 	cif.m.Lock()
+
 	if cif.cache == nil {
-		cif.cache = make(map[schema.GroupVersionResource]*result)
+		cif.cache = make(map[schema.GroupVersionResource]*informerCache)
 	}
-	elt, ok := cif.cache[gvr]
+
+	ic, ok := cif.cache[gvr]
 	if !ok {
-		elt = &result{}
-		elt.init = func() {
-			elt.Lock()
-			defer elt.Unlock()
+		ic = &informerCache{}
+		ic.init = func() {
+			ic.Lock()
+			defer ic.Unlock()
 
 			// double-checked lock to ensure we call the Delegate
 			// only once even if multiple goroutines end up inside
 			// init() simultaneously
-			if elt.hasInformer() {
+			if ic.hasInformer() {
 				return
 			}
 
-			elt.inf, elt.lister, elt.err = cif.Delegate.Get(gvr)
+			ic.inf, ic.lister, ic.err = cif.Delegate.Get(gvr)
 		}
-		cif.cache[gvr] = elt
+		cif.cache[gvr] = ic
 	}
+
 	// If this were done via "defer", then TestDifferentGVRs will fail.
 	cif.m.Unlock()
 
 	// The call to the delegate could be slow because it syncs informers, so do
 	// this outside of the main lock.
-	return elt.Get()
+	return ic.Get()
 }
 
-type result struct {
+type informerCache struct {
 	sync.RWMutex
 
 	init func()
@@ -79,19 +82,19 @@ type result struct {
 
 // Get returns the cached informer. If it does not yet exist, we first try to
 // acquire one by executing the cache's init function.
-func (t *result) Get() (cache.SharedIndexInformer, cache.GenericLister, error) {
-	if !t.initialized() {
-		t.init()
+func (ic *informerCache) Get() (cache.SharedIndexInformer, cache.GenericLister, error) {
+	if !ic.initialized() {
+		ic.init()
 	}
-	return t.inf, t.lister, t.err
+	return ic.inf, ic.lister, ic.err
 }
 
-func (t *result) initialized() bool {
-	t.RLock()
-	defer t.RUnlock()
-	return t.hasInformer()
+func (ic *informerCache) initialized() bool {
+	ic.RLock()
+	defer ic.RUnlock()
+	return ic.hasInformer()
 }
 
-func (t *result) hasInformer() bool {
-	return t.inf != nil && t.lister != nil
+func (ic *informerCache) hasInformer() bool {
+	return ic.inf != nil && ic.lister != nil
 }

--- a/apis/duck/cached_test.go
+++ b/apis/duck/cached_test.go
@@ -29,17 +29,22 @@ import (
 )
 
 type BlockingInformerFactory struct {
-	block   chan struct{}
-	getting int32
+	block  chan struct{}
+	nCalls int32
 }
 
 var _ InformerFactory = (*BlockingInformerFactory)(nil)
 
 func (bif *BlockingInformerFactory) Get(gvr schema.GroupVersionResource) (cache.SharedIndexInformer, cache.GenericLister, error) {
-	atomic.AddInt32(&bif.getting, 1)
-	// Wait here until we can acquire the lock!
+	atomic.AddInt32(&bif.nCalls, 1)
+	// Wait here until we can acquire the lock
 	<-bif.block
-	return nil, nil, nil
+
+	// return dummies to avoid subsequent calls to informerCache.init
+	inf := &fakeSharedIndexInformer{}
+	lister := fakeGenericLister(gvr.GroupResource())
+
+	return inf, lister, nil
 }
 
 func TestSameGVR(t *testing.T) {
@@ -49,21 +54,25 @@ func TestSameGVR(t *testing.T) {
 		Delegate: bif,
 	}
 
-	grp, _ := errgroup.WithContext(context.TODO())
-	returned := int32(0)
+	// counts the number of calls to cif.Get that returned
+	retGetCount := int32(0)
 
-	// Use the same GVR each iteration to ensure we hit the cache
-	// and don't initialize too many InformerFactory's thru our
+	errGrp, _ := errgroup.WithContext(context.TODO())
+
+	// Use the same GVR each iteration to ensure we hit the cache and don't
+	// initialize the informerCache for that GVR multiple times through our
 	// Delegate.
 	gvr := schema.GroupVersionResource{
 		Group:    "testing.knative.dev",
 		Version:  "v3",
 		Resource: "caches",
 	}
-	for i := 0; i < 10; i++ {
-		grp.Go(func() error {
+
+	const iter = 10
+	for i := 0; i < iter; i++ {
+		errGrp.Go(func() error {
 			_, _, err := cif.Get(gvr)
-			atomic.AddInt32(&returned, 1)
+			atomic.AddInt32(&retGetCount, 1)
 			return err
 		})
 	}
@@ -71,19 +80,29 @@ func TestSameGVR(t *testing.T) {
 	// Give the goroutines time to make progress.
 	time.Sleep(100 * time.Millisecond)
 
-	// Check that none have returned and we have one Get in progress.
-	if got, want := atomic.LoadInt32(&returned), int32(0); got != want {
-		t.Errorf("Got %v returned, wanted %v", got, want)
+	// Check that no call to cif.Get have returned and bif.Get was called
+	// only once.
+	if got, want := atomic.LoadInt32(&retGetCount), int32(0); got != want {
+		t.Errorf("Got %d returned call(s) to cif.Get, wanted %d", got, want)
 	}
-	if got, want := atomic.LoadInt32(&bif.getting), int32(1); got != want {
-		t.Errorf("Got %v calls to bif.Get, wanted %v", got, want)
+	if got, want := atomic.LoadInt32(&bif.nCalls), int32(1); got != want {
+		t.Errorf("Got %d call(s) to bif.Get, wanted %d", got, want)
 	}
 
 	// Allow the Get calls to proceed.
 	close(bif.block)
 
-	if err := grp.Wait(); err != nil {
-		t.Errorf("Wait() = %v", err)
+	if err := errGrp.Wait(); err != nil {
+		t.Fatalf("Error while calling cif.Get: %v", err)
+	}
+
+	// Check that all calls to cif.Get have returned and calls to bif.Get
+	// didn't increase.
+	if got, want := atomic.LoadInt32(&retGetCount), int32(iter); got != want {
+		t.Errorf("Got %d returned call(s) to cif.Get, wanted %d", got, want)
+	}
+	if got, want := atomic.LoadInt32(&bif.nCalls), int32(1); got != want {
+		t.Errorf("Got %d call(s) to bif.Get, wanted %d", got, want)
 	}
 }
 
@@ -94,9 +113,13 @@ func TestDifferentGVRs(t *testing.T) {
 		Delegate: bif,
 	}
 
-	grp, _ := errgroup.WithContext(context.TODO())
-	returned := int32(0)
-	for i := 0; i < 10; i++ {
+	// counts the number of calls to cif.Get that returned
+	retGetCount := int32(0)
+
+	errGrp, _ := errgroup.WithContext(context.TODO())
+
+	const iter = 10
+	for i := 0; i < iter; i++ {
 		// Use a different GVR each iteration to check that calls
 		// to bif.Get can proceed even if a call is in progress
 		// for another GVR.
@@ -105,9 +128,10 @@ func TestDifferentGVRs(t *testing.T) {
 			Version:  fmt.Sprintf("v%d", i),
 			Resource: "caches",
 		}
-		grp.Go(func() error {
+
+		errGrp.Go(func() error {
 			_, _, err := cif.Get(gvr)
-			atomic.AddInt32(&returned, 1)
+			atomic.AddInt32(&retGetCount, 1)
 			return err
 		})
 	}
@@ -115,18 +139,38 @@ func TestDifferentGVRs(t *testing.T) {
 	// Give the goroutines time to make progress.
 	time.Sleep(100 * time.Millisecond)
 
-	// Check that none have returned and we have 10 Gets in progress.
-	if got, want := atomic.LoadInt32(&returned), int32(0); got != want {
-		t.Errorf("Got %v returned, wanted %v", got, want)
+	// Check that no call to cif.Get have returned and bif.Get was called
+	// once per iteration.
+	if got, want := atomic.LoadInt32(&retGetCount), int32(0); got != want {
+		t.Errorf("Got %d returned call(s) to cif.Get, wanted %d", got, want)
 	}
-	if got, want := atomic.LoadInt32(&bif.getting), int32(10); got != want {
-		t.Errorf("Got %v calls to bif.Get, wanted %v", got, want)
+	if got, want := atomic.LoadInt32(&bif.nCalls), int32(iter); got != want {
+		t.Errorf("Got %d call(s) to bif.Get, wanted %d", got, want)
 	}
 
 	// Allow the Get calls to proceed.
 	close(bif.block)
 
-	if err := grp.Wait(); err != nil {
-		t.Errorf("Wait() = %v", err)
+	if err := errGrp.Wait(); err != nil {
+		t.Fatalf("Error while calling cif.Get: %v", err)
 	}
+
+	// Check that all calls to cif.Get have returned and the number of
+	// calls to bif.Get didn't increase.
+	if got, want := atomic.LoadInt32(&retGetCount), int32(iter); got != want {
+		t.Errorf("Got %d returned call(s) to cif.Get, wanted %d", got, want)
+	}
+	if got, want := atomic.LoadInt32(&bif.nCalls), int32(iter); got != want {
+		t.Errorf("Got %d call(s) to bif.Get, wanted %d", got, want)
+	}
+}
+
+// fakeGenericLister returns a dummy cache.GenericLister.
+func fakeGenericLister(gr schema.GroupResource) cache.GenericLister {
+	var dummyKeyFunc cache.KeyFunc = func(interface{}) (string, error) {
+		return "", nil
+	}
+
+	dummyIndexer := cache.NewIndexer(dummyKeyFunc, cache.Indexers{})
+	return cache.NewGenericLister(dummyIndexer, gr)
 }


### PR DESCRIPTION
As described in https://github.com/knative/eventing/issues/2924#issuecomment-612600796, running the `init` function for a  given GVR _only once_ is a bit too optimistic. If that `init` function fails for any reason, the failure is then cached forever.

Instead of guarding the execution of `init` behind a `sync.Once`, we can simply assert that an informer has already been acquired and, if not, try `init()` again in the next call to `informerCache.Get()`. A `RWMutex` was added to avoid race conditions during calls to `init`.

Fixes knative/eventing#2924

---

**Test run**

Broker controller running with the changes from this PR, InMemoryChannel not deployed:
```console
$ kn dev get broker
NAME      READY   REASON                  URL   AGE
default   False   ChannelTemplateFailed         36s
```
Deploy InMemoryChannel:
```console
$ ko apply -L -f config/channels/in-memory-channel
2020/04/13 18:47:24 Using base gcr.io/distroless/static:nonroot for knative.dev/eventing/cmd/in_memory/channel_dispatcher
2020/04/13 18:47:24 Using base gcr.io/distroless/static:nonroot for knative.dev/eventing/cmd/in_memory/channel_controller
[...]
deployment.apps/imc-controller created
deployment.apps/imc-dispatcher created
```
The InMemoryChannel is being created without the need to restart the Broker controller:
```console
$ kn dev get broker
NAME      READY   REASON                 URL                                           AGE
default   False   EndpointsUnavailable   http://default-broker.dev.svc.cluster.local   56s
```
The Broker becomes ready:
```console
$ kn dev get broker
NAME      READY   REASON   URL                                           AGE
default   True             http://default-broker.dev.svc.cluster.local   59s
```