### PR TITLE
Use loggers when emitting count messages

### DIFF
--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -136,10 +136,14 @@ func MainWithContext(ctx context.Context, component string, ctors ...injection.C
 // MainWithConfig runs the generic main flow for non-webhook controllers. Use
 // WebhookMainWithConfig if you need to serve webhooks.
 func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, ctors ...injection.ControllerConstructor) {
-	log.Printf("Registering %d clients", len(injection.Default.GetClients()))
-	log.Printf("Registering %d informer factories", len(injection.Default.GetInformerFactories()))
-	log.Printf("Registering %d informers", len(injection.Default.GetInformers()))
-	log.Printf("Registering %d controllers", len(ctors))
+	logger, atomicLevel := SetupLoggerOrDie(ctx, component)
+	defer flush(logger)
+	ctx = logging.WithLogger(ctx, logger)
+
+	logger.Infof("Registering %d clients", len(injection.Default.GetClients()))
+	logger.Infof("Registering %d informer factories", len(injection.Default.GetInformerFactories()))
+	logger.Infof("Registering %d informers", len(injection.Default.GetInformers()))
+	logger.Infof("Registering %d controllers", len(ctors))
 
 	MemStatsOrDie(ctx)
 
@@ -149,9 +153,6 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 
 	ctx, informers := injection.Default.SetupInformers(ctx, cfg)
 
-	logger, atomicLevel := SetupLoggerOrDie(ctx, component)
-	defer flush(logger)
-	ctx = logging.WithLogger(ctx, logger)
 	profilingHandler := profiling.NewHandler(logger, false)
 	profilingServer := profiling.NewServer(profilingHandler)
 	eg, egCtx := errgroup.WithContext(ctx)
@@ -213,10 +214,14 @@ func WebhookMainWithContext(ctx context.Context, component string, ctors ...inje
 // with the given config. Use MainWithConfig if you do not need to serve
 // webhooks.
 func WebhookMainWithConfig(ctx context.Context, component string, cfg *rest.Config, ctors ...injection.ControllerConstructor) {
-	log.Printf("Registering %d clients", len(injection.Default.GetClients()))
-	log.Printf("Registering %d informer factories", len(injection.Default.GetInformerFactories()))
-	log.Printf("Registering %d informers", len(injection.Default.GetInformers()))
-	log.Printf("Registering %d controllers", len(ctors))
+	logger, atomicLevel := SetupLoggerOrDie(ctx, component)
+	defer flush(logger)
+	ctx = logging.WithLogger(ctx, logger)
+
+	logger.Infof("Registering %d clients", len(injection.Default.GetClients()))
+	logger.Infof("Registering %d informer factories", len(injection.Default.GetInformerFactories()))
+	logger.Infof("Registering %d informers", len(injection.Default.GetInformers()))
+	logger.Infof("Registering %d controllers", len(ctors))
 
 	MemStatsOrDie(ctx)
 
@@ -225,9 +230,6 @@ func WebhookMainWithConfig(ctx context.Context, component string, cfg *rest.Conf
 	cfg.Burst = len(ctors) * rest.DefaultBurst
 	ctx, informers := injection.Default.SetupInformers(ctx, cfg)
 
-	logger, atomicLevel := SetupLoggerOrDie(ctx, component)
-	defer flush(logger)
-	ctx = logging.WithLogger(ctx, logger)
 	profilingHandler := profiling.NewHandler(logger, false)
 	profilingServer := profiling.NewServer(profilingHandler)
 


### PR DESCRIPTION
Fixes #1225

https://github.com/knative/pkg/blob/08b31df9e66a7ed7dbbfaf65de817f09d66cb79d/injection/sharedmain/main.go#L139
https://github.com/knative/pkg/blob/08b31df9e66a7ed7dbbfaf65de817f09d66cb79d/injection/sharedmain/main.go#L216

These lines:
```
log.Printf("Registering %d clients", len(injection.Default.GetClients()))
log.Printf("Registering %d informer factories", len(injection.Default.GetInformerFactories()))
log.Printf("Registering %d informers", len(injection.Default.GetInformers()))
log.Printf("Registering %d controllers", len(ctors))
```

Should use the zap logger, instead of printing directly to stderr