### PR TITLE
Skip doing any work if `Also` receives no errors

### DIFF
--- a/apis/field_error.go
+++ b/apis/field_error.go
@@ -109,6 +109,11 @@ func (fe *FieldError) ViaFieldKey(field string, key string) *FieldError {
 
 // Also collects errors, returns a new collection of existing errors and new errors.
 func (fe *FieldError) Also(errs ...*FieldError) *FieldError {
+	// Avoid doing any work, if we don't have to.
+	if l := len(errs); l == 0 || l == 1 && errs[0].isEmpty() {
+		return fe
+	}
+
 	var newErr *FieldError
 	// collect the current objects errors, if it has any
 	if !fe.isEmpty() {

--- a/apis/field_error_test.go
+++ b/apis/field_error_test.go
@@ -595,10 +595,10 @@ not without this: bar.C`,
 
 			if test.want != "" {
 				if got, want := fe.Error(), test.want; got != want {
-					t.Errorf("%s: Error() = %v, wanted %v", test.name, got, want)
+					t.Errorf("\nGot:  %v,\nwant: %v diff(-want,+got)\n%s", got, want, cmp.Diff(want, got))
 				}
 			} else if fe != nil {
-				t.Errorf("%s: ViaField() = %v, wanted nil", test.name, fe)
+				t.Errorf("ViaField() = %v, wanted nil", fe)
 			}
 		})
 	}
@@ -611,6 +611,11 @@ func TestAlsoNil(t *testing.T) {
 	}
 	errs = errs.Also(nil)
 
+	if got, want := errs.Error(), "original: foo"; got != want {
+		t.Errorf("TestAlsoNil: Also(nil).Error() = %v, wanted %v", got, want)
+	}
+
+	errs = errs.Also([]*FieldError{nil}...)
 	if got, want := errs.Error(), "original: foo"; got != want {
 		t.Errorf("TestAlsoNil: Also(nil).Error() = %v, wanted %v", got, want)
 	}
@@ -723,23 +728,47 @@ more details`,
 
 func TestAlsoStaysNil(t *testing.T) {
 	var err *FieldError
-	if err != nil {
-		t.Errorf("expected nil, got %v, wanted nil", err)
-	}
 
 	err = err.Also(nil)
 	if err != nil {
-		t.Errorf("expected nil, got %v, wanted nil", err)
+		t.Errorf("Got: %v, want nil", err)
 	}
 
 	err = err.ViaField("nil").Also(nil)
 	if err != nil {
-		t.Errorf("expected nil, got %v, wanted nil", err)
+		t.Errorf("Got: %v, want nil", err)
 	}
 
 	err = err.Also(&FieldError{})
 	if err != nil {
 		t.Errorf("expected nil, got %v, wanted nil", err)
+	}
+}
+
+func TestAlsoMultiple(t *testing.T) {
+	var err *FieldError
+
+	errs := []*FieldError{
+		&FieldError{
+			Message: "1",
+			Paths:   []string{"bar"},
+		},
+		&FieldError{
+			Message: "2",
+			Paths:   []string{"baz"},
+		},
+	}
+	err = err.Also(errs...)
+	const want = "1: bar\n2: baz"
+	if got := err.Error(); got != want {
+		t.Errorf("Got = %q, want: %q", got, want)
+	}
+
+	// This shows the order of Also calls does not matter.
+	err = nil
+	err = err.Also(errs[0]).Also(errs[1])
+	if got := err.Error(); got != want {
+		t.Errorf("Got = %q, want: %q", got, want)
 	}
 }
 

--- a/apis/field_error_test.go
+++ b/apis/field_error_test.go
@@ -748,16 +748,13 @@ func TestAlsoStaysNil(t *testing.T) {
 func TestAlsoMultiple(t *testing.T) {
 	var err *FieldError
 
-	errs := []*FieldError{
-		&FieldError{
-			Message: "1",
-			Paths:   []string{"bar"},
-		},
-		&FieldError{
-			Message: "2",
-			Paths:   []string{"baz"},
-		},
-	}
+	errs := []*FieldError{{
+		Message: "1",
+		Paths:   []string{"bar"},
+	}, {
+		Message: "2",
+		Paths:   []string{"baz"},
+	}}
 	err = err.Also(errs...)
 	const want = "1: bar\n2: baz"
 	if got := err.Error(); got != want {


### PR DESCRIPTION
1. if no errors are passed skip doing stuff (checks, allocations, etc)
2. if there's one error passed and it's empty (the same)
  - this is a quite popular pattern where in API validation we do:
    `x.Also(validateY())` and if that succeeded then it'll be an empty
    error. Which is in reality most of the time.
3. Improve tests by better printing
4. better test coverage shows commutativity of Also(a, b) and
   Also(a).Also(b)

/assign mattmoor