### PR TITLE
Enable use of StatefulSet in sharedmain.

### DIFF
--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -241,7 +241,7 @@ func WebhookMainWithConfig(ctx context.Context, component string, cfg *rest.Conf
 	leConfig := leaderElectionConfig.GetComponentConfig(component)
 	if leConfig.LeaderElect {
 		// Signal that we are executing in a context with leader election.
-		ctx = kle.WithStandardLeaderElectorBuilder(ctx, kubeclient.Get(ctx), leConfig)
+		ctx = kle.WithDynamicLeaderElectorBuilder(ctx, kubeclient.Get(ctx), leConfig)
 	}
 
 	controllers, webhooks := ControllersAndWebhooksFromCtors(ctx, cmw, ctors...)

--- a/leaderelection/config.go
+++ b/leaderelection/config.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/kelseyhightower/envconfig"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -129,9 +130,22 @@ type ComponentConfig struct {
 // StatefulSetConfig represents the required information for a StatefulSet service.
 type StatefulSetConfig struct {
 	StatefulSetName string
-	ServiceName     string
-	Port            string
-	Protocol        string
+	ServiceName     string `envconfig:"STATEFUL_SERVICE_NAME" required:"true"`
+	Port            string `envconfig:"STATEFUL_SERVICE_PORT" default:"80"`
+	Protocol        string `envconfig:"STATEFUL_SERVICE_PROTOCOL" default:"http"`
+}
+
+func NewStatefulSetConfig() (*StatefulSetConfig, error) {
+	var ssc StatefulSetConfig
+	ssn, _, err := ParseControllerOrdinal()
+	if err != nil {
+		return nil, err
+	}
+	ssc.StatefulSetName = ssn
+	if err := envconfig.Process("", &ssc); err != nil {
+		return nil, err
+	}
+	return &ssc, nil
 }
 
 func defaultComponentConfig(name string) ComponentConfig {

--- a/leaderelection/context.go
+++ b/leaderelection/context.go
@@ -33,6 +33,16 @@ import (
 	"knative.dev/pkg/system"
 )
 
+// WithDynamicLeaderElectorBuilder sets up the statefulset elector based on environment,
+// falling back on the standard elector.
+func WithDynamicLeaderElectorBuilder(ctx context.Context, kc kubernetes.Interface, cc ComponentConfig) context.Context {
+	ssc, err := NewStatefulSetConfig()
+	if err == nil {
+		return WithStatefulSetLeaderElectorBuilder(ctx, cc, *ssc)
+	}
+	return WithStandardLeaderElectorBuilder(ctx, kc, cc)
+}
+
 // WithStandardLeaderElectorBuilder infuses a context with the ability to build
 // LeaderElectors with the provided component configuration acquiring resource
 // locks via the provided kubernetes client.

--- a/leaderelection/ordinal.go
+++ b/leaderelection/ordinal.go
@@ -27,13 +27,20 @@ import (
 // should be set to the pod name via the downward API.
 const controllerOrdinalEnv = "CONTROLLER_ORDINAL"
 
+// ParseControllerOrdinal returns the parts of the StatefulSet's pod name.
+func ParseControllerOrdinal() (string, uint64, error) {
+	v := os.Getenv(controllerOrdinalEnv)
+	if i := strings.LastIndex(v, "-"); i != -1 {
+		ui, err := strconv.ParseUint(v[i+1:], 10, 64)
+		return v[:i], ui, err
+	}
+
+	return "", 0, fmt.Errorf("ordinal not found in %s=%s", controllerOrdinalEnv, v)
+}
+
 // ControllerOrdinal tries to get ordinal from the pod name of a StatefulSet,
 // which is provided from the environment variable CONTROLLER_ORDINAL.
 func ControllerOrdinal() (uint64, error) {
-	v := os.Getenv(controllerOrdinalEnv)
-	if i := strings.LastIndex(v, "-"); i != -1 {
-		return strconv.ParseUint(v[i+1:], 10, 64)
-	}
-
-	return 0, fmt.Errorf("ordinal not found in %s=%s", controllerOrdinalEnv, v)
+	_, ui, err := ParseControllerOrdinal()
+	return ui, err
 }

--- a/leaderelection/ordinal_test.go
+++ b/leaderelection/ordinal_test.go
@@ -24,10 +24,11 @@ import (
 
 func TestControllerOrdinal(t *testing.T) {
 	testCases := []struct {
-		testname string
-		podName  string
-		want     uint64
-		err      error
+		testname    string
+		podName     string
+		wantName    string
+		wantOrdinal uint64
+		err         error
 	}{{
 		testname: "NotSet",
 		err:      fmt.Errorf("ordinal not found in %s=", controllerOrdinalEnv),
@@ -40,12 +41,15 @@ func TestControllerOrdinal(t *testing.T) {
 		podName:  "as-invalid",
 		err:      fmt.Errorf(`strconv.ParseUint: parsing "invalid": invalid syntax`),
 	}, {
-		testname: "ValidName",
-		podName:  "as-0",
+		testname:    "ValidName",
+		podName:     "as-0",
+		wantName:    "as",
+		wantOrdinal: 0,
 	}, {
-		testname: "ValidName",
-		podName:  "as-1",
-		want:     1,
+		testname:    "ValidName",
+		podName:     "as-1",
+		wantName:    "as",
+		wantOrdinal: 1,
 	}}
 
 	defer os.Unsetenv(controllerOrdinalEnv)
@@ -57,15 +61,26 @@ func TestControllerOrdinal(t *testing.T) {
 				}
 			}
 
-			got, gotErr := ControllerOrdinal()
+			gotOrdinal, gotOrdinalErr := ControllerOrdinal()
 			if tt.err != nil {
-				if gotErr == nil || gotErr.Error() != tt.err.Error() {
-					t.Errorf("got %v, want = %v, ", gotErr, tt.err)
+				if gotOrdinalErr == nil || gotOrdinalErr.Error() != tt.err.Error() {
+					t.Errorf("got %v, want = %v, ", gotOrdinalErr, tt.err)
 				}
-			} else if gotErr != nil {
-				t.Error("ControllerOrdinal() =", gotErr)
-			} else if got != tt.want {
-				t.Errorf("ControllerOrdinal() = %d, want = %d", got, tt.want)
+			} else if gotOrdinalErr != nil {
+				t.Error("ControllerOrdinal() = ", gotOrdinalErr)
+			} else if gotOrdinal != tt.wantOrdinal {
+				t.Errorf("ControllerOrdinal() = %d, want = %d", gotOrdinal, tt.wantOrdinal)
+			}
+
+			gotName, _, gotNameErr := ParseControllerOrdinal()
+			if tt.err != nil {
+				if gotNameErr == nil || gotNameErr.Error() != tt.err.Error() {
+					t.Errorf("got %v, want = %v, ", gotNameErr, tt.err)
+				}
+			} else if gotNameErr != nil {
+				t.Error("ParseControllerOrdinal() = ", gotNameErr)
+			} else if gotName != tt.wantName {
+				t.Errorf("ParseControllerOrdinal() = %s, want = %s", gotName, tt.wantName)
 			}
 		})
 	}


### PR DESCRIPTION
This change allows for (just webhook for now) controllers going through sharedmain to opt into Yanwei's logic by setting several environment variables.

I was able to pull this change in downstream and change the webhook to use a StatefulSet with the following environment:
```
+        # These settings are used for statefulset-based
+        # leader selection.
+        - name: CONTROLLER_ORDINAL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: STATEFUL_SERVICE_NAME
+          value: "webhook"
```

Running the above with 10 replicas and 10 buckets worked as intended (keys were evenly distributed across the replicas).