### PR TITLE
populate the v1alpha1.Hostname from the URI as per the spec

### DIFF
--- a/apis/duck/v1alpha1/addressable_types.go
+++ b/apis/duck/v1alpha1/addressable_types.go
@@ -106,9 +106,15 @@ func (a *Addressable) ConvertFrom(ctx context.Context, from apis.Convertible) er
 	switch source := from.(type) {
 	case *v1.Addressable:
 		a.URL = source.URL.DeepCopy()
+		if a.URL != nil {
+			a.Hostname = a.URL.Host
+		}
 		return nil
 	case *v1beta1.Addressable:
 		a.URL = source.URL.DeepCopy()
+		if a.URL != nil {
+			a.Hostname = a.URL.Host
+		}
 		return nil
 	default:
 		return fmt.Errorf("unknown version, got: %T", from)


### PR DESCRIPTION
As discovered as part of the move to v1beta1 reconcile work, the v1alpha1 down conversion is dropping the Hostname from the Status.
https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_eventing/3070/pull-knative-eventing-integration-tests/1255611066595938304

```
    --- FAIL: TestChannelStatus/TestChannelStatus-{Channel_messaging.knative.dev/v1alpha1} (2.34s)
        test_runner.go:95: namespace is : "v1alpha1-lhmqk"
        channel_status_test_helper.go:50: Running channel status conformance test with channel {"Channel" "messaging.knative.dev/v1alpha1"}
        channel_status_test_helper.go:54: Creating channel {Kind:Channel APIVersion:messaging.knative.dev/v1alpha1}-channel-req-labels
        creation.go:52: Creating channel &TypeMeta{Kind:Channel,APIVersion:messaging.knative.dev/v1alpha1,}-channel-req-labels
        channel_status_test_helper.go:78: No hostname found for {"Channel" "messaging.knative.dev/v1alpha1"}
```