### PR TITLE
Allow hashgen to process multiple files

### DIFF
--- a/configmap/hash-gen/main.go
+++ b/configmap/hash-gen/main.go
@@ -29,9 +29,10 @@ import (
 )
 
 func main() {
-	fileName := os.Args[1]
-	if err := processFile(fileName); err != nil {
-		log.Fatal(err)
+	for _, fileName := range os.Args[1:] {
+		if err := processFile(fileName); err != nil {
+			log.Fatal(err)
+		}
 	}
 }
 


### PR DESCRIPTION
So we can use one `go run` to process all the configmaps, avoiding recompilation each time (see https://github.com/knative/serving/pull/8281).

/assign @markusthoemmes 