### PR TITLE
Switch KRShaped interface to retrieve entire condition set

### DIFF
--- a/apis/duck/v1/kresource_type.go
+++ b/apis/duck/v1/kresource_type.go
@@ -34,7 +34,7 @@ type KRShaped interface {
 
 	GetStatus() *Status
 
-	GetTopLevelConditionType() apis.ConditionType
+	GetConditionSet() apis.ConditionSet
 }
 
 // Asserts KResource conformance with KRShaped
@@ -91,12 +91,12 @@ func (t *KResource) GetStatus() *Status {
 	return &t.Status
 }
 
-// GetTopLevelConditionType retrieves the happy condition of this resource. Implements the KRShaped interface.
-func (t *KResource) GetTopLevelConditionType() apis.ConditionType {
+// GetConditionSet retrieves the condition set for this resource. Implements the KRShaped interface.
+func (t *KResource) GetConditionSet() apis.ConditionSet {
 	// Note: KResources are unmarshalled from existing resources. This will only work properly for resources that
 	// have already been initialized to their type.
 	if cond := t.Status.GetCondition(apis.ConditionSucceeded); cond != nil {
-		return apis.ConditionSucceeded
+		return apis.NewBatchConditionSet()
 	}
-	return apis.ConditionReady
+	return apis.NewLivingConditionSet()
 }

--- a/apis/duck/v1/kresource_type.go
+++ b/apis/duck/v1/kresource_type.go
@@ -26,7 +26,7 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-// KRShaped is an interface for retrieving the duck elements of an arbitraty resource.
+// KRShaped is an interface for retrieving the duck elements of an arbitrary resource.
 type KRShaped interface {
 	metav1.ObjectMetaAccessor
 

--- a/apis/duck/v1/kresource_type_test.go
+++ b/apis/duck/v1/kresource_type_test.go
@@ -22,22 +22,36 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-func TestGetTopLevelCondition(t *testing.T) {
-	resource := KResource{}
-
-	condSet := apis.NewLivingConditionSet("Foo")
-	mgr := condSet.Manage(resource.GetStatus())
-	mgr.InitializeConditions()
-
-	if resource.GetTopLevelConditionType() != apis.ConditionReady {
-		t.Error("Expected Ready as happy condition for living condition set type")
+func TestGetConditionSet(t *testing.T) {
+	testCases := []struct {
+		name                      string
+		condSet                   apis.ConditionSet
+		expectedTopLevelCondition apis.ConditionType
+	}{
+		{
+			name:                      "living set",
+			condSet:                   apis.NewLivingConditionSet(),
+			expectedTopLevelCondition: apis.ConditionReady,
+		},
+		{
+			name:                      "batch set",
+			condSet:                   apis.NewBatchConditionSet(),
+			expectedTopLevelCondition: apis.ConditionSucceeded,
+		},
 	}
 
-	condSet = apis.NewBatchConditionSet("Foo")
-	mgr = condSet.Manage(resource.GetStatus())
-	mgr.InitializeConditions()
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			resource := KResource{}
 
-	if resource.GetTopLevelConditionType() != apis.ConditionSucceeded {
-		t.Error("Expected Succeeded as happy condition for living condition set type")
+			condSet := test.condSet
+			mgr := condSet.Manage(resource.GetStatus())
+			mgr.InitializeConditions()
+
+			if mgr.GetTopLevelCondition().Type != test.expectedTopLevelCondition {
+				t.Errorf("wrong top-level condition got=%s want=%s",
+					mgr.GetTopLevelCondition().Type, test.expectedTopLevelCondition)
+			}
+		})
 	}
 }

--- a/apis/duck/v1/kresource_type_test.go
+++ b/apis/duck/v1/kresource_type_test.go
@@ -43,10 +43,9 @@ func TestGetConditionSet(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			resource := KResource{}
+			test.condSet.Manage(resource.GetStatus()).InitializeConditions()
 
-			condSet := test.condSet
-			mgr := condSet.Manage(resource.GetStatus())
-			mgr.InitializeConditions()
+			mgr := resource.GetConditionSet().Manage(resource.GetStatus())
 
 			if mgr.GetTopLevelCondition().Type != test.expectedTopLevelCondition {
 				t.Errorf("wrong top-level condition got=%s want=%s",

--- a/apis/test/example/v1alpha1/fiz_types.go
+++ b/apis/test/example/v1alpha1/fiz_types.go
@@ -104,7 +104,7 @@ func (f *ClusterFiz) GetStatus() *duckv1.Status {
 	return &f.Status.Status
 }
 
-// GetTopLevelConditionType retrieves the happy condition of this resource. Implements the KRShaped interface.
-func (*ClusterFiz) GetTopLevelConditionType() apis.ConditionType {
-	return apis.ConditionReady
+// GetConditionSet retrieves the condition set for this resource. Implements the KRShaped interface.
+func (*ClusterFiz) GetConditionSet() apis.ConditionSet {
+	return apis.NewLivingConditionSet()
 }

--- a/apis/test/example/v1alpha1/foo_types.go
+++ b/apis/test/example/v1alpha1/foo_types.go
@@ -103,7 +103,7 @@ func (f *Foo) GetStatus() *duckv1.Status {
 	return &f.Status.Status
 }
 
-// GetTopLevelConditionType retrieves the happy condition of this resource. Implements the KRShaped interface.
-func (*Foo) GetTopLevelConditionType() apis.ConditionType {
-	return apis.ConditionSucceeded
+// GetConditionSet retrieves the condition set for this resource. Implements the KRShaped interface.
+func (*Foo) GetConditionSet() apis.ConditionSet {
+	return apis.NewLivingConditionSet()
 }

--- a/apis/test/pub/v1alpha1/bar_types.go
+++ b/apis/test/pub/v1alpha1/bar_types.go
@@ -103,7 +103,7 @@ func (b *Bar) GetStatus() *duckv1.Status {
 	return &b.Status.Status
 }
 
-// GetTopLevelConditionType retrieves the happy condition of this resource. Implements the KRShaped interface.
-func (*Bar) GetTopLevelConditionType() apis.ConditionType {
-	return apis.ConditionReady
+// GetConditionSet retrieves the condition set for this resource. Implements the KRShaped interface.
+func (*Bar) GetConditionSet() apis.ConditionSet {
+	return apis.NewLivingConditionSet()
 }


### PR DESCRIPTION
Issue #1226
- Switch interface to retrieve the entire conditions set

As I looked at integrating this downstream I've realized this will be more flexible so that we can have generic awareness of all the conditions that exist for a resource. This will also allow us to ensure they are initialized.
 