### PR TITLE
Inject config into controller context.

### DIFF
--- a/injection/context.go
+++ b/injection/context.go
@@ -18,6 +18,8 @@ package injection
 
 import (
 	"context"
+
+	"k8s.io/client-go/rest"
 )
 
 // nsKey is the key that namespaces are associated with on
@@ -46,4 +48,21 @@ func GetNamespaceScope(ctx context.Context) string {
 		return ""
 	}
 	return value.(string)
+}
+
+// cfgKey is the key that the config is associated with.
+type cfgKey struct{}
+
+// WithConfig associates a given config with the context.
+func WithConfig(ctx context.Context, cfg *rest.Config) context.Context {
+	return context.WithValue(ctx, cfgKey{}, cfg)
+}
+
+// GetConfig gets the current config from the context.
+func GetConfig(ctx context.Context) *rest.Config {
+	value := ctx.Value(cfgKey{})
+	if value == nil {
+		return nil
+	}
+	return value.(*rest.Config)
 }

--- a/injection/context_test.go
+++ b/injection/context_test.go
@@ -19,9 +19,11 @@ package injection
 import (
 	"context"
 	"testing"
+
+	"k8s.io/client-go/rest"
 )
 
-func TestGetBaseline(t *testing.T) {
+func TestContextNamespace(t *testing.T) {
 	ctx := context.Background()
 
 	if HasNamespaceScope(ctx) {
@@ -37,5 +39,20 @@ func TestGetBaseline(t *testing.T) {
 
 	if got := GetNamespaceScope(ctx); got != want {
 		t.Errorf("GetNamespaceScope() = %v, wanted %v", got, want)
+	}
+}
+
+func TestContextConfig(t *testing.T) {
+	ctx := context.Background()
+
+	if cfg := GetConfig(ctx); cfg != nil {
+		t.Errorf("GetConfig() = %v, wanted nil", cfg)
+	}
+
+	want := &rest.Config{}
+	ctx = WithConfig(ctx, want)
+
+	if cfg := GetConfig(ctx); cfg != want {
+		t.Errorf("GetConfig() = %v, wanted %v", cfg, want)
 	}
 }

--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -143,6 +143,7 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 	// Adjust our client's rate limits based on the number of controllers we are running.
 	cfg.QPS = float32(len(ctors)) * rest.DefaultQPS
 	cfg.Burst = len(ctors) * rest.DefaultBurst
+	ctx = injection.WithConfig(ctx, cfg)
 
 	ctx, informers := injection.Default.SetupInformers(ctx, cfg)
 


### PR DESCRIPTION
This makes the config used to start all the clients available on the context starting the controllers. That enables us to use that config to create secondary clients in the controllers with the same config.

/assign @mattmoor @n3wscott 