### PR TITLE
Make Prometheus exporter port configurable via env

### DIFF
--- a/metrics/config.go
+++ b/metrics/config.go
@@ -67,6 +67,7 @@ const (
 	CollectorAddressKey = "metrics.opencensus-address"
 	CollectorSecureKey  = "metrics.opencensus-require-tls"
 
+	prometheusPortEnvName = "METRICS_PROMETHEUS_PORT"
 	defaultPrometheusPort = 9090
 	maxPrometheusPort     = 65535
 	minPrometheusPort     = 1024
@@ -217,11 +218,18 @@ func createMetricsConfig(ops ExporterOptions, logger *zap.SugaredLogger) (*metri
 	if mc.backendDestination == Prometheus {
 		pp := ops.PrometheusPort
 		if pp == 0 {
-			pp = defaultPrometheusPort
+			var err error
+			pp, err = prometheusPort()
+			if err != nil {
+				return nil, fmt.Errorf("failed to determine Prometheus port: %w", err)
+			}
 		}
+
 		if pp < minPrometheusPort || pp > maxPrometheusPort {
-			return nil, fmt.Errorf("invalid port %v, should between %v and %v", pp, minPrometheusPort, maxPrometheusPort)
+			return nil, fmt.Errorf("invalid port %d, should be between %d and %d",
+				pp, minPrometheusPort, maxPrometheusPort)
 		}
+
 		mc.prometheusPort = pp
 	}
 
@@ -325,6 +333,25 @@ following import:
 import (
 	_ "knative.dev/pkg/metrics/testing"
 )`, DomainEnv, DomainEnv))
+}
+
+// prometheusPort returns the TCP port number configured via the environment
+// for the Prometheus metrics exporter if it's set, a default value otherwise.
+// No validation is performed on the port value, other than ensuring that value
+// is a valid port number (16-bit unsigned integer).
+func prometheusPort() (int, error) {
+	ppStr := os.Getenv(prometheusPortEnvName)
+	if ppStr == "" {
+		return defaultPrometheusPort, nil
+	}
+
+	pp, err := strconv.ParseUint(ppStr, 10, 16)
+	if err != nil {
+		return -1, fmt.Errorf("the environment variable %q could not be parsed as a port number: %w",
+			prometheusPortEnvName, err)
+	}
+
+	return int(pp), nil
 }
 
 // JsonToMetricsOptions converts a json string of a

--- a/metrics/config_test.go
+++ b/metrics/config_test.go
@@ -17,8 +17,11 @@ package metrics
 
 import (
 	"context"
+	"math"
 	"os"
 	"path"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -135,7 +138,7 @@ var (
 			Component:      testComponent,
 			PrometheusPort: 1023,
 		},
-		expectedErr: "invalid port 1023, should between 1024 and 65535",
+		expectedErr: "invalid port 1023, should be between 1024 and 65535",
 	}, {
 		name: "tooBigPrometheusPort",
 		ops: ExporterOptions{
@@ -146,7 +149,7 @@ var (
 			Component:      testComponent,
 			PrometheusPort: 65536,
 		},
-		expectedErr: "invalid port 65536, should between 1024 and 65535",
+		expectedErr: "invalid port 65536, should be between 1024 and 65535",
 	}}
 
 	successTests = []struct {
@@ -505,42 +508,6 @@ var (
 		},
 		expectedNewExporter: true,
 	}}
-
-	envTests = []struct {
-		name           string
-		ops            ExporterOptions
-		expectedConfig metricsConfig
-	}{{
-		name: "stackdriverFromEnv",
-		ops: ExporterOptions{
-			ConfigMap: map[string]string{},
-			Domain:    servingDomain,
-			Component: testComponent,
-		},
-		expectedConfig: metricsConfig{
-			domain:                            servingDomain,
-			component:                         testComponent,
-			backendDestination:                Stackdriver,
-			reportingPeriod:                   60 * time.Second,
-			isStackdriverBackend:              true,
-			stackdriverMetricTypePrefix:       path.Join(servingDomain, testComponent),
-			stackdriverCustomMetricTypePrefix: path.Join(customMetricTypePrefix, defaultCustomMetricSubDomain, testComponent),
-		},
-	}, {
-		name: "validPrometheus",
-		ops: ExporterOptions{
-			ConfigMap: map[string]string{BackendDestinationKey: string(Prometheus)},
-			Domain:    servingDomain,
-			Component: testComponent,
-		},
-		expectedConfig: metricsConfig{
-			domain:             servingDomain,
-			component:          testComponent,
-			backendDestination: Prometheus,
-			reportingPeriod:    5 * time.Second,
-			prometheusPort:     defaultPrometheusPort,
-		},
-	}}
 )
 
 func successTestsInit() {
@@ -574,9 +541,87 @@ func TestGetMetricsConfig(t *testing.T) {
 }
 
 func TestGetMetricsConfig_fromEnv(t *testing.T) {
-	os.Setenv(defaultBackendEnvName, "stackdriver")
-	for _, test := range envTests {
+	successTests := []struct {
+		name           string
+		varName        string
+		varValue       string
+		ops            ExporterOptions
+		expectedConfig metricsConfig
+	}{{
+		name:     "Stackdriver backend from env, no config",
+		varName:  defaultBackendEnvName,
+		varValue: string(Stackdriver),
+		ops: ExporterOptions{
+			ConfigMap: map[string]string{},
+			Domain:    servingDomain,
+			Component: testComponent,
+		},
+		expectedConfig: metricsConfig{
+			domain:                            servingDomain,
+			component:                         testComponent,
+			backendDestination:                Stackdriver,
+			reportingPeriod:                   60 * time.Second,
+			isStackdriverBackend:              true,
+			stackdriverMetricTypePrefix:       path.Join(servingDomain, testComponent),
+			stackdriverCustomMetricTypePrefix: path.Join(customMetricTypePrefix, defaultCustomMetricSubDomain, testComponent),
+		},
+	}, {
+		name:     "Stackdriver backend from env, Prometheus backend from config",
+		varName:  defaultBackendEnvName,
+		varValue: string(Stackdriver),
+		ops: ExporterOptions{
+			ConfigMap: map[string]string{BackendDestinationKey: string(Prometheus)},
+			Domain:    servingDomain,
+			Component: testComponent,
+		},
+		expectedConfig: metricsConfig{
+			domain:             servingDomain,
+			component:          testComponent,
+			backendDestination: Prometheus,
+			reportingPeriod:    5 * time.Second,
+			prometheusPort:     defaultPrometheusPort,
+		},
+	}, {
+		name:     "PrometheusPort from env",
+		varName:  prometheusPortEnvName,
+		varValue: "9999",
+		ops: ExporterOptions{
+			ConfigMap: map[string]string{},
+			Domain:    servingDomain,
+			Component: testComponent,
+		},
+		expectedConfig: metricsConfig{
+			domain:             servingDomain,
+			component:          testComponent,
+			backendDestination: Prometheus,
+			reportingPeriod:    5 * time.Second,
+			prometheusPort:     9999,
+		},
+	}}
+
+	failureTests := []struct {
+		name                string
+		varName             string
+		varValue            string
+		ops                 ExporterOptions
+		expectedErrContains string
+	}{{
+		name:     "Invalid PrometheusPort from env",
+		varName:  prometheusPortEnvName,
+		varValue: strconv.Itoa(math.MaxUint16 + 1),
+		ops: ExporterOptions{
+			ConfigMap: map[string]string{},
+			Domain:    servingDomain,
+			Component: testComponent,
+		},
+		expectedErrContains: "value out of range",
+	}}
+
+	for _, test := range successTests {
 		t.Run(test.name, func(t *testing.T) {
+			os.Setenv(test.varName, test.varValue)
+			defer os.Unsetenv(test.varName)
+
 			defer ClearAll()
 			mc, err := createMetricsConfig(test.ops, TestLogger(t))
 			if err != nil {
@@ -587,7 +632,22 @@ func TestGetMetricsConfig_fromEnv(t *testing.T) {
 			}
 		})
 	}
-	os.Unsetenv(defaultBackendEnvName)
+
+	for _, test := range failureTests {
+		t.Run(test.name, func(t *testing.T) {
+			os.Setenv(test.varName, test.varValue)
+			defer os.Unsetenv(test.varName)
+
+			defer ClearAll()
+			mc, err := createMetricsConfig(test.ops, TestLogger(t))
+			if mc != nil {
+				t.Errorf("Wanted no config, got %v", mc)
+			}
+			if err == nil || !strings.Contains(err.Error(), test.expectedErrContains) {
+				t.Errorf("Wanted err to contain: %q, got: %v", test.expectedErrContains, err)
+			}
+		})
+	}
 }
 
 func TestIsNewExporterRequiredFromNilConfig(t *testing.T) {


### PR DESCRIPTION
## Proposed Changes

- Add support for a new environment variable `METRICS_PROMETHEUS_PORT` that can override the default Prometheus port in the metrics exporter.

Rational: the default port 9090 clashes with Serving's queue proxy when a receive adapter is deployed as a Knative Service. There is currently no way to make that work without explicitly disabling metrics by setting the `K_METRICS_CONFIG` env var to `""`.

Second tentative after closing knative/eventing#3316.