### PR TITLE
Return TypeMeta as part of the conversion response

### DIFF
--- a/webhook/conversion.go
+++ b/webhook/conversion.go
@@ -54,6 +54,10 @@ func conversionHandler(rootLogger *zap.SugaredLogger, stats StatsReporter, c Con
 
 		ctx := logging.WithLogger(r.Context(), logger)
 		response := apixv1.ConversionReview{
+			// Use the same type meta as the request - this is required by the K8s API
+			// note: v1beta1 & v1 ConversionReview shapes are identical so even though
+			// we're using v1 types we still support v1beta1 conversion requests
+			TypeMeta: review.TypeMeta,
 			Response: c.Convert(ctx, review.Request),
 		}
 

--- a/webhook/conversion_integration_test.go
+++ b/webhook/conversion_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"golang.org/x/sync/errgroup"
 	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -135,6 +136,10 @@ func TestConversionValidResponse(t *testing.T) {
 
 	if reviewResponse.Response.UID != "some-uid" {
 		t.Errorf("expected the response uid to be the stubbed version")
+	}
+
+	if diff := cmp.Diff(review.TypeMeta, reviewResponse.TypeMeta); diff != "" {
+		t.Errorf("expected the response typeMeta to be the same as the request (-want, +got)\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
This is a requirement when adopting CRD v1 APIs

Addresses: https://github.com/knative/serving/issues/6584