### PR TITLE
Expect resources are krshaped by default

### DIFF
--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
@@ -21,6 +21,7 @@ package customresourcedefinition
 import (
 	context "context"
 	json "encoding/json"
+	fmt "fmt"
 	reflect "reflect"
 
 	zap "go.uber.org/zap"
@@ -161,7 +162,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		// Set and update the finalizer on resource if r.reconciler
 		// implements Finalizer.
 		if resource, err = r.setFinalizerIfFinalizer(ctx, resource); err != nil {
-			logger.Warnw("Failed to set finalizers", zap.Error(err))
+			return fmt.Errorf("failed to set finalizers: %w", err)
 		}
 
 		// Reconcile this copy of the resource and then write back any status
@@ -176,7 +177,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		// and reconciled cleanly (nil or normal event), remove the finalizer.
 		reconcileEvent = fin.FinalizeKind(ctx, resource)
 		if resource, err = r.clearFinalizer(ctx, resource, reconcileEvent); err != nil {
-			logger.Warnw("Failed to clear finalizers", zap.Error(err))
+			return fmt.Errorf("failed to clear finalizers: %w", err)
 		}
 	}
 

--- a/codegen/cmd/injection-gen/generators/packages.go
+++ b/codegen/cmd/injection-gen/generators/packages.go
@@ -201,7 +201,7 @@ func isKRShaped(tags map[string]map[string]string) bool {
 	if !has {
 		return false
 	}
-	return vals["krshapedlogic"] == "true"
+	return vals["krshapedlogic"] != "false"
 }
 
 func isNonNamespaced(tags map[string]map[string]string) bool {


### PR DESCRIPTION
- Switches to always generating krshapedlogic by default
    -krshapedlogic=false can be used to disable

/hold will test-integrate this with downstream
Tested and waiting on:
https://github.com/knative/eventing/pull/3356
https://github.com/knative/serving/pull/8388