### PR TITLE
Add a passthrough method RegisterResourceView

### DIFF
--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -85,13 +85,24 @@ func UpdateExporterFromConfigMap(component string, logger *zap.SugaredLogger) fu
 	return ConfigMapWatcher(component, nil, logger)
 }
 
-// RegisterResourceView is placeholder for real implementation in https://github.com/knative/pkg/pull/1392.
+// RegisterResourceView is similar to view.Register(), except that it will
+// register the view across all Resources tracked by the system, rather than
+// simply the default view.
+// this is a placeholder for real implementation in https://github.com/knative/pkg/pull/1392.
 // That PR will introduce a breaking change, as we need to convert some view.Register to RegisterResourceView in
 // all callers, in serving, eventing, and eventing-contrib.
 // Since that PR is huge, a better approach is to introduce the breaking change up front, by creating this
 // passthrough method, and fixing all the callers before merging that PR.
 func RegisterResourceView(views ...*view.View) error {
 	return view.Register(views...)
+}
+
+// UnregisterResourceView is similar to view.unRegister(), except that it will
+// unregister the view across all Resources tracked by the system, rather than
+// simply the default view.
+// this is a placeholder for real implementation in https://github.com/knative/pkg/pull/1392.
+func UnregisterResourceView(views ...*view.View) {
+	view.Unregister(views...)
 }
 
 // ConfigMapWatcher returns a helper func which updates the exporter configuration based on

--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -86,7 +86,7 @@ func UpdateExporterFromConfigMap(component string, logger *zap.SugaredLogger) fu
 }
 
 // RegisterResourceView is placeholder for real implementation in https://github.com/knative/pkg/pull/1392.
-// That PR will introduce a breaking change, as we need to  all view.Register to RegisterResourceView in
+// That PR will introduce a breaking change, as we need to convert some view.Register to RegisterResourceView in
 // all callers, in serving, eventing, and eventing-contrib.
 // Since that PR is huge, a better approach is to introduce the breaking change up front, by creating this
 // passthrough method, and fixing all the callers before merging that PR.

--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -85,6 +85,15 @@ func UpdateExporterFromConfigMap(component string, logger *zap.SugaredLogger) fu
 	return ConfigMapWatcher(component, nil, logger)
 }
 
+// RegisterResourceView is placeholder for real implementation in https://github.com/knative/pkg/pull/1392.
+// That PR will introduce a breaking change, as we need to  all view.Register to RegisterResourceView in 
+// all callers, in serving, eventing, and eventing-contrib.
+// Since that PR is huge, a better approach is to introduce the breaking change up front, by creating this
+// passthrough method, and fixing all the callers before merging that PR.
+func RegisterResourceView(views ...*view.View) error {
+	return view.Register(views...)
+}
+
 // ConfigMapWatcher returns a helper func which updates the exporter configuration based on
 // values in the supplied ConfigMap. This method captures a corev1.SecretLister which is used
 // to configure mTLS with the opencensus agent.

--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -86,7 +86,7 @@ func UpdateExporterFromConfigMap(component string, logger *zap.SugaredLogger) fu
 }
 
 // RegisterResourceView is placeholder for real implementation in https://github.com/knative/pkg/pull/1392.
-// That PR will introduce a breaking change, as we need to  all view.Register to RegisterResourceView in 
+// That PR will introduce a breaking change, as we need to  all view.Register to RegisterResourceView in
 // all callers, in serving, eventing, and eventing-contrib.
 // Since that PR is huge, a better approach is to introduce the breaking change up front, by creating this
 // passthrough method, and fixing all the callers before merging that PR.


### PR DESCRIPTION
During the testing of stackdriver exporter with the dynamic labels in PR https://github.com/knative/pkg/pull/1392, we found out that we need to introduce a breaking change.

With the recorder extract the metric tags into resource labels, and send the measurement to the meter associated with the resource.  The problem is that currently `view.Register` is used, and the view only registered to the default meter, not the corresponding meter to the resource.  If we use `RegisterResourceView` instead, then it will work because it register the views to all meters.

If we merge that PR in its current form, we also need to fix all callers at the same time.  That will be too risky.  Therefore @evankanderson and I came up with this approach, by introducing the change up front.  After this one we will fix all callers(serving, eventing, eventing-contrib) to use this new method, so https://github.com/knative/pkg/pull/1392 won't be breaking change.

This will be replaced with the real implementation in https://github.com/knative/pkg/pull/1392.