### PR TITLE
Explicitly name controller filters.

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -98,13 +98,13 @@ func Filter(gvk schema.GroupVersionKind) func(obj interface{}) bool {
 //
 // Deprecated: Use FilterControlledByGVK instead.
 func FilterGroupVersionKind(gvk schema.GroupVersionKind) func(obj interface{}) bool {
-	return FilterControlledByGVK(gvk)
+	return FilterControllerGVK(gvk)
 }
 
-// FilterControlledByGVK makes it simple to create FilterFunc's for use with
+// FilterControllerGVK makes it simple to create FilterFunc's for use with
 // cache.FilteringResourceEventHandler that filter based on the
 // schema.GroupVersionKind of the controlling resources.
-func FilterControlledByGVK(gvk schema.GroupVersionKind) func(obj interface{}) bool {
+func FilterControllerGVK(gvk schema.GroupVersionKind) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		object, ok := obj.(metav1.Object)
 		if !ok {
@@ -124,13 +124,13 @@ func FilterControlledByGVK(gvk schema.GroupVersionKind) func(obj interface{}) bo
 //
 // Deprecated: Use FilterControlledByGK instead
 func FilterGroupKind(gk schema.GroupKind) func(obj interface{}) bool {
-	return FilterControlledByGK(gk)
+	return FilterControllerGK(gk)
 }
 
-// FilterControlledByGK makes it simple to create FilterFunc's for use with
+// FilterControllerGK makes it simple to create FilterFunc's for use with
 // cache.FilteringResourceEventHandler that filter based on the
 // schema.GroupKind of the controlling resources.
-func FilterControlledByGK(gk schema.GroupKind) func(obj interface{}) bool {
+func FilterControllerGK(gk schema.GroupKind) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		object, ok := obj.(metav1.Object)
 		if !ok {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -95,7 +95,16 @@ func Filter(gvk schema.GroupVersionKind) func(obj interface{}) bool {
 // FilterGroupVersionKind makes it simple to create FilterFunc's for use with
 // cache.FilteringResourceEventHandler that filter based on the
 // schema.GroupVersionKind of the controlling resources.
+//
+// Deprecated: Use FilterControlledByGVK instead.
 func FilterGroupVersionKind(gvk schema.GroupVersionKind) func(obj interface{}) bool {
+	return FilterControlledByGVK(gvk)
+}
+
+// FilterControlledByGVK makes it simple to create FilterFunc's for use with
+// cache.FilteringResourceEventHandler that filter based on the
+// schema.GroupVersionKind of the controlling resources.
+func FilterControlledByGVK(gvk schema.GroupVersionKind) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		object, ok := obj.(metav1.Object)
 		if !ok {
@@ -112,7 +121,16 @@ func FilterGroupVersionKind(gvk schema.GroupVersionKind) func(obj interface{}) b
 // FilterGroupKind makes it simple to create FilterFunc's for use with
 // cache.FilteringResourceEventHandler that filter based on the
 // schema.GroupKind of the controlling resources.
+//
+// Deprecated: Use FilterControlledByGK instead
 func FilterGroupKind(gk schema.GroupKind) func(obj interface{}) bool {
+	return FilterControlledByGK(gk)
+}
+
+// FilterControlledByGK makes it simple to create FilterFunc's for use with
+// cache.FilteringResourceEventHandler that filter based on the
+// schema.GroupKind of the controlling resources.
+func FilterControlledByGK(gk schema.GroupKind) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		object, ok := obj.(metav1.Object)
 		if !ok {


### PR DESCRIPTION
Everytime I read the generic "Filter" or "FilterGroupVersionKind" my brain needs to do an extra roundtrip to realize that this actually filters on the **controller** having that GVK/GK. This adds new functions that explictly state that to avoid that roundtrip.

Old functions are just deprecated so this can be rolled out without a downstream break.

/assign @dprotaso 