### PR TITLE
add nil check to postprocess

### DIFF
--- a/reconciler/reconcile_common.go
+++ b/reconciler/reconcile_common.go
@@ -49,7 +49,9 @@ func PostProcessReconcile(ctx context.Context, resource duckv1.KRShaped) {
 	newStatus.ObservedGeneration = resource.GetGeneration()
 
 	rc := mgr.GetTopLevelCondition()
-	if rc != nil && rc.Reason == failedGenerationBump {
+	if rc == nil {
+		logger.Warn("A reconciliation included no top-level condition")
+	} else if rc.Reason == failedGenerationBump {
 		logger.Warn("A reconciler observed a new generation without updating the resource status")
 	}
 }

--- a/reconciler/reconcile_common.go
+++ b/reconciler/reconcile_common.go
@@ -48,8 +48,7 @@ func PostProcessReconcile(ctx context.Context, resource duckv1.KRShaped) {
 	// generation regardless of success or failure.
 	newStatus.ObservedGeneration = resource.GetGeneration()
 
-	rc := mgr.GetTopLevelCondition()
-	if rc == nil {
+	if rc := mgr.GetTopLevelCondition(); rc == nil {
 		logger.Warn("A reconciliation included no top-level condition")
 	} else if rc.Reason == failedGenerationBump {
 		logger.Warn("A reconciler observed a new generation without updating the resource status")

--- a/reconciler/reconcile_common.go
+++ b/reconciler/reconcile_common.go
@@ -49,7 +49,7 @@ func PostProcessReconcile(ctx context.Context, resource duckv1.KRShaped) {
 	newStatus.ObservedGeneration = resource.GetGeneration()
 
 	rc := mgr.GetTopLevelCondition()
-	if rc.Reason == failedGenerationBump {
+	if rc != nil && rc.Reason == failedGenerationBump {
 		logger.Warn("A reconciler observed a new generation without updating the resource status")
 	}
 }


### PR DESCRIPTION
We are expecting that pre-process will have added a top-level condition, but if for some reason the reconciler clears conditions we want to  log a warning. As-is this might panic.