### PR TITLE
[release-0.15] Have the webhook responses return TypeMeta

### DIFF
--- a/webhook/admission.go
+++ b/webhook/admission.go
@@ -88,7 +88,13 @@ func admissionHandler(rootLogger *zap.SugaredLogger, stats StatsReporter, c Admi
 
 		ctx := logging.WithLogger(r.Context(), logger)
 
-		var response admissionv1beta1.AdmissionReview
+		response := admissionv1beta1.AdmissionReview{
+			// Use the same type meta as the request - this is required by the K8s API
+			// note: v1beta1 & v1 AdmissionReview shapes are identical so even though
+			// we're using v1 types we still support v1beta1 admission requests
+			TypeMeta: review.TypeMeta,
+		}
+
 		reviewResponse := c.Admit(ctx, review.Request)
 		var patchType string
 		if reviewResponse.PatchType != nil {

--- a/webhook/admission_integration_test.go
+++ b/webhook/admission_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"golang.org/x/sync/errgroup"
 	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
@@ -154,6 +155,11 @@ func TestAdmissionValidResponseForResource(t *testing.T) {
 		err = json.NewDecoder(bytes.NewReader(responseBody)).Decode(&reviewResponse)
 		if err != nil {
 			t.Errorf("Failed to decode response: %v", err)
+			return
+		}
+
+		if diff := cmp.Diff(rev.TypeMeta, reviewResponse.TypeMeta); diff != "" {
+			t.Errorf("expected the response typeMeta to be the same as the request (-want, +got)\n%s", diff)
 			return
 		}
 	}()

--- a/webhook/conversion.go
+++ b/webhook/conversion.go
@@ -54,6 +54,10 @@ func conversionHandler(rootLogger *zap.SugaredLogger, stats StatsReporter, c Con
 
 		ctx := logging.WithLogger(r.Context(), logger)
 		response := apixv1beta1.ConversionReview{
+			// Use the same type meta as the request - this is required by the K8s API
+			// note: v1beta1 & v1 ConversionReview shapes are identical so even though
+			// we're using v1 types we still support v1beta1 conversion requests
+			TypeMeta: review.TypeMeta,
 			Response: c.Convert(ctx, review.Request),
 		}
 

--- a/webhook/conversion_integration_test.go
+++ b/webhook/conversion_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"golang.org/x/sync/errgroup"
 	apixv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -135,6 +136,10 @@ func TestConversionValidResponse(t *testing.T) {
 
 	if reviewResponse.Response.UID != "some-uid" {
 		t.Errorf("expected the response uid to be the stubbed version")
+	}
+
+	if diff := cmp.Diff(review.TypeMeta, reviewResponse.TypeMeta); diff != "" {
+		t.Errorf("expected the response typeMeta to be the same as the request (-want, +got)\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
This is required for v1 APIs and it's blocking smooth upgrades from 0.15 to 0.16

https://github.com/knative/eventing/pull/3409#issuecomment-649703275