### PR TITLE
Include GetTopLevelConditionType for KRShaped

### DIFF
--- a/apis/duck/v1/kresource_type.go
+++ b/apis/duck/v1/kresource_type.go
@@ -34,7 +34,7 @@ type KRShaped interface {
 
 	GetStatus() *Status
 
-	GetHappyConditionType() apis.ConditionType
+	GetTopLevelConditionType() apis.ConditionType
 }
 
 // Asserts KResource conformance with KRShaped
@@ -91,8 +91,8 @@ func (t *KResource) GetStatus() *Status {
 	return &t.Status
 }
 
-// GetHappyConditionType retrieves the happy condition of this resource. Implements the KRShaped interface.
-func (t *KResource) GetHappyConditionType() apis.ConditionType {
+// GetTopLevelConditionType retrieves the happy condition of this resource. Implements the KRShaped interface.
+func (t *KResource) GetTopLevelConditionType() apis.ConditionType {
 	// Note: KResources are unmarshalled from existing resources. This will only work properly for resources that
 	// have already been initialized to their type.
 	if cond := t.Status.GetCondition(apis.ConditionSucceeded); cond != nil {

--- a/apis/duck/v1/kresource_type.go
+++ b/apis/duck/v1/kresource_type.go
@@ -33,6 +33,8 @@ type KRShaped interface {
 	GetTypeMeta() *metav1.TypeMeta
 
 	GetStatus() *Status
+
+	GetHappyConditionType() apis.ConditionType
 }
 
 // Asserts KResource conformance with KRShaped
@@ -87,4 +89,14 @@ func (t *KResource) GetTypeMeta() *metav1.TypeMeta {
 // GetStatus retrieves the status of the KResource. Implements the KRShaped interface.
 func (t *KResource) GetStatus() *Status {
 	return &t.Status
+}
+
+// GetHappyConditionType retrieves the happy condition of this resource. Implements the KRShaped interface.
+func (t *KResource) GetHappyConditionType() apis.ConditionType {
+	// Note: KResources are unmarshalled from existing resources. This will only work properly for resources that
+	// have already been initialized to their type.
+	if cond := t.Status.GetCondition(apis.ConditionSucceeded); cond != nil {
+		return apis.ConditionSucceeded
+	}
+	return apis.ConditionReady
 }

--- a/apis/duck/v1/kresource_type_test.go
+++ b/apis/duck/v1/kresource_type_test.go
@@ -22,14 +22,14 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-func TestGetHappyCondition(t *testing.T) {
+func TestGetTopLevelCondition(t *testing.T) {
 	resource := KResource{}
 
 	condSet := apis.NewLivingConditionSet("Foo")
 	mgr := condSet.Manage(resource.GetStatus())
 	mgr.InitializeConditions()
 
-	if resource.GetHappyConditionType() != apis.ConditionReady {
+	if resource.GetTopLevelConditionType() != apis.ConditionReady {
 		t.Error("Expected Ready as happy condition for living condition set type")
 	}
 
@@ -37,7 +37,7 @@ func TestGetHappyCondition(t *testing.T) {
 	mgr = condSet.Manage(resource.GetStatus())
 	mgr.InitializeConditions()
 
-	if resource.GetHappyConditionType() != apis.ConditionSucceeded {
+	if resource.GetTopLevelConditionType() != apis.ConditionSucceeded {
 		t.Error("Expected Succeeded as happy condition for living condition set type")
 	}
 }

--- a/apis/duck/v1/kresource_type_test.go
+++ b/apis/duck/v1/kresource_type_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"testing"
+
+	"knative.dev/pkg/apis"
+)
+
+func TestGetHappyCondition(t *testing.T) {
+	resource := KResource{}
+
+	condSet := apis.NewLivingConditionSet("Foo")
+	mgr := condSet.Manage(resource.GetStatus())
+	mgr.InitializeConditions()
+
+	if resource.GetHappyConditionType() != apis.ConditionReady {
+		t.Error("Expected Ready as happy condition for living condition set type")
+	}
+
+	condSet = apis.NewBatchConditionSet("Foo")
+	mgr = condSet.Manage(resource.GetStatus())
+	mgr.InitializeConditions()
+
+	if resource.GetHappyConditionType() != apis.ConditionSucceeded {
+		t.Error("Expected Succeeded as happy condition for living condition set type")
+	}
+}

--- a/apis/test/example/v1alpha1/fiz_types.go
+++ b/apis/test/example/v1alpha1/fiz_types.go
@@ -103,3 +103,8 @@ func (f *ClusterFiz) GetTypeMeta() *metav1.TypeMeta {
 func (f *ClusterFiz) GetStatus() *duckv1.Status {
 	return &f.Status.Status
 }
+
+// GetHappyConditionType retrieves the happy condition of this resource. Implements the KRShaped interface.
+func (f *ClusterFiz) GetHappyConditionType() apis.ConditionType {
+	return apis.ConditionReady
+}

--- a/apis/test/example/v1alpha1/fiz_types.go
+++ b/apis/test/example/v1alpha1/fiz_types.go
@@ -104,7 +104,7 @@ func (f *ClusterFiz) GetStatus() *duckv1.Status {
 	return &f.Status.Status
 }
 
-// GetHappyConditionType retrieves the happy condition of this resource. Implements the KRShaped interface.
-func (f *ClusterFiz) GetHappyConditionType() apis.ConditionType {
+// GetTopLevelConditionType retrieves the happy condition of this resource. Implements the KRShaped interface.
+func (*ClusterFiz) GetTopLevelConditionType() apis.ConditionType {
 	return apis.ConditionReady
 }

--- a/apis/test/example/v1alpha1/foo_types.go
+++ b/apis/test/example/v1alpha1/foo_types.go
@@ -102,3 +102,8 @@ func (f *Foo) GetTypeMeta() *metav1.TypeMeta {
 func (f *Foo) GetStatus() *duckv1.Status {
 	return &f.Status.Status
 }
+
+// GetHappyConditionType retrieves the happy condition of this resource. Implements the KRShaped interface.
+func (t *Foo) GetHappyConditionType() apis.ConditionType {
+	return apis.ConditionSucceeded
+}

--- a/apis/test/example/v1alpha1/foo_types.go
+++ b/apis/test/example/v1alpha1/foo_types.go
@@ -103,7 +103,7 @@ func (f *Foo) GetStatus() *duckv1.Status {
 	return &f.Status.Status
 }
 
-// GetHappyConditionType retrieves the happy condition of this resource. Implements the KRShaped interface.
-func (t *Foo) GetHappyConditionType() apis.ConditionType {
+// GetTopLevelConditionType retrieves the happy condition of this resource. Implements the KRShaped interface.
+func (*Foo) GetTopLevelConditionType() apis.ConditionType {
 	return apis.ConditionSucceeded
 }

--- a/apis/test/pub/v1alpha1/bar_types.go
+++ b/apis/test/pub/v1alpha1/bar_types.go
@@ -102,3 +102,8 @@ func (b *Bar) GetTypeMeta() *metav1.TypeMeta {
 func (b *Bar) GetStatus() *duckv1.Status {
 	return &b.Status.Status
 }
+
+// GetHappyConditionType retrieves the happy condition of this resource. Implements the KRShaped interface.
+func (t *Bar) GetHappyConditionType() apis.ConditionType {
+	return apis.ConditionReady
+}

--- a/apis/test/pub/v1alpha1/bar_types.go
+++ b/apis/test/pub/v1alpha1/bar_types.go
@@ -103,7 +103,7 @@ func (b *Bar) GetStatus() *duckv1.Status {
 	return &b.Status.Status
 }
 
-// GetHappyConditionType retrieves the happy condition of this resource. Implements the KRShaped interface.
-func (t *Bar) GetHappyConditionType() apis.ConditionType {
+// GetTopLevelConditionType retrieves the happy condition of this resource. Implements the KRShaped interface.
+func (*Bar) GetTopLevelConditionType() apis.ConditionType {
 	return apis.ConditionReady
 }


### PR DESCRIPTION
Issue #1226

- Each type will report its expected happy condition
- KRShaped will detect its happy type by looking at its own conditions.
- Added a unit test

At the moment each implementer either makes a LivingConditionSet manager or a BatchConditionSet manager within each resource. However this allows for polymorphic logic since each type will report its own happy condition.

Longer term we could simplify by just having GetConditionSet(resource) and the manager can figure out what the condition ought to be. This will make it easier to share common logic.