### PR TITLE
Add an option to skip automated status updates in a reconciler.

### DIFF
--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/controller.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/controller.go
@@ -102,6 +102,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		if opts.AgentName != "" {
 			agentName = opts.AgentName
 		}
+		if opts.SkipStatusUpdates {
+			rec.skipStatusUpdates = true
+		}
 	}
 
 	rec.Recorder = createRecorder(ctx, agentName)

--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
@@ -108,6 +108,10 @@ type reconcilerImpl struct {
 
 	// finalizerName is the name of the finalizer to reconcile.
 	finalizerName string
+
+	// skipStatusUpdates configures whether or not this reconciler automatically updates
+	// the status of the reconciled resource.
+	skipStatusUpdates bool
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -254,20 +258,22 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		reconcileEvent = rof.ObserveFinalizeKind(ctx, resource)
 	}
 
-	// Synchronize the status.
-	if equality.Semantic.DeepEqual(original.Status, resource.Status) {
-		// If we didn't change anything then don't call updateStatus.
-		// This is important because the copy we loaded from the injectionInformer's
-		// cache may be stale and we don't want to overwrite a prior update
-		// to status with this stale state.
-	} else if !isLeader {
-		logger.Warn("Saw status changes when we aren't the leader!")
-		// TODO: Consider logging the diff at Debug?
-	} else if err = r.updateStatus(original, resource); err != nil {
-		logger.Warnw("Failed to update resource status", zap.Error(err))
-		r.Recorder.Eventf(resource, corev1.EventTypeWarning, "UpdateFailed",
-			"Failed to update status for %q: %v", resource.Name, err)
-		return err
+	if r.skipStatusUpdates {
+		// Synchronize the status.
+		if equality.Semantic.DeepEqual(original.Status, resource.Status) {
+			// If we didn't change anything then don't call updateStatus.
+			// This is important because the copy we loaded from the injectionInformer's
+			// cache may be stale and we don't want to overwrite a prior update
+			// to status with this stale state.
+		} else if !isLeader {
+			logger.Warn("Saw status changes when we aren't the leader!")
+			// TODO: Consider logging the diff at Debug?
+		} else if err = r.updateStatus(original, resource); err != nil {
+			logger.Warnw("Failed to update resource status", zap.Error(err))
+			r.Recorder.Eventf(resource, corev1.EventTypeWarning, "UpdateFailed",
+				"Failed to update status for %q: %v", resource.Name, err)
+			return err
+		}
 	}
 
 	// Report the reconciler event, if any.

--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
@@ -258,7 +258,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		reconcileEvent = rof.ObserveFinalizeKind(ctx, resource)
 	}
 
