### PR TITLE
Expose the `dialWithBackOff` utility

### DIFF
--- a/network/transports.go
+++ b/network/transports.go
@@ -55,9 +55,9 @@ var backOffTemplate = wait.Backoff{
 
 var errDialTimeout = errors.New("timed out dialing")
 
-// dialWithBackOff executes `net.Dialer.DialContext()` with exponentially increasing
+// DialWithBackOff executes `net.Dialer.DialContext()` with exponentially increasing
 // dial timeouts. In addition it sleeps with random jitter between tries.
-func dialWithBackOff(ctx context.Context, network, address string) (net.Conn, error) {
+func DialWithBackOff(ctx context.Context, network, address string) (net.Conn, error) {
 	return dialBackOffHelper(ctx, network, address, backOffTemplate, sleepTO)
 }
 
@@ -97,7 +97,7 @@ func newHTTPTransport(connTimeout time.Duration, disableKeepAlives bool) http.Ro
 		DisableKeepAlives:     disableKeepAlives,
 
 		// This is bespoke.
-		DialContext: dialWithBackOff,
+		DialContext: DialWithBackOff,
 	}
 }
 

--- a/network/transports_test.go
+++ b/network/transports_test.go
@@ -74,7 +74,7 @@ func TestHTTPRoundTripper(t *testing.T) {
 
 func TestDialWithBackoff(t *testing.T) {
 	// Nobody's listening on a random port. Usually.
-	c, err := dialWithBackOff(context.Background(), "tcp4", "127.0.0.1:41482")
+	c, err := DialWithBackOff(context.Background(), "tcp4", "127.0.0.1:41482")
 	if err == nil {
 		c.Close()
 		t.Error("Unexpected success dialing")
@@ -97,7 +97,7 @@ func TestDialWithBackoff(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	defer s.Close()
 
-	c, err = dialWithBackOff(context.Background(), "tcp4", strings.TrimPrefix(s.URL, "http://"))
+	c, err = DialWithBackOff(context.Background(), "tcp4", strings.TrimPrefix(s.URL, "http://"))
 	if err != nil {
 		t.Fatalf("dial error = %v, want nil", err)
 	}


### PR DESCRIPTION
I'd like to use this to retry TCP dial error in conformance/ingress tests.