### PR TITLE
Fail reconciliation when a ReconcileEvent is wrapped inside an error

### DIFF
--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -339,13 +339,19 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 		if reconciler.EventAs(reconcileEvent, &event) {
 			logger.Infow("Returned an event", zap.Any("event", reconcileEvent))
 			r.Recorder.Eventf(resource, event.EventType, event.Reason, event.Format, event.Args...)
+
+			// the event was wrapped inside an error, consider the reconciliation as failed
+			if _, isEvent := reconcileEvent.(*reconciler.ReconcilerEvent); !isEvent {
+				return reconcileEvent
+			}
 			return nil
-		} else {
-			logger.Errorw("Returned an error", zap.Error(reconcileEvent))
-			r.Recorder.Event(resource, {{.corev1EventTypeWarning|raw}}, "InternalError", reconcileEvent.Error())
-			return reconcileEvent
 		}
+
+		logger.Errorw("Returned an error", zap.Error(reconcileEvent))
+		r.Recorder.Event(resource, {{.corev1EventTypeWarning|raw}}, "InternalError", reconcileEvent.Error())
+		return reconcileEvent
 	}
+
 	return nil
 }
 `


### PR DESCRIPTION
Allows errors to be re-enqueued event if they wrap a `ReconcilerEvent`.

The event is recorded whether it's wrapped or not, but a non-wrapped `ReconcilerEvent` is not considered as a `Reconcile()` error (current behaviour).

Too bad Kubernetes doesn't have a `corev1.EventTypeError`, _sighs_.

Closes #1266

---

examples:

```golang
// causes a re-enqueue
myevent := reconciler.NewEvent(corev1.EventTypeWarning, oopsReason, "oops")
return fmt.Errorf("this is bad: %w", myEvent)
```
```golang
// does NOT cause a re-enqueue
return reconciler.NewEvent(corev1.EventTypeWarning, oopsReason, "oops")
```
```golang
// reminder: permanentError can be used to prevent a re-enqueue regardless
// of the contents of the error
myevent := reconciler.NewEvent(corev1.EventTypeWarning, oopsReason, "oops")
return controller.NewPermanentError(fmt.Errorf("this is bad: %w", myEvent))
```
