### PR TITLE
Release leader election lock as soon as we exit.

### DIFF
--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -474,6 +474,7 @@ func RunLeaderElected(ctx context.Context, logger *zap.SugaredLogger, run func(c
 				logger.Fatal("leaderelection lost")
 			},
 		},
+		ReleaseOnCancel: true,
 		// TODO: use health check watchdog, knative/pkg#1048
 		Name: component,
 	})


### PR DESCRIPTION
This releases the lease as soon as the provided context is cancelled.

While we're technically not quite done exiting once we see the cancel signal, the time overlap should be good enough as we'll stop the controller as soon as we see the cancel signal and the newly acquired leaders need to launch their informers etc. first. That should be close enough to being already shut down.

In the worst worst case, we have a very brief time of two controllers stamping each other. I think that's seldom enough to not warrant more orchestration logic.

Note: There's currently a bug in releasing the lock successfully, being fixed here: https://github.com/kubernetes/kubernetes/pull/88192