### PR TITLE
Fix the comment for volatile time

### DIFF
--- a/apis/volatile_time.go
+++ b/apis/volatile_time.go
@@ -24,7 +24,10 @@ import (
 // VolatileTime wraps metav1.Time
 //
 // Unlike metav1.Time, VolatileTimes are considered semantically equal when
-// using go-cmp, so differing VolatileTime values are not considered different.
+// using kubernetes semantic equality checks.
+// Thus differing VolatileTime values are not considered different.
+// Note, go-cmp will still return inequality, see unit test if you
+// need this behavior for go-cmp.
 type VolatileTime struct {
 	Inner metav1.Time
 }
@@ -42,7 +45,7 @@ func (t *VolatileTime) UnmarshalJSON(b []byte) error {
 func init() {
 	equality.Semantic.AddFunc(
 		// Always treat VolatileTime fields as equivalent.
-		func(a, b VolatileTime) bool {
+		func(VolatileTime, VolatileTime) bool {
 			return true
 		},
 	)

--- a/apis/volatile_time_test.go
+++ b/apis/volatile_time_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -83,5 +84,15 @@ func TestVolatileTimeEquality(t *testing.T) {
 
 	if !equality.Semantic.DeepEqual(tt1, tt2) {
 		t.Error("equality.Semantic.DeepEqual() = false, wanted true")
+	}
+	if cmp.Equal(tt1, tt2) {
+		t.Error("go-cmp.Equal should have still returned false")
+	}
+
+	opt := cmp.Comparer(func(VolatileTime, VolatileTime) bool {
+		return true
+	})
+	if !cmp.Equal(tt1, tt2, opt) {
+		t.Error("go-cmp.Equal with opt should returned true")
 	}
 }


### PR DESCRIPTION
And provide a UT and an example how to do this with go-cmp

/assign @n3wscott mattmoor
/cc @ImJasonH 