### PR TITLE
[WIP] Add a new "Goose" e2e test tool for leaderelection.

### DIFF
--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/controller.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/controller.go
@@ -26,6 +26,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	clientsetscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	labels "k8s.io/apimachinery/pkg/labels"
+	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -35,6 +37,7 @@ import (
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	controller "knative.dev/pkg/controller"
 	logging "knative.dev/pkg/logging"
+	reconciler "knative.dev/pkg/reconciler"
 )
 
 const (
@@ -56,9 +59,26 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	customresourcedefinitionInformer := customresourcedefinition.Get(ctx)
 
+	lister := customresourcedefinitionInformer.Lister()
+
 	rec := &reconcilerImpl{
+		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
+			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) {
+				all, err := lister.List(labels.Everything())
+				if err != nil {
+					logger.Fatalf("Unable to accept promotion: %v", err)
+				}
+				for _, elt := range all {
+					// TODO: Consider letting users specify a filter in options.
+					enq(bkt, types.NamespacedName{
+						Namespace: elt.GetNamespace(),
+						Name:      elt.GetName(),
+					})
+				}
+			},
+		},
 		Client:        client.Get(ctx),
-		Lister:        customresourcedefinitionInformer.Lister(),
+		Lister:        lister,
 		reconciler:    r,
 		finalizerName: defaultFinalizerName,
 	}

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
@@ -31,6 +31,7 @@ import (
 	equality "k8s.io/apimachinery/pkg/api/equality"
 	errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	labels "k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"
 	sets "k8s.io/apimachinery/pkg/util/sets"
 	cache "k8s.io/client-go/tools/cache"
@@ -63,8 +64,30 @@ type Finalizer interface {
 	FinalizeKind(ctx context.Context, o *v1beta1.CustomResourceDefinition) reconciler.Event
 }
 
+// ReadOnlyInterface defines the strongly typed interfaces to be implemented by a
+// controller reconciling v1beta1.CustomResourceDefinition if they want to process resources for which
+// they are not the leader.
+type ReadOnlyInterface interface {
+	// ObserveKind implements logic to observe v1beta1.CustomResourceDefinition.
+	// This method should not write to the API.
+	ObserveKind(ctx context.Context, o *v1beta1.CustomResourceDefinition) reconciler.Event
+}
+
+// ReadOnlyFinalizer defines the strongly typed interfaces to be implemented by a
+// controller finalizing v1beta1.CustomResourceDefinition if they want to process tombstoned resources
+// even when they are not the leader.  Due to the nature of how finalizers are handled
+// there are no guarantees that this will be called.
+type ReadOnlyFinalizer interface {
+	// ObserveFinalizeKind implements custom logic to observe the final state of v1beta1.CustomResourceDefinition.
+	// This method should not write to the API.
+	ObserveFinalizeKind(ctx context.Context, o *v1beta1.CustomResourceDefinition) reconciler.Event
+}
+
 // reconcilerImpl implements controller.Reconciler for v1beta1.CustomResourceDefinition resources.
 type reconcilerImpl struct {
+	// LeaderAwareFuncs is inlined to help us implement reconciler.LeaderAware
+	reconciler.LeaderAwareFuncs
+
 	// Client is used to write back status updates.
 	Client clientset.Interface
 
@@ -89,13 +112,38 @@ type reconcilerImpl struct {
 // Check that our Reconciler implements controller.Reconciler
 var _ controller.Reconciler = (*reconcilerImpl)(nil)
 
+// Check that our generated Reconciler is always LeaderAware.
+var _ reconciler.LeaderAware = (*reconcilerImpl)(nil)
+
 func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client clientset.Interface, lister apiextensionsv1beta1.CustomResourceDefinitionLister, recorder record.EventRecorder, r Interface, options ...controller.Options) controller.Reconciler {
 	// Check the options function input. It should be 0 or 1.
 	if len(options) > 1 {
 		logger.Fatalf("up to one options struct is supported, found %d", len(options))
 	}
 
+	// Fail fast when users inadvertently implement the other LeaderAware interface.
+	// For the typed reconcilers, Promote shouldn't take any arguments.
+	if _, ok := r.(reconciler.LeaderAware); ok {
+		logger.Fatalf("%T implements the incorrect LeaderAware interface.  Promote() should not take an argument as genreconciler handles the enqueuing automatically.", r)
+	}
+	// TODO: Consider validating when folks implement ReadOnlyFinalizer, but not Finalizer.
+
 	rec := &reconcilerImpl{
+		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
+			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) {
+				all, err := lister.List(labels.Everything())
+				if err != nil {
+					logger.Fatalf("Unable to accept promotion: %v", err)
+				}
+				for _, elt := range all {
+					// TODO: Consider letting users specify a filter in options.
+					enq(bkt, types.NamespacedName{
+						Namespace: elt.GetNamespace(),
+						Name:      elt.GetName(),
+					})
+				}
+			},
+		},
 		Client:        client,
 		Lister:        lister,
 		Recorder:      recorder,
@@ -119,6 +167,25 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client client
 func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
 
+	// Convert the namespace/name string into a distinct namespace and name
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		logger.Errorf("invalid resource key: %s", key)
+		return nil
+	}
+	// Establish whether we are the leader for use below.
+	isLeader := r.IsLeader(types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	})
+	roi, isROI := r.reconciler.(ReadOnlyInterface)
+	rof, isROF := r.reconciler.(ReadOnlyFinalizer)
+	if !isLeader && !isROI && !isROF {
+		// If we are not the leader, and we don't implement either ReadOnly
+		// interface, then take a fast-path out.
+		return nil
+	}
+
 	// If configStore is set, attach the frozen configuration to the context.
 	if r.configStore != nil {
 		ctx = r.configStore.ToContext(ctx)
@@ -126,15 +193,6 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	// Add the recorder to context.
 	ctx = controller.WithEventRecorder(ctx, r.Recorder)
-
-	// Convert the namespace/name string into a distinct namespace and name
-
-	_, name, err := cache.SplitMetaNamespaceKey(key)
-
-	if err != nil {
-		logger.Errorf("invalid resource key: %s", key)
-		return nil
-	}
 
 	// Get the resource with this namespace/name.
 
@@ -155,19 +213,29 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	var reconcileEvent reconciler.Event
 	if resource.GetDeletionTimestamp().IsZero() {
-		// Append the target method to the logger.
-		logger = logger.With(zap.String("targetMethod", "ReconcileKind"))
+		if isLeader {
+			// Append the target method to the logger.
+			logger = logger.With(zap.String("targetMethod", "ReconcileKind"))
 
-		// Set and update the finalizer on resource if r.reconciler
-		// implements Finalizer.
-		if resource, err = r.setFinalizerIfFinalizer(ctx, resource); err != nil {
-			logger.Warnw("Failed to set finalizers", zap.Error(err))
+			// Set and update the finalizer on resource if r.reconciler
+			// implements Finalizer.
+			if resource, err = r.setFinalizerIfFinalizer(ctx, resource); err != nil {
+				logger.Warnw("Failed to set finalizers", zap.Error(err))
+			}
+
+			// Reconcile this copy of the resource and then write back any status
+			// updates regardless of whether the reconciliation errored out.
+			reconcileEvent = r.reconciler.ReconcileKind(ctx, resource)
+
+		} else if isROI {
+			// Append the target method to the logger.
+			logger = logger.With(zap.String("targetMethod", "ObserveKind"))
+
+			// Observe any changes to this resource, since we are not the leader.
+			reconcileEvent = roi.ObserveKind(ctx, resource)
 		}
 
-		// Reconcile this copy of the resource and then write back any status
-		// updates regardless of whether the reconciliation errored out.
-		reconcileEvent = r.reconciler.ReconcileKind(ctx, resource)
-	} else if fin, ok := r.reconciler.(Finalizer); ok {
+	} else if fin, ok := r.reconciler.(Finalizer); isLeader && ok {
 		// Append the target method to the logger.
 		logger = logger.With(zap.String("targetMethod", "FinalizeKind"))
 
@@ -177,6 +245,12 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		if resource, err = r.clearFinalizer(ctx, resource, reconcileEvent); err != nil {
 			logger.Warnw("Failed to clear finalizers", zap.Error(err))
 		}
+	} else if !isLeader && isROF {
+		// Append the target method to the logger.
+		logger = logger.With(zap.String("targetMethod", "ObserveFinalizeKind"))
+
+		// For finalizing reconcilers, just observe when we aren't the leader.
+		reconcileEvent = rof.ObserveFinalizeKind(ctx, resource)
 	}
 
 	// Synchronize the status.
@@ -185,6 +259,9 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		// This is important because the copy we loaded from the injectionInformer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
+	} else if !isLeader {
+		logger.Warn("Saw status changes when we aren't the leader!")
+		// TODO: Consider logging the diff at Debug?
 	} else if err = r.updateStatus(original, resource); err != nil {
 		logger.Warnw("Failed to update resource status", zap.Error(err))
 		r.Recorder.Eventf(resource, v1.EventTypeWarning, "UpdateFailed",
@@ -198,13 +275,19 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		if reconciler.EventAs(reconcileEvent, &event) {
 			logger.Infow("Returned an event", zap.Any("event", reconcileEvent))
 			r.Recorder.Eventf(resource, event.EventType, event.Reason, event.Format, event.Args...)
+
+			// the event was wrapped inside an error, consider the reconciliation as failed
+			if _, isEvent := reconcileEvent.(*reconciler.ReconcilerEvent); !isEvent {
+				return reconcileEvent
+			}
 			return nil
-		} else {
-			logger.Errorw("Returned an error", zap.Error(reconcileEvent))
-			r.Recorder.Event(resource, v1.EventTypeWarning, "InternalError", reconcileEvent.Error())
-			return reconcileEvent
 		}
+
+		logger.Errorw("Returned an error", zap.Error(reconcileEvent))
+		r.Recorder.Event(resource, v1.EventTypeWarning, "InternalError", reconcileEvent.Error())
+		return reconcileEvent
 	}
+
 	return nil
 }
 

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/stub/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/stub/reconciler.go
@@ -46,6 +46,15 @@ var _ customresourcedefinition.Interface = (*Reconciler)(nil)
 // Optionally check that our Reconciler implements Finalizer
 //var _ customresourcedefinition.Finalizer = (*Reconciler)(nil)
 
+// Optionally check that our Reconciler implements ReadOnlyInterface
+// Implement this to observe resources even when we are not the leader.
+//var _ customresourcedefinition.ReadOnlyInterface = (*Reconciler)(nil)
+
+// Optionally check that our Reconciler implements ReadOnlyFinalizer
+// Implement this to observe tombstoned resources even when we are not
+// the leader (best effort).
+//var _ customresourcedefinition.ReadOnlyFinalizer = (*Reconciler)(nil)
+
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1beta1.CustomResourceDefinition) reconciler.Event {
 	// TODO: use this if the resource implements InitializeConditions.
@@ -62,5 +71,17 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1beta1.CustomResourc
 // when the resource is deleted.
 //func (r *Reconciler) FinalizeKind(ctx context.Context, o *v1beta1.CustomResourceDefinition) reconciler.Event {
 //	// TODO: add custom finalization logic here.
+//	return nil
+//}
+
+// Optionally, use ObserveKind to observe the resource when we are not the leader.
+// func (r *Reconciler) ObserveKind(ctx context.Context, o *v1beta1.CustomResourceDefinition) reconciler.Event {
+// 	// TODO: add custom observation logic here.
+// 	return nil
+// }
+
+// Optionally, use ObserveFinalizeKind to observe resources being finalized when we are no the leader.
+//func (r *Reconciler) ObserveFinalizeKind(ctx context.Context, o *v1beta1.CustomResourceDefinition) reconciler.Event {
+// 	// TODO: add custom observation logic here.
 //	return nil
 //}

--- a/client/injection/kube/reconciler/core/v1/namespace/controller.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/controller.go
@@ -25,6 +25,8 @@ import (
 	strings "strings"
 
 	corev1 "k8s.io/api/core/v1"
+	labels "k8s.io/apimachinery/pkg/labels"
+	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -33,6 +35,7 @@ import (
 	namespace "knative.dev/pkg/client/injection/kube/informers/core/v1/namespace"
 	controller "knative.dev/pkg/controller"
 	logging "knative.dev/pkg/logging"
+	reconciler "knative.dev/pkg/reconciler"
 )
 
 const (
@@ -54,9 +57,26 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	namespaceInformer := namespace.Get(ctx)
 
+	lister := namespaceInformer.Lister()
+
 	rec := &reconcilerImpl{
+		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
+			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) {
+				all, err := lister.List(labels.Everything())
+				if err != nil {
+					logger.Fatalf("Unable to accept promotion: %v", err)
+				}
+				for _, elt := range all {
+					// TODO: Consider letting users specify a filter in options.
+					enq(bkt, types.NamespacedName{
+						Namespace: elt.GetNamespace(),
+						Name:      elt.GetName(),
+					})
+				}
+			},
+		},
 		Client:        client.Get(ctx),
-		Lister:        namespaceInformer.Lister(),
+		Lister:        lister,
 		reconciler:    r,
 		finalizerName: defaultFinalizerName,
 	}

--- a/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
@@ -28,6 +28,7 @@ import (
 	equality "k8s.io/apimachinery/pkg/api/equality"
 	errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	labels "k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"
 	sets "k8s.io/apimachinery/pkg/util/sets"
 	kubernetes "k8s.io/client-go/kubernetes"
@@ -62,8 +63,30 @@ type Finalizer interface {
 	FinalizeKind(ctx context.Context, o *v1.Namespace) reconciler.Event
 }
 
+// ReadOnlyInterface defines the strongly typed interfaces to be implemented by a
+// controller reconciling v1.Namespace if they want to process resources for which
+// they are not the leader.
+type ReadOnlyInterface interface {
+	// ObserveKind implements logic to observe v1.Namespace.
+	// This method should not write to the API.
+	ObserveKind(ctx context.Context, o *v1.Namespace) reconciler.Event
+}
+
+// ReadOnlyFinalizer defines the strongly typed interfaces to be implemented by a
+// controller finalizing v1.Namespace if they want to process tombstoned resources
+// even when they are not the leader.  Due to the nature of how finalizers are handled
+// there are no guarantees that this will be called.
+type ReadOnlyFinalizer interface {
+	// ObserveFinalizeKind implements custom logic to observe the final state of v1.Namespace.
+	// This method should not write to the API.
+	ObserveFinalizeKind(ctx context.Context, o *v1.Namespace) reconciler.Event
+}
+
 // reconcilerImpl implements controller.Reconciler for v1.Namespace resources.
 type reconcilerImpl struct {
+	// LeaderAwareFuncs is inlined to help us implement reconciler.LeaderAware
+	reconciler.LeaderAwareFuncs
+
 	// Client is used to write back status updates.
 	Client kubernetes.Interface
 
@@ -88,13 +111,38 @@ type reconcilerImpl struct {
 // Check that our Reconciler implements controller.Reconciler
 var _ controller.Reconciler = (*reconcilerImpl)(nil)
 
+// Check that our generated Reconciler is always LeaderAware.
+var _ reconciler.LeaderAware = (*reconcilerImpl)(nil)
+
 func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client kubernetes.Interface, lister corev1.NamespaceLister, recorder record.EventRecorder, r Interface, options ...controller.Options) controller.Reconciler {
 	// Check the options function input. It should be 0 or 1.
 	if len(options) > 1 {
 		logger.Fatalf("up to one options struct is supported, found %d", len(options))
 	}
 
+	// Fail fast when users inadvertently implement the other LeaderAware interface.
+	// For the typed reconcilers, Promote shouldn't take any arguments.
+	if _, ok := r.(reconciler.LeaderAware); ok {
+		logger.Fatalf("%T implements the incorrect LeaderAware interface.  Promote() should not take an argument as genreconciler handles the enqueuing automatically.", r)
+	}
+	// TODO: Consider validating when folks implement ReadOnlyFinalizer, but not Finalizer.
+
 	rec := &reconcilerImpl{
+		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
+			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) {
+				all, err := lister.List(labels.Everything())
+				if err != nil {
+					logger.Fatalf("Unable to accept promotion: %v", err)
+				}
+				for _, elt := range all {
+					// TODO: Consider letting users specify a filter in options.
+					enq(bkt, types.NamespacedName{
+						Namespace: elt.GetNamespace(),
+						Name:      elt.GetName(),
+					})
+				}
+			},
+		},
 		Client:        client,
 		Lister:        lister,
 		Recorder:      recorder,
@@ -118,6 +166,25 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client kubern
 func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
 
+	// Convert the namespace/name string into a distinct namespace and name
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		logger.Errorf("invalid resource key: %s", key)
+		return nil
+	}
+	// Establish whether we are the leader for use below.
+	isLeader := r.IsLeader(types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	})
+	roi, isROI := r.reconciler.(ReadOnlyInterface)
+	rof, isROF := r.reconciler.(ReadOnlyFinalizer)
+	if !isLeader && !isROI && !isROF {
+		// If we are not the leader, and we don't implement either ReadOnly
+		// interface, then take a fast-path out.
+		return nil
+	}
+
 	// If configStore is set, attach the frozen configuration to the context.
 	if r.configStore != nil {
 		ctx = r.configStore.ToContext(ctx)
@@ -125,15 +192,6 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	// Add the recorder to context.
 	ctx = controller.WithEventRecorder(ctx, r.Recorder)
-
-	// Convert the namespace/name string into a distinct namespace and name
-
-	_, name, err := cache.SplitMetaNamespaceKey(key)
-
-	if err != nil {
-		logger.Errorf("invalid resource key: %s", key)
-		return nil
-	}
 
 	// Get the resource with this namespace/name.
 
@@ -154,19 +212,29 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	var reconcileEvent reconciler.Event
 	if resource.GetDeletionTimestamp().IsZero() {
-		// Append the target method to the logger.
-		logger = logger.With(zap.String("targetMethod", "ReconcileKind"))
+		if isLeader {
+			// Append the target method to the logger.
+			logger = logger.With(zap.String("targetMethod", "ReconcileKind"))
 
-		// Set and update the finalizer on resource if r.reconciler
-		// implements Finalizer.
-		if resource, err = r.setFinalizerIfFinalizer(ctx, resource); err != nil {
-			logger.Warnw("Failed to set finalizers", zap.Error(err))
+			// Set and update the finalizer on resource if r.reconciler
+			// implements Finalizer.
+			if resource, err = r.setFinalizerIfFinalizer(ctx, resource); err != nil {
+				logger.Warnw("Failed to set finalizers", zap.Error(err))
+			}
+
+			// Reconcile this copy of the resource and then write back any status
+			// updates regardless of whether the reconciliation errored out.
+			reconcileEvent = r.reconciler.ReconcileKind(ctx, resource)
+
+		} else if isROI {
+			// Append the target method to the logger.
+			logger = logger.With(zap.String("targetMethod", "ObserveKind"))
+
+			// Observe any changes to this resource, since we are not the leader.
+			reconcileEvent = roi.ObserveKind(ctx, resource)
 		}
 
-		// Reconcile this copy of the resource and then write back any status
-		// updates regardless of whether the reconciliation errored out.
-		reconcileEvent = r.reconciler.ReconcileKind(ctx, resource)
-	} else if fin, ok := r.reconciler.(Finalizer); ok {
+	} else if fin, ok := r.reconciler.(Finalizer); isLeader && ok {
 		// Append the target method to the logger.
 		logger = logger.With(zap.String("targetMethod", "FinalizeKind"))
 
@@ -176,6 +244,12 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		if resource, err = r.clearFinalizer(ctx, resource, reconcileEvent); err != nil {
 			logger.Warnw("Failed to clear finalizers", zap.Error(err))
 		}
+	} else if !isLeader && isROF {
+		// Append the target method to the logger.
+		logger = logger.With(zap.String("targetMethod", "ObserveFinalizeKind"))
+
+		// For finalizing reconcilers, just observe when we aren't the leader.
+		reconcileEvent = rof.ObserveFinalizeKind(ctx, resource)
 	}
 
 	// Synchronize the status.
@@ -184,6 +258,9 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		// This is important because the copy we loaded from the injectionInformer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
+	} else if !isLeader {
+		logger.Warn("Saw status changes when we aren't the leader!")
+		// TODO: Consider logging the diff at Debug?
 	} else if err = r.updateStatus(original, resource); err != nil {
 		logger.Warnw("Failed to update resource status", zap.Error(err))
 		r.Recorder.Eventf(resource, v1.EventTypeWarning, "UpdateFailed",
@@ -197,13 +274,19 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		if reconciler.EventAs(reconcileEvent, &event) {
 			logger.Infow("Returned an event", zap.Any("event", reconcileEvent))
 			r.Recorder.Eventf(resource, event.EventType, event.Reason, event.Format, event.Args...)
+
+			// the event was wrapped inside an error, consider the reconciliation as failed
+			if _, isEvent := reconcileEvent.(*reconciler.ReconcilerEvent); !isEvent {
+				return reconcileEvent
+			}
 			return nil
-		} else {
-			logger.Errorw("Returned an error", zap.Error(reconcileEvent))
-			r.Recorder.Event(resource, v1.EventTypeWarning, "InternalError", reconcileEvent.Error())
-			return reconcileEvent
 		}
+
+		logger.Errorw("Returned an error", zap.Error(reconcileEvent))
+		r.Recorder.Event(resource, v1.EventTypeWarning, "InternalError", reconcileEvent.Error())
+		return reconcileEvent
 	}
+
 	return nil
 }
 

--- a/client/injection/kube/reconciler/core/v1/namespace/stub/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/stub/reconciler.go
@@ -45,6 +45,15 @@ var _ namespace.Interface = (*Reconciler)(nil)
 // Optionally check that our Reconciler implements Finalizer
 //var _ namespace.Finalizer = (*Reconciler)(nil)
 
+// Optionally check that our Reconciler implements ReadOnlyInterface
+// Implement this to observe resources even when we are not the leader.
+//var _ namespace.ReadOnlyInterface = (*Reconciler)(nil)
+
+// Optionally check that our Reconciler implements ReadOnlyFinalizer
+// Implement this to observe tombstoned resources even when we are not
+// the leader (best effort).
+//var _ namespace.ReadOnlyFinalizer = (*Reconciler)(nil)
+
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1.Namespace) reconciler.Event {
 	// TODO: use this if the resource implements InitializeConditions.
@@ -61,5 +70,17 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1.Namespace) reconci
 // when the resource is deleted.
 //func (r *Reconciler) FinalizeKind(ctx context.Context, o *v1.Namespace) reconciler.Event {
 //	// TODO: add custom finalization logic here.
+//	return nil
+//}
+
+// Optionally, use ObserveKind to observe the resource when we are not the leader.
+// func (r *Reconciler) ObserveKind(ctx context.Context, o *v1.Namespace) reconciler.Event {
+// 	// TODO: add custom observation logic here.
+// 	return nil
+// }
+
+// Optionally, use ObserveFinalizeKind to observe resources being finalized when we are no the leader.
+//func (r *Reconciler) ObserveFinalizeKind(ctx context.Context, o *v1.Namespace) reconciler.Event {
+// 	// TODO: add custom observation logic here.
 //	return nil
 //}

--- a/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -142,9 +142,21 @@ func (g *reconcilerControllerGenerator) GenerateType(c *generator.Context, t *ty
 			Package: "context",
 			Name:    "Context",
 		}),
