### PR TITLE
Use a hexadecimal representation for the example checksum.

### DIFF
--- a/configmap/example.go
+++ b/configmap/example.go
@@ -17,6 +17,7 @@ limitations under the License.
 package configmap
 
 import (
+	"fmt"
 	"hash/crc32"
 )
 
@@ -29,6 +30,6 @@ const (
 )
 
 // Checksum generates a checksum for the example value to be compared against a respective label.
-func Checksum(value string) uint32 {
-	return crc32.ChecksumIEEE([]byte(value))
+func Checksum(value string) string {
+	return fmt.Sprintf("%08x", crc32.ChecksumIEEE([]byte(value)))
 }

--- a/configmap/example_test.go
+++ b/configmap/example_test.go
@@ -21,21 +21,21 @@ import "testing"
 func TestChecksum(t *testing.T) {
 	tests := []struct {
 		in   string
-		want uint32
+		want string
 	}{{
 		in:   "",
-		want: 0,
+		want: "00000000",
 	}, {
 		in:   "1",
-		want: 2212294583,
+		want: "83dcefb7",
 	}, {
 		in:   "a somewhat longer test",
-		want: 4278087538,
+		want: "fefe6f72",
 	}}
 
 	for _, test := range tests {
 		if got := Checksum(test.in); got != test.want {
-			t.Errorf("Checksum(%q) = %d, want %d", test.in, got, test.want)
+			t.Errorf("Checksum(%q) = %s, want %s", test.in, got, test.want)
 		}
 	}
 }

--- a/configmap/hash-gen/main.go
+++ b/configmap/hash-gen/main.go
@@ -74,7 +74,7 @@ func process(data []byte) ([]byte, error) {
 		return nil, errors.New("'metadata.labels' not found")
 	}
 
-	checksum := fmt.Sprint(configmap.Checksum(example.Value))
+	checksum := configmap.Checksum(example.Value)
 	existingLabel := value(labels, configmap.ExampleChecksumLabel)
 	if existingLabel != nil {
 		existingLabel.Value = checksum

--- a/configmap/hash-gen/testdata/add_want.yaml
+++ b/configmap/hash-gen/testdata/add_want.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-    knative.dev/example-checksum: "2958957236"
+    knative.dev/example-checksum: b05e1ab4
 data:
   leave-me: "alone"
   _example: |

--- a/configmap/hash-gen/testdata/update_want.yaml
+++ b/configmap/hash-gen/testdata/update_want.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-    knative.dev/example-checksum: "2958957236"
+    knative.dev/example-checksum: b05e1ab4
 data:
   leave-me: "alone"
   _example: |

--- a/configmap/testing/configmap.go
+++ b/configmap/testing/configmap.go
@@ -86,7 +86,7 @@ func ConfigMapsFromTestFile(t *testing.T, name string, allowed ...string) (*core
 	// Check that the hashed exampleBody matches the assigned label, if present.
 	gotChecksum, hasExampleChecksumLabel := orig.Labels[configmap.ExampleChecksumLabel]
 	if hasExampleBody && hasExampleChecksumLabel {
-		wantChecksum := fmt.Sprint(configmap.Checksum(exampleBody))
+		wantChecksum := configmap.Checksum(exampleBody)
 		if gotChecksum != wantChecksum {
 			t.Errorf("example checksum label = %s, want %s", gotChecksum, wantChecksum)
 		}

--- a/webhook/configmaps/configmaps.go
+++ b/webhook/configmaps/configmaps.go
@@ -187,7 +187,7 @@ func (ac *reconciler) validate(ctx context.Context, req *admissionv1beta1.Admiss
 	exampleData, hasExampleData := newObj.Data[configmap.ExampleKey]
 	exampleChecksum, hasExampleChecksumLabel := newObj.Labels[configmap.ExampleChecksumLabel]
 	if hasExampleData && hasExampleChecksumLabel &&
-		exampleChecksum != fmt.Sprint(configmap.Checksum(exampleData)) {
+		exampleChecksum != configmap.Checksum(exampleData) {
 		return fmt.Errorf(
 			"%q modified, you likely wanted to create an unindented configuration",
 			configmap.ExampleKey)


### PR DESCRIPTION
As per @julz comment on https://github.com/knative/serving/pull/8123 this is more usual. I like it better anyway as the `Checksum` function now controls the representation.

/assign @julz 