### PR TITLE
Junithelper refactor into a function that can be re-used.

### DIFF
--- a/test/junit/junit.go
+++ b/test/junit/junit.go
@@ -21,6 +21,8 @@ package junit
 import (
 	"encoding/xml"
 	"fmt"
+	"io/ioutil"
+	"log"
 )
 
 // TestStatusEnum is a enum for test result status
@@ -143,4 +145,25 @@ func UnMarshal(buf []byte) (*TestSuites, error) {
 		return nil, err
 	}
 	return &testSuites, nil
+}
+
+// CreateXMLErrorMsg outputs a junit testsuite, testname and error message to the destination path
+// in XML format
+func CreateXMLErrorMsg(testSuite, testName, errMsg, dest string) {
+	suites := TestSuites{}
+	suite := TestSuite{Name: testSuite}
+	var errP *string
+	if errMsg != "" {
+		errP = &errMsg
+	}
+	suite.AddTestCase(TestCase{
+		Name:    testName,
+		Failure: errP,
+	})
+	suites.AddTestSuite(&suite)
+	contents, err := suites.ToBytes("", "")
+	if err != nil {
+		log.Fatal(err)
+	}
+	ioutil.WriteFile(dest, contents, 0644)
 }

--- a/test/junit/junit_test.go
+++ b/test/junit/junit_test.go
@@ -19,6 +19,9 @@ limitations under the License.
 package junit
 
 import (
+	"io/ioutil"
+	"os"
+	"path"
 	"testing"
 )
 
@@ -146,5 +149,26 @@ func TestAddTestSuite(t *testing.T) {
 
 	if len(testSuites.Suites) != 2 {
 		t.Fatalf("Expected 2, actual %d", len(testSuites.Suites))
+	}
+}
+
+func TestCreateXMLErrorMsg(t *testing.T) {
+	testDir := "test_output"
+	os.RemoveAll(testDir) // clean up in case there were stale side-effects from previous runs
+	if err := os.Mkdir(testDir, 0777); err != nil {
+		t.Fatalf("cannot create directory %q", testDir)
+	}
+	defer os.RemoveAll(testDir) // clean up
+	dest := path.Join(testDir, "TestCreateXMLErrorTestFile")
+	CreateXMLErrorMsg("dummySuite", "dummyTest", "dummyError has occured", dest)
+	expected := `<testsuites><testsuite name="dummySuite" time="0" failures="1" tests="1"><testcase name="dummyTest" time="0" classname=""><failure>dummyError has occured</failure><properties></properties></testcase><properties></properties></testsuite></testsuites>`
+
+	got, err := ioutil.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("cannot read %q, error %v", dest, err)
+	}
+
+	if string(got) != expected {
+		t.Fatalf("expected:\n%q\n, got:\n%q", expected, got)
 	}
 }

--- a/testutils/junithelper/main.go
+++ b/testutils/junithelper/main.go
@@ -18,8 +18,6 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
-	"log"
 
 	"knative.dev/pkg/test/junit"
 )
@@ -38,20 +36,5 @@ func main() {
 	flag.StringVar(&dest, "dest", "junit_result.xml", "Where junit xml writes to")
 	flag.Parse()
 
-	suites := junit.TestSuites{}
-	suite := junit.TestSuite{Name: suite}
-	var errP *string
-	if errMsg != "" {
-		errP = &errMsg
-	}
-	suite.AddTestCase(junit.TestCase{
-		Name:    name,
-		Failure: errP,
-	})
-	suites.AddTestSuite(&suite)
-	contents, err := suites.ToBytes("", "")
-	if err != nil {
-		log.Fatal(err)
-	}
-	ioutil.WriteFile(dest, contents, 0644)
+	junit.CreateXMLErrorMsg(suite, name, errMsg, dest)
 }


### PR DESCRIPTION
Junithelper was previously just a command, refactoring it as a function so it can be re-used by upstream vendors.

/cc @chizhg @chaodaiG 