### PR TITLE
Initialize conditions in preprocess

### DIFF
--- a/reconciler/reconcile_common.go
+++ b/reconciler/reconcile_common.go
@@ -32,6 +32,8 @@ func PreProcessReconcile(ctx context.Context, resource duckv1.KRShaped) {
 	if newStatus.ObservedGeneration != resource.GetGeneration() {
 		condSet := resource.GetConditionSet()
 		manager := condSet.Manage(newStatus)
+		// Ensure conditions are initialized before we modify.
+		manager.InitializeConditions()
 
 		// Reset Ready/Successful to unknown. The reconciler is expected to overwrite this.
 		manager.MarkUnknown(condSet.GetTopLevelConditionType(), failedGenerationBump, "unsuccessfully observed a new generation")

--- a/reconciler/reconcile_common_test.go
+++ b/reconciler/reconcile_common_test.go
@@ -27,19 +27,34 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-func makeResource(topLevelCond string) *duckv1.KResource {
+type TestResource struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Status duckv1.Status `json:"status"`
+}
+
+func (t *TestResource) GetStatus() *duckv1.Status {
+	return &t.Status
+}
+
+func (*TestResource) GetConditionSet() apis.ConditionSet {
+	return apis.NewLivingConditionSet("Foo", "Bar")
+}
+
+func makeResource() *TestResource {
 	fooCond := apis.Condition{
 		Type:    "Foo",
 		Status:  corev1.ConditionTrue,
 		Message: "Something something foo",
 	}
 	readyCond := apis.Condition{
-		Type:    apis.ConditionType(topLevelCond),
+		Type:    apis.ConditionType(apis.ConditionReady),
 		Status:  corev1.ConditionTrue,
 		Message: "Something something bar",
 	}
 
-	return &duckv1.KResource{
+	return &TestResource{
 		ObjectMeta: metav1.ObjectMeta{
 			Generation: 42,
 		},
@@ -51,37 +66,29 @@ func makeResource(topLevelCond string) *duckv1.KResource {
 	}
 }
 
-func TestPreProcessResetsReady(t *testing.T) {
-	testCases := []struct {
-		name                      string
-		initTopLevelCond          string
-		expectedTopLevelCondition apis.ConditionType
-	}{{
-		name:                      "top level Ready",
-		initTopLevelCond:          "Ready",
-		expectedTopLevelCondition: apis.ConditionReady,
-	}, {
-		name:                      "top level Succeeded",
-		initTopLevelCond:          "Succeeded",
-		expectedTopLevelCondition: apis.ConditionSucceeded,
-	}}
+func TestPreProcess(t *testing.T) {
+	resource := makeResource()
+	krShape := duckv1.KRShaped(resource)
 
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			resource := makeResource(test.initTopLevelCond)
-			krShape := duckv1.KRShaped(resource)
+	PreProcessReconcile(context.Background(), krShape)
 
-			PreProcessReconcile(context.Background(), krShape)
+	if rc := resource.Status.GetCondition("Ready"); rc.Status != "Unknown" {
+		t.Errorf("Expected unchanged ready status got=%s want=Unknown", rc.Status)
+	}
 
-			if rc := resource.Status.GetCondition(test.expectedTopLevelCondition); rc.Status != "Unknown" {
-				t.Errorf("Expected unchanged ready status got=%s want=Unknown", rc.Status)
-			}
-		})
+	// Ensure Foo is untouched
+	if rc := resource.Status.GetCondition("Foo"); rc.Status != "True" {
+		t.Errorf("Expected dependant condition to remain got=%s want=True", rc.Status)
+	}
+
+	// Ensure Bar is initialized
+	if rc := resource.Status.GetCondition("Bar"); rc.Status != "True" {
+		t.Errorf("Expected conditions to be initialized got=%s want=True", rc.Status)
 	}
 }
 
 func TestPostProcessReconcileBumpsGeneration(t *testing.T) {
-	resource := makeResource("Ready")
+	resource := makeResource()
 
 	krShape := duckv1.KRShaped(resource)
 	PostProcessReconcile(context.Background(), krShape)


### PR DESCRIPTION
Initialize conditions in preprocess

This is an oft-repeated piece of code that we have in reconcilers. We should ensure conditions are initialized before we reconcile.