### PR TITLE
[RELEASE-0.13] Drop 'no longer exist' line to DEBUG.

### DIFF
--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -257,7 +257,7 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 	original, err := r.Lister.{{.type|apiGroup}}(namespace).Get(name)
 	if {{.apierrsIsNotFound|raw}}(err) {
 		// The resource may no longer exist, in which case we stop processing.
-		logger.Errorf("resource %q no longer exists", key)
+		logger.Debugf("resource %q no longer exists", key)
 		return nil
 	} else if err != nil {
 		return err


### PR DESCRIPTION
Backport of 5036c917e57219394482615050ee92ed9cf687d9 for the 0.13 release line.