### PR TITLE
Assorted linting fixes.

### DIFF
--- a/apiextensions/storageversion/migrator_test.go
+++ b/apiextensions/storageversion/migrator_test.go
@@ -39,11 +39,6 @@ var (
 		Group: "group.dev",
 	}
 
-	fakeListGK = schema.GroupKind{
-		Kind:  "FakeList",
-		Group: "group.dev",
-	}
-
 	fakeGR = schema.GroupResource{
 		Resource: "fakes",
 		Group:    "group.dev",

--- a/apis/condition_set.go
+++ b/apis/condition_set.go
@@ -109,7 +109,7 @@ func NewBatchConditionSet(d ...ConditionType) ConditionSet {
 // important for the caller. The first ConditionType is the overarching status
 // for that will be used to signal the resources' status is Ready or Succeeded.
 func newConditionSet(happy ConditionType, dependents ...ConditionType) ConditionSet {
-	var deps []ConditionType
+	deps := make([]ConditionType, 0, len(dependents))
 	for _, d := range dependents {
 		// Skip duplicates
 		if d == happy || contains(deps, d) {

--- a/apis/condition_set_impl_test.go
+++ b/apis/condition_set_impl_test.go
@@ -403,7 +403,7 @@ func TestConditionSeverity(t *testing.T) {
 
 // getTypes is a small helped to strip out the used ConditionTypes from Conditions
 func getTypes(conds Conditions) []ConditionType {
-	var types []ConditionType
+	types := make([]ConditionType, 0, len(conds))
 	for _, c := range conds {
 		types = append(types, c.Type)
 	}

--- a/controller/stats_reporter_test.go
+++ b/controller/stats_reporter_test.go
@@ -79,11 +79,11 @@ func TestReportReconcile(t *testing.T) {
 		initialReconcileLatency = d[0].Data.(*view.DistributionData).Sum()
 	}
 
-	expectSuccess(t, func() error { return r.ReportReconcile(time.Duration(10*time.Millisecond), "test/key", "true") })
+	expectSuccess(t, func() error { return r.ReportReconcile(10*time.Millisecond, "test/key", "true") })
 	checkCountData(t, "reconcile_count", wantTags, initialReconcileCount+1)
 	checkDistributionData(t, "reconcile_latency", wantTags, initialReconcileLatency+10)
 
-	expectSuccess(t, func() error { return r.ReportReconcile(time.Duration(15*time.Millisecond), "test/key", "true") })
+	expectSuccess(t, func() error { return r.ReportReconcile(15*time.Millisecond, "test/key", "true") })
 	checkCountData(t, "reconcile_count", wantTags, initialReconcileCount+2)
 	checkDistributionData(t, "reconcile_latency", wantTags, initialReconcileLatency+25)
 }

--- a/test/cmd/command.go
+++ b/test/cmd/command.go
@@ -93,7 +93,7 @@ func runCommand(cmdLine string, options ...Option) (string, error) {
 // RunCommands will run the commands sequentially.
 // If there is an error when running a command, it will return directly with all standard output so far and the error.
 func runCommands(cmdLines ...string) (string, error) {
-	var outputs []string
+	outputs := make([]string, 0, len(cmdLines))
 	for _, cmdLine := range cmdLines {
 		output, err := RunCommand(cmdLine)
 		outputs = append(outputs, output)

--- a/test/gcs/gcs.go
+++ b/test/gcs/gcs.go
@@ -194,8 +194,8 @@ func getObjectsAttrs(ctx context.Context, bucketName, storagePath, exclusionFilt
 // if exclusionFilter is "/", returns all direct children, including both files and directories.
 // see https://godoc.org/cloud.google.com/go/storage#Query
 func list(ctx context.Context, bucketName, storagePath, exclusionFilter string) []string {
-	var filePaths []string
 	objsAttrs := getObjectsAttrs(ctx, bucketName, storagePath, exclusionFilter)
+	filePaths := make([]string, 0, len(objsAttrs))
 	for _, attrs := range objsAttrs {
 		filePaths = append(filePaths, path.Join(attrs.Prefix, attrs.Name))
 	}

--- a/test/ghutil/fakeghutil/fakeghutil.go
+++ b/test/ghutil/fakeghutil/fakeghutil.go
@@ -118,8 +118,9 @@ func (fgc *FakeGithubClient) ReopenIssue(org, repo string, issueNumber int) erro
 
 // ListComments gets all comments from issue
 func (fgc *FakeGithubClient) ListComments(org, repo string, issueNumber int) ([]*github.IssueComment, error) {
-	var comments []*github.IssueComment
-	for _, comment := range fgc.Comments[issueNumber] {
+	ghComments := fgc.Comments[issueNumber]
+	comments := make([]*github.IssueComment, 0, len(ghComments))
+	for _, comment := range ghComments {
 		comments = append(comments, comment)
 	}
 	return comments, nil
@@ -240,7 +241,7 @@ func (fgc *FakeGithubClient) ListFiles(org, repo string, ID int) ([]*github.Comm
 	var res []*github.CommitFile
 	commits, err := fgc.ListCommits(org, repo, ID)
 	if nil != err {
-		return res, err
+		return nil, err
 	}
 	for _, commit := range commits {
 		files, ok := fgc.CommitFiles[*commit.SHA]

--- a/test/logging/spew_encoder.go
+++ b/test/logging/spew_encoder.go
@@ -162,7 +162,7 @@ func (enc *SpewEncoder) writeContext(line *buffer.Buffer, extra []Field) {
 
 	enc.addTabIfNecessary(line)
 	line.AppendString("\nContext:\n")
-	var keys []string
+	keys := make([]string, 0, len(context.Fields))
 	for k := range context.Fields {
 		keys = append(keys, k)
 	}

--- a/test/prow/prow.go
+++ b/test/prow/prow.go
@@ -211,8 +211,9 @@ func (j *Job) GetFinishedBuilds() []Build {
 // by parsing "Started.json" and "Finished.json" on gcs, could be very expensive if there are
 // large number of builds
 func (j *Job) GetBuilds() []Build {
-	var builds []Build
-	for _, ID := range j.GetBuildIDs() {
+	buildIDs := j.GetBuildIDs()
+	builds := make([]Build, 0, len(buildIDs))
+	for _, ID := range buildIDs {
 		builds = append(builds, *j.NewBuild(ID))
 	}
 	return builds

--- a/test/webhook-apicoverage/webhook/webhook.go
+++ b/test/webhook-apicoverage/webhook/webhook.go
@@ -153,7 +153,7 @@ func (acw *APICoverageWebhook) registerWebhook(rules []admissionregistrationv1be
 }
 
 func (acw *APICoverageWebhook) getValidationRules(resources map[schema.GroupVersionKind]resourcesemantics.GenericCRD) []admissionregistrationv1beta1.RuleWithOperations {
-	var rules []admissionregistrationv1beta1.RuleWithOperations
+	rules := make([]admissionregistrationv1beta1.RuleWithOperations, 0, len(resources))
 	for gvk := range resources {
 		plural := strings.ToLower(inflect.Pluralize(gvk.Kind))
 

--- a/testutils/clustermanager/e2e-tests/common/common_test.go
+++ b/testutils/clustermanager/e2e-tests/common/common_test.go
@@ -82,7 +82,7 @@ func TestGetRepoName(t *testing.T) {
 		}
 
 		out, err := GetRepoName()
-		if string(data.expOut) != out || !reflect.DeepEqual(err, data.expErr) {
+		if data.expOut != out || !reflect.DeepEqual(err, data.expErr) {
 			t.Errorf("testing getting repo name with:\n\tmocked git output: '%s'\n\tmocked git err: '%v'\nwant: out - '%s', err - '%v'\ngot: out - '%s', err - '%v'",
 				data.out, data.err, data.expOut, data.expErr, out, err)
 		}

--- a/testutils/clustermanager/e2e-tests/config.go
+++ b/testutils/clustermanager/e2e-tests/config.go
@@ -45,7 +45,7 @@ var (
 	// - stockout (https://github.com/knative/test-infra/issues/592)
 	// - latest GKE not available in this region/zone yet (https://github.com/knative/test-infra/issues/694)
 	retryableCreationErrors = []*regexp.Regexp{
-		regexp.MustCompile(`.*Master version "[0-9a-z\\-.]+" is unsupported.*`),
+		regexp.MustCompile(`.*Master version "[0-9a-z\-.]+" is unsupported.*`),
 		regexp.MustCompile(`.*No valid versions with the prefix "[0-9.]+" found.*`),
 		regexp.MustCompile(`.*does not have enough resources available to fulfill.*`),
 		regexp.MustCompile(`.*only \d+ nodes out of \d+ have registered; this is likely due to Nodes failing to start correctly.*`),

--- a/testutils/clustermanager/e2e-tests/config.go
+++ b/testutils/clustermanager/e2e-tests/config.go
@@ -45,9 +45,9 @@ var (
 	// - stockout (https://github.com/knative/test-infra/issues/592)
 	// - latest GKE not available in this region/zone yet (https://github.com/knative/test-infra/issues/694)
 	retryableCreationErrors = []*regexp.Regexp{
-		regexp.MustCompile(".*Master version \"[0-9a-z\\-.]+\" is unsupported.*"),
-		regexp.MustCompile(".*No valid versions with the prefix \"[0-9.]+\" found.*"),
-		regexp.MustCompile(".*does not have enough resources available to fulfill.*"),
-		regexp.MustCompile(".*only \\d+ nodes out of \\d+ have registered; this is likely due to Nodes failing to start correctly.*"),
+		regexp.MustCompile(`.*Master version "[0-9a-z\\-.]+" is unsupported.*`),
+		regexp.MustCompile(`.*No valid versions with the prefix "[0-9.]+" found.*`),
+		regexp.MustCompile(`.*does not have enough resources available to fulfill.*`),
+		regexp.MustCompile(`.*only \d+ nodes out of \d+ have registered; this is likely due to Nodes failing to start correctly.*`),
 	}
 )

--- a/webhook/psbinding/psbinding.go
+++ b/webhook/psbinding/psbinding.go
@@ -302,7 +302,7 @@ func (ac *Reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 		ac.inexact = inexact
 	}()
 
-	var rules []admissionregistrationv1beta1.RuleWithOperations
+	rules := make([]admissionregistrationv1beta1.RuleWithOperations, 0, len(gks))
 	for gk, versions := range gks {
 		plural := strings.ToLower(inflect.Pluralize(gk.Kind))
 

--- a/webhook/psbinding/psbinding.go
+++ b/webhook/psbinding/psbinding.go
@@ -28,6 +28,7 @@ import (
 	"github.com/markbates/inflect"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -38,7 +39,6 @@ import (
 	"knative.dev/pkg/apis/duck"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/system"
@@ -356,9 +356,7 @@ func (ac *Reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 		webhook.Webhooks[i].ClientConfig.Service.Path = ptr.String(ac.Path())
 	}
 
-	if ok, err := kmp.SafeEqual(configuredWebhook, webhook); err != nil {
-		return fmt.Errorf("error diffing webhooks: %w", err)
-	} else if !ok {
+	if ok := equality.Semantic.DeepEqual(configuredWebhook, webhook); !ok {
 		logging.FromContext(ctx).Info("Updating webhook")
 		mwhclient := ac.Client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
 		if _, err := mwhclient.Update(webhook); err != nil {

--- a/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/webhook/resourcesemantics/defaulting/defaulting.go
@@ -127,7 +127,7 @@ func (ac *reconciler) Admit(ctx context.Context, request *admissionv1beta1.Admis
 func (ac *reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byte) error {
 	logger := logging.FromContext(ctx)
 
-	var rules []admissionregistrationv1beta1.RuleWithOperations
+	rules := make([]admissionregistrationv1beta1.RuleWithOperations, 0, len(ac.handlers))
 	for gvk := range ac.handlers {
 		plural := strings.ToLower(inflect.Pluralize(gvk.Kind))
 

--- a/webhook/resourcesemantics/validation/reconcile_config.go
+++ b/webhook/resourcesemantics/validation/reconcile_config.go
@@ -89,7 +89,7 @@ func (ac *reconciler) Reconcile(ctx context.Context, key string) error {
 func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []byte) error {
 	logger := logging.FromContext(ctx)
 
-	var rules []admissionregistrationv1beta1.RuleWithOperations
+	rules := make([]admissionregistrationv1beta1.RuleWithOperations, 0, len(ac.handlers))
 	for gvk := range ac.handlers {
 		plural := strings.ToLower(inflect.Pluralize(gvk.Kind))
 

--- a/webhook/webhook_integration_test.go
+++ b/webhook/webhook_integration_test.go
@@ -48,7 +48,7 @@ func createResource(name string) *pkgtest.Resource {
 	}
 }
 
-const testTimeout = time.Duration(10 * time.Second)
+const testTimeout = 10 * time.Second
 
 func TestMissingContentType(t *testing.T) {
 	wh, serverURL, ctx, cancel, err := testSetup(t)


### PR DESCRIPTION
- Remove unused code.
- Use raw strings in regexes to avoid escaping and double escaping.
- Remove unneeded type conversions.
- Preallocate slices where possible.

/assign @mattmoor 