### PR TITLE
Add a CallIfConfigured function to be used to gate metric emission.

### DIFF
--- a/metrics/config.go
+++ b/metrics/config.go
@@ -152,11 +152,6 @@ func NewStackdriverClientConfigFromMap(config map[string]string) *StackdriverCli
 // record applies the `ros` Options to each measurement in `mss` and then records the resulting
 // measurements in the metricsConfig's designated backend.
 func (mc *metricsConfig) record(ctx context.Context, mss []stats.Measurement, ros ...stats.Options) error {
-	if mc == nil {
-		// Don't record data points if the metric config is not initialized yet.
-		// At this point, it's unclear whether should record or not.
-		return nil
-	}
 	if mc.recorder == nil {
 		return stats.RecordWithOptions(ctx, append(ros, stats.WithMeasurements(mss...))...)
 	}

--- a/metrics/record.go
+++ b/metrics/record.go
@@ -25,14 +25,27 @@ import (
 // TODO should be properly refactored and pieces should move to eventing and serving, as appropriate.
 // 	See https://github.com/knative/pkg/issues/608
 
+// Takes a function that would record a metric, and returns one that only does so if
+// the metric config has been configured.
+func CallIfConfigured(observer func(ctx context.Context, ms []stats.Measurement, ros ...stats.Options) error) func(ctx context.Context, ms []stats.Measurement, ros ...stats.Options) {
+	return func(ctx context.Context, ms []stats.Measurement, ros ...stats.Options) {
+		if getCurMetricsConfig() == nil {
+			return
+		}
+		if err := observer(ctx, ms, ros...); err != nil {
+		        // TODO: We were ignoring this?
+		}
+	}
+}
+
 // Record stores the given Measurement from `ms` in the current metrics backend.
 func Record(ctx context.Context, ms stats.Measurement, ros ...stats.Options) {
-	getCurMetricsConfig().record(ctx, []stats.Measurement{ms}, ros...)
+	CallIfConfigured(getCurMetricsConfig().record)(ctx, []stats.Measurement{ms}, ros...)
 }
 
 // RecordBatch stores the given Measurements from `mss` in the current metrics backend.
 func RecordBatch(ctx context.Context, mss ...stats.Measurement) {
-	getCurMetricsConfig().record(ctx, mss)
+	CallIfConfigured(getCurMetricsConfig().record)(ctx, mss)
 }
 
 // Buckets125 generates an array of buckets with approximate powers-of-two


### PR DESCRIPTION
Specifically, this is useful to transform the function passed into kubemetrics.
Without this gating the emission of kubeclient metrics, we emit some custom
stackdriver metrics.