### PR TITLE
Add a ShouldEmitMetrics function and use it

### DIFF
--- a/metrics/record.go
+++ b/metrics/record.go
@@ -25,14 +25,24 @@ import (
 // TODO should be properly refactored and pieces should move to eventing and serving, as appropriate.
 // 	See https://github.com/knative/pkg/issues/608
 
+// Takes a function that would record a metric, and returns one that only does so if
+// the metric config has been configured.
+func ShouldEmitMetrics() bool {
+	return getCurMetricsConfig() != nil
+}
+
 // Record stores the given Measurement from `ms` in the current metrics backend.
 func Record(ctx context.Context, ms stats.Measurement, ros ...stats.Options) {
-	getCurMetricsConfig().record(ctx, []stats.Measurement{ms}, ros...)
+	if ShouldEmitMetrics() {
+		getCurMetricsConfig().record(ctx, []stats.Measurement{ms}, ros...)
+	}
 }
 
 // RecordBatch stores the given Measurements from `mss` in the current metrics backend.
 func RecordBatch(ctx context.Context, mss ...stats.Measurement) {
-	getCurMetricsConfig().record(ctx, mss)
+	if ShouldEmitMetrics() {
+		getCurMetricsConfig().record(ctx, mss)
+	}
 }
 
 // Buckets125 generates an array of buckets with approximate powers-of-two

--- a/metrics/record.go
+++ b/metrics/record.go
@@ -25,8 +25,8 @@ import (
 // TODO should be properly refactored and pieces should move to eventing and serving, as appropriate.
 // 	See https://github.com/knative/pkg/issues/608
 
-// Takes a function that would record a metric, and returns one that only does so if
-// the metric config has been configured.
+// Returns whether the metrics configuration has been loaded and thus whether metrics
+// can begin to be recorded.
 func ShouldEmitMetrics() bool {
 	return getCurMetricsConfig() != nil
 }

--- a/metrics/record_test.go
+++ b/metrics/record_test.go
@@ -125,6 +125,9 @@ func testRecord(t *testing.T, measure *stats.Int64Measure, shouldReportCases []c
 			setCurMetricsConfig(test.metricsConfig)
 			Record(ctx, test.measurement)
 			metricstest.CheckLastValueData(t, test.measurement.Measure().Name(), map[string]string{}, test.measurement.Value())
+			if !ShouldEmitMetrics() {
+				t.Fatal("Metrics were recorded when ShouldEmitMetrics() == false")
+			}
 		})
 	}
 
@@ -154,6 +157,11 @@ func testRecord(t *testing.T, measure *stats.Int64Measure, shouldReportCases []c
 			Record(ctx, test.measurement)
 			metricstest.CheckLastValueData(t, test.measurement.Measure().Name(), map[string]string{},
 				float64(len(shouldReportCases))) // The value is still the last one of shouldReportCases
+			if test.metricsConfig == nil && ShouldEmitMetrics() {
+				t.Fatal("Metrics were recorded when there was no metrics config.")
+			} else if test.metricsConfig != nil && !ShouldEmitMetrics() {
+				t.Fatal("Metrics were not recorded when there is a metrics config.")
+			}
 		})
 	}
 }


### PR DESCRIPTION
Specifically, this is useful to transform the Metrics passed into kubemetrics.
Without this gating the emission of kubeclient metrics, we emit some custom
stackdriver metrics while we wait for the config to load / be applied.