### PR TITLE
Added common name to cert tmpl

### DIFF
--- a/webhook/certificates/resources/certs.go
+++ b/webhook/certificates/resources/certs.go
@@ -55,7 +55,7 @@ func createCertTemplate(name, namespace string, notAfter time.Time) (*x509.Certi
 	}
 
 	tmpl := x509.Certificate{
-		SerialNumber:          serialNumber,
+		SerialNumber: serialNumber,
 		Subject: pkix.Name{
 			Organization: []string{organization},
 			CommonName:   commonName,

--- a/webhook/certificates/resources/certs.go
+++ b/webhook/certificates/resources/certs.go
@@ -58,7 +58,7 @@ func createCertTemplate(name, namespace string, notAfter time.Time) (*x509.Certi
 		SerialNumber:          serialNumber,
 		Subject: pkix.Name{
 			Organization: []string{organization},
-			CommonName: commonName,
+			CommonName:   commonName,
 		},
 		SignatureAlgorithm:    x509.SHA256WithRSA,
 		NotBefore:             time.Now(),

--- a/webhook/certificates/resources/certs.go
+++ b/webhook/certificates/resources/certs.go
@@ -56,7 +56,10 @@ func createCertTemplate(name, namespace string, notAfter time.Time) (*x509.Certi
 
 	tmpl := x509.Certificate{
 		SerialNumber:          serialNumber,
-		Subject:               pkix.Name{Organization: []string{organization}, CommonName: commonName},
+		Subject: pkix.Name{
+			Organization: []string{organization},
+			CommonName: commonName,
+		},
 		SignatureAlgorithm:    x509.SHA256WithRSA,
 		NotBefore:             time.Now(),
 		NotAfter:              notAfter,

--- a/webhook/certificates/resources/certs.go
+++ b/webhook/certificates/resources/certs.go
@@ -46,16 +46,17 @@ func createCertTemplate(name, namespace string, notAfter time.Time) (*x509.Certi
 	}
 
 	serviceName := name + "." + namespace
+	commonName := serviceName + ".svc"
 	serviceNames := []string{
 		name,
 		serviceName,
-		serviceName + ".svc",
+		commonName,
 		serviceName + ".svc.cluster.local",
 	}
 
 	tmpl := x509.Certificate{
 		SerialNumber:          serialNumber,
-		Subject:               pkix.Name{Organization: []string{organization}},
+		Subject:               pkix.Name{Organization: []string{organization}, CommonName: commonName},
 		SignatureAlgorithm:    x509.SHA256WithRSA,
 		NotBefore:             time.Now(),
 		NotAfter:              notAfter,

--- a/webhook/certificates/resources/certs_test.go
+++ b/webhook/certificates/resources/certs_test.go
@@ -59,6 +59,13 @@ func TestCreateCerts(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	//Verify common name
+	expectedCommonName := "got-the-hook.knative-webhook.svc"
+
+	if diff := cmp.Diff(caParsedCert.CommonName, expectedCommonName); diff != "" {
+                t.Fatalf("Unexpected Cert Common Name (-want +got) : %v", diff)
+        }
+
 	// Verify domain names
 	expectedDNSNames := []string{
 		"got-the-hook",
@@ -69,6 +76,10 @@ func TestCreateCerts(t *testing.T) {
 	if diff := cmp.Diff(caParsedCert.DNSNames, expectedDNSNames); diff != "" {
 		t.Fatalf("Unexpected CA Cert DNS Name (-want +got) : %v", diff)
 	}
+
+	if diff := cmp.Diff(caParsedCert.DNSNames, expectedDNSNames); diff != "" {
+                t.Fatalf("Unexpected CA Cert DNS Name (-want +got) : %v", diff)
+        }
 
 	// Verify Server Cert is Signed by CA Cert
 	if err = sCert.CheckSignatureFrom(caParsedCert); err != nil {

--- a/webhook/certificates/resources/certs_test.go
+++ b/webhook/certificates/resources/certs_test.go
@@ -62,7 +62,7 @@ func TestCreateCerts(t *testing.T) {
 	// Verify common name
 	const expectedCommonName = "got-the-hook.knative-webhook.svc"
 
-	if caParsedCert.CommonName != expectedCommonName {
+	if caParsedCert.Subject.CommonName != expectedCommonName {
 		t.Fatalf("Unexpected Cert Common Name (-want +got) : %v", diff)
 	}
 

--- a/webhook/certificates/resources/certs_test.go
+++ b/webhook/certificates/resources/certs_test.go
@@ -78,8 +78,8 @@ func TestCreateCerts(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(caParsedCert.DNSNames, expectedDNSNames); diff != "" {
-                t.Fatalf("Unexpected CA Cert DNS Name (-want +got) : %v", diff)
-        }
+		t.Fatalf("Unexpected CA Cert DNS Name (-want +got) : %v", diff)
+	}
 
 	// Verify Server Cert is Signed by CA Cert
 	if err = sCert.CheckSignatureFrom(caParsedCert); err != nil {

--- a/webhook/certificates/resources/certs_test.go
+++ b/webhook/certificates/resources/certs_test.go
@@ -63,8 +63,8 @@ func TestCreateCerts(t *testing.T) {
 	const expectedCommonName = "got-the-hook.knative-webhook.svc"
 
 	if caParsedCert.CommonName != expectedCommonName {
-                t.Fatalf("Unexpected Cert Common Name (-want +got) : %v", diff)
-        }
+		t.Fatalf("Unexpected Cert Common Name (-want +got) : %v", diff)
+	}
 
 	// Verify domain names
 	expectedDNSNames := []string{

--- a/webhook/certificates/resources/certs_test.go
+++ b/webhook/certificates/resources/certs_test.go
@@ -63,7 +63,7 @@ func TestCreateCerts(t *testing.T) {
 	const expectedCommonName = "got-the-hook.knative-webhook.svc"
 
 	if caParsedCert.Subject.CommonName != expectedCommonName {
-		t.Fatalf("Unexpected Cert Common Name (-want +got) : %v", diff)
+		t.Fatalf("Unexpected Cert Common Name %v, wanted %v", caParsedCert.Subject.CommonName, expectedCommonName)
 	}
 
 	// Verify domain names

--- a/webhook/certificates/resources/certs_test.go
+++ b/webhook/certificates/resources/certs_test.go
@@ -63,7 +63,7 @@ func TestCreateCerts(t *testing.T) {
 	const expectedCommonName = "got-the-hook.knative-webhook.svc"
 
 	if caParsedCert.Subject.CommonName != expectedCommonName {
-		t.Fatalf("Unexpected Cert Common Name %v, wanted %v", caParsedCert.Subject.CommonName, expectedCommonName)
+		t.Fatalf("Unexpected Cert Common Name %q, wanted %q", caParsedCert.Subject.CommonName, expectedCommonName)
 	}
 
 	// Verify domain names

--- a/webhook/certificates/resources/certs_test.go
+++ b/webhook/certificates/resources/certs_test.go
@@ -78,7 +78,7 @@ func TestCreateCerts(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(caParsedCert.DNSNames, expectedDNSNames); diff != "" {
-		t.Fatalf("Unexpected CA Cert DNS Name (-want +got) : %v", diff)
+		t.Fatalf("Unexpected CA Cert DNS Name (-want +got): %s", diff)
 	}
 
 	// Verify Server Cert is Signed by CA Cert

--- a/webhook/certificates/resources/certs_test.go
+++ b/webhook/certificates/resources/certs_test.go
@@ -59,7 +59,7 @@ func TestCreateCerts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	//Verify common name
+	// Verify common name
 	expectedCommonName := "got-the-hook.knative-webhook.svc"
 
 	if diff := cmp.Diff(caParsedCert.CommonName, expectedCommonName); diff != "" {

--- a/webhook/certificates/resources/certs_test.go
+++ b/webhook/certificates/resources/certs_test.go
@@ -62,7 +62,7 @@ func TestCreateCerts(t *testing.T) {
 	// Verify common name
 	const expectedCommonName = "got-the-hook.knative-webhook.svc"
 
-	if diff := cmp.Diff(caParsedCert.CommonName, expectedCommonName); diff != "" {
+	if caParsedCert.CommonName != expectedCommonName {
                 t.Fatalf("Unexpected Cert Common Name (-want +got) : %v", diff)
         }
 

--- a/webhook/certificates/resources/certs_test.go
+++ b/webhook/certificates/resources/certs_test.go
@@ -60,7 +60,7 @@ func TestCreateCerts(t *testing.T) {
 	}
 
 	// Verify common name
-	expectedCommonName := "got-the-hook.knative-webhook.svc"
+	const expectedCommonName = "got-the-hook.knative-webhook.svc"
 
 	if diff := cmp.Diff(caParsedCert.CommonName, expectedCommonName); diff != "" {
                 t.Fatalf("Unexpected Cert Common Name (-want +got) : %v", diff)


### PR DESCRIPTION
# Changes
This adds a common name to the certificates generated for the webhook service to
prevent issues with applications that do CN checking vs SAN checking.

This provides compatibilty for Istio v1.5

There should be no impacts because there was previously no CN on the certificate

Another approach would allow users to provide custom CA certs for this serivce

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->



