### PR TITLE
Generate unique workqueue names.

### DIFF
--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/controller.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/controller.go
@@ -20,6 +20,9 @@ package customresourcedefinition
 
 import (
 	context "context"
+	fmt "fmt"
+	reflect "reflect"
+	strings "strings"
 
 	corev1 "k8s.io/api/core/v1"
 	clientsetscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
@@ -37,7 +40,6 @@ import (
 const (
 	defaultControllerAgentName = "customresourcedefinition-controller"
 	defaultFinalizerName       = "customresourcedefinitions.apiextensions.k8s.io"
-	defaultQueueName           = "customresourcedefinitions"
 )
 
 // NewImpl returns a controller.Impl that handles queuing and feeding work from
@@ -80,7 +82,11 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		reconciler:    r,
 		finalizerName: defaultFinalizerName,
 	}
-	impl := controller.NewImpl(rec, logger, defaultQueueName)
+
+	t := reflect.TypeOf(r).Elem()
+	queueName := fmt.Sprintf("%s.%s", strings.ReplaceAll(t.PkgPath(), "/", "-"), t.Name())
+
+	impl := controller.NewImpl(rec, logger, queueName)
 
 	// Pass impl to the options. Save any optional results.
 	for _, fn := range optionsFns {

--- a/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -142,6 +142,18 @@ func (g *reconcilerControllerGenerator) GenerateType(c *generator.Context, t *ty
 			Package: "context",
 			Name:    "Context",
 		}),
+		"fmtSprintf": c.Universe.Function(types.Name{
+			Package: "fmt",
+			Name:    "Sprintf",
+		}),
+		"stringsReplaceAll": c.Universe.Function(types.Name{
+			Package: "strings",
+			Name:    "ReplaceAll",
+		}),
+		"reflectTypeOf": c.Universe.Function(types.Name{
+			Package: "reflect",
+			Name:    "TypeOf",
+		}),
 	}
 
 	sw.Do(reconcilerControllerNewImpl, m)
@@ -153,7 +165,6 @@ var reconcilerControllerNewImpl = `
 const (
 	defaultControllerAgentName = "{{.type|lowercaseSingular}}-controller"
 	defaultFinalizerName       = "{{.type|allLowercasePlural}}.{{.group}}"
-	defaultQueueName           = "{{.type|allLowercasePlural}}"
 	{{if .hasClass}}
 	// ClassAnnotationKey points to the annotation for the class of this resource.
 	ClassAnnotationKey = "{{ .class }}"
@@ -201,7 +212,11 @@ func NewImpl(ctx {{.contextContext|raw}}, r Interface{{if .hasClass}}, classValu
 		finalizerName: defaultFinalizerName,
 		{{if .hasClass}}classValue: classValue,{{end}}
 	}
-	impl := {{.controllerNewImpl|raw}}(rec, logger, defaultQueueName)
+
+	t := {{.reflectTypeOf|raw}}(r).Elem()
+	queueName := {{.fmtSprintf|raw}}("%s.%s", {{.stringsReplaceAll|raw}}(t.PkgPath(), "/", "-"), t.Name())
+
+	impl := {{.controllerNewImpl|raw}}(rec, logger, queueName)
 
 	// Pass impl to the options. Save any optional results.
 	for _, fn := range optionsFns {


### PR DESCRIPTION
This changes the names we give workqueues in genreconciler to avoid collisions when multiple reconcilers in a single process use the same generated reconciler base.

There are a few examples of this in serving, both route and configuration have collisions.  Right now I think this mainly affects metrics published by the workqueues, but I noticed this leveraging the same for resource lock naming.