### PR TITLE
Use TraceContextB3Egress for spoof client

### DIFF
--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -135,7 +135,7 @@ func New(
 	// Enable Zipkin tracing
 	roundTripper := &ochttp.Transport{
 		Base:        transport,
-		Propagation: tracecontextb3.TraceContextEgress,
+		Propagation: tracecontextb3.TraceContextB3Egress,
 	}
 
 	sc := SpoofingClient{


### PR DESCRIPTION
Serving's TestShouldHaveHeadersSet expects `x-b3-spanid` and
`x-b3-traceid` headers from client, but it was removed by https://github.com/knative/pkg/commit/5658d93fb07ee641a4e0155f3f9c262da7199035.

Due to this, non-Istio ingress like Kourier and Contour started failing the conformance test:

https://testgrid.knative.dev/serving#kourier-stable&include-filter-by-regex=TestShouldHaveHeadersSet
https://testgrid.knative.dev/serving#contour-latest&include-filter-by-regex=TestShouldHaveHeadersSet

So this patch changes to use TraceContextB3Egress for spoof client.