### PR TITLE
Use annotation rather than label for configmap checksum

### DIFF
--- a/configmap/example.go
+++ b/configmap/example.go
@@ -25,11 +25,11 @@ const (
 	// ExampleKey signifies a given example configuration in a ConfigMap.
 	ExampleKey = "_example"
 
-	// ExampleChecksumLabel is the label that stores the computed checksum.
-	ExampleChecksumLabel = "knative.dev/example-checksum"
+	// ExampleChecksumAnnotation is the annotation that stores the computed checksum.
+	ExampleChecksumAnnotation = "knative.dev/example-checksum"
 )
 
-// Checksum generates a checksum for the example value to be compared against a respective label.
+// Checksum generates a checksum for the example value to be compared against a respective annotation.
 func Checksum(value string) string {
 	return fmt.Sprintf("%08x", crc32.ChecksumIEEE([]byte(value)))
 }

--- a/configmap/hash-gen/main.go
+++ b/configmap/hash-gen/main.go
@@ -68,19 +68,24 @@ func process(data []byte) ([]byte, error) {
 		return nil, nil
 	}
 
-	labels := traverse(content, "metadata", "labels")
-	if labels == nil {
-		// TODO(markusthoemmes): Potentially handle missing metadata and labels?
-		return nil, errors.New("'metadata.labels' not found")
+	metadata := traverse(content, "metadata")
+	if metadata == nil {
+		return nil, errors.New("'metadata' not found")
+	}
+
+	annotations := traverse(metadata, "annotations")
+	if annotations == nil {
+		annotations = &yaml.Node{Kind: yaml.MappingNode}
+		metadata.Content = append(metadata.Content, strNode("annotations"), annotations)
 	}
 
 	checksum := configmap.Checksum(example.Value)
-	existingLabel := value(labels, configmap.ExampleChecksumLabel)
-	if existingLabel != nil {
-		existingLabel.Value = checksum
+	existingAnnotation := value(annotations, configmap.ExampleChecksumAnnotation)
+	if existingAnnotation != nil {
+		existingAnnotation.Value = checksum
 	} else {
-		labels.Content = append(labels.Content,
-			strNode(configmap.ExampleChecksumLabel),
+		annotations.Content = append(annotations.Content,
+			strNode(configmap.ExampleChecksumAnnotation),
 			strNode(checksum))
 	}
 

--- a/configmap/hash-gen/testdata/add_want.yaml
+++ b/configmap/hash-gen/testdata/add_want.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
+  annotations:
     knative.dev/example-checksum: b05e1ab4
 data:
   leave-me: "alone"

--- a/configmap/hash-gen/testdata/update.yaml
+++ b/configmap/hash-gen/testdata/update.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
+  annotations:
     knative.dev/example-checksum: bla
 data:
   leave-me: "alone"

--- a/configmap/hash-gen/testdata/update_want.yaml
+++ b/configmap/hash-gen/testdata/update_want.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
+  annotations:
     knative.dev/example-checksum: b05e1ab4
 data:
   leave-me: "alone"

--- a/configmap/testing/configmap.go
+++ b/configmap/testing/configmap.go
@@ -83,12 +83,12 @@ func ConfigMapsFromTestFile(t *testing.T, name string, allowed ...string) (*core
 		}
 	}
 
-	// Check that the hashed exampleBody matches the assigned label, if present.
-	gotChecksum, hasExampleChecksumLabel := orig.Labels[configmap.ExampleChecksumLabel]
-	if hasExampleBody && hasExampleChecksumLabel {
+	// Check that the hashed exampleBody matches the assigned annotation, if present.
+	gotChecksum, hasExampleChecksumAnnotation := orig.Annotations[configmap.ExampleChecksumAnnotation]
+	if hasExampleBody && hasExampleChecksumAnnotation {
 		wantChecksum := configmap.Checksum(exampleBody)
 		if gotChecksum != wantChecksum {
-			t.Errorf("example checksum label = %s, want %s", gotChecksum, wantChecksum)
+			t.Errorf("example checksum annotation = %s, want %s", gotChecksum, wantChecksum)
 		}
 	}
 

--- a/webhook/configmaps/configmaps.go
+++ b/webhook/configmaps/configmaps.go
@@ -185,8 +185,8 @@ func (ac *reconciler) validate(ctx context.Context, req *admissionv1beta1.Admiss
 	}
 
 	exampleData, hasExampleData := newObj.Data[configmap.ExampleKey]
-	exampleChecksum, hasExampleChecksumLabel := newObj.Labels[configmap.ExampleChecksumLabel]
-	if hasExampleData && hasExampleChecksumLabel &&
+	exampleChecksum, hasExampleChecksumAnnotation := newObj.Annotations[configmap.ExampleChecksumAnnotation]
+	if hasExampleData && hasExampleChecksumAnnotation &&
 		exampleChecksum != configmap.Checksum(exampleData) {
 		return fmt.Errorf(
 			"%q modified, you likely wanted to create an unindented configuration",

--- a/webhook/configmaps/configmaps_test.go
+++ b/webhook/configmaps/configmaps_test.go
@@ -222,8 +222,8 @@ func TestDenyInvalidUpdateConfigMapExample(t *testing.T) {
 
 	r := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				configmap.ExampleChecksumLabel: "foo",
+			Annotations: map[string]string{
+				configmap.ExampleChecksumAnnotation: "foo",
 			},
 		},
 		Data: map[string]string{


### PR DESCRIPTION
Slightly more correct to use an annotation rather than a label since this isn't something one would select on.

/assign @markusthoemmes 