### PR TITLE
Don't swallow errors from stackdriver init.

### DIFF
--- a/metrics/stackdriver_exporter.go
+++ b/metrics/stackdriver_exporter.go
@@ -102,11 +102,12 @@ func init() {
 
 func newOpencensusSDExporter(o stackdriver.Options) (view.Exporter, error) {
 	e, err := stackdriver.NewExporter(o)
-	if err == nil {
-		// Start the exporter.
-		// TODO(https://github.com/knative/pkg/issues/866): Move this to an interface.
-		e.StartMetricsExporter()
+	if err != nil {
+		return nil, err
 	}
+	// Start the exporter.
+	// TODO(https://github.com/knative/pkg/issues/866): Move this to an interface.
+	e.StartMetricsExporter()
 	return e, nil
 }
 

--- a/metrics/stackdriver_exporter.go
+++ b/metrics/stackdriver_exporter.go
@@ -107,7 +107,9 @@ func newOpencensusSDExporter(o stackdriver.Options) (view.Exporter, error) {
 	}
 	// Start the exporter.
 	// TODO(https://github.com/knative/pkg/issues/866): Move this to an interface.
-	e.StartMetricsExporter()
+	if err := e.StartMetricsExporter(); err != nil {
+		return nil, err
+	}
 	return e, nil
 }
 


### PR DESCRIPTION
Found this while poking at writing an e2e test case for stackdriver.

Without this patch, I get a panic. With the patch, I get:

> unable to init: stackdriver: couldn't initialize trace client: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.

/assign @jjzeng-seattle 