### PR TITLE
Assorted linting fixes.

### DIFF
--- a/apis/duck/typed_test.go
+++ b/apis/duck/typed_test.go
@@ -109,8 +109,8 @@ func TestInvalidResource(t *testing.T) {
 
 	_, _, got := tif.Get(SchemeGroupVersion.WithResource("resources"))
 
-	if got != testErr {
-		t.Errorf("Error = %v, want: %v", got, testErr)
+	if got != errTest {
+		t.Errorf("Error = %v, want: %v", got, errTest)
 	}
 }
 
@@ -296,7 +296,7 @@ func (bo *badObject) DeepCopyObject() runtime.Object {
 	return &badObject{}
 }
 
-var testErr = errors.New("failed to get list")
+var errTest = errors.New("failed to get list")
 
 type invalidResourceClient struct {
 	*fake.FakeDynamicClient
@@ -311,5 +311,5 @@ type invalidResource struct {
 }
 
 func (*invalidResource) List(options metav1.ListOptions) (*unstructured.UnstructuredList, error) {
-	return nil, testErr
+	return nil, errTest
 }

--- a/apis/field_error.go
+++ b/apis/field_error.go
@@ -383,7 +383,7 @@ func ErrOutOfBoundsValue(value, lower, upper interface{}, fieldPath string) *Fie
 func CheckDisallowedFields(request, maskedRequest interface{}) *FieldError {
 	if disallowed, err := kmp.CompareSetFields(request, maskedRequest); err != nil {
 		return &FieldError{
-			Message: fmt.Sprintf("Internal Error"),
+			Message: "Internal Error",
 			Paths:   []string{CurrentField},
 		}
 	} else if len(disallowed) > 0 {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -933,8 +933,8 @@ func TestStartAndShutdownWithLeaderAwareWithLostElection(t *testing.T) {
 			Spec: coordinationv1.LeaseSpec{
 				HolderIdentity:       ptr.String("not-us"),
 				LeaseDurationSeconds: ptr.Int32(3000),
-				AcquireTime:          &metav1.MicroTime{time.Now()},
-				RenewTime:            &metav1.MicroTime{time.Now().Add(3000 * time.Second)},
+				AcquireTime:          &metav1.MicroTime{Time: time.Now()},
+				RenewTime:            &metav1.MicroTime{Time: time.Now().Add(3000 * time.Second)},
 			},
 		},
 	)

--- a/reconciler/leader.go
+++ b/reconciler/leader.go
@@ -95,7 +95,6 @@ func (laf *LeaderAwareFuncs) Promote(b Bucket, enq func(Bucket, types.Namespaced
 			laf.buckets = make(map[string]Bucket, 1)
 		}
 		laf.buckets[b.Name()] = b
-		return
 	}()
 
 	if promote := laf.PromoteFunc; promote != nil {

--- a/test/ghutil/fakeghutil/fakeghutil.go
+++ b/test/ghutil/fakeghutil/fakeghutil.go
@@ -333,7 +333,7 @@ func (fgc *FakeGithubClient) CreatePullRequest(org, repo, head, base, title, bod
 
 // ListBranches lists branchs for given repo
 func (fgc *FakeGithubClient) ListBranches(org, repo string) ([]*github.Branch, error) {
-	var branches []*github.Branch
+	branches := make([]*github.Branch, 0, len(fgc.Branches))
 	for _, b := range fgc.Branches {
 		branches = append(branches, b...)
 	}

--- a/test/webhook-apicoverage/view/html_template.go
+++ b/test/webhook-apicoverage/view/html_template.go
@@ -16,11 +16,7 @@ limitations under the License.
 
 package view
 
-import (
-	"fmt"
-)
-
-var TypeCoverageTempl = fmt.Sprint(`<!DOCTYPE html>
+var TypeCoverageTempl = `<!DOCTYPE html>
 <html>
 <style type="text/css">
   <!--
@@ -81,9 +77,9 @@ var TypeCoverageTempl = fmt.Sprint(`<!DOCTYPE html>
 </table>
 </body>
 </html>
-`)
+`
 
-var AggregateCoverageTmpl = fmt.Sprint(`<!DOCTYPE html>
+var AggregateCoverageTmpl = `<!DOCTYPE html>
 <html>
 <style type="text/css">
   <!--
@@ -108,4 +104,4 @@ var AggregateCoverageTmpl = fmt.Sprint(`<!DOCTYPE html>
 </table>
 </body>
 </html>
-`)
+`

--- a/test/webhook-apicoverage/view/xml_template.go
+++ b/test/webhook-apicoverage/view/xml_template.go
@@ -16,11 +16,7 @@ limitations under the License.
 
 package view
 
-import (
-	"fmt"
-)
-
-var JunitResultTmpl = fmt.Sprint(`<testsuites>
+var JunitResultTmpl = `<testsuites>
   <testsuite name="" time="0" {{ if .IsFailedBuild }} failures="1" {{ else }} failures = "0" {{ end }} tests="0">
       <testcase name="Overall" time="0" classname="go_coverage">
 				{{ if .IsFailedBuild }}
@@ -38,4 +34,4 @@ var JunitResultTmpl = fmt.Sprint(`<testsuites>
       </testcase>
     {{end}}
   </testsuite>
-</testsuites>`)
+</testsuites>`


### PR DESCRIPTION
- Error variables should start with "err" or "Err".
- Remove unnecessary `fmt.Sprint[f]`.
- Remove redundant `return`.
- Preallocate slices where possible.