### PR TITLE
Simplify the krshaped interface, just use k8s interfaces for TypeMeta and ObjectMeta

### DIFF
--- a/apis/duck/v1/kresource_type.go
+++ b/apis/duck/v1/kresource_type.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"knative.dev/pkg/apis"
 )
@@ -29,8 +30,7 @@ import (
 // KRShaped is an interface for retrieving the duck elements of an arbitrary resource.
 type KRShaped interface {
 	metav1.Object
-
-	GetTypeMeta() *metav1.TypeMeta
+	schema.ObjectKind 
 
 	GetStatus() *Status
 
@@ -79,11 +79,6 @@ type KResourceList struct {
 	metav1.ListMeta `json:"metadata"`
 
 	Items []KResource `json:"items"`
-}
-
-// GetTypeMeta retrieves the ObjectMeta of the KResource. Implements the KRShaped interface.
-func (t *KResource) GetTypeMeta() *metav1.TypeMeta {
-	return &t.TypeMeta
 }
 
 // GetStatus retrieves the status of the KResource. Implements the KRShaped interface.

--- a/apis/duck/v1/kresource_type.go
+++ b/apis/duck/v1/kresource_type.go
@@ -28,7 +28,7 @@ import (
 
 // KRShaped is an interface for retrieving the duck elements of an arbitrary resource.
 type KRShaped interface {
-	metav1.ObjectMetaAccessor
+	metav1.Object
 
 	GetTypeMeta() *metav1.TypeMeta
 

--- a/apis/duck/v1/kresource_type.go
+++ b/apis/duck/v1/kresource_type.go
@@ -30,7 +30,7 @@ import (
 // KRShaped is an interface for retrieving the duck elements of an arbitrary resource.
 type KRShaped interface {
 	metav1.Object
-	schema.ObjectKind 
+	schema.ObjectKind
 
 	GetStatus() *Status
 

--- a/apis/test/example/v1alpha1/fiz_types.go
+++ b/apis/test/example/v1alpha1/fiz_types.go
@@ -94,11 +94,6 @@ func (f *ClusterFiz) Validate(ctx context.Context) *apis.FieldError {
 	return nil
 }
 
-// GetTypeMeta retrieves the ObjectMeta of the ClusterFiz. Implements the KRShaped interface.
-func (f *ClusterFiz) GetTypeMeta() *metav1.TypeMeta {
-	return &f.TypeMeta
-}
-
 // GetStatus retrieves the status of the ClusterFiz. Implements the KRShaped interface.
 func (f *ClusterFiz) GetStatus() *duckv1.Status {
 	return &f.Status.Status

--- a/apis/test/example/v1alpha1/foo_types.go
+++ b/apis/test/example/v1alpha1/foo_types.go
@@ -93,11 +93,6 @@ func (f *Foo) Validate(ctx context.Context) *apis.FieldError {
 	return nil
 }
 
-// GetTypeMeta retrieves the ObjectMeta of the Foo. Implements the KRShaped interface.
-func (f *Foo) GetTypeMeta() *metav1.TypeMeta {
-	return &f.TypeMeta
-}
-
 // GetStatus retrieves the status of the Foo Implements the KRShaped interface.
 func (f *Foo) GetStatus() *duckv1.Status {
 	return &f.Status.Status

--- a/apis/test/pub/v1alpha1/bar_types.go
+++ b/apis/test/pub/v1alpha1/bar_types.go
@@ -93,11 +93,6 @@ func (b *Bar) Validate(ctx context.Context) *apis.FieldError {
 	return nil
 }
 
-// GetTypeMeta retrieves the ObjectMeta of the Bar. Implements the KRShaped interface.
-func (b *Bar) GetTypeMeta() *metav1.TypeMeta {
-	return &b.TypeMeta
-}
-
 // GetStatus retrieves the status of the Bar. Implements the KRShaped interface.
 func (b *Bar) GetStatus() *duckv1.Status {
 	return &b.Status.Status

--- a/reconciler/reconcile_common.go
+++ b/reconciler/reconcile_common.go
@@ -29,7 +29,7 @@ const failedGenerationBump = "NewObservedGenFailure"
 func PreProcessReconcile(ctx context.Context, resource duckv1.KRShaped) {
 	newStatus := resource.GetStatus()
 
-	if newStatus.ObservedGeneration != resource.GetObjectMeta().GetGeneration() {
+	if newStatus.ObservedGeneration != resource.GetGeneration() {
 		condSet := resource.GetConditionSet()
 		manager := condSet.Manage(newStatus)
 
@@ -46,7 +46,7 @@ func PostProcessReconcile(ctx context.Context, resource duckv1.KRShaped) {
 
 	// Bump observed generation to denote that we have processed this
 	// generation regardless of success or failure.
-	newStatus.ObservedGeneration = resource.GetObjectMeta().GetGeneration()
+	newStatus.ObservedGeneration = resource.GetGeneration()
 
 	rc := mgr.GetTopLevelCondition()
 	if rc.Reason == failedGenerationBump {

--- a/reconciler/reconcile_common_test.go
+++ b/reconciler/reconcile_common_test.go
@@ -90,7 +90,7 @@ func TestPostProcessReconcileBumpsGeneration(t *testing.T) {
 		t.Errorf("Expected observed generation bump got=%d want=%d", resource.Status.ObservedGeneration, resource.Generation)
 	}
 
-	if krShape.GetStatus().ObservedGeneration != krShape.GetObjectMeta().GetGeneration() {
+	if krShape.GetStatus().ObservedGeneration != krShape.GetGeneration() {
 		t.Errorf("Expected observed generation bump got=%d want=%d", resource.Status.ObservedGeneration, resource.Generation)
 	}
 }


### PR DESCRIPTION
I had been using the GetObjectMeta accessor, but since these are inlined we can just use the metav1.Object interface directly.

Likewise we'll use the schema.ObjectKind interface to access TypeMeta information