### PR TITLE
Fix beta duck conversion & omit conversion if nil

### DIFF
--- a/apis/duck/v1/status_types.go
+++ b/apis/duck/v1/status_types.go
@@ -94,8 +94,10 @@ func (s *Status) GetCondition(t apis.ConditionType) *apis.Condition {
 // return true the condition type will be copied to the sink
 func (source *Status) ConvertTo(ctx context.Context, sink *Status, predicates ...func(apis.ConditionType) bool) {
 	sink.ObservedGeneration = source.ObservedGeneration
-	// This will deep copy the map.
-	sink.Annotations = kmeta.UnionMaps(source.Annotations, nil)
+	if source.Annotations != nil {
+		// This will deep copy the map.
+		sink.Annotations = kmeta.UnionMaps(source.Annotations, nil)
+	}
 
 	conditions := make(apis.Conditions, 0, len(source.Conditions))
 	for _, c := range source.Conditions {

--- a/apis/duck/v1/status_types_test.go
+++ b/apis/duck/v1/status_types_test.go
@@ -184,4 +184,11 @@ func TestConditionSet(t *testing.T) {
 	if got, want := s2.Annotations, s.Annotations; !cmp.Equal(got, want) {
 		t.Errorf("Annotations mismatch: diff(-want,+got):\n%s", cmp.Diff(want, got))
 	}
+
+	s.Annotations = nil
+	s2 = &Status{}
+	s.ConvertTo(context.Background(), s2)
+	if s2.Annotations != nil {
+		t.Error("Annotations were not nil:", s2.Annotations)
+	}
 }

--- a/apis/duck/v1beta1/status_types.go
+++ b/apis/duck/v1beta1/status_types.go
@@ -26,6 +26,7 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
+	"knative.dev/pkg/kmeta"
 )
 
 // +genduck
@@ -107,6 +108,9 @@ func (s *Status) GetCondition(t apis.ConditionType) *apis.Condition {
 // ConvertTo helps implement apis.Convertible for types embedding this Status.
 func (source *Status) ConvertTo(ctx context.Context, sink *Status) {
 	sink.ObservedGeneration = source.ObservedGeneration
+	if source.Annotations != nil {
+		sink.Annotations = kmeta.UnionMaps(source.Annotations, nil)
+	}
 	for _, c := range source.Conditions {
 		switch c.Type {
 		// Copy over the "happy" condition, which is the only condition that

--- a/apis/duck/v1beta1/status_types_test.go
+++ b/apis/duck/v1beta1/status_types_test.go
@@ -60,7 +60,13 @@ func TestConditionSet(t *testing.T) {
 
 	const wantGeneration = 42
 
-	s := &Status{ObservedGeneration: wantGeneration}
+	s := &Status{
+		ObservedGeneration: wantGeneration,
+		Annotations: map[string]string{
+			"burning": "the",
+			"bridges": "down",
+		},
+	}
 	mgr := condSet.Manage(s)
 
 	mgr.InitializeConditions()
@@ -82,8 +88,11 @@ func TestConditionSet(t *testing.T) {
 		t.Errorf("len(s2.Conditions) = %d, wanted %d", got, want)
 	}
 	if gotGeneration := s2.ObservedGeneration; wantGeneration != gotGeneration {
-		t.Errorf("len(s2.ObservedGeneration) = %d, wanted %d",
+		t.Errorf("s2.ObservedGeneration = %d, wanted %d",
 			gotGeneration, wantGeneration)
+	}
+	if got, want := s2.Annotations, s.Annotations; !cmp.Equal(got, want) {
+		t.Errorf("Annotations mismatch: diff(-want,+got):\n%s", cmp.Diff(want, got))
 	}
 
 	for _, c := range []apis.ConditionType{"Foo"} {
@@ -134,5 +143,11 @@ func TestConditionSet(t *testing.T) {
 	if gotGeneration := s2.ObservedGeneration; wantGeneration != gotGeneration {
 		t.Errorf("len(s2.ObservedGeneration) = %d, wanted %d",
 			gotGeneration, wantGeneration)
+	}
+	s.Annotations = nil
+	s2 = &Status{}
+	s.ConvertTo(context.Background(), s2)
+	if s2.Annotations != nil {
+		t.Error("Annotations were not nil:", s2.Annotations)
 	}
 }


### PR DESCRIPTION
Some tests were failing for `nil != map{}` check (which is better off with `cmpopts.EquateEmpty` anyway, especially when considering wire roundtrip). 
But regardless, no need to create a map if source is nil.

Also apprarently beta duck is a thing.

/assign @dprotaso @vaikas 