### PR TITLE
Use our new tag parser to find genreconciler

### DIFF
--- a/codegen/cmd/injection-gen/generators/packages.go
+++ b/codegen/cmd/injection-gen/generators/packages.go
@@ -173,17 +173,11 @@ func MustParseClientGenTags(lines []string) Tags {
 		Tags: util.MustParseClientGenTags(lines),
 	}
 
-	values := types.ExtractCommentTags("+", lines)
+	values := ExtractCommentTags("+", lines)
 
 	_, ret.GenerateDuck = values["genduck"]
 
-	_, genRec := values["genreconciler"]
-	_, genRecClass := values["genreconciler:class"]
-
-	// Generate Reconciler code if genreconciler OR genreconciler:class exist.
-	if genRec || genRecClass {
-		ret.GenerateReconciler = true
-	}
+	_, ret.GenerateReconciler = values["genreconciler"]
 
 	return ret
 }


### PR DESCRIPTION
Previously we used the k8s tag parser which splits on '=' to look for
"+genreconciler" or "+genreconciler:class"

Now we have a parser that splits on ':' and expects a comma separated list so we can simplify the search.

The old parser leads to a bug if we try to do things in this order without more hardcoding:
"+genreconciler:krshaped=true,class=foo"