### PR TITLE
Use config map parsing lib and enhance it further.

### DIFF
--- a/configmap/parse.go
+++ b/configmap/parse.go
@@ -17,9 +17,12 @@ limitations under the License.
 package configmap
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // ParseFunc is a function taking ConfigMap data and applying a parse operation to it.
@@ -51,7 +54,7 @@ func AsInt32(key string, target *int32) ParseFunc {
 		if raw, ok := data[key]; ok {
 			val, err := strconv.ParseInt(raw, 10, 32)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to parse %q: %w", key, err)
 			}
 			*target = int32(val)
 		}
@@ -65,7 +68,7 @@ func AsInt64(key string, target *int64) ParseFunc {
 		if raw, ok := data[key]; ok {
 			val, err := strconv.ParseInt(raw, 10, 64)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to parse %q: %w", key, err)
 			}
 			*target = val
 		}
@@ -79,7 +82,7 @@ func AsFloat64(key string, target *float64) ParseFunc {
 		if raw, ok := data[key]; ok {
 			val, err := strconv.ParseFloat(raw, 64)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to parse %q: %w", key, err)
 			}
 			*target = val
 		}
@@ -93,9 +96,19 @@ func AsDuration(key string, target *time.Duration) ParseFunc {
 		if raw, ok := data[key]; ok {
 			val, err := time.ParseDuration(raw)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to parse %q: %w", key, err)
 			}
 			*target = val
+		}
+		return nil
+	}
+}
+
+// AsStringSet parses the value at key as a sets.String (split by ',') into the target, if it exists.
+func AsStringSet(key string, target *sets.String) ParseFunc {
+	return func(data map[string]string) error {
+		if raw, ok := data[key]; ok {
+			*target = sets.NewString(strings.Split(raw, ",")...)
 		}
 		return nil
 	}

--- a/configmap/parse_test.go
+++ b/configmap/parse_test.go
@@ -19,15 +19,19 @@ package configmap
 import (
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type testConfig struct {
-	str string
-	boo bool
-	i32 int32
-	i64 int64
-	f64 float64
-	dur time.Duration
+	Str string
+	Boo bool
+	I32 int32
+	I64 int64
+	F64 float64
+	Dur time.Duration
+	Set sets.String
 }
 
 func TestParse(t *testing.T) {
@@ -46,32 +50,34 @@ func TestParse(t *testing.T) {
 			"test-int64":    "2",
 			"test-float64":  "1.0",
 			"test-duration": "1m",
+			"test-set":      "a,b,c",
 		},
 		want: testConfig{
-			str: "foo.bar",
-			boo: true,
-			i32: 1,
-			i64: 2,
-			f64: 1.0,
-			dur: time.Minute,
+			Str: "foo.bar",
+			Boo: true,
+			I32: 1,
+			I64: 2,
+			F64: 1.0,
+			Dur: time.Minute,
+			Set: sets.NewString("a", "b", "c"),
 		},
 	}, {
 		name: "respect defaults",
 		conf: testConfig{
-			str: "foo.bar",
-			boo: true,
-			i32: 1,
-			i64: 2,
-			f64: 1.0,
-			dur: time.Minute,
+			Str: "foo.bar",
+			Boo: true,
+			I32: 1,
+			I64: 2,
+			F64: 1.0,
+			Dur: time.Minute,
 		},
 		want: testConfig{
-			str: "foo.bar",
-			boo: true,
-			i32: 1,
-			i64: 2,
-			f64: 1.0,
-			dur: time.Minute,
+			Str: "foo.bar",
+			Boo: true,
+			I32: 1,
+			I64: 2,
+			F64: 1.0,
+			Dur: time.Minute,
 		},
 	}, {
 		name: "bool defaults to false",
@@ -79,7 +85,7 @@ func TestParse(t *testing.T) {
 			"test-bool": "foo",
 		},
 		want: testConfig{
-			boo: false,
+			Boo: false,
 		},
 	}, {
 		name: "int32 error",
@@ -110,17 +116,18 @@ func TestParse(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if err := Parse(test.data,
-				AsString("test-string", &test.conf.str),
-				AsBool("test-bool", &test.conf.boo),
-				AsInt32("test-int32", &test.conf.i32),
-				AsInt64("test-int64", &test.conf.i64),
-				AsFloat64("test-float64", &test.conf.f64),
-				AsDuration("test-duration", &test.conf.dur),
+				AsString("test-string", &test.conf.Str),
+				AsBool("test-bool", &test.conf.Boo),
+				AsInt32("test-int32", &test.conf.I32),
+				AsInt64("test-int64", &test.conf.I64),
+				AsFloat64("test-float64", &test.conf.F64),
+				AsDuration("test-duration", &test.conf.Dur),
+				AsStringSet("test-set", &test.conf.Set),
 			); (err == nil) == test.expectErr {
 				t.Fatal("Failed to parse data:", err)
 			}
 
-			if test.conf != test.want {
+			if !cmp.Equal(test.conf, test.want) {
 				t.Fatalf("parsed = %v, want %v", test.conf, test.want)
 			}
 		})

--- a/configmap/parse_test.go
+++ b/configmap/parse_test.go
@@ -25,13 +25,13 @@ import (
 )
 
 type testConfig struct {
-	Str string
-	Boo bool
-	I32 int32
-	I64 int64
-	F64 float64
-	Dur time.Duration
-	Set sets.String
+	str string
+	boo bool
+	i32 int32
+	i64 int64
+	f64 float64
+	dur time.Duration
+	set sets.String
 }
 
 func TestParse(t *testing.T) {
@@ -53,31 +53,31 @@ func TestParse(t *testing.T) {
 			"test-set":      "a,b,c",
 		},
 		want: testConfig{
-			Str: "foo.bar",
-			Boo: true,
-			I32: 1,
-			I64: 2,
-			F64: 1.0,
-			Dur: time.Minute,
-			Set: sets.NewString("a", "b", "c"),
+			str: "foo.bar",
+			boo: true,
+			i32: 1,
+			i64: 2,
+			f64: 1.0,
+			dur: time.Minute,
+			set: sets.NewString("a", "b", "c"),
 		},
 	}, {
 		name: "respect defaults",
 		conf: testConfig{
-			Str: "foo.bar",
-			Boo: true,
-			I32: 1,
-			I64: 2,
-			F64: 1.0,
-			Dur: time.Minute,
+			str: "foo.bar",
+			boo: true,
+			i32: 1,
+			i64: 2,
+			f64: 1.0,
+			dur: time.Minute,
 		},
 		want: testConfig{
-			Str: "foo.bar",
-			Boo: true,
-			I32: 1,
-			I64: 2,
-			F64: 1.0,
-			Dur: time.Minute,
+			str: "foo.bar",
+			boo: true,
+			i32: 1,
+			i64: 2,
+			f64: 1.0,
+			dur: time.Minute,
 		},
 	}, {
 		name: "bool defaults to false",
@@ -85,7 +85,7 @@ func TestParse(t *testing.T) {
 			"test-bool": "foo",
 		},
 		want: testConfig{
-			Boo: false,
+			boo: false,
 		},
 	}, {
 		name: "int32 error",
@@ -116,18 +116,18 @@ func TestParse(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if err := Parse(test.data,
-				AsString("test-string", &test.conf.Str),
-				AsBool("test-bool", &test.conf.Boo),
-				AsInt32("test-int32", &test.conf.I32),
-				AsInt64("test-int64", &test.conf.I64),
-				AsFloat64("test-float64", &test.conf.F64),
-				AsDuration("test-duration", &test.conf.Dur),
-				AsStringSet("test-set", &test.conf.Set),
+				AsString("test-string", &test.conf.str),
+				AsBool("test-bool", &test.conf.boo),
+				AsInt32("test-int32", &test.conf.i32),
+				AsInt64("test-int64", &test.conf.i64),
+				AsFloat64("test-float64", &test.conf.f64),
+				AsDuration("test-duration", &test.conf.dur),
+				AsStringSet("test-set", &test.conf.set),
 			); (err == nil) == test.expectErr {
 				t.Fatal("Failed to parse data:", err)
 			}
 
-			if !cmp.Equal(test.conf, test.want) {
+			if !cmp.Equal(test.conf, test.want, cmp.AllowUnexported(testConfig{})) {
 				t.Fatalf("parsed = %v, want %v", test.conf, test.want)
 			}
 		})

--- a/leaderelection/config.go
+++ b/leaderelection/config.go
@@ -19,12 +19,13 @@ package leaderelection
 import (
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
+
+	cm "knative.dev/pkg/configmap"
 )
 
 const ConfigMapNameEnv = "CONFIG_LEADERELECTION_NAME"
@@ -35,41 +36,23 @@ var validResourceLocks = sets.NewString("leases", "configmaps", "endpoints")
 func NewConfigFromMap(data map[string]string) (*Config, error) {
 	config := defaultConfig()
 
-	if resourceLock, ok := data["resourceLock"]; ok {
-		if !validResourceLocks.Has(resourceLock) {
-			return nil, fmt.Errorf(`resourceLock: invalid value %q: valid values are "leases","configmaps","endpoints"`, resourceLock)
-		}
-		config.ResourceLock = resourceLock
+	if err := cm.Parse(data,
+		cm.AsString("resourceLock", &config.ResourceLock),
+
+		cm.AsDuration("leaseDuration", &config.LeaseDuration),
+		cm.AsDuration("renewDeadline", &config.RenewDeadline),
+		cm.AsDuration("retryPeriod", &config.RetryPeriod),
+
+		// enabledComponents are not validated here, because they are dependent on
+		// the component. Components should provide additional validation for this
+		// field.
+		cm.AsStringSet("enabledComponents", &config.EnabledComponents),
+	); err != nil {
+		return nil, err
 	}
 
-	for _, d := range []struct {
-		key string
-		val *time.Duration
-	}{{
-		"leaseDuration",
-		&config.LeaseDuration,
-	}, {
-		"renewDeadline",
-		&config.RenewDeadline,
-	}, {
-		"retryPeriod",
-		&config.RetryPeriod,
-	}} {
-		if v, ok := data[d.key]; ok {
-			dur, err := time.ParseDuration(v)
-			if err != nil {
-				return nil, fmt.Errorf("%s: invalid duration: %q", d.key, v)
-			}
-			*d.val = dur
-		}
-	}
-
-	// enabledComponents are not validated here, because they are dependent on
-	// the component. Components should provide additional validation for this
-	// field.
-	if enabledComponents, ok := data["enabledComponents"]; ok {
-		tokens := strings.Split(enabledComponents, ",")
-		config.EnabledComponents = sets.NewString(tokens...)
+	if !validResourceLocks.Has(config.ResourceLock) {
+		return nil, fmt.Errorf(`resourceLock: invalid value %q: valid values are "leases","configmaps","endpoints"`, config.ResourceLock)
 	}
 
 	return config, nil

--- a/leaderelection/config_test.go
+++ b/leaderelection/config_test.go
@@ -18,7 +18,6 @@ package leaderelection
 
 import (
 	"errors"
-	"reflect"
 	"testing"
 	"time"
 
@@ -84,19 +83,19 @@ func TestNewConfigMapFromData(t *testing.T) {
 		data: kmeta.UnionMaps(okData(), map[string]string{
 			"leaseDuration": "flops",
 		}),
-		err: errors.New(`leaseDuration: invalid duration: "flops"`),
+		err: errors.New(`failed to parse "leaseDuration": time: invalid duration flops`),
 	}, {
 		name: "invalid renewDeadline",
 		data: kmeta.UnionMaps(okData(), map[string]string{
 			"renewDeadline": "flops",
 		}),
-		err: errors.New(`renewDeadline: invalid duration: "flops"`),
+		err: errors.New(`failed to parse "renewDeadline": time: invalid duration flops`),
 	}, {
 		name: "invalid retryPeriod",
 		data: kmeta.UnionMaps(okData(), map[string]string{
 			"retryPeriod": "flops",
 		}),
-		err: errors.New(`retryPeriod: invalid duration: "flops"`),
+		err: errors.New(`failed to parse "retryPeriod": time: invalid duration flops`),
 	}}
 
 	for _, tc := range cases {
@@ -105,7 +104,8 @@ func TestNewConfigMapFromData(t *testing.T) {
 				&corev1.ConfigMap{
 					Data: tc.data,
 				})
-			if !reflect.DeepEqual(tc.err, actualErr) {
+
+			if tc.err != nil && tc.err.Error() != actualErr.Error() {
 				t.Fatalf("Error = %v, want: %v", actualErr, tc.err)
 			}
 

--- a/metrics/config_observability.go
+++ b/metrics/config_observability.go
@@ -18,10 +18,10 @@ package metrics
 
 import (
 	"os"
-	"strings"
 	texttemplate "text/template"
 
 	corev1 "k8s.io/api/core/v1"
+	cm "knative.dev/pkg/configmap"
 )
 
 const (
@@ -71,32 +71,23 @@ func defaultConfig() *ObservabilityConfig {
 // NewObservabilityConfigFromConfigMap creates a ObservabilityConfig from the supplied ConfigMap
 func NewObservabilityConfigFromConfigMap(configMap *corev1.ConfigMap) (*ObservabilityConfig, error) {
 	oc := defaultConfig()
-	if evlc, ok := configMap.Data["logging.enable-var-log-collection"]; ok {
-		oc.EnableVarLogCollection = strings.EqualFold(evlc, "true")
+
+	if err := cm.Parse(configMap.Data,
+		cm.AsBool("logging.enable-var-log-collection", &oc.EnableVarLogCollection),
+		cm.AsString("logging.revision-url-template", &oc.LoggingURLTemplate),
+		cm.AsString("logging.request-log-template", &oc.RequestLogTemplate),
+		cm.AsBool("logging.enable-probe-request-log", &oc.EnableProbeRequestLog),
+		cm.AsString("metrics.request-metrics-backend-destination", &oc.RequestMetricsBackend),
+		cm.AsBool("profiling.enable", &oc.EnableProfiling),
+	); err != nil {
+		return nil, err
 	}
 
-	if rut, ok := configMap.Data["logging.revision-url-template"]; ok {
-		oc.LoggingURLTemplate = rut
-	}
-
-	if rlt, ok := configMap.Data["logging.request-log-template"]; ok {
+	if oc.RequestLogTemplate != "" {
 		// Verify that we get valid templates.
-		if _, err := texttemplate.New("requestLog").Parse(rlt); err != nil {
+		if _, err := texttemplate.New("requestLog").Parse(oc.RequestLogTemplate); err != nil {
 			return nil, err
 		}
-		oc.RequestLogTemplate = rlt
-	}
-
-	if eprl, ok := configMap.Data["logging.enable-probe-request-log"]; ok {
-		oc.EnableProbeRequestLog = strings.EqualFold(eprl, "true")
-	}
-
-	if mb, ok := configMap.Data["metrics.request-metrics-backend-destination"]; ok {
-		oc.RequestMetricsBackend = mb
-	}
-
-	if prof, ok := configMap.Data["profiling.enable"]; ok {
-		oc.EnableProfiling = strings.EqualFold(prof, "true")
 	}
 
 	return oc, nil

--- a/tracing/config/tracing.go
+++ b/tracing/config/tracing.go
@@ -25,6 +25,7 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	corev1 "k8s.io/api/core/v1"
+	cm "knative.dev/pkg/configmap"
 )
 
 const (
@@ -98,15 +99,20 @@ func NewTracingConfigFromMap(cfgMap map[string]string) (*Config, error) {
 		}
 	}
 
-	if endpoint, ok := cfgMap[zipkinEndpointKey]; !ok && tc.Backend == Zipkin {
-		return nil, errors.New("zipkin tracing enabled without a zipkin endpoint specified")
-	} else {
-		tc.ZipkinEndpoint = endpoint
+	if err := cm.Parse(cfgMap,
+		cm.AsString(zipkinEndpointKey, &tc.ZipkinEndpoint),
+		cm.AsString(stackdriverProjectIDKey, &tc.StackdriverProjectID),
+		cm.AsBool(debugKey, &tc.Debug),
+		cm.AsFloat64(sampleRateKey, &tc.SampleRate),
+	); err != nil {
+		return nil, err
 	}
 
-	if projectID, ok := cfgMap[stackdriverProjectIDKey]; ok {
-		tc.StackdriverProjectID = projectID
-	} else if tc.Backend == Stackdriver {
+	if tc.Backend == Zipkin && tc.ZipkinEndpoint == "" {
+		return nil, errors.New("zipkin tracing enabled without a zipkin endpoint specified")
+	}
+
+	if tc.Backend == Stackdriver && tc.StackdriverProjectID == "" {
 		projectID, err := metadata.ProjectID()
 		if err != nil {
 			return nil, fmt.Errorf("stackdriver tracing enabled without a project-id specified: %w", err)
@@ -114,23 +120,8 @@ func NewTracingConfigFromMap(cfgMap map[string]string) (*Config, error) {
 		tc.StackdriverProjectID = projectID
 	}
 
-	if debug, ok := cfgMap[debugKey]; ok {
-		debugBool, err := strconv.ParseBool(debug)
-		if err != nil {
-			return nil, fmt.Errorf("failed parsing tracing config %q", debugKey)
-		}
-		tc.Debug = debugBool
-	}
-
-	if sampleRate, ok := cfgMap[sampleRateKey]; ok {
-		sampleRateFloat, err := strconv.ParseFloat(sampleRate, 64)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse sampleRate in tracing config: %w", err)
-		}
-		if sampleRateFloat < 0 || sampleRateFloat > 1 {
-			return nil, fmt.Errorf("sampleRate = %v must be in [0, 1] range", sampleRateFloat)
-		}
-		tc.SampleRate = sampleRateFloat
+	if tc.SampleRate < 0 || tc.SampleRate > 1 {
+		return nil, fmt.Errorf("sampleRate = %v must be in [0, 1] range", tc.SampleRate)
 	}
 
 	return tc, nil

--- a/tracing/config/tracing.go
+++ b/tracing/config/tracing.go
@@ -121,7 +121,7 @@ func NewTracingConfigFromMap(cfgMap map[string]string) (*Config, error) {
 	}
 
 	if tc.SampleRate < 0 || tc.SampleRate > 1 {
-		return nil, fmt.Errorf("sampleRate = %v must be in [0, 1] range", tc.SampleRate)
+		return nil, fmt.Errorf("sample-rate = %v must be in [0, 1] range", tc.SampleRate)
 	}
 
 	return tc, nil

--- a/tracing/config/tracing_test.go
+++ b/tracing/config/tracing_test.go
@@ -258,11 +258,6 @@ func TestNewConfigFailures(t *testing.T) {
 			sampleRateKey: "1.01",
 		},
 	}, {
-		name: "debug key not a bool",
-		input: map[string]string{
-			debugKey: "not a bool",
-		},
-	}, {
 		name: "zipkin set without backend",
 		input: map[string]string{
 			backendKey: "zipkin",


### PR DESCRIPTION
- Use pkg/configmap parser for observability and leaderelection config. Logging config ain't worth it and I didn't yet dare to touch metric config.
- Adds a new helper for parsing StringSets. That one is useful in multiple places.
- Enhance the error reporting to always include the parsed key to be useful in error messages.