### PR TITLE
Allows for webhooks to exclude certain namespaces

### DIFF
--- a/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/webhook/resourcesemantics/defaulting/defaulting.go
@@ -30,6 +30,7 @@ import (
 	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	admissionlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
@@ -172,6 +173,12 @@ func (ac *reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 			continue
 		}
 		webhook.Webhooks[i].Rules = rules
+		webhook.Webhooks[i].NamespaceSelector = &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key:      "pkg.knative.dev/skipWebhooks",
+				Operator: metav1.LabelSelectorOpDoesNotExist,
+			}},
+		}
 		webhook.Webhooks[i].ClientConfig.CABundle = caCert
 		if webhook.Webhooks[i].ClientConfig.Service == nil {
 			return fmt.Errorf("missing service reference for webhook: %s", wh.Name)

--- a/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/webhook/resourcesemantics/defaulting/defaulting.go
@@ -175,7 +175,7 @@ func (ac *reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 		webhook.Webhooks[i].Rules = rules
 		webhook.Webhooks[i].NamespaceSelector = &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{{
-				Key:      "pkg.knative.dev/skip-webhooks",
+				Key:      "webhooks.knative.dev/exclude",
 				Operator: metav1.LabelSelectorOpDoesNotExist,
 			}},
 		}

--- a/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/webhook/resourcesemantics/defaulting/defaulting.go
@@ -175,7 +175,7 @@ func (ac *reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 		webhook.Webhooks[i].Rules = rules
 		webhook.Webhooks[i].NamespaceSelector = &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{{
-				Key:      "pkg.knative.dev/skipWebhooks",
+				Key:      "pkg.knative.dev/skip-webhooks",
 				Operator: metav1.LabelSelectorOpDoesNotExist,
 			}},
 		}

--- a/webhook/resourcesemantics/defaulting/table_test.go
+++ b/webhook/resourcesemantics/defaulting/table_test.go
@@ -60,7 +60,7 @@ func TestReconcile(t *testing.T) {
 	// This is the namespace selector setup
 	namespaceSelector := &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{{
-			Key:      "pkg.knative.dev/skipWebhooks",
+			Key:      "pkg.knative.dev/skip-webhooks",
 			Operator: metav1.LabelSelectorOpDoesNotExist,
 		}},
 	}

--- a/webhook/resourcesemantics/defaulting/table_test.go
+++ b/webhook/resourcesemantics/defaulting/table_test.go
@@ -60,7 +60,7 @@ func TestReconcile(t *testing.T) {
 	// This is the namespace selector setup
 	namespaceSelector := &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{{
-			Key:      "pkg.knative.dev/skip-webhooks",
+			Key:      "webhooks.knative.dev/exclude",
 			Operator: metav1.LabelSelectorOpDoesNotExist,
 		}},
 	}

--- a/webhook/resourcesemantics/defaulting/table_test.go
+++ b/webhook/resourcesemantics/defaulting/table_test.go
@@ -57,6 +57,14 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
+	// This is the namespace selector setup
+	namespaceSelector := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      "pkg.knative.dev/skipWebhooks",
+			Operator: metav1.LabelSelectorOpDoesNotExist,
+		}},
+	}
+
 	// These are the rules we expect given the context of "handlers".
 	expectedRules := []admissionregistrationv1beta1.RuleWithOperations{{
 		Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE"},
@@ -167,7 +175,8 @@ func TestReconcile(t *testing.T) {
 						CABundle: []byte("present"),
 					},
 					// Rules are added.
-					Rules: expectedRules,
+					Rules:             expectedRules,
+					NamespaceSelector: namespaceSelector,
 				}},
 			},
 		}},
@@ -221,7 +230,8 @@ func TestReconcile(t *testing.T) {
 						CABundle: []byte("present"),
 					},
 					// Rules are fixed.
-					Rules: expectedRules,
+					Rules:             expectedRules,
+					NamespaceSelector: namespaceSelector,
 				}},
 			},
 		}},
@@ -279,7 +289,8 @@ func TestReconcile(t *testing.T) {
 						CABundle: []byte("present"),
 					},
 					// Rules are fixed.
-					Rules: expectedRules,
+					Rules:             expectedRules,
+					NamespaceSelector: namespaceSelector,
 				}},
 			},
 		}},
@@ -304,7 +315,8 @@ func TestReconcile(t *testing.T) {
 						CABundle: []byte("present"),
 					},
 					// Rules are fine.
-					Rules: expectedRules,
+					Rules:             expectedRules,
+					NamespaceSelector: namespaceSelector,
 				}},
 			},
 		},

--- a/webhook/resourcesemantics/validation/reconcile_config.go
+++ b/webhook/resourcesemantics/validation/reconcile_config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/markbates/inflect"
 	"go.uber.org/zap"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	admissionlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
@@ -135,6 +136,12 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 			continue
 		}
 		webhook.Webhooks[i].Rules = rules
+		webhook.Webhooks[i].NamespaceSelector = &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key:      "pkg.knative.dev/skipWebhooks",
+				Operator: metav1.LabelSelectorOpDoesNotExist,
+			}},
+		}
 		webhook.Webhooks[i].ClientConfig.CABundle = caCert
 		if webhook.Webhooks[i].ClientConfig.Service == nil {
 			return fmt.Errorf("missing service reference for webhook: %s", wh.Name)

--- a/webhook/resourcesemantics/validation/reconcile_config.go
+++ b/webhook/resourcesemantics/validation/reconcile_config.go
@@ -138,7 +138,7 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 		webhook.Webhooks[i].Rules = rules
 		webhook.Webhooks[i].NamespaceSelector = &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{{
-				Key:      "pkg.knative.dev/skip-webhooks",
+				Key:      "webhooks.knative.dev/exclude",
 				Operator: metav1.LabelSelectorOpDoesNotExist,
 			}},
 		}

--- a/webhook/resourcesemantics/validation/reconcile_config.go
+++ b/webhook/resourcesemantics/validation/reconcile_config.go
@@ -138,7 +138,7 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 		webhook.Webhooks[i].Rules = rules
 		webhook.Webhooks[i].NamespaceSelector = &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{{
-				Key:      "pkg.knative.dev/skipWebhooks",
+				Key:      "pkg.knative.dev/skip-webhooks",
 				Operator: metav1.LabelSelectorOpDoesNotExist,
 			}},
 		}

--- a/webhook/resourcesemantics/validation/reconcile_config_test.go
+++ b/webhook/resourcesemantics/validation/reconcile_config_test.go
@@ -60,7 +60,7 @@ func TestReconcile(t *testing.T) {
 	// This is the namespace selector setup
 	namespaceSelector := &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{{
-			Key:      "pkg.knative.dev/skipWebhooks",
+			Key:      "pkg.knative.dev/skip-webhooks",
 			Operator: metav1.LabelSelectorOpDoesNotExist,
 		}},
 	}

--- a/webhook/resourcesemantics/validation/reconcile_config_test.go
+++ b/webhook/resourcesemantics/validation/reconcile_config_test.go
@@ -57,6 +57,14 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
+	// This is the namespace selector setup
+	namespaceSelector := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      "pkg.knative.dev/skipWebhooks",
+			Operator: metav1.LabelSelectorOpDoesNotExist,
+		}},
+	}
+
 	// These are the rules we expect given the context of "handlers".
 	expectedRules := []admissionregistrationv1beta1.RuleWithOperations{{
 		Operations: []admissionregistrationv1beta1.OperationType{"CREATE", "UPDATE", "DELETE"},
@@ -167,7 +175,8 @@ func TestReconcile(t *testing.T) {
 						CABundle: []byte("present"),
 					},
 					// Rules are added.
-					Rules: expectedRules,
+					Rules:             expectedRules,
+					NamespaceSelector: namespaceSelector,
 				}},
 			},
 		}},
@@ -221,7 +230,8 @@ func TestReconcile(t *testing.T) {
 						CABundle: []byte("present"),
 					},
 					// Rules are fixed.
-					Rules: expectedRules,
+					Rules:             expectedRules,
+					NamespaceSelector: namespaceSelector,
 				}},
 			},
 		}},
@@ -279,7 +289,8 @@ func TestReconcile(t *testing.T) {
 						CABundle: []byte("present"),
 					},
 					// Rules are fixed.
-					Rules: expectedRules,
+					Rules:             expectedRules,
+					NamespaceSelector: namespaceSelector,
 				}},
 			},
 		}},
@@ -304,7 +315,8 @@ func TestReconcile(t *testing.T) {
 						CABundle: []byte("present"),
 					},
 					// Rules are fine.
-					Rules: expectedRules,
+					Rules:             expectedRules,
+					NamespaceSelector: namespaceSelector,
 				}},
 			},
 		},

--- a/webhook/resourcesemantics/validation/reconcile_config_test.go
+++ b/webhook/resourcesemantics/validation/reconcile_config_test.go
@@ -60,7 +60,7 @@ func TestReconcile(t *testing.T) {
 	// This is the namespace selector setup
 	namespaceSelector := &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{{
-			Key:      "pkg.knative.dev/skip-webhooks",
+			Key:      "webhooks.knative.dev/exclude",
 			Operator: metav1.LabelSelectorOpDoesNotExist,
 		}},
 	}


### PR DESCRIPTION
Added a namespaces selector to the mutating webhook configuration which
allows for excluding namespaces from the webhook

Fixes #1379