### PR TITLE
Add the flag on the config-observability, for enabling the tag label on the request metrics

### DIFF
--- a/metrics/config_observability.go
+++ b/metrics/config_observability.go
@@ -59,6 +59,10 @@ type ObservabilityConfig struct {
 	// EnableProfiling indicates whether it is allowed to retrieve runtime profiling data from
 	// the pods via an HTTP server in the format expected by the pprof visualization tool.
 	EnableProfiling bool
+
+	// EnableTagLabelOnRequestMetrics specifies if the route tag, which is specified in the tag header,
+	// is used as a label on the request metrics or not.
+	EnableTagLabelOnRequestMetrics bool
 }
 
 func defaultConfig() *ObservabilityConfig {
@@ -79,6 +83,7 @@ func NewObservabilityConfigFromConfigMap(configMap *corev1.ConfigMap) (*Observab
 		cm.AsBool("logging.enable-probe-request-log", &oc.EnableProbeRequestLog),
 		cm.AsString("metrics.request-metrics-backend-destination", &oc.RequestMetricsBackend),
 		cm.AsBool("profiling.enable", &oc.EnableProfiling),
+		cm.AsBool("metrics.enable-tag-label-on-request-metrics", &oc.EnableTagLabelOnRequestMetrics),
 	); err != nil {
 		return nil, err
 	}

--- a/metrics/config_observability_test.go
+++ b/metrics/config_observability_test.go
@@ -35,12 +35,13 @@ func TestObservabilityConfiguration(t *testing.T) {
 		name:    "observability configuration with all inputs",
 		wantErr: false,
 		wantConfig: &ObservabilityConfig{
-			EnableProbeRequestLog:  true,
-			EnableProfiling:        true,
-			EnableVarLogCollection: true,
-			LoggingURLTemplate:     "https://logging.io",
-			RequestLogTemplate:     `{"requestMethod": "{{.Request.Method}}"}`,
-			RequestMetricsBackend:  "stackdriver",
+			EnableProbeRequestLog:          true,
+			EnableProfiling:                true,
+			EnableVarLogCollection:         true,
+			LoggingURLTemplate:             "https://logging.io",
+			RequestLogTemplate:             `{"requestMethod": "{{.Request.Method}}"}`,
+			RequestMetricsBackend:          "stackdriver",
+			EnableTagLabelOnRequestMetrics: true,
 		},
 		data: map[string]string{
 			"logging.enable-probe-request-log":            "true",
@@ -50,6 +51,7 @@ func TestObservabilityConfiguration(t *testing.T) {
 			"logging.write-request-logs":                  "true",
 			"metrics.request-metrics-backend-destination": "stackdriver",
 			"profiling.enable":                            "true",
+			"metrics.enable-tag-label-on-request-metrics": "true",
 		},
 	}, {
 		name:       "observability config with no map",


### PR DESCRIPTION
To toggle the feature in https://github.com/knative/serving/pull/8103, this PR introduces new flag in `config-observability`. 

The name of the flag is `metrics.enable-tag-label-on-request-metrics` and if it is `true`, all the metrics `requests-*` exposed by the queue-proxy will have additional label `tag`, which is the value of the tag header.

The default value is `false`.