### PR TITLE
use coordination.Leases exclusively for leader election

### DIFF
--- a/leaderelection/config.go
+++ b/leaderelection/config.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	cm "knative.dev/pkg/configmap"
 )
@@ -34,7 +35,7 @@ const configMapNameEnv = "CONFIG_LEADERELECTION_NAME"
 // This is a variable so that it may be customized in the binary entrypoint.
 var MaxBuckets uint32 = 10
 
-var validResourceLocks = sets.NewString("leases", "configmaps", "endpoints")
+var validResourceLocks = sets.NewString(resourcelock.LeasesResourceLock)
 
 // NewConfigFromMap returns a Config for the given map, or an error.
 func NewConfigFromMap(data map[string]string) (*Config, error) {

--- a/leaderelection/config.go
+++ b/leaderelection/config.go
@@ -62,7 +62,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		return nil, fmt.Errorf("buckets: value must be between %d <= %d <= %d", 1, config.Buckets, MaxBuckets)
 	}
 	if !validResourceLocks.Has(config.ResourceLock) {
-		return nil, fmt.Errorf(`resourceLock: invalid value %q: valid values are "leases","configmaps","endpoints"`, config.ResourceLock)
+		return nil, fmt.Errorf(`resourceLock: invalid value %q: valid values are "leases"`, config.ResourceLock)
 	}
 
 	return config, nil

--- a/leaderelection/config_test.go
+++ b/leaderelection/config_test.go
@@ -92,7 +92,7 @@ func TestNewConfigMapFromData(t *testing.T) {
 		data: kmeta.UnionMaps(okData(), map[string]string{
 			"resourceLock": "flarps",
 		}),
-		err: errors.New(`resourceLock: invalid value "flarps": valid values are "leases","configmaps","endpoints"`),
+		err: errors.New(`resourceLock: invalid value "flarps": valid values are "leases"`),
 	}, {
 		name: "invalid leaseDuration",
 		data: kmeta.UnionMaps(okData(), map[string]string{


### PR DESCRIPTION
Prior locks were for K8s version <1.14

Fixes: #1427

I left the plumbing of the lock setting through everything since there may be a new lock in the future we would want to switch to - if folks feel like this is unnecessary let me know and I can rip it out