### PR TITLE
Add elapsed wait time in timeout message.

### DIFF
--- a/network/transports.go
+++ b/network/transports.go
@@ -19,6 +19,7 @@ package network
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -74,6 +75,7 @@ func dialBackOffHelper(ctx context.Context, network, address string, bo wait.Bac
 		KeepAlive: 5 * time.Second,
 		DualStack: true,
 	}
+	start := time.Now()
 	for {
 		c, err := dialer.DialContext(ctx, network, address)
 		if err != nil {
@@ -89,7 +91,8 @@ func dialBackOffHelper(ctx context.Context, network, address string, bo wait.Bac
 		}
 		return c, nil
 	}
-	return nil, errDialTimeout
+	elapsed := time.Now().Sub(start)
+	return nil, fmt.Errorf("timed out dialing(%.2fs)", elapsed.Seconds())
 }
 
 func newHTTPTransport(connTimeout time.Duration, disableKeepAlives bool) http.RoundTripper {

--- a/network/transports.go
+++ b/network/transports.go
@@ -92,7 +92,7 @@ func dialBackOffHelper(ctx context.Context, network, address string, bo wait.Bac
 		return c, nil
 	}
 	elapsed := time.Now().Sub(start)
-	return nil, fmt.Errorf("timed out dialing(%.2fs)", elapsed.Seconds())
+	return nil, fmt.Errorf("timed out dialing after %.2fs", elapsed.Seconds())
 }
 
 func newHTTPTransport(connTimeout time.Duration, disableKeepAlives bool) http.RoundTripper {

--- a/network/transports_test.go
+++ b/network/transports_test.go
@@ -90,7 +90,7 @@ func TestDialWithBackoff(t *testing.T) {
 		c.Close()
 		t.Error("Unexpected success dialing")
 	}
-	expectedErrPrefix := "timed out dialing"
+	const expectedErrPrefix = "timed out dialing"
 	if err == nil || !strings.HasPrefix(err.Error(), expectedErrPrefix) {
 		t.Errorf("Error = %v, want: %s(...)", err, expectedErrPrefix)
 	}

--- a/network/transports_test.go
+++ b/network/transports_test.go
@@ -90,8 +90,9 @@ func TestDialWithBackoff(t *testing.T) {
 		c.Close()
 		t.Error("Unexpected success dialing")
 	}
-	if err != errDialTimeout {
-		t.Errorf("Error = %v, want: %v", err, errDialTimeout)
+	expectedErrPrefix := "timed out dialing"
+	if err == nil || !strings.HasPrefix(err.Error(), expectedErrPrefix) {
+		t.Errorf("Error = %v, want: %s(...)", err, expectedErrPrefix)
 	}
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))


### PR DESCRIPTION
This would give us some ideas about the total wait time when we look at logs, to make it easier to decide if we want to adjust the timeout setting.