### PR TITLE
Fix logging around pkg

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -427,20 +427,20 @@ func (c *Impl) processNextWorkItem() bool {
 	// Embed the key into the logger and attach that to the context we pass
 	// to the Reconciler.
 	logger := c.logger.With(zap.String(logkey.TraceId, uuid.New().String()), zap.String(logkey.Key, keyStr))
-	ctx := logging.WithLogger(context.TODO(), logger)
+	ctx := logging.WithLogger(context.Background(), logger)
 
 	// Run Reconcile, passing it the namespace/name string of the
 	// resource to be synced.
 	if err = c.Reconciler.Reconcile(ctx, keyStr); err != nil {
 		c.handleErr(err, key)
-		logger.Infof("Reconcile failed. Time taken: %v.", time.Since(startTime))
+		logger.Info("Reconcile failed. Time taken: ", time.Since(startTime))
 		return true
 	}
 
 	// Finally, if no error occurs we Forget this item so it does not
 	// have any delay when another change happens.
 	c.WorkQueue.Forget(key)
-	logger.Infof("Reconcile succeeded. Time taken: %v.", time.Since(startTime))
+	logger.Info("Reconcile succeeded. Time taken: ", time.Since(startTime))
 
 	return true
 }

--- a/logging/config.go
+++ b/logging/config.go
@@ -52,7 +52,7 @@ var (
 func NewLogger(configJSON string, levelOverride string, opts ...zap.Option) (*zap.SugaredLogger, zap.AtomicLevel) {
 	logger, atomicLevel, err := newLoggerFromConfig(configJSON, levelOverride, opts)
 	if err == nil {
-		return enrichLoggerWithCommitID(logger.Sugar()), atomicLevel
+		return enrichLoggerWithCommitID(logger), atomicLevel
 	}
 
 	loggingCfg := zap.NewProductionConfig()
@@ -66,18 +66,18 @@ func NewLogger(configJSON string, levelOverride string, opts ...zap.Option) (*za
 	if err2 != nil {
 		panic(err2)
 	}
-	return enrichLoggerWithCommitID(logger.Named(fallbackLoggerName).Sugar()), loggingCfg.Level
+	return enrichLoggerWithCommitID(logger.Named(fallbackLoggerName)), loggingCfg.Level
 }
 
-func enrichLoggerWithCommitID(logger *zap.SugaredLogger) *zap.SugaredLogger {
+func enrichLoggerWithCommitID(logger *zap.Logger) *zap.SugaredLogger {
 	commmitID, err := changeset.Get()
 	if err == nil {
 		// Enrich logs with GitHub commit ID.
-		return logger.With(zap.String(logkey.GitHubCommitID, commmitID))
+		return logger.With(zap.String(logkey.GitHubCommitID, commmitID)).Sugar()
 	}
 
-	logger.Infof("Fetch GitHub commit ID from kodata failed: %v", err)
-	return logger
+	logger.Info("Fetch GitHub commit ID from kodata failed", zap.Error(err))
+	return logger.Sugar()
 }
 
 // NewLoggerFromConfig creates a logger using the provided Config

--- a/websocket/connection.go
+++ b/websocket/connection.go
@@ -129,12 +129,12 @@ func NewDurableConnection(target string, messageChan chan []byte, logger *zap.Su
 		for {
 			select {
 			default:
-				logger.Infof("Connecting to %s", target)
+				logger.Info("Connecting to ", target)
 				if err := c.connect(); err != nil {
-					logger.With(zap.Error(err)).Errorf("Connecting to %s failed", target)
+					logger.Errorw("Failed connecting to "+target, zap.Error(err))
 					continue
 				}
-				logger.Debugf("Connected to %s", target)
+				logger.Debug("Connected to ", target)
 				if err := c.keepalive(); err != nil {
 					logger.With(zap.Error(err)).Errorf("Connection to %s broke down, reconnecting...", target)
 				}


### PR DESCRIPTION
- use more performant functions (mostly remove formatters were possible)
- move zap.Error() to the call site, rather than creating a new sugared logger with a key attached (not cheap)
- fix *w usages where the key was not provided.

/assign mattmoor