-		"fmtSprintf": c.Universe.Function(types.Name{
-			Package: "fmt",
-			Name:    "Sprintf",
+		"reconcilerLeaderAwareFuncs": c.Universe.Type(types.Name{
+			Package: "knative.dev/pkg/reconciler",
+			Name:    "LeaderAwareFuncs",
+		}),
+		"reconcilerBucket": c.Universe.Type(types.Name{
+			Package: "knative.dev/pkg/reconciler",
+			Name:    "Bucket",
+		}),
+		"typesNamespacedName": c.Universe.Type(types.Name{
+			Package: "k8s.io/apimachinery/pkg/types",
+			Name:    "NamespacedName",
+		}),
+		"labelsEverything": c.Universe.Function(types.Name{
+			Package: "k8s.io/apimachinery/pkg/labels",
+			Name:    "Everything",
 		}),
 		"stringsReplaceAll": c.Universe.Function(types.Name{
 			Package: "strings",
@@ -153,6 +165,10 @@ func (g *reconcilerControllerGenerator) GenerateType(c *generator.Context, t *ty
 		"reflectTypeOf": c.Universe.Function(types.Name{
 			Package: "reflect",
 			Name:    "TypeOf",
+		}),
+		"fmtSprintf": c.Universe.Function(types.Name{
+			Package: "fmt",
+			Name:    "Sprintf",
 		}),
 	}
 
@@ -185,9 +201,26 @@ func NewImpl(ctx {{.contextContext|raw}}, r Interface{{if .hasClass}}, classValu
 
 	{{.type|lowercaseSingular}}Informer := {{.informerGet|raw}}(ctx)
 
+	lister := {{.type|lowercaseSingular}}Informer.Lister()
+
 	rec := &reconcilerImpl{
+		LeaderAwareFuncs: {{.reconcilerLeaderAwareFuncs|raw}}{
+			PromoteFunc: func(bkt {{.reconcilerBucket|raw}}, enq func({{.reconcilerBucket|raw}}, {{.typesNamespacedName|raw}})) {
+				all, err := lister.List({{.labelsEverything|raw}}())
+				if err != nil {
+					logger.Fatalf("Unable to accept promotion: %v", err)
+				}
+				for _, elt := range all {
+					// TODO: Consider letting users specify a filter in options.
+					enq(bkt, {{.typesNamespacedName|raw}}{
+						Namespace: elt.GetNamespace(),
+						Name: elt.GetName(),
+					})
+				}
+			},
+		},
 		Client:  {{.clientGet|raw}}(ctx),
-		Lister:  {{.type|lowercaseSingular}}Informer.Lister(),
+		Lister:  lister,
 		reconciler:    r,
 		finalizerName: defaultFinalizerName,
 		{{if .hasClass}}classValue: classValue,{{end}}

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -151,6 +151,30 @@ func (g *reconcilerReconcilerGenerator) GenerateType(c *generator.Context, t *ty
 		"equalitySemantic":    c.Universe.Package("k8s.io/apimachinery/pkg/api/equality").Variable("Semantic"),
 		"jsonMarshal":         c.Universe.Package("encoding/json").Function("Marshal"),
 		"typesMergePatchType": c.Universe.Package("k8s.io/apimachinery/pkg/types").Constant("MergePatchType"),
+		"syncRWMutex": c.Universe.Type(types.Name{
+			Package: "sync",
+			Name:    "RWMutex",
+		}),
+		"reconcilerLeaderAware": c.Universe.Type(types.Name{
+			Package: "knative.dev/pkg/reconciler",
+			Name:    "LeaderAware",
+		}),
+		"reconcilerLeaderAwareFuncs": c.Universe.Type(types.Name{
+			Package: "knative.dev/pkg/reconciler",
+			Name:    "LeaderAwareFuncs",
+		}),
+		"reconcilerBucket": c.Universe.Type(types.Name{
+			Package: "knative.dev/pkg/reconciler",
+			Name:    "Bucket",
+		}),
+		"typesNamespacedName": c.Universe.Type(types.Name{
+			Package: "k8s.io/apimachinery/pkg/types",
+			Name:    "NamespacedName",
+		}),
+		"labelsEverything": c.Universe.Function(types.Name{
+			Package: "k8s.io/apimachinery/pkg/labels",
+			Name:    "Everything",
+		}),
 	}
 
 	sw.Do(reconcilerInterfaceFactory, m)
@@ -186,8 +210,30 @@ type Finalizer interface {
 	FinalizeKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}}
 }
 
+// ReadOnlyInterface defines the strongly typed interfaces to be implemented by a
+// controller reconciling {{.type|raw}} if they want to process resources for which
+// they are not the leader.
+type ReadOnlyInterface interface {
+	// ObserveKind implements logic to observe {{.type|raw}}.
+	// This method should not write to the API.
+	ObserveKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}}
+}
+
+// ReadOnlyFinalizer defines the strongly typed interfaces to be implemented by a
+// controller finalizing {{.type|raw}} if they want to process tombstoned resources
+// even when they are not the leader.  Due to the nature of how finalizers are handled
+// there are no guarantees that this will be called.
+type ReadOnlyFinalizer interface {
+	// ObserveFinalizeKind implements custom logic to observe the final state of {{.type|raw}}.
+	// This method should not write to the API.
+	ObserveFinalizeKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}}
+}
+
 // reconcilerImpl implements controller.Reconciler for {{.type|raw}} resources.
 type reconcilerImpl struct {
+	// LeaderAwareFuncs is inlined to help us implement {{.reconcilerLeaderAware|raw}}
+	{{.reconcilerLeaderAwareFuncs|raw}}
+
 	// Client is used to write back status updates.
 	Client {{.clientsetInterface|raw}}
 
@@ -216,6 +262,8 @@ type reconcilerImpl struct {
 
 // Check that our Reconciler implements controller.Reconciler
 var _ controller.Reconciler = (*reconcilerImpl)(nil)
+// Check that our generated Reconciler is always LeaderAware.
+var _ {{.reconcilerLeaderAware|raw}}  = (*reconcilerImpl)(nil)
 
 `
 
@@ -226,7 +274,29 @@ func NewReconciler(ctx {{.contextContext|raw}}, logger *{{.zapSugaredLogger|raw}
 		logger.Fatalf("up to one options struct is supported, found %d", len(options))
 	}
 
+	// Fail fast when users inadvertently implement the other LeaderAware interface.
+	// For the typed reconcilers, Promote shouldn't take any arguments.
+	if _, ok := r.({{.reconcilerLeaderAware|raw}}); ok {
+		logger.Fatalf("%T implements the incorrect LeaderAware interface.  Promote() should not take an argument as genreconciler handles the enqueuing automatically.", r)
+	}
+	// TODO: Consider validating when folks implement ReadOnlyFinalizer, but not Finalizer.
+
 	rec := &reconcilerImpl{
+		LeaderAwareFuncs: {{.reconcilerLeaderAwareFuncs|raw}}{
+			PromoteFunc: func(bkt {{.reconcilerBucket|raw}}, enq func({{.reconcilerBucket|raw}}, {{.typesNamespacedName|raw}})) {
+				all, err := lister.List({{.labelsEverything|raw}}())
+				if err != nil {
+					logger.Fatalf("Unable to accept promotion: %v", err)
+				}
+				for _, elt := range all {
+					// TODO: Consider letting users specify a filter in options.
+					enq(bkt, {{.typesNamespacedName|raw}}{
+						Namespace: elt.GetNamespace(),
+						Name: elt.GetName(),
+					})
+				}
+			},
+		},
 		Client: client,
 		Lister: lister,
 		Recorder: recorder,
@@ -253,6 +323,25 @@ var reconcilerImplFactory = `
 func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) error {
 	logger := {{.loggingFromContext|raw}}(ctx)
 
+	// Convert the namespace/name string into a distinct namespace and name
+	namespace, name, err := {{.cacheSplitMetaNamespaceKey|raw}}(key)
+	if err != nil {
+		logger.Errorf("invalid resource key: %s", key)
+		return nil
+	}
+	// Establish whether we are the leader for use below.
+	isLeader := r.IsLeader({{.typesNamespacedName|raw}}{
+		Namespace: namespace,
+		Name: name,
+	})
+	roi, isROI := r.reconciler.(ReadOnlyInterface)
+	rof, isROF := r.reconciler.(ReadOnlyFinalizer);
+	if !isLeader && !isROI && !isROF {
+		// If we are not the leader, and we don't implement either ReadOnly
+		// interface, then take a fast-path out.
+		return nil
+	}
+
 	// If configStore is set, attach the frozen configuration to the context.
 	if r.configStore != nil {
 		ctx = r.configStore.ToContext(ctx)
@@ -261,19 +350,7 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 	// Add the recorder to context.
 	ctx = {{.controllerWithEventRecorder|raw}}(ctx, r.Recorder)
 
-	// Convert the namespace/name string into a distinct namespace and name
-	{{if .nonNamespaced}}
-	_, name, err := {{.cacheSplitMetaNamespaceKey|raw}}(key)
-	{{else}}
-	namespace, name, err := {{.cacheSplitMetaNamespaceKey|raw}}(key)
-	{{end}}
-	if err != nil {
-		logger.Errorf("invalid resource key: %s", key)
-		return nil
-	}
-
 	// Get the resource with this namespace/name.
-
 	{{if .nonNamespaced}}
 	getter := r.Lister
 	{{else}}
@@ -302,27 +379,35 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 
 	var reconcileEvent {{.reconcilerEvent|raw}}
 	if resource.GetDeletionTimestamp().IsZero() {
-		// Append the target method to the logger.
-		logger = logger.With(zap.String("targetMethod", "ReconcileKind"))
+		if isLeader {
+			// Append the target method to the logger.
+			logger = logger.With(zap.String("targetMethod", "ReconcileKind"))
 
-		// Set and update the finalizer on resource if r.reconciler
-		// implements Finalizer.
-		if resource, err = r.setFinalizerIfFinalizer(ctx, resource); err != nil {
-			logger.Warnw("Failed to set finalizers", zap.Error(err))
+			// Set and update the finalizer on resource if r.reconciler
+			// implements Finalizer.
+			if resource, err = r.setFinalizerIfFinalizer(ctx, resource); err != nil {
+				logger.Warnw("Failed to set finalizers", zap.Error(err))
+			}
+			{{if .isKRShaped}}
+			reconciler.PreProcessReconcile(ctx, resource)
+			{{end}}
+
+			// Reconcile this copy of the resource and then write back any status
+			// updates regardless of whether the reconciliation errored out.
+			reconcileEvent = r.reconciler.ReconcileKind(ctx, resource)
+
+			{{if .isKRShaped}}
+			reconciler.PostProcessReconcile(ctx, resource)
+			{{end}}
+		} else if isROI {
+			// Append the target method to the logger.
+			logger = logger.With(zap.String("targetMethod", "ObserveKind"))
+
+			// Observe any changes to this resource, since we are not the leader.
+			reconcileEvent = roi.ObserveKind(ctx, resource)
 		}
 
-		{{if .isKRShaped}}
-		reconciler.PreProcessReconcile(ctx, resource)
-		{{end}}
-
-		// Reconcile this copy of the resource and then write back any status
-		// updates regardless of whether the reconciliation errored out.
-		reconcileEvent = r.reconciler.ReconcileKind(ctx, resource)
-
-		{{if .isKRShaped}}
-		reconciler.PostProcessReconcile(ctx, resource)
-		{{end}}
-	} else if fin, ok := r.reconciler.(Finalizer); ok {
+	} else if fin, ok := r.reconciler.(Finalizer); isLeader && ok {
 		// Append the target method to the logger.
 		logger = logger.With(zap.String("targetMethod", "FinalizeKind"))
 
@@ -332,6 +417,12 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 		if resource, err = r.clearFinalizer(ctx, resource, reconcileEvent); err != nil {
 			logger.Warnw("Failed to clear finalizers", zap.Error(err))
 		}
+	} else if !isLeader && isROF {
+		// Append the target method to the logger.
+		logger = logger.With(zap.String("targetMethod", "ObserveFinalizeKind"))
+
+		// For finalizing reconcilers, just observe when we aren't the leader.
+		reconcileEvent = rof.ObserveFinalizeKind(ctx, resource)
 	}
 
 	// Synchronize the status.
@@ -340,6 +431,9 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 		// This is important because the copy we loaded from the injectionInformer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
+	} else if !isLeader {
+		logger.Warn("Saw status changes when we aren't the leader!")
+		// TODO: Consider logging the diff at Debug?
 	} else if err = r.updateStatus(original, resource); err != nil {
 		logger.Warnw("Failed to update resource status", zap.Error(err))
 		r.Recorder.Eventf(resource, {{.corev1EventTypeWarning|raw}}, "UpdateFailed",
@@ -518,4 +612,5 @@ func (r *reconcilerImpl) clearFinalizer(ctx {{.contextContext|raw}}, resource *{
 	// Synchronize the finalizers filtered by r.finalizerName.
 	return r.updateFinalizersFiltered(ctx, resource)
 }
+
 `

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
@@ -77,6 +77,14 @@ func (g *reconcilerReconcilerStubGenerator) GenerateType(c *generator.Context, t
 			Package: g.reconcilerPkg,
 			Name:    "Finalizer",
 		}),
+		"reconcilerReadOnlyInterface": c.Universe.Type(types.Name{
+			Package: g.reconcilerPkg,
+			Name:    "ReadOnlyInterface",
+		}),
+		"reconcilerReadOnlyFinalizer": c.Universe.Type(types.Name{
+			Package: g.reconcilerPkg,
+			Name:    "ReadOnlyFinalizer",
+		}),
 		"corev1EventTypeNormal": c.Universe.Type(types.Name{
 			Package: "k8s.io/api/core/v1",
 			Name:    "EventTypeNormal",
@@ -112,16 +120,24 @@ var _ {{.reconcilerInterface|raw}} = (*Reconciler)(nil)
 // Optionally check that our Reconciler implements Finalizer
 //var _ {{.reconcilerFinalizer|raw}} = (*Reconciler)(nil)
 
+// Optionally check that our Reconciler implements ReadOnlyInterface
+// Implement this to observe resources even when we are not the leader.
+//var _ {{.reconcilerReadOnlyInterface|raw}} = (*Reconciler)(nil)
+
+// Optionally check that our Reconciler implements ReadOnlyFinalizer
+// Implement this to observe tombstoned resources even when we are not
+// the leader (best effort).
+//var _ {{.reconcilerReadOnlyFinalizer|raw}} = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
-    // TODO: use this if the resource implements InitializeConditions.
+	// TODO: use this if the resource implements InitializeConditions.
 	// o.Status.InitializeConditions()
 
 	// TODO: add custom reconciliation logic here.
 
 	// TODO: use this if the object has .status.ObservedGeneration.
-    // o.Status.ObservedGeneration = o.Generation
+	// o.Status.ObservedGeneration = o.Generation
 	return newReconciledNormal(o.Namespace, o.Name)
 }
 
@@ -129,6 +145,18 @@ func (r *Reconciler) ReconcileKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}
 // when the resource is deleted.
 //func (r *Reconciler) FinalizeKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
 //	// TODO: add custom finalization logic here.
+//	return nil
+//}
+
+// Optionally, use ObserveKind to observe the resource when we are not the leader.
+// func (r *Reconciler) ObserveKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
+// 	// TODO: add custom observation logic here.
+// 	return nil
+// }
+
+// Optionally, use ObserveFinalizeKind to observe resources being finalized when we are no the leader.
+//func (r *Reconciler) ObserveFinalizeKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
+// 	// TODO: add custom observation logic here.
 //	return nil
 //}
 `

--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -232,6 +232,18 @@ func WebhookMainWithConfig(ctx context.Context, component string, cfg *rest.Conf
 
 	CheckK8sClientMinimumVersionOrDie(ctx, logger)
 	cmw := SetupConfigMapWatchOrDie(ctx, logger)
+
+	// Set up leader election config
+	leaderElectionConfig, err := GetLeaderElectionConfig(ctx)
+	if err != nil {
+		logger.Fatalf("Error loading leader election configuration: %v", err)
+	}
+	leConfig := leaderElectionConfig.GetComponentConfig(component)
+	if leConfig.LeaderElect {
+		// Signal that we are executing in a context with leader election.
+		ctx = kle.WithLeaderElectorBuilder(ctx, kubeclient.Get(ctx), leConfig)
+	}
+
 	controllers, webhooks := ControllersAndWebhooksFromCtors(ctx, cmw, ctors...)
 	WatchLoggingConfigOrDie(ctx, cmw, logger, atomicLevel, component)
 	WatchObservabilityConfigOrDie(ctx, cmw, profilingHandler, logger, component)
@@ -242,7 +254,6 @@ func WebhookMainWithConfig(ctx context.Context, component string, cfg *rest.Conf
 	// If we have one or more admission controllers, then start the webhook
 	// and pass them in.
 	var wh *webhook.Webhook
-	var err error
 	if len(webhooks) > 0 {
 		// Register webhook metrics
 		webhook.RegisterMetrics()

--- a/leaderelection/context.go
+++ b/leaderelection/context.go
@@ -75,7 +75,7 @@ func (b *builder) BuildElector(ctx context.Context, la reconciler.LeaderAware, n
 	}
 
 	// TODO(mattmoor): Extract this from b.lec for this name?
-	const count uint32 = 1
+	const count uint32 = 3
 
 	buckets := make([]*leaderelection.LeaderElector, 0, count)
 	for i := uint32(0); i < count; i++ {

--- a/leaderelection/context.go
+++ b/leaderelection/context.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/reconciler"
+	"knative.dev/pkg/system"
+)
+
+// WithLeaderElectorBuilder infuses a context with the ability to build
+// LeaderElectors with the provided component configuration acquiring resource
+// locks via the provided kubernetes client.
+func WithLeaderElectorBuilder(ctx context.Context, kc kubernetes.Interface, cc ComponentConfig) context.Context {
+	return context.WithValue(ctx, builderKey{}, &builder{
+		kc:  kc,
+		lec: cc,
+	})
+}
+
+// HasLeaderElection returns whether there is leader election configuration
+// associated with the context
+func HasLeaderElection(ctx context.Context) bool {
+	val := ctx.Value(builderKey{})
+	return val != nil
+}
+
+// BuildElector builds a leaderelection.LeaderElector for the named LeaderAware
+// reconciler using a builder added to the context via WithLeaderElectorBuilder.
+func BuildElector(ctx context.Context, la reconciler.LeaderAware, name string, enq func(reconciler.Bucket, types.NamespacedName)) ([]*leaderelection.LeaderElector, error) {
+	val := ctx.Value(builderKey{})
+	if val == nil {
+		return nil, errors.New("Builder not found")
+	}
+	return val.(*builder).BuildElector(ctx, la, name, enq)
+}
+
+type builderKey struct{}
+
+type builder struct {
+	kc  kubernetes.Interface
+	lec ComponentConfig
+}
+
+func (b *builder) BuildElector(ctx context.Context, la reconciler.LeaderAware, name string, enq func(reconciler.Bucket, types.NamespacedName)) ([]*leaderelection.LeaderElector, error) {
+	logger := logging.FromContext(ctx)
+
+	id, err := UniqueID()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(mattmoor): Extract this from b.lec for this name?
+	const count uint32 = 1
+
+	buckets := make([]*leaderelection.LeaderElector, 0, count)
+	for i := uint32(0); i < count; i++ {
+		bkt := &bucket{
+			component: b.lec.Component,
+			name:      name,
+			index:     i,
+			total:     count,
+		}
+
+		rl, err := resourcelock.New(b.lec.ResourceLock,
+			system.Namespace(), // use namespace we are running in
+			bkt.String(),
+			b.kc.CoreV1(),
+			b.kc.CoordinationV1(),
+			resourcelock.ResourceLockConfig{
+				Identity: id,
+			})
+		if err != nil {
+			return nil, err
+		}
+		logger.Infof("%s will run in leader-elected mode with id %q", bkt.String(), rl.Identity())
+
+		le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+			Lock:          rl,
+			LeaseDuration: b.lec.LeaseDuration,
+			RenewDeadline: b.lec.RenewDeadline,
+			RetryPeriod:   b.lec.RetryPeriod,
+			Callbacks: leaderelection.LeaderCallbacks{
+				OnStartedLeading: func(context.Context) {
+					logger.Infof("%q has started leading %q", rl.Identity(), bkt.String())
+					la.Promote(bkt, enq)
+				},
+				OnStoppedLeading: func() {
+					logger.Infof("%q has stopped leading %q", rl.Identity(), bkt.String())
+					la.Demote(bkt)
+				},
+			},
+			ReleaseOnCancel: true,
+
+			// TODO: use health check watchdog, knative/pkg#1048
+			Name: b.lec.Component,
+		})
+		if err != nil {
+			return nil, err
+		}
+		// TODO: use health check watchdog, knative/pkg#1048
+		// if lec.WatchDog != nil {
+		// 	lec.WatchDog.SetLeaderElection(le)
+		// }
+		buckets = append(buckets, le)
+	}
+	return buckets, nil
+}
+
+type bucket struct {
+	component string
+	name      string
+
+	// We are bucket {index} of {total}
+	index uint32
+	total uint32
+}
+
+var _ reconciler.Bucket = (*bucket)(nil)
+
+// String implements reconciler.Bucket
+func (b *bucket) String() string {
+	// The resource name is the lowercase:
+	//   {component}.{workqueue}.{index}-of-{total}
+	return strings.ToLower(fmt.Sprintf("%s.%s.%02d-of-%02d", b.component, b.name, b.index, b.total))
+}
+
+// Has implements reconciler.Bucket
+func (b *bucket) Has(nn types.NamespacedName) bool {
+	h := fnv.New32a()
+	h.Write([]byte(nn.Namespace + "." + nn.Name))
+	ii := h.Sum32() % b.total
+	return b.index == ii
+}

--- a/leaderelection/context_test.go
+++ b/leaderelection/context_test.go
@@ -1,0 +1,142 @@
+// +build !race
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	fakekube "k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+	"knative.dev/pkg/reconciler"
+	_ "knative.dev/pkg/system/testing"
+)
+
+func TestWithBuilder(t *testing.T) {
+	cc := ComponentConfig{
+		Component:     "component",
+		LeaderElect:   true,
+		ResourceLock:  "leases",
+		LeaseDuration: 15 * time.Second,
+		RenewDeadline: 10 * time.Second,
+		RetryPeriod:   2 * time.Second,
+	}
+	kc := fakekube.NewSimpleClientset()
+	ctx := context.Background()
+
+	promoted := make(chan struct{})
+	demoted := make(chan struct{})
+	laf := &reconciler.LeaderAwareFuncs{
+		PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) {
+			close(promoted)
+		},
+		DemoteFunc: func(bkt reconciler.Bucket) {
+			close(demoted)
+		},
+	}
+	enq := func(reconciler.Bucket, types.NamespacedName) {}
+
+	created := make(chan struct{})
+	kc.PrependReactor("create", "leases",
+		func(action ktesting.Action) (bool, runtime.Object, error) {
+			close(created)
+			return false, nil, nil
+		},
+	)
+
+	updated := make(chan struct{})
+	kc.PrependReactor("update", "leases",
+		func(action ktesting.Action) (bool, runtime.Object, error) {
+			// Only close update once.
+			select {
+			case <-updated:
+			default:
+				close(updated)
+			}
+			return false, nil, nil
+		},
+	)
+
+	if HasLeaderElection(ctx) {
+		t.Error("HasLeaderElection() = true, wanted false")
+	}
+	if le, err := BuildElector(ctx, laf, "name", enq); err == nil {
+		t.Errorf("BuildElector() = %v, wanted error", le)
+	}
+
+	ctx = WithLeaderElectorBuilder(ctx, kc, cc)
+	if !HasLeaderElection(ctx) {
+		t.Error("HasLeaderElection() = false, wanted true")
+	}
+
+	les, err := BuildElector(ctx, laf, "name", enq)
+	if err != nil {
+		t.Errorf("BuildElector() = %v", err)
+	}
+
+	// We shouldn't see leases until we Run the elector.
+	select {
+	case <-promoted:
+		t.Error("Got promoted, want no actions.")
+	case <-demoted:
+		t.Error("Got demoted, want no actions.")
+	case <-created:
+		t.Error("Got created, want no actions.")
+	case <-updated:
+		t.Error("Got updated, want no actions.")
+	default:
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	for _, le := range les {
+		go le.Run(ctx)
+	}
+
+	select {
+	case <-created:
+		// We expect the lease to be created.
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timed out waiting for lease creation.")
+	}
+	select {
+	case <-promoted:
+		// We expect to have been promoted.
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timed out waiting for promotion.")
+	}
+
+	// Cancelling the context should case us to give up leadership.
+	cancel()
+
+	select {
+	case <-updated:
+		// We expect the lease to be updated.
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timed out waiting for lease update.")
+	}
+	select {
+	case <-demoted:
+		// We expect to have been demoted.
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timed out waiting for demotion.")
+	}
+}

--- a/leaderelection/goose/main.go
+++ b/leaderelection/goose/main.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The goose binary is an e2e testing tool for leader election, which loads
+// the leader election configuration within the system namespace and
+// periodically kills one of the leader pods for each HA component.
+package main
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/injection/sharedmain"
+	"knative.dev/pkg/signals"
+	"knative.dev/pkg/system"
+)
+
+// honk will periodically kill a leader shard of a component reconciler's leader set.
+func honk(ctx context.Context, component string) error {
+	log.Printf("Honking at %q", component)
+
+	kc := kubeclient.Get(ctx)
+	for {
+		select {
+		case <-time.After(30 * time.Second):
+			leases, err := kc.CoordinationV1().Leases(system.Namespace()).List(metav1.ListOptions{})
+			if err != nil {
+				return err
+			}
+
+			shards := make(map[string]sets.String, 1)
+			for _, lease := range leases.Items {
+				if lease.Spec.HolderIdentity == nil {
+					log.Printf("Found lease %q held by nobody!", lease.Name)
+					continue
+				}
+				pod := strings.Split(*lease.Spec.HolderIdentity, "_")[0]
+
+				var reconciler string
+				if lease.Name == component {
+					// for back-compat
+					reconciler = "all"
+				} else if parts := strings.Split(lease.Name, "."); len(parts) < 3 || parts[0] != component {
+					continue
+				} else {
+					// Shave off the prefix and the sharding
+					reconciler = strings.Join(parts[1:len(parts)-1], ".")
+				}
+
+				set := shards[reconciler]
+				if set == nil {
+					set = sets.NewString()
+				}
+				set.Insert(pod)
+				shards[reconciler] = set
+			}
+
+			killem := sets.NewString()
+
+			for _, v := range shards {
+				if v.HasAny(killem.UnsortedList()...) {
+					// This is covered by killem
+					continue
+				}
+
+				tribute, _ := v.PopAny()
+				killem.Insert(tribute)
+			}
+
+			for _, name := range killem.List() {
+				err := kc.CoreV1().Pods(system.Namespace()).Delete(name, &metav1.DeleteOptions{})
+				if err != nil {
+					return err
+				}
+			}
+
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func main() {
+	ctx := signals.NewContext()
+
+	ctx, informers := injection.Default.SetupInformers(ctx, sharedmain.ParseAndGetConfigOrDie())
+	if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
+		log.Fatalf("Failed to start informers %v", err)
+	}
+
+	lec, err := sharedmain.GetLeaderElectionConfig(ctx)
+	if err != nil {
+		log.Fatalf("Unable to load leader election configuration: %v", err)
+	}
+	if lec.ResourceLock != "leases" {
+		log.Fatalf("Goose only supports leases, but got %q", lec.ResourceLock)
+	}
+
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, x := range lec.EnabledComponents.List() {
+		x := x
+		eg.Go(func() error {
+			return honk(ctx, x)
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		log.Fatalf("Ended with err: %v", err)
+	}
+}

--- a/reconciler/leader.go
+++ b/reconciler/leader.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Bucket is an opaque type used to scope leadership.
+type Bucket interface {
+	// String returns a string representing this bucket, which uniquely
+	// identifies the bucket and is suitable for use as a resource lock name.
+	String() string
+
+	// Has determines whether this Bucket covers a particular key.
+	Has(key types.NamespacedName) bool
+}
+
+// AllBuckets returns a Bucket that "Has()" all keys.
+func AllBuckets() Bucket {
+	return &bucket{}
+}
+
+// LeaderAware is implemented by Reconcilers that are aware of their leader status.
+type LeaderAware interface {
+	// IsLeader returns the leader status for the specified Bucket
+	IsLeader(types.NamespacedName) bool
+
+	// Promote is called when we become the leader of a given Bucket.  It must be
+	// supplied with an enqueue function through which a Bucket resync may be triggered.
+	Promote(b Bucket, enq func(Bucket, types.NamespacedName))
+
+	// Demote is called when we stop being the leader for the specified Bucket.
+	Demote(Bucket)
+}
+
+// LeaderAwareFuncs implements LeaderAware using the given functions for handling
+// promotion and demotion.
+type LeaderAwareFuncs struct {
+	sync.RWMutex
+	buckets map[string]Bucket
+
+	PromoteFunc func(b Bucket, enq func(Bucket, types.NamespacedName))
+	DemoteFunc  func(b Bucket)
+}
+
+var _ LeaderAware = (*LeaderAwareFuncs)(nil)
+
+// IsLeader implements LeaderAware
+func (laf *LeaderAwareFuncs) IsLeader(key types.NamespacedName) bool {
+	laf.RLock()
+	defer laf.RUnlock()
+
+	for _, bkt := range laf.buckets {
+		if bkt.Has(key) {
+			return true
+		}
+	}
+	return false
+}
+
+// Promote implements LeaderAware
+func (laf *LeaderAwareFuncs) Promote(b Bucket, enq func(Bucket, types.NamespacedName)) {
+	promote := func() func(Bucket, func(Bucket, types.NamespacedName)) {
+		laf.Lock()
+		defer laf.Unlock()
+		if laf.buckets == nil {
+			laf.buckets = make(map[string]Bucket, 1)
+		}
+		laf.buckets[b.String()] = b
+		return laf.PromoteFunc
+	}()
+
+	if promote != nil {
+		promote(b, enq)
+	}
+}
+
+// Demote implements LeaderAware
+func (laf *LeaderAwareFuncs) Demote(b Bucket) {
+	demote := func() func(Bucket) {
+		laf.Lock()
+		defer laf.Unlock()
+		delete(laf.buckets, b.String())
+		return laf.DemoteFunc
+	}()
+
+	if demote != nil {
+		demote(b)
+	}
+}
+
+type bucket struct{}
+
+var _ Bucket = (*bucket)(nil)
+
+// String implements Bucket
+func (b *bucket) String() string {
+	return ""
+}
+
+// Has implements Bucket
+func (b *bucket) Has(nn types.NamespacedName) bool {
+	return true
+}

--- a/reconciler/leader_test.go
+++ b/reconciler/leader_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestLeaderAwareFuncs(t *testing.T) {
+
+	laf := LeaderAwareFuncs{}
+
+	wantBkt := AllBuckets()
+
+	wantKey := types.NamespacedName{
+		Namespace: "foo",
+		Name:      "bar",
+	}
+	called := false
+	wantFunc := func(gotBkt Bucket, gotKey types.NamespacedName) {
+		called = true
+		if !cmp.Equal(gotKey, wantKey) {
+			t.Errorf("key (-want, +got) = %s", cmp.Diff(wantKey, gotKey))
+		}
+		if !cmp.Equal(gotBkt, wantBkt) {
+			t.Errorf("bucket (-want, +got) = %s", cmp.Diff(wantBkt, gotBkt))
+		}
+	}
+
+	laf.PromoteFunc = func(bkt Bucket, gotFunc func(Bucket, types.NamespacedName)) {
+		gotFunc(bkt, wantKey)
+		if !called {
+			t.Error("gotFunc didn't call wantFunc!")
+		}
+
+		// Check that we're not called while the lock is held,
+		// and that we are already the Leader.
+		if !laf.IsLeader(wantKey) {
+			t.Error("IsLeader() = false, wanted true")
+		}
+	}
+	laf.DemoteFunc = func(bkt Bucket) {
+		// Check that we're not called while the lock is held,
+		// and that we are no longer leader.
+		if laf.IsLeader(wantKey) {
+			t.Error("IsLeader() = true, wanted false")
+		}
+	}
+
+	// We don't start as leader.
+	if laf.IsLeader(wantKey) {
+		t.Error("IsLeader() = true, wanted false")
+	}
+
+	// After Promote we are leader.
+	laf.Promote(wantBkt, wantFunc)
+	if !laf.IsLeader(wantKey) {
+		t.Error("IsLeader() = false, wanted true")
+	}
+
+	// After Demote we are not leader.
+	laf.Demote(wantBkt)
+	if laf.IsLeader(wantKey) {
+		t.Error("IsLeader() = true, wanted false")
+	}
+}

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -37,4 +37,16 @@ function pre_build_tests() {
   return 0
 }
 
+# Run the unit tests with an additional flag '-mod=vendor' to avoid
+# downloading the deps in unit tests CI job
+function unit_tests() {
+  # Run the default way.
+  default_unit_test_runner || failed=1
+
+  # Run unit testing select packages without race detection,
+  # so that they may use: // +build !race
+  report_go_test ./leaderelection || failed=1
+
+}
+
 main $@

--- a/webhook/certificates/certificates.go
+++ b/webhook/certificates/certificates.go
@@ -23,10 +23,12 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	certresources "knative.dev/pkg/webhook/certificates/resources"
 )
@@ -37,6 +39,8 @@ const (
 )
 
 type reconciler struct {
+	pkgreconciler.LeaderAwareFuncs
+
 	client       kubernetes.Interface
 	secretlister corelisters.SecretLister
 	secretName   string
@@ -44,10 +48,18 @@ type reconciler struct {
 }
 
 var _ controller.Reconciler = (*reconciler)(nil)
+var _ pkgreconciler.LeaderAware = (*reconciler)(nil)
 
 // Reconcile implements controller.Reconciler
 func (r *reconciler) Reconcile(ctx context.Context, key string) error {
-	return r.reconcileCertificate(ctx)
+	if r.IsLeader(types.NamespacedName{
+		Namespace: system.Namespace(),
+		Name:      r.secretName,
+	}) {
+		// only reconciler the certificate when we are leader.
+		return r.reconcileCertificate(ctx)
+	}
+	return nil
 }
 
 func (r *reconciler) reconcileCertificate(ctx context.Context) error {

--- a/webhook/certificates/controller.go
+++ b/webhook/certificates/controller.go
@@ -23,10 +23,12 @@ import (
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/webhook"
 )
@@ -45,6 +47,15 @@ func NewController(
 	options := webhook.GetOptions(ctx)
 
 	wh := &reconciler{
+		LeaderAwareFuncs: pkgreconciler.LeaderAwareFuncs{
+			// Enqueue the key whenever we become leader.
+			PromoteFunc: func(bkt pkgreconciler.Bucket, enq func(pkgreconciler.Bucket, types.NamespacedName)) {
+				enq(bkt, types.NamespacedName{
+					Namespace: system.Namespace(),
+					Name:      options.SecretName,
+				})
+			},
+		},
 		secretName:  options.SecretName,
 		serviceName: options.ServiceName,
 
@@ -52,8 +63,7 @@ func NewController(
 		secretlister: secretInformer.Lister(),
 	}
 
-	logger := logging.FromContext(ctx)
-	c := controller.NewImpl(wh, logger, "WebhookCertificates")
+	c := controller.NewImpl(wh, logging.FromContext(ctx), "WebhookCertificates")
 
 	// Reconcile when the cert bundle changes.
 	secretInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/webhook/configmaps/configmaps.go
+++ b/webhook/configmaps/configmaps.go
@@ -28,6 +28,7 @@ import (
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	admissionlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -37,6 +38,7 @@ import (
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/webhook"
 	certresources "knative.dev/pkg/webhook/certificates/resources"
@@ -45,6 +47,7 @@ import (
 // reconciler implements the AdmissionController for ConfigMaps
 type reconciler struct {
 	webhook.StatelessAdmissionImpl
+	pkgreconciler.LeaderAwareFuncs
 
 	name         string
 	path         string
@@ -58,12 +61,18 @@ type reconciler struct {
 }
 
 var _ controller.Reconciler = (*reconciler)(nil)
+var _ pkgreconciler.LeaderAware = (*reconciler)(nil)
 var _ webhook.AdmissionController = (*reconciler)(nil)
 var _ webhook.StatelessAdmissionController = (*reconciler)(nil)
 
 // Reconcile implements controller.Reconciler
 func (ac *reconciler) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
+
+	if !ac.IsLeader(types.NamespacedName{Name: ac.name}) {
+		logger.Debugf("Skipping key %q, not the leader.", key)
+		return nil
+	}
 
 	secret, err := ac.secretlister.Secrets(system.Namespace()).Get(ac.secretName)
 	if err != nil {

--- a/webhook/configmaps/controller.go
+++ b/webhook/configmaps/controller.go
@@ -24,11 +24,13 @@ import (
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	vwhinformer "knative.dev/pkg/client/injection/kube/informers/admissionregistration/v1beta1/validatingwebhookconfiguration"
 	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
+	"knative.dev/pkg/logging"
+	pkgreconciler "knative.dev/pkg/reconciler"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/webhook"
 )
@@ -46,6 +48,13 @@ func NewAdmissionController(
 	options := webhook.GetOptions(ctx)
 
 	wh := &reconciler{
+		LeaderAwareFuncs: pkgreconciler.LeaderAwareFuncs{
+			// Have this reconciler enqueue our singleton whenever it becomes leader.
+			PromoteFunc: func(bkt pkgreconciler.Bucket, enq func(pkgreconciler.Bucket, types.NamespacedName)) {
+				enq(bkt, types.NamespacedName{Name: name})
+			},
+		},
+
 		name: name,
 		path: path,
 
@@ -61,8 +70,7 @@ func NewAdmissionController(
 		wh.registerConfig(configName, constructor)
 	}
 
-	logger := logging.FromContext(ctx)
-	c := controller.NewImpl(wh, logger, "ConfigMapWebhook")
+	c := controller.NewImpl(wh, logging.FromContext(ctx), "ConfigMapWebhook")
 
 	// Reconcile when the named ValidatingWebhookConfiguration changes.
 	vwhInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/webhook/psbinding/controller.go
+++ b/webhook/psbinding/controller.go
@@ -30,6 +30,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/webhook"
 )
@@ -66,6 +67,8 @@ type GetListAll func(context.Context, cache.ResourceEventHandler) ListAll
 // to NewAdmissionController and BaseReconciler.
 type BindableContext func(context.Context, Bindable) (context.Context, error)
 
+var sentinel = types.NamespacedName{}
+
 // NewAdmissionController constructs the webhook portion of the pair of
 // reconcilers that implement the semantics of our Binding.
 func NewAdmissionController(
@@ -86,9 +89,14 @@ func NewAdmissionController(
 	wh := NewReconciler(name, path, options.SecretName, client, mwhInformer.Lister(), secretInformer.Lister(), withContext, reconcilerOptions...)
 	c := controller.NewImpl(wh, logging.FromContext(ctx), name)
 
+	// Enqueue a sentinel when we become leader.
+	wh.PromoteFunc = func(bkt pkgreconciler.Bucket, enq func(pkgreconciler.Bucket, types.NamespacedName)) {
+		enq(bkt, sentinel)
+	}
+
 	// It doesn't matter what we enqueue because we will always Reconcile
 	// the named MWH resource.
-	handler := controller.HandleAll(c.EnqueueSentinel(types.NamespacedName{}))
+	handler := controller.HandleAll(c.EnqueueSentinel(sentinel))
 
 	// Reconcile when the named MutatingWebhookConfiguration changes.
 	mwhInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/webhook/psbinding/psbinding.go
+++ b/webhook/psbinding/psbinding.go
@@ -41,6 +41,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/webhook"
 	certresources "knative.dev/pkg/webhook/certificates/resources"
@@ -97,6 +98,8 @@ func NewReconciler(
 //  2. Admit: which leverages the index built by the Reconciler to apply
 //     mutations to resources.
 type Reconciler struct {
+	pkgreconciler.LeaderAwareFuncs
+
 	Name        string
 	HandlerPath string
 	SecretName  string
@@ -120,6 +123,7 @@ type Reconciler struct {
 }
 
 var _ controller.Reconciler = (*Reconciler)(nil)
+var _ pkgreconciler.LeaderAware = (*Reconciler)(nil)
 var _ webhook.AdmissionController = (*Reconciler)(nil)
 
 // We need to specifically exclude our deployment(s) from consideration, but this provides a way
@@ -301,6 +305,12 @@ func (ac *Reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 		ac.exact = exact
 		ac.inexact = inexact
 	}()
+
+	// After we've updated our indices, bail out unless we are the leader.
+	// Only the leader should be mutating the webhook.
+	if !ac.IsLeader(sentinel) {
+		return nil
+	}
 
 	rules := make([]admissionregistrationv1beta1.RuleWithOperations, 0, len(gks))
 	for gk, versions := range gks {

--- a/webhook/psbinding/reconciler.go
+++ b/webhook/psbinding/reconciler.go
@@ -41,6 +41,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/tracker"
 )
 
@@ -52,6 +53,8 @@ var jsonLabelPatch = map[string]interface{}{
 
 // BaseReconciler helps implement controller.Reconciler for Binding resources.
 type BaseReconciler struct {
+	pkgreconciler.LeaderAwareFuncs
+
 	// The GVR of the "primary key" resource for this reconciler.
 	// This is used along with the DynamicClient for updating the status
 	// and managing finalizers of the resources being reconciled.
@@ -89,6 +92,7 @@ type BaseReconciler struct {
 
 // Check that our Reconciler implements controller.Reconciler
 var _ controller.Reconciler = (*BaseReconciler)(nil)
+var _ pkgreconciler.LeaderAware = (*BaseReconciler)(nil)
 
 // Reconcile implements controller.Reconciler
 func (r *BaseReconciler) Reconcile(ctx context.Context, key string) error {
@@ -96,6 +100,15 @@ func (r *BaseReconciler) Reconcile(ctx context.Context, key string) error {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		logging.FromContext(ctx).Errorf("invalid resource key: %s", key)
+		return nil
+	}
+
+	// Only the leader should reconcile binding resources.
+	if !r.IsLeader(types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}) {
+		logging.FromContext(ctx).Debugf("Skipping key %q, not the leader.", key)
 		return nil
 	}
 

--- a/webhook/resourcesemantics/conversion/reconciler.go
+++ b/webhook/resourcesemantics/conversion/reconciler.go
@@ -24,17 +24,21 @@ import (
 	apixclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apixlisters "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/webhook"
 	certresources "knative.dev/pkg/webhook/certificates/resources"
 )
 
 type reconciler struct {
+	pkgreconciler.LeaderAwareFuncs
+
 	kinds       map[schema.GroupKind]GroupKindConversion
 	path        string
 	secretName  string
@@ -47,6 +51,7 @@ type reconciler struct {
 
 var _ webhook.ConversionController = (*reconciler)(nil)
 var _ controller.Reconciler = (*reconciler)(nil)
+var _ pkgreconciler.LeaderAware = (*reconciler)(nil)
 
 // Path implements webhook.ConversionController
 func (r *reconciler) Path() string {
@@ -56,6 +61,11 @@ func (r *reconciler) Path() string {
 // Reconciler implements controller.Reconciler
 func (r *reconciler) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
+
+	if !r.IsLeader(types.NamespacedName{Name: key}) {
+		logger.Debugf("Skipping key %q, not the leader.", key)
+		return nil
+	}
 
 	// Look up the webhook secret, and fetch the CA cert bundle.
 	secret, err := r.secretLister.Secrets(system.Namespace()).Get(r.secretName)

--- a/webhook/resourcesemantics/defaulting/controller.go
+++ b/webhook/resourcesemantics/defaulting/controller.go
@@ -23,11 +23,13 @@ import (
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	mwhinformer "knative.dev/pkg/client/injection/kube/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration"
 	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
+	"knative.dev/pkg/logging"
+	pkgreconciler "knative.dev/pkg/reconciler"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/webhook"
 	"knative.dev/pkg/webhook/resourcesemantics"
@@ -48,6 +50,13 @@ func NewAdmissionController(
 	options := webhook.GetOptions(ctx)
 
 	wh := &reconciler{
+		LeaderAwareFuncs: pkgreconciler.LeaderAwareFuncs{
+			// Have this reconciler enqueue our singleton whenever it becomes leader.
+			PromoteFunc: func(bkt pkgreconciler.Bucket, enq func(pkgreconciler.Bucket, types.NamespacedName)) {
+				enq(bkt, types.NamespacedName{Name: name})
+			},
+		},
+
 		name:     name,
 		path:     path,
 		handlers: handlers,

--- a/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/webhook/resourcesemantics/defaulting/defaulting.go
@@ -31,6 +31,7 @@ import (
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	admissionlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -40,6 +41,7 @@ import (
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/webhook"
 	certresources "knative.dev/pkg/webhook/certificates/resources"
@@ -51,6 +53,7 @@ var errMissingNewObject = errors.New("the new object may not be nil")
 // reconciler implements the AdmissionController for resources
 type reconciler struct {
 	webhook.StatelessAdmissionImpl
+	pkgreconciler.LeaderAwareFuncs
 
 	name     string
 	path     string
@@ -67,12 +70,18 @@ type reconciler struct {
 }
 
 var _ controller.Reconciler = (*reconciler)(nil)
+var _ pkgreconciler.LeaderAware = (*reconciler)(nil)
 var _ webhook.AdmissionController = (*reconciler)(nil)
 var _ webhook.StatelessAdmissionController = (*reconciler)(nil)
 
 // Reconcile implements controller.Reconciler
 func (ac *reconciler) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
+
+	if !ac.IsLeader(types.NamespacedName{Name: ac.name}) {
+		logger.Debugf("Skipping key %q, not the leader.", key)
+		return nil
+	}
 
 	// Look up the webhook secret, and fetch the CA cert bundle.
 	secret, err := ac.secretlister.Secrets(system.Namespace()).Get(ac.secretName)

--- a/webhook/resourcesemantics/validation/controller.go
+++ b/webhook/resourcesemantics/validation/controller.go
@@ -23,11 +23,13 @@ import (
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	vwhinformer "knative.dev/pkg/client/injection/kube/informers/admissionregistration/v1beta1/validatingwebhookconfiguration"
 	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
+	"knative.dev/pkg/logging"
+	pkgreconciler "knative.dev/pkg/reconciler"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/webhook"
 	"knative.dev/pkg/webhook/resourcesemantics"
@@ -62,6 +64,13 @@ func NewAdmissionController(
 	}
 
 	wh := &reconciler{
+		LeaderAwareFuncs: pkgreconciler.LeaderAwareFuncs{
+			// Have this reconciler enqueue our singleton whenever it becomes leader.
+			PromoteFunc: func(bkt pkgreconciler.Bucket, enq func(pkgreconciler.Bucket, types.NamespacedName)) {
+				enq(bkt, types.NamespacedName{Name: name})
+			},
+		},
+
 		name:      name,
 		path:      path,
 		handlers:  handlers,

--- a/webhook/resourcesemantics/validation/reconcile_config.go
+++ b/webhook/resourcesemantics/validation/reconcile_config.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	admissionlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -33,6 +34,7 @@ import (
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/webhook"
 	certresources "knative.dev/pkg/webhook/certificates/resources"
@@ -42,6 +44,7 @@ import (
 // reconciler implements the AdmissionController for resources
 type reconciler struct {
 	webhook.StatelessAdmissionImpl
+	pkgreconciler.LeaderAwareFuncs
 
 	name      string
 	path      string
@@ -59,6 +62,7 @@ type reconciler struct {
 }
 
 var _ controller.Reconciler = (*reconciler)(nil)
+var _ pkgreconciler.LeaderAware = (*reconciler)(nil)
 var _ webhook.AdmissionController = (*reconciler)(nil)
 var _ webhook.StatelessAdmissionController = (*reconciler)(nil)
 
@@ -70,6 +74,11 @@ func (ac *reconciler) Path() string {
 // Reconcile implements controller.Reconciler
 func (ac *reconciler) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
+
+	if !ac.IsLeader(types.NamespacedName{Name: ac.name}) {
+		logger.Debugf("Skipping key %q, not the leader.", key)
+		return nil
+	}
 
 	// Look up the webhook secret, and fetch the CA cert bundle.
 	secret, err := ac.secretlister.Secrets(system.Namespace()).Get(ac.secretName)

--- a/webhook/testing/factory.go
+++ b/webhook/testing/factory.go
@@ -24,6 +24,7 @@ import (
 	fakeapixclient "knative.dev/pkg/client/injection/apiextensions/client/fake"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
+	"knative.dev/pkg/reconciler"
 
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ktesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 
@@ -98,6 +100,11 @@ func MakeFactory(ctor Ctor) rtesting.Factory {
 		c := ctor(ctx, &ls, configmap.NewStaticWatcher())
 		// Update the context with the stuff we decorated it with.
 		r.Ctx = ctx
+
+		// If the reconcilers is leader aware, then promote it.
+		if la, ok := c.(reconciler.LeaderAware); ok {
+			la.Promote(reconciler.AllBuckets(), func(reconciler.Bucket, types.NamespacedName) {})
+		}
 
 		for _, reactor := range r.WithReactors {
 			kubeClient.PrependReactor("*", "*", reactor)


### PR DESCRIPTION
This adds a new main package under knative.dev/pkg/leaderelection/goose, which
loads the leader election configuration, and periodically enumerates the leases
in the system namespace and kills a leader pod for each sharded reconciler
under a component.

Based on https://github.com/knative/pkg/pull/1304