### PR TITLE
Make onAfterStore synchronous to the update itself.

### DIFF
--- a/configmap/store.go
+++ b/configmap/store.go
@@ -157,9 +157,7 @@ func (s *UntypedStore) OnConfigChanged(c *corev1.ConfigMap) {
 	s.logger.Infof("%s config %q config was added or updated: %#v", s.name, name, result)
 	storage.Store(result)
 
-	go func() {
-		for _, f := range s.onAfterStore {
-			f(name, result)
-		}
-	}()
+	for _, f := range s.onAfterStore {
+		f(name, result)
+	}
 }


### PR DESCRIPTION
Generally, the `onAfterStore` function is used to kick off a global resync, which should be a very quick operation. Having `onAfterStore` being called asynchronously on a goroutine makes it very hard or straight out impossible to control it, especially in tests.

If there's a costly operation being done `onAfterStore`, it should be up to the caller to decide to make that asynchronous and thus put it into a goroutine.

This contributes to a lot of test flakes, at least in Knative Serving.

/assign @vagababov 