### PR TITLE
Add a constant with default shutdown wait time

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -36,6 +36,12 @@ const (
 	// We should consider exposing this as a configuration.
 	DefaultConnTimeout = 200 * time.Millisecond
 
+	// DefaultDrainTimeout is the time that Knative components on the data
+	// path will wait before shutting down server, but after starting to fail
+	// readiness probes to ensure network layer propagation and so that no requests
+	// are routed to this pod.
+	DefaultDrainTimeout = 30 * time.Second
+
 	// UserAgentKey is the constant for header "User-Agent".
 	UserAgentKey = "User-Agent"
 


### PR DESCRIPTION
We have in situ constants, which are not always consistent.

/assign @markusthoemmes mattmoor

As discussed today. 