### PR TITLE
Use the generic networking constant for shutdown

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -73,13 +73,6 @@ const (
 	Connect Operation = admissionv1beta1.Connect
 )
 
-var (
-	// GracePeriod is the duration that the webhook will wait after it's
-	// context is cancelled (and probes are failing) before shutting down
-	// the http server.
-	GracePeriod = 30 * time.Second
-)
-
 // Webhook implements the external webhook for validation of
 // resources and configuration.
 type Webhook struct {
@@ -145,7 +138,7 @@ func New(
 		Logger:       logger,
 		synced:       cancel,
 		stopCh:       make(chan struct{}),
-		gracePeriod:  GracePeriod,
+		gracePeriod:  network.DefaultDrainTimeout,
 	}
 
 	webhook.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -47,11 +47,6 @@ const (
 	user1            = "brutto@knative.dev"
 )
 
-func init() {
-	// Don't hang forever when running tests.
-	GracePeriod = 100 * time.Millisecond
-}
-
 func newNonRunningTestWebhook(t *testing.T, options Options, acs ...interface{}) (
 	ctx context.Context, ac *Webhook, cancel context.CancelFunc) {
 	t.Helper()
@@ -73,6 +68,7 @@ func newNonRunningTestWebhook(t *testing.T, options Options, acs ...interface{})
 	if err != nil {
 		t.Fatalf("Failed to create new admission controller: %v", err)
 	}
+	ac.gracePeriod = 100 * time.Millisecond
 	return
 }
 


### PR DESCRIPTION
- use standard const, which is better
- stop modifying the default in the test, which is ugh a bit :)

/assign mattmoor @dprotaso  