### PR TITLE
Implement Unwrap() and Is() for permanentErrors

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -448,7 +448,7 @@ func (c *Impl) processNextWorkItem() bool {
 func (c *Impl) handleErr(err error, key types.NamespacedName) {
 	c.logger.Errorw("Reconcile error", zap.Error(err))
 
-	// Re-queue the key if it's an transient error.
+	// Re-queue the key if it's a transient error.
 	// We want to check that the queue is shutting down here
 	// since controller Run might have exited by now (since while this item was
 	// being processed, queue.Len==0).
@@ -483,8 +483,8 @@ func (c *Impl) FilteredGlobalResync(f func(interface{}) bool, si cache.SharedInf
 }
 
 // NewPermanentError returns a new instance of permanentError.
-// Users can wrap an error as permanentError with this in reconcile,
-// when he does not expect the key to get re-queued.
+// Users can wrap an error as permanentError with this in reconcile
+// when they do not expect the key to get re-queued.
 func NewPermanentError(err error) error {
 	return permanentError{e: err}
 }
@@ -495,14 +495,10 @@ type permanentError struct {
 	e error
 }
 
-// IsPermanentError returns true if given error is permanentError
+// IsPermanentError returns true if the given error is a permanentError.
 func IsPermanentError(err error) bool {
-	switch err.(type) {
-	case permanentError:
-		return true
-	default:
-		return false
-	}
+	_, ok := err.(permanentError)
+	return ok
 }
 
 // Error implements the Error() interface of error.
@@ -512,6 +508,12 @@ func (err permanentError) Error() string {
 	}
 
 	return err.e.Error()
+}
+
+// Unwrap implements the Unwrap() interface of error. It returns the error
+// wrapped inside permanentError.
+func (err permanentError) Unwrap() error {
+	return err.e
 }
 
 // Informer is the group of methods that a type must implement to be passed to

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -495,11 +496,20 @@ type permanentError struct {
 	e error
 }
 
-// IsPermanentError returns true if the given error is a permanentError.
+// IsPermanentError returns true if the given error is a permanentError or
+// wraps a permanentError.
 func IsPermanentError(err error) bool {
-	_, ok := err.(permanentError)
+	return errors.Is(err, permanentError{})
+}
+
+// Is implements the Is() interface of error. It returns whether the target
+// error can be treated as equivalent to a permanentError.
+func (permanentError) Is(target error) bool {
+	_, ok := target.(permanentError)
 	return ok
 }
+
+var _ error = permanentError{}
 
 // Error implements the Error() interface of error.
 func (err permanentError) Error() string {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -881,6 +882,11 @@ func TestPermanentError(t *testing.T) {
 	}
 	if IsPermanentError(err) {
 		t.Errorf("Expected type %T to not be a permanentError", err)
+	}
+
+	wrapPermErr := fmt.Errorf("wrapped: %w", permErr)
+	if !IsPermanentError(wrapPermErr) {
+		t.Error("Expected wrapped permanentError to be equivalent to a permanentError")
 	}
 
 	unwrapErr := new(fakeError)


### PR DESCRIPTION
Without the `Unwrap()` method, `ReconcilerEvents` can't be unwrapped from `permanentError`s (L198), and we jump directly over the block (L209).

https://github.com/knative/pkg/blob/a468cb85692fc17e6abd2677f0b88f3337089723/client/injection/kube/reconciler/core/v1/namespace/reconciler.go#L196-L212

`Is()` allows for `permanentError`s to be wrapped themselves and still be considered as permanent.