### PR TITLE
Ingore files under benchmark folder

### DIFF
--- a/testutils/clustermanager/perf-tests/pkg/benchmark.go
+++ b/testutils/clustermanager/perf-tests/pkg/benchmark.go
@@ -62,13 +62,15 @@ type ClusterConfig struct {
 // here we returns all subfolder names of the root folder.
 func benchmarkNames(benchmarkRoot string) ([]string, error) {
 	names := make([]string, 0)
-	dirs, err := ioutil.ReadDir(benchmarkRoot)
+	files, err := ioutil.ReadDir(benchmarkRoot)
 	if err != nil {
 		return names, fmt.Errorf("failed to list all benchmarks under %q: %w", benchmarkRoot, err)
 	}
 
-	for _, dir := range dirs {
-		names = append(names, dir.Name())
+	for _, f := range files {
+		if f.Mode().IsDir() {
+			names = append(names, f.Name())
+		}
 	}
 	return names, nil
 }

--- a/testutils/clustermanager/perf-tests/pkg/testdir/test-benchmark
+++ b/testutils/clustermanager/perf-tests/pkg/testdir/test-benchmark
@@ -1,0 +1,1 @@
+A file will not be considered as a benchmark.


### PR DESCRIPTION
Do not consider files under the benchmark folder as benchmarks.
This PR will fix the Prow job errors after `.ko.yaml` was added to the `benchmarks` folder in serving, see https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-recreate-clusters/1275330518623195136

/cc @vagababov 