### PR TITLE
Fix the logging in spoof

### DIFF
--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -223,7 +223,7 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker, error
 			for _, checker := range errorRetryCheckers {
 				retry, newErr := checker(err)
 				if retry {
-					sc.Logf("Retrying %s: %v", req.URL, newErr)
+					sc.Logf("Retrying %s: %v", req.URL.String(), newErr)
 					return false, nil
 				}
 			}


### PR DESCRIPTION
Currently we're getting:

```
Retrying [http://activator-with-cc.default.svc.cluster.local?sleep=100 retrying for DNS error: Get http://activator-with-cc.default.svc.cluster.local?sleep=100: dial tcp: lookup activator-with-cc.default.svc.cluster.local on 10.27.240.10:53: no such host]: %!v(MISSING)

```

Which is not cool. So fix it to report proper string.
URL is known to be non-nil here.

/assign @chizhg @chaodaiG 