### PR TITLE
Add SendRaw to websocket client

### DIFF
--- a/websocket/connection.go
+++ b/websocket/connection.go
@@ -312,6 +312,11 @@ func (c *ManagedConnection) Send(msg interface{}) error {
 	return c.write(websocket.BinaryMessage, b.Bytes())
 }
 
+// SendRaw sends a message over the websocket connection without performing any encoding.
+func (c *ManagedConnection) SendRaw(messageType int, msg []byte) error {
+	return c.write(messageType, msg)
+}
+
 // Shutdown closes the websocket connection.
 func (c *ManagedConnection) Shutdown() error {
 	c.closeOnce.Do(func() {

--- a/websocket/connection_test.go
+++ b/websocket/connection_test.go
@@ -190,6 +190,25 @@ func TestSendMessage(t *testing.T) {
 	}
 }
 
+func TestSendRawMessage(t *testing.T) {
+	spy := &inspectableConnection{
+		writeMessageCalls: make(chan struct{}, 1),
+	}
+	conn := newConnection(staticConnFactory(spy), nil)
+	conn.connect()
+
+	if got := conn.Status(); got != nil {
+		t.Errorf("Status() = %v, wanted nil", got)
+	}
+
+	if got := conn.SendRaw(websocket.BinaryMessage, []byte("test")); got != nil {
+		t.Fatalf("Expected no error but got: %+v", got)
+	}
+	if len(spy.writeMessageCalls) != 1 {
+		t.Fatalf("Expected 'WriteMessage' to be called once, but was called %v times", spy.writeMessageCalls)
+	}
+}
+
 func TestReceiveMessage(t *testing.T) {
 	testMessage := "testmessage"
 


### PR DESCRIPTION
Allows sending non-gob-encoded data over the web socket, in service of https://github.com/knative/serving/pull/8266.
