### PR TITLE
Define flag --leader-election-enabled for sharedmain

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -918,7 +918,6 @@ func TestStartAndShutdownWithLeaderAwareWithLostElection(t *testing.T) {
 	}
 	cc := leaderelection.ComponentConfig{
 		Component:     "component",
-		LeaderElect:   true,
 		ResourceLock:  "leases",
 		LeaseDuration: 15 * time.Second,
 		RenewDeadline: 10 * time.Second,

--- a/leaderelection/config.go
+++ b/leaderelection/config.go
@@ -46,13 +46,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		cm.AsDuration("leaseDuration", &config.LeaseDuration),
 		cm.AsDuration("renewDeadline", &config.RenewDeadline),
 		cm.AsDuration("retryPeriod", &config.RetryPeriod),
-
 		cm.AsUint32("buckets", &config.Buckets),
-
-		// enabledComponents are not validated here, because they are dependent on
-		// the component. Components should provide additional validation for this
-		// field.
-		cm.AsStringSet("enabledComponents", &config.EnabledComponents),
 	); err != nil {
 		return nil, err
 	}
@@ -89,36 +83,19 @@ type Config struct {
 }
 
 func (c *Config) GetComponentConfig(name string) ComponentConfig {
-	if c.EnabledComponents.Has(name) {
-		return ComponentConfig{
-			Component:     name,
-			LeaderElect:   true,
-			Buckets:       c.Buckets,
-			ResourceLock:  c.ResourceLock,
-			LeaseDuration: c.LeaseDuration,
-			RenewDeadline: c.RenewDeadline,
-			RetryPeriod:   c.RetryPeriod,
-		}
-	}
-
-	return defaultComponentConfig(name)
-}
-
-func defaultConfig() *Config {
-	return &Config{
-		ResourceLock:      "leases",
-		Buckets:           1,
-		LeaseDuration:     15 * time.Second,
-		RenewDeadline:     10 * time.Second,
-		RetryPeriod:       2 * time.Second,
-		EnabledComponents: sets.NewString(),
+	return ComponentConfig{
+		Component:     name,
+		Buckets:       c.Buckets,
+		ResourceLock:  c.ResourceLock,
+		LeaseDuration: c.LeaseDuration,
+		RenewDeadline: c.RenewDeadline,
+		RetryPeriod:   c.RetryPeriod,
 	}
 }
 
 // ComponentConfig represents the leader election config for a single component.
 type ComponentConfig struct {
 	Component     string
-	LeaderElect   bool
 	Buckets       uint32
 	ResourceLock  string
 	LeaseDuration time.Duration
@@ -126,10 +103,13 @@ type ComponentConfig struct {
 	RetryPeriod   time.Duration
 }
 
-func defaultComponentConfig(name string) ComponentConfig {
-	return ComponentConfig{
-		Component:   name,
-		LeaderElect: false,
+func defaultConfig() *Config {
+	return &Config{
+		ResourceLock:  "leases",
+		Buckets:       1,
+		LeaseDuration: 15 * time.Second,
+		RenewDeadline: 10 * time.Second,
+		RetryPeriod:   2 * time.Second,
 	}
 }
 

--- a/leaderelection/config_test.go
+++ b/leaderelection/config_test.go
@@ -25,18 +25,16 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/kmeta"
 )
 
 func okConfig() *Config {
 	return &Config{
-		ResourceLock:      "leases",
-		Buckets:           1,
-		LeaseDuration:     15 * time.Second,
-		RenewDeadline:     10 * time.Second,
-		RetryPeriod:       2 * time.Second,
-		EnabledComponents: sets.NewString(),
+		ResourceLock:  "leases",
+		Buckets:       1,
+		LeaseDuration: 15 * time.Second,
+		RenewDeadline: 10 * time.Second,
+		RetryPeriod:   2 * time.Second,
 	}
 }
 
@@ -47,96 +45,91 @@ func okData() map[string]string {
 		// values in this data come from the defaults suggested in the
 		// code:
 		// https://github.com/kubernetes/client-go/blob/kubernetes-1.16.0/tools/leaderelection/leaderelection.go
-		"leaseDuration":     "15s",
-		"renewDeadline":     "10s",
-		"retryPeriod":       "2s",
-		"enabledComponents": "controller",
+		"leaseDuration": "15s",
+		"renewDeadline": "10s",
+		"retryPeriod":   "2s",
 	}
 }
 
-func TestNewConfigMapFromData(t *testing.T) {
+func TestNewConfigFromConfigMap(t *testing.T) {
 	cases := []struct {
-		name     string
-		data     map[string]string
-		expected *Config
-		err      error
+		name      string
+		configMap *corev1.ConfigMap
+		expected  *Config
+		err       error
 	}{{
-		name: "disabled but OK config",
-		data: func() map[string]string {
-			data := okData()
-			delete(data, "enabledComponents")
-			return data
-		}(),
-		expected: okConfig(),
+		name:      "default config",
+		configMap: nil,
+		expected:  defaultConfig(),
 	}, {
-		name: "OK config - controller enabled",
-		data: okData(),
+		name:      "OK config",
+		configMap: &corev1.ConfigMap{Data: okData()},
+		expected:  okConfig(),
+	}, {
+		name: "OK config - enabled with multiple buckets",
+		configMap: &corev1.ConfigMap{
+			Data: kmeta.UnionMaps(okData(), map[string]string{
+				"buckets": "5",
+			})},
 		expected: func() *Config {
 			config := okConfig()
-			config.EnabledComponents.Insert("controller")
-			return config
-		}(),
-	}, {
-		name: "OK config - controller enabled with multiple buckets",
-		data: kmeta.UnionMaps(okData(), map[string]string{
-			"buckets": "5",
-		}),
-		expected: func() *Config {
-			config := okConfig()
-			config.EnabledComponents.Insert("controller")
 			config.Buckets = 5
 			return config
 		}(),
 	}, {
 		name: "invalid resourceLock",
-		data: kmeta.UnionMaps(okData(), map[string]string{
-			"resourceLock": "flarps",
-		}),
+		configMap: &corev1.ConfigMap{
+			Data: kmeta.UnionMaps(okData(), map[string]string{
+				"resourceLock": "flarps",
+			})},
 		err: errors.New(`resourceLock: invalid value "flarps": valid values are "leases","configmaps","endpoints"`),
 	}, {
 		name: "invalid leaseDuration",
-		data: kmeta.UnionMaps(okData(), map[string]string{
-			"leaseDuration": "flops",
-		}),
+		configMap: &corev1.ConfigMap{
+			Data: kmeta.UnionMaps(okData(), map[string]string{
+				"leaseDuration": "flops",
+			})},
 		err: errors.New(`failed to parse "leaseDuration": time: invalid duration flops`),
 	}, {
 		name: "invalid renewDeadline",
-		data: kmeta.UnionMaps(okData(), map[string]string{
-			"renewDeadline": "flops",
-		}),
+		configMap: &corev1.ConfigMap{
+			Data: kmeta.UnionMaps(okData(), map[string]string{
+				"renewDeadline": "flops",
+			})},
 		err: errors.New(`failed to parse "renewDeadline": time: invalid duration flops`),
 	}, {
 		name: "invalid retryPeriod",
-		data: kmeta.UnionMaps(okData(), map[string]string{
-			"retryPeriod": "flops",
-		}),
+		configMap: &corev1.ConfigMap{
+			Data: kmeta.UnionMaps(okData(), map[string]string{
+				"retryPeriod": "flops",
+			})},
 		err: errors.New(`failed to parse "retryPeriod": time: invalid duration flops`),
 	}, {
 		name: "invalid buckets - not an int",
-		data: kmeta.UnionMaps(okData(), map[string]string{
-			"buckets": "not-an-int",
-		}),
+		configMap: &corev1.ConfigMap{
+			Data: kmeta.UnionMaps(okData(), map[string]string{
+				"buckets": "not-an-int",
+			})},
 		err: errors.New(`failed to parse "buckets": strconv.ParseUint: parsing "not-an-int": invalid syntax`),
 	}, {
 		name: "invalid buckets - too small",
-		data: kmeta.UnionMaps(okData(), map[string]string{
-			"buckets": "0",
-		}),
+		configMap: &corev1.ConfigMap{
+			Data: kmeta.UnionMaps(okData(), map[string]string{
+				"buckets": "0",
+			})},
 		err: fmt.Errorf("buckets: value must be between 1 <= 0 <= %d", MaxBuckets),
 	}, {
 		name: "invalid buckets - too large",
-		data: kmeta.UnionMaps(okData(), map[string]string{
-			"buckets": strconv.Itoa(int(MaxBuckets + 1)),
-		}),
+		configMap: &corev1.ConfigMap{
+			Data: kmeta.UnionMaps(okData(), map[string]string{
+				"buckets": strconv.Itoa(int(MaxBuckets + 1)),
+			})},
 		err: fmt.Errorf(`buckets: value must be between 1 <= %d <= %d`, MaxBuckets+1, MaxBuckets),
 	}}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualConfig, actualErr := NewConfigFromConfigMap(
-				&corev1.ConfigMap{
-					Data: tc.data,
-				})
+			actualConfig, actualErr := NewConfigFromConfigMap(tc.configMap)
 
 			if tc.err != nil && tc.err.Error() != actualErr.Error() {
 				t.Fatalf("Error = %v, want: %v", actualErr, tc.err)
@@ -158,32 +151,17 @@ func TestGetComponentConfig(t *testing.T) {
 	}{{
 		name: "component enabled",
 		config: Config{
-			ResourceLock:      "leases",
-			LeaseDuration:     15 * time.Second,
-			RenewDeadline:     10 * time.Second,
-			RetryPeriod:       2 * time.Second,
-			EnabledComponents: sets.NewString(expectedName),
-		},
-		expected: ComponentConfig{
-			Component:     expectedName,
-			LeaderElect:   true,
 			ResourceLock:  "leases",
 			LeaseDuration: 15 * time.Second,
 			RenewDeadline: 10 * time.Second,
 			RetryPeriod:   2 * time.Second,
 		},
-	}, {
-		name: "component disabled",
-		config: Config{
-			ResourceLock:      "leases",
-			LeaseDuration:     15 * time.Second,
-			RenewDeadline:     10 * time.Second,
-			RetryPeriod:       2 * time.Second,
-			EnabledComponents: sets.NewString("not-the-component"),
-		},
 		expected: ComponentConfig{
-			Component:   expectedName,
-			LeaderElect: false,
+			Component:     expectedName,
+			ResourceLock:  "leases",
+			LeaseDuration: 15 * time.Second,
+			RenewDeadline: 10 * time.Second,
+			RetryPeriod:   2 * time.Second,
 		},
 	}}
 

--- a/leaderelection/context_test.go
+++ b/leaderelection/context_test.go
@@ -35,7 +35,6 @@ import (
 func TestWithBuilder(t *testing.T) {
 	cc := ComponentConfig{
 		Component:     "component",
-		LeaderElect:   true,
 		Buckets:       1,
 		ResourceLock:  "leases",
 		LeaseDuration: 15 * time.Second,


### PR DESCRIPTION
Fixes https://github.com/knative/pkg/issues/1319

Preview of knative-serving using this flag is at https://github.com/knative/serving/pull/8205 (this preview is slightly out-of-date. The flag name changed from `--leader-election-disabled` to `--leader-election-enabled`

When/if this is merged , there will be changes needed in knative/serving, net-istio, net-kourier, net-certmanager because the common flags master and kubeconfig are now at "sharedmain" package level. These are in fact common to all the repositories so no need to duplicate them everywhere. See the knative-serving PR for details