### PR TITLE
Set observed gen in gen-reconciler

### DIFF
--- a/apis/test/example/v1alpha1/foo_types.go
+++ b/apis/test/example/v1alpha1/foo_types.go
@@ -28,6 +28,7 @@ import (
 
 // +genclient
 // +genreconciler
+// +genducklogic
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Foo is for testing.

--- a/codegen/cmd/injection-gen/generators/packages.go
+++ b/codegen/cmd/injection-gen/generators/packages.go
@@ -206,6 +206,12 @@ func isNonNamespaced(t *types.Type) bool {
 	return nonNamespaced
 }
 
+func genDuckLogic(t *types.Type) bool {
+	comments := append(append([]string{}, t.SecondClosestCommentLines...), t.CommentLines...)
+	_, duckLogic := types.ExtractCommentTags("+", comments)["genducklogic"]
+	return duckLogic
+}
+
 func vendorless(p string) string {
 	if pos := strings.LastIndex(p, "/vendor/"); pos != -1 {
 		return p[pos+len("/vendor/"):]
@@ -418,6 +424,7 @@ func reconcilerPackages(basePackage string, groupPkgName string, gv clientgentyp
 
 		reconcilerClass, hasReconcilerClass := extractReconcilerClassTag(t)
 		nonNamespaced := isNonNamespaced(t)
+		genDuck := genDuckLogic(t)
 
 		packagePath := filepath.Join(packagePath, strings.ToLower(t.Name.Name))
 
@@ -506,6 +513,7 @@ func reconcilerPackages(basePackage string, groupPkgName string, gv clientgentyp
 					reconcilerClass:    reconcilerClass,
 					hasReconcilerClass: hasReconcilerClass,
 					nonNamespaced:      nonNamespaced,
+					genDuckLogic:       genDuck,
 				})
 
 				return generators


### PR DESCRIPTION
Issue #1226

Automatically bump ObservedGeneration in the generated reconciler and set status to unknown for unhandled errors.

looks for `// +genducklogic` to run this part of the code generation. This can serve as a jumping-off point to share other arbitrary logic among duck-type shaped resources.