### PR TITLE
Remove the trailing \n

### DIFF
--- a/configmap/example.go
+++ b/configmap/example.go
@@ -26,11 +26,12 @@ const (
 	// ExampleKey signifies a given example configuration in a ConfigMap.
 	ExampleKey = "_example"
 
-	// ExampleChecksumLabel is the label that stores the computed checksum.
-	ExampleChecksumLabel = "knative.dev/example-checksum"
+	// ExampleChecksumAnnotation is the annotation that stores the computed checksum.
+	ExampleChecksumAnnotation = "knative.dev/example-checksum"
 )
 
-// Checksum generates a checksum for the example value to be compared against a respective label.
+// Checksum generates a checksum for the example value to be compared against
+// a respective annotation.
 // Heading and trailing spaces are ignored.
 func Checksum(value string) string {
 	return fmt.Sprintf("%08x", crc32.ChecksumIEEE([]byte(strings.TrimSpace(value))))

--- a/configmap/example.go
+++ b/configmap/example.go
@@ -19,17 +19,19 @@ package configmap
 import (
 	"fmt"
 	"hash/crc32"
+	"strings"
 )
 
 const (
 	// ExampleKey signifies a given example configuration in a ConfigMap.
 	ExampleKey = "_example"
 
-	// ExampleChecksumAnnotation is the annotation that stores the computed checksum.
-	ExampleChecksumAnnotation = "knative.dev/example-checksum"
+	// ExampleChecksumLabel is the label that stores the computed checksum.
+	ExampleChecksumLabel = "knative.dev/example-checksum"
 )
 
-// Checksum generates a checksum for the example value to be compared against a respective annotation.
+// Checksum generates a checksum for the example value to be compared against a respective label.
+// Heading and trailing spaces are ignored.
 func Checksum(value string) string {
-	return fmt.Sprintf("%08x", crc32.ChecksumIEEE([]byte(value)))
+	return fmt.Sprintf("%08x", crc32.ChecksumIEEE([]byte(strings.TrimSpace(value))))
 }

--- a/configmap/example.go
+++ b/configmap/example.go
@@ -32,7 +32,7 @@ const (
 
 // Checksum generates a checksum for the example value to be compared against
 // a respective annotation.
-// Heading and trailing spaces are ignored.
+// Leading and trailing spaces are ignored.
 func Checksum(value string) string {
 	return fmt.Sprintf("%08x", crc32.ChecksumIEEE([]byte(strings.TrimSpace(value))))
 }

--- a/configmap/example_test.go
+++ b/configmap/example_test.go
@@ -29,6 +29,9 @@ func TestChecksum(t *testing.T) {
 		in:   "1",
 		want: "83dcefb7",
 	}, {
+		in: "   a somewhat longer test			",
+		want: "fefe6f72",
+	}, {
 		in:   "a somewhat longer test",
 		want: "fefe6f72",
 	}}

--- a/configmap/hash-gen/testdata/add_want.yaml
+++ b/configmap/hash-gen/testdata/add_want.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: b05e1ab4
+    knative.dev/example-checksum: 81e8e656
 data:
   leave-me: "alone"
   _example: |

--- a/configmap/hash-gen/testdata/update_want.yaml
+++ b/configmap/hash-gen/testdata/update_want.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: b05e1ab4
+    knative.dev/example-checksum: 81e8e656
 data:
   leave-me: "alone"
   _example: |


### PR DESCRIPTION
Due to the parser difference we had 2 different values in WH and in the hash gen

Fixes: https://github.com/knative/serving/issues/8211

/assign @markusthoemmes 