-	if r.skipStatusUpdates {
+	if !r.skipStatusUpdates {
 		// Synchronize the status.
 		if equality.Semantic.DeepEqual(original.Status, resource.Status) {
 			// If we didn't change anything then don't call updateStatus.

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/controller.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/controller.go
@@ -102,6 +102,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		if opts.AgentName != "" {
 			agentName = opts.AgentName
 		}
+		if opts.SkipStatusUpdates {
+			rec.skipStatusUpdates = true
+		}
 	}
 
 	rec.Recorder = createRecorder(ctx, agentName)

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
@@ -108,6 +108,10 @@ type reconcilerImpl struct {
 
 	// finalizerName is the name of the finalizer to reconcile.
 	finalizerName string
+
+	// skipStatusUpdates configures whether or not this reconciler automatically updates
+	// the status of the reconciled resource.
+	skipStatusUpdates bool
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -254,20 +258,22 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		reconcileEvent = rof.ObserveFinalizeKind(ctx, resource)
 	}
 
-	// Synchronize the status.
-	if equality.Semantic.DeepEqual(original.Status, resource.Status) {
-		// If we didn't change anything then don't call updateStatus.
-		// This is important because the copy we loaded from the injectionInformer's
-		// cache may be stale and we don't want to overwrite a prior update
-		// to status with this stale state.
-	} else if !isLeader {
-		logger.Warn("Saw status changes when we aren't the leader!")
-		// TODO: Consider logging the diff at Debug?
-	} else if err = r.updateStatus(original, resource); err != nil {
-		logger.Warnw("Failed to update resource status", zap.Error(err))
-		r.Recorder.Eventf(resource, v1.EventTypeWarning, "UpdateFailed",
-			"Failed to update status for %q: %v", resource.Name, err)
-		return err
+	if r.skipStatusUpdates {
+		// Synchronize the status.
+		if equality.Semantic.DeepEqual(original.Status, resource.Status) {
+			// If we didn't change anything then don't call updateStatus.
+			// This is important because the copy we loaded from the injectionInformer's
+			// cache may be stale and we don't want to overwrite a prior update
+			// to status with this stale state.
+		} else if !isLeader {
+			logger.Warn("Saw status changes when we aren't the leader!")
+			// TODO: Consider logging the diff at Debug?
+		} else if err = r.updateStatus(original, resource); err != nil {
+			logger.Warnw("Failed to update resource status", zap.Error(err))
+			r.Recorder.Eventf(resource, v1.EventTypeWarning, "UpdateFailed",
+				"Failed to update status for %q: %v", resource.Name, err)
+			return err
+		}
 	}
 
 	// Report the reconciler event, if any.

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
@@ -258,7 +258,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		reconcileEvent = rof.ObserveFinalizeKind(ctx, resource)
 	}
 
-	if r.skipStatusUpdates {
+	if !r.skipStatusUpdates {
 		// Synchronize the status.
 		if equality.Semantic.DeepEqual(original.Status, resource.Status) {
 			// If we didn't change anything then don't call updateStatus.

--- a/client/injection/kube/reconciler/core/v1/namespace/controller.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/controller.go
@@ -100,6 +100,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		if opts.AgentName != "" {
 			agentName = opts.AgentName
 		}
+		if opts.SkipStatusUpdates {
+			rec.skipStatusUpdates = true
+		}
 	}
 
 	rec.Recorder = createRecorder(ctx, agentName)

--- a/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
@@ -107,6 +107,10 @@ type reconcilerImpl struct {
 
 	// finalizerName is the name of the finalizer to reconcile.
 	finalizerName string
+
+	// skipStatusUpdates configures whether or not this reconciler automatically updates
+	// the status of the reconciled resource.
+	skipStatusUpdates bool
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -253,20 +257,22 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		reconcileEvent = rof.ObserveFinalizeKind(ctx, resource)
 	}
 
-	// Synchronize the status.
-	if equality.Semantic.DeepEqual(original.Status, resource.Status) {
-		// If we didn't change anything then don't call updateStatus.
-		// This is important because the copy we loaded from the injectionInformer's
-		// cache may be stale and we don't want to overwrite a prior update
-		// to status with this stale state.
-	} else if !isLeader {
-		logger.Warn("Saw status changes when we aren't the leader!")
-		// TODO: Consider logging the diff at Debug?
-	} else if err = r.updateStatus(original, resource); err != nil {
-		logger.Warnw("Failed to update resource status", zap.Error(err))
-		r.Recorder.Eventf(resource, v1.EventTypeWarning, "UpdateFailed",
-			"Failed to update status for %q: %v", resource.Name, err)
-		return err
+	if r.skipStatusUpdates {
+		// Synchronize the status.
+		if equality.Semantic.DeepEqual(original.Status, resource.Status) {
+			// If we didn't change anything then don't call updateStatus.
+			// This is important because the copy we loaded from the injectionInformer's
+			// cache may be stale and we don't want to overwrite a prior update
+			// to status with this stale state.
+		} else if !isLeader {
+			logger.Warn("Saw status changes when we aren't the leader!")
+			// TODO: Consider logging the diff at Debug?
+		} else if err = r.updateStatus(original, resource); err != nil {
+			logger.Warnw("Failed to update resource status", zap.Error(err))
+			r.Recorder.Eventf(resource, v1.EventTypeWarning, "UpdateFailed",
+				"Failed to update status for %q: %v", resource.Name, err)
+			return err
+		}
 	}
 
 	// Report the reconciler event, if any.

--- a/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
@@ -257,7 +257,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		reconcileEvent = rof.ObserveFinalizeKind(ctx, resource)
 	}
 
-	if r.skipStatusUpdates {
+	if !r.skipStatusUpdates {
 		// Synchronize the status.
 		if equality.Semantic.DeepEqual(original.Status, resource.Status) {
 			// If we didn't change anything then don't call updateStatus.

--- a/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -245,6 +245,9 @@ func NewImpl(ctx {{.contextContext|raw}}, r Interface{{if .hasClass}}, classValu
 		if opts.AgentName != "" {
 			agentName = opts.AgentName
 		}
+		if opts.SkipStatusUpdates {
+			rec.skipStatusUpdates = true
+		}
 	}
 
 	rec.Recorder = createRecorder(ctx, agentName)

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -430,7 +430,7 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 		reconcileEvent = rof.ObserveFinalizeKind(ctx, resource)
 	}
 
-	if r.skipStatusUpdates {
+	if !r.skipStatusUpdates {
 		// Synchronize the status.
 		if {{.equalitySemantic|raw}}.DeepEqual(original.Status, resource.Status) {
 			// If we didn't change anything then don't call updateStatus.

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -255,6 +255,10 @@ type reconcilerImpl struct {
 	// finalizerName is the name of the finalizer to reconcile.
 	finalizerName string
 
+	// skipStatusUpdates configures whether or not this reconciler automatically updates
+	// the status of the reconciled resource.
+	skipStatusUpdates bool
+
 	{{if .hasClass}}
 	// classValue is the resource annotation[{{ .class }}] instance value this reconciler instance filters on.
 	classValue string
@@ -426,20 +430,22 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 		reconcileEvent = rof.ObserveFinalizeKind(ctx, resource)
 	}
 
-	// Synchronize the status.
-	if {{.equalitySemantic|raw}}.DeepEqual(original.Status, resource.Status) {
-		// If we didn't change anything then don't call updateStatus.
-		// This is important because the copy we loaded from the injectionInformer's
-		// cache may be stale and we don't want to overwrite a prior update
-		// to status with this stale state.
-	} else if !isLeader {
-		logger.Warn("Saw status changes when we aren't the leader!")
-		// TODO: Consider logging the diff at Debug?
-	} else if err = r.updateStatus(original, resource); err != nil {
-		logger.Warnw("Failed to update resource status", zap.Error(err))
-		r.Recorder.Eventf(resource, {{.corev1EventTypeWarning|raw}}, "UpdateFailed",
-			"Failed to update status for %q: %v", resource.Name, err)
-		return err
+	if r.skipStatusUpdates {
+		// Synchronize the status.
+		if {{.equalitySemantic|raw}}.DeepEqual(original.Status, resource.Status) {
+			// If we didn't change anything then don't call updateStatus.
+			// This is important because the copy we loaded from the injectionInformer's
+			// cache may be stale and we don't want to overwrite a prior update
+			// to status with this stale state.
+		} else if !isLeader {
+			logger.Warn("Saw status changes when we aren't the leader!")
+			// TODO: Consider logging the diff at Debug?
+		} else if err = r.updateStatus(original, resource); err != nil {
+			logger.Warnw("Failed to update resource status", zap.Error(err))
+			r.Recorder.Eventf(resource, {{.corev1EventTypeWarning|raw}}, "UpdateFailed",
+				"Failed to update status for %q: %v", resource.Name, err)
+			return err
+		}
 	}
 
 	// Report the reconciler event, if any.

--- a/controller/options.go
+++ b/controller/options.go
@@ -31,6 +31,10 @@ type Options struct {
 	// AgentName is the name of the agent this reconciler uses. This overrides
 	// the default controller's agent name.
 	AgentName string
+
+	// SkipStatusUpdates configures this reconciler to either do automated status
+	// updates (default) or skip them if this is set to true.
+	SkipStatusUpdates bool
 }
 
 // OptionsFn is a callback method signature that accepts an Impl and returns


### PR DESCRIPTION
This option is necessary to be able to create reconcilers like Serving's labeler, that is purely adding labels to resources. If that fails, the new automated observed generation handling changes the status and that gets written to the API currently, which is not desired.