### PR TITLE
Create our own comment parser for codegen

### DIFF
--- a/codegen/cmd/injection-gen/generators/comment_parser.go
+++ b/codegen/cmd/injection-gen/generators/comment_parser.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package generators
+
+import "strings"
+
+// Adapted from the k8s.io comment parser https://github.com/kubernetes/gengo/blob/master/types/comments.go
+
+// ExtractCommentTags parses comments for lines of the form:
+//
+//   'marker' + ':' "key=value,key2=value2".
+//
+// Values are optional; empty map is the default.  A tag can be specified more than
+// one time and all values are returned.  If the resulting map has an entry for
+// a key, the value (a slice) is guaranteed to have at least 1 element.
+//
+// Example: if you pass "+" for 'marker', and the following lines are in
+// the comments:
+//   +foo:key=value1,key2=value2
+//   +bar
+//
+// Then this function will return:
+//   map[string]map[string]string{"foo":{"key":value1","key2":"value2"}, "bar": {}}
+//
+// Users are not expected to repeat values.
+func ExtractCommentTags(marker string, lines []string) map[string]map[string]string {
+	out := map[string]map[string]string{}
+	for _, line := range lines {
+		line = strings.Trim(line, " ")
+		if len(line) == 0 {
+			continue
+		}
+		if !strings.HasPrefix(line, marker) {
+			continue
+		}
+
+		options := strings.SplitN(line[len(marker):], ":", 2)
+		if len(options) == 2 {
+			vals := strings.Split(options[1], ",")
+
+			opts := out[options[0]]
+			if opts == nil {
+				opts = map[string]string{}
+			}
+
+			for _, pair := range vals {
+				kv := strings.SplitN(pair, "=", 2)
+				if len(kv) == 2 {
+					opts[kv[0]] = kv[1]
+				} else if len(kv) == 1 {
+					opts[kv[0]] = ""
+				}
+			}
+			out[options[0]] = opts
+
+		} else if len(options) == 1 {
+			if _, has := out[options[0]]; !has {
+				out[options[0]] = nil
+			}
+		}
+	}
+	return out
+}

--- a/codegen/cmd/injection-gen/generators/comment_parser.go
+++ b/codegen/cmd/injection-gen/generators/comment_parser.go
@@ -53,19 +53,17 @@ func ExtractCommentTags(marker string, lines []string) map[string]map[string]str
 
 			opts := out[options[0]]
 			if opts == nil {
-				opts = map[string]string{}
+				opts = make(map[string]string, len(vals))
 			}
 
 			for _, pair := range vals {
-				kv := strings.SplitN(pair, "=", 2)
-				if len(kv) == 2 {
+				if kv := strings.SplitN(pair, "=", 2); len(kv) == 2 {
 					opts[kv[0]] = kv[1]
 				} else if len(kv) == 1 {
 					opts[kv[0]] = ""
 				}
 			}
 			out[options[0]] = opts
-
 		} else if len(options) == 1 {
 			if _, has := out[options[0]]; !has {
 				out[options[0]] = nil

--- a/codegen/cmd/injection-gen/generators/comment_parser_test.go
+++ b/codegen/cmd/injection-gen/generators/comment_parser_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package generators
+
+import "testing"
+
+func TestParseComments(t *testing.T) {
+
+	comment := []string{
+		"This is an example comment to parse",
+		"",
+		" +foo",
+		"+bar",
+		"+with:option",
+		"+pair:key=value",
+		"+manypairs:key1=value1,key2=value2",
+	}
+
+	extracted := ExtractCommentTags("+", comment)
+
+	if val, ok := extracted["foo"]; !ok || val != nil {
+		t.Errorf("Failed to extract single key got=%t,%v want=true,nil", ok, val)
+	}
+
+	if val, ok := extracted["bar"]; !ok || val != nil {
+		t.Errorf("Failed to extract single key got=%t,%v want=true,nil", ok, val)
+	}
+
+	if val, ok := extracted["with"]; !ok || val["option"] != "" {
+		t.Errorf("Failed to extract single key got=%t,%v want=true,{\"option\":\"\"}", ok, val)
+	}
+
+	if val, ok := extracted["pair"]; !ok || val["key"] != "value" {
+		t.Errorf("Failed to extract single key got=%t,%v want=true,{\"key\":\"value\"}", ok, val)
+	}
+
+	if val, ok := extracted["manypairs"]; !ok || val["key1"] != "value1" || val["key2"] != "value2" {
+		t.Errorf("Failed to extract single key got=%t,%v want=true,{\"key\":\"value\"}", ok, val)
+	}
+}
+
+func TestMergeDuplicates(t *testing.T) {
+
+	comment := []string{
+		"This is an example comment to parse",
+		"",
+		"+foo",
+		" +foo",
+		"+bar:key=value",
+		"+bar",
+		"+manypairs:key1=value1",
+		"+manypairs:key2=value2",
+	}
+
+	extracted := ExtractCommentTags("+", comment)
+
+	if val, ok := extracted["foo"]; !ok || val != nil {
+		t.Errorf("Failed to extract single key got=%t,%v want=true,nil", ok, val)
+	}
+
+	if val, ok := extracted["bar"]; !ok || val["key"] != "value" {
+		t.Errorf("Failed to extract single key got=%t,%v want=true,{\"key\":\"value\"}", ok, val)
+	}
+
+	if val, ok := extracted["manypairs"]; !ok || val["key1"] != "value1" || val["key2"] != "value2" {
+		t.Errorf("Failed to extract single key got=%t,%v want=true,{\"key\":\"value\"}", ok, val)
+	}
+}


### PR DESCRIPTION
Issue #1226

Per comments in PR #1226 there was some dissatisfaction with our comment parsing.
This parser allows for codegen tags of the form` +foo:key=value,key2=value2`

We currently cheat by using the k8s parser and search for the prefix `+foo:key` to achieve such a result, but that doesn't allow for multiple comma-separated values per line.

Although this is a break from the current parser: https://github.com/kubernetes/gengo/blob/master/types/comments.go
We're already kind of abusing it with our "+genreconciler:class" prefix search.