### PR TITLE
Always initialize conditions and set defaults when reconciling

### DIFF
--- a/reconciler/reconcile_common.go
+++ b/reconciler/reconcile_common.go
@@ -52,12 +52,12 @@ func PreProcessReconcile(ctx context.Context, resource duckv1.KRShaped) {
 // PostProcessReconcile contains logic to apply after reconciliation of a resource.
 func PostProcessReconcile(ctx context.Context, resource duckv1.KRShaped) {
 	logger := logging.FromContext(ctx)
-	newStatus := resource.GetStatus()
-	mgr := resource.GetConditionSet().Manage(newStatus)
+	status := resource.GetStatus()
+	mgr := resource.GetConditionSet().Manage(status)
 
 	// Bump observed generation to denote that we have processed this
 	// generation regardless of success or failure.
-	newStatus.ObservedGeneration = resource.GetGeneration()
+	status.ObservedGeneration = resource.GetGeneration()
 
 	if rc := mgr.GetTopLevelCondition(); rc == nil {
 		logger.Warn("A reconciliation included no top-level condition")

--- a/reconciler/reconcile_common_test.go
+++ b/reconciler/reconcile_common_test.go
@@ -34,6 +34,10 @@ type TestResource struct {
 	Status duckv1.Status `json:"status"`
 }
 
+func (t *TestResource) SetDefaults(context.Context) {
+	t.Annotations = map[string]string{"default": "was set"}
+}
+
 func (t *TestResource) GetStatus() *duckv1.Status {
 	return &t.Status
 }
@@ -71,6 +75,10 @@ func TestPreProcess(t *testing.T) {
 	krShape := duckv1.KRShaped(resource)
 
 	PreProcessReconcile(context.Background(), krShape)
+
+	if resource.Annotations["default"] != "was set" {
+		t.Errorf("Expected default annotations set got=%v", resource.Annotations)
+	}
 
 	if rc := resource.Status.GetCondition("Ready"); rc.Status != "Unknown" {
 		t.Errorf("Expected unchanged ready status got=%s want=Unknown", rc.Status)


### PR DESCRIPTION
Fixes #1401

We always want to initialize resources in case the defaults have changed or conditions have been added as we change versions (even if they haven't been written to).

We already do this for most reconcilers, but it will be easier to do in the common spot:
https://github.com/knative/serving/blob/d9d5ae4393ef31f1aa639be5bb6e9c0079e39bce/pkg/reconciler/route/route.go#L112

In the future if we can default-on-read or run this on upgrade-only it would be nice to not need to do it for every single reconciliation.