### PR TITLE
Normalize newlines in webhook example checksum.

### DIFF
--- a/configmap/example.go
+++ b/configmap/example.go
@@ -19,6 +19,7 @@ package configmap
 import (
 	"fmt"
 	"hash/crc32"
+	"regexp"
 	"strings"
 )
 
@@ -30,9 +31,14 @@ const (
 	ExampleChecksumAnnotation = "knative.dev/example-checksum"
 )
 
+var (
+	// Allows for normalizing by collapsing newlines.
+	sequentialNewlines = regexp.MustCompile("\n+")
+)
+
 // Checksum generates a checksum for the example value to be compared against
 // a respective annotation.
 // Leading and trailing spaces are ignored.
 func Checksum(value string) string {
-	return fmt.Sprintf("%08x", crc32.ChecksumIEEE([]byte(strings.TrimSpace(value))))
+	return fmt.Sprintf("%08x", crc32.ChecksumIEEE([]byte(sequentialNewlines.ReplaceAllString(strings.TrimSpace(value), `\n`))))
 }

--- a/configmap/example.go
+++ b/configmap/example.go
@@ -33,7 +33,7 @@ const (
 
 var (
 	// Allows for normalizing by collapsing newlines.
-	sequentialNewlines = regexp.MustCompile("\n+")
+	sequentialNewlines = regexp.MustCompile("(?:(?:\r)?\n)+")
 )
 
 // Checksum generates a checksum for the example value to be compared against

--- a/configmap/example.go
+++ b/configmap/example.go
@@ -33,7 +33,7 @@ const (
 
 var (
 	// Allows for normalizing by collapsing newlines.
-	sequentialNewlines = regexp.MustCompile("(?:(?:\r)?\n)+")
+	sequentialNewlines = regexp.MustCompile("(?:\r?\n)+")
 )
 
 // Checksum generates a checksum for the example value to be compared against

--- a/configmap/example_test.go
+++ b/configmap/example_test.go
@@ -26,6 +26,12 @@ func TestChecksum(t *testing.T) {
 		in:   "",
 		want: "00000000",
 	}, {
+		in:   "a somewhat\nlonger\ntext",
+		want: "2b4ed320",
+	}, {
+		in:   "a somewhat\n\n\nlonger\n\ntext",
+		want: "2b4ed320",
+	}, {
 		in:   "1",
 		want: "83dcefb7",
 	}, {

--- a/configmap/example_test.go
+++ b/configmap/example_test.go
@@ -32,6 +32,9 @@ func TestChecksum(t *testing.T) {
 		in:   "a somewhat\n\n\nlonger\n\ntext",
 		want: "2b4ed320",
 	}, {
+                in:   "a somewhat\r\n\r\n\r\nlonger\r\n\r\ntext",
+                want: "2b4ed320",
+        }, {
 		in:   "1",
 		want: "83dcefb7",
 	}, {

--- a/configmap/example_test.go
+++ b/configmap/example_test.go
@@ -32,9 +32,9 @@ func TestChecksum(t *testing.T) {
 		in:   "a somewhat\n\n\nlonger\n\ntext",
 		want: "2b4ed320",
 	}, {
-                in:   "a somewhat\r\n\r\n\r\nlonger\r\n\r\ntext",
-                want: "2b4ed320",
-        }, {
+		in:   "a somewhat\r\n\r\n\r\nlonger\r\n\r\ntext",
+		want: "2b4ed320",
+	}, {
 		in:   "1",
 		want: "83dcefb7",
 	}, {

--- a/configmap/hash-gen/testdata/add_want.yaml
+++ b/configmap/hash-gen/testdata/add_want.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: 81e8e656
+    knative.dev/example-checksum: 05d48218
 data:
   leave-me: "alone"
   _example: |

--- a/configmap/hash-gen/testdata/update_want.yaml
+++ b/configmap/hash-gen/testdata/update_want.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: 81e8e656
+    knative.dev/example-checksum: 05d48218
 data:
   leave-me: "alone"
   _example: |


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/8313

kubeclient seems to normalize newlines, which causes issues when you patch via that library.