### PR TITLE
add self to aliases and add reviewers to OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -73,5 +73,5 @@ aliases:
   - dprotaso
   - mattmoor
   - tcnghia
-  webhook-reviwers:
+  webhook-reviewers:
   - whaught

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,14 +8,20 @@ aliases:
   - mattmoor
   - vaikas
   - n3wscott
+  apis-reviewers:
+  - whaught
 
   apis-duck-approvers:
   - mattmoor
   - vaikas
+  apis-duck-reviewers:
+  - whaught
 
   codegen-approvers:
   - mattmoor
   - n3wscott
+  codegen-reviewers:
+  - whaught
 
   configmap-approvers:
   - mattmoor
@@ -28,6 +34,8 @@ aliases:
   - mattmoor
   - tcnghia
   - vagababov
+  controller-reviewers:
+  - whaught
 
   kmeta-approvers:
   - mattmoor
@@ -65,4 +73,5 @@ aliases:
   - dprotaso
   - mattmoor
   - tcnghia
-
+  webhook-reviwers:
+  - whaught

--- a/apis/OWNERS
+++ b/apis/OWNERS
@@ -2,3 +2,6 @@
 
 approvers:
 - apis-approvers
+
+reviewers:
+- apis-reviewers

--- a/apis/duck/OWNERS
+++ b/apis/duck/OWNERS
@@ -2,3 +2,6 @@
 
 approvers:
 - apis-duck-approvers
+
+reviewers:
+- apis-duck-reviewers

--- a/codegen/OWNERS
+++ b/codegen/OWNERS
@@ -2,3 +2,6 @@
 
 approvers:
 - codegen-approvers
+
+reviewers:
+- codegen-reviewers

--- a/controller/OWNERS
+++ b/controller/OWNERS
@@ -2,3 +2,6 @@
 
 approvers:
 - controller-approvers
+
+reviewers:
+- controller-reviewers

--- a/pool/OWNERS
+++ b/pool/OWNERS
@@ -3,5 +3,8 @@
 approvers:
 - controller-approvers
 
+reviewers:
+- controller-reviewers
+
 labels:
 - area/API

--- a/reconciler/OWNERS
+++ b/reconciler/OWNERS
@@ -2,3 +2,6 @@
 
 approvers:
 - controller-approvers
+
+reviewers:
+- controller-reviewers

--- a/webhook/OWNERS
+++ b/webhook/OWNERS
@@ -2,3 +2,6 @@
 
 approvers:
 - webhook-approvers
+
+reviewers:
+- webhook-reviewers


### PR DESCRIPTION
- Adding self [whaught] to reviewers for a few areas. 
- Also adding relevant reviewers sections to OWNERS files

Note: This is possibly broken up more than it needs to be. Also it may make sense to add @n3wscott into the controllers group