### PR TITLE
Update generated reconciler code with a switch

### DIFF
--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
@@ -258,17 +258,22 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		reconcileEvent = rof.ObserveFinalizeKind(ctx, resource)
 	}
 
-	if !r.skipStatusUpdates {
-		// Synchronize the status.
-		if equality.Semantic.DeepEqual(original.Status, resource.Status) {
-			// If we didn't change anything then don't call updateStatus.
-			// This is important because the copy we loaded from the injectionInformer's
-			// cache may be stale and we don't want to overwrite a prior update
-			// to status with this stale state.
-		} else if !isLeader {
-			logger.Warn("Saw status changes when we aren't the leader!")
-			// TODO: Consider logging the diff at Debug?
-		} else if err = r.updateStatus(original, resource); err != nil {
+	// Synchronize the status.
+	switch {
+	case !r.skipStatusUpdates:
+		// This reconciler implementation is configured to skip resource updates.
+		// This may mean this reconciler does not observe spec, but reconciles external changes.
+	case !isLeader:
+		// High-availability reconcilers may have many replicas watching the resource, but only
+		// the elected leader is expected to write modifications.
+		logger.Warn("Saw status changes when we aren't the leader!")
+	case equality.Semantic.DeepEqual(original.Status, resource.Status):
+		// If we didn't change anything then don't call updateStatus.
+		// This is important because the copy we loaded from the injectionInformer's
+		// cache may be stale and we don't want to overwrite a prior update
+		// to status with this stale state.
+	default:
+		if err = r.updateStatus(original, resource); err != nil {
 			logger.Warnw("Failed to update resource status", zap.Error(err))
 			r.Recorder.Eventf(resource, corev1.EventTypeWarning, "UpdateFailed",
 				"Failed to update status for %q: %v", resource.Name, err)

--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
@@ -260,7 +260,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	// Synchronize the status.
 	switch {
-	case !r.skipStatusUpdates:
+	case r.skipStatusUpdates:
 		// This reconciler implementation is configured to skip resource updates.
 		// This may mean this reconciler does not observe spec, but reconciles external changes.
 	case !isLeader:

--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
@@ -263,15 +263,15 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	case r.skipStatusUpdates:
 		// This reconciler implementation is configured to skip resource updates.
 		// This may mean this reconciler does not observe spec, but reconciles external changes.
-	case !isLeader:
-		// High-availability reconcilers may have many replicas watching the resource, but only
-		// the elected leader is expected to write modifications.
-		logger.Warn("Saw status changes when we aren't the leader!")
 	case equality.Semantic.DeepEqual(original.Status, resource.Status):
 		// If we didn't change anything then don't call updateStatus.
 		// This is important because the copy we loaded from the injectionInformer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
+	case !isLeader:
+		// High-availability reconcilers may have many replicas watching the resource, but only
+		// the elected leader is expected to write modifications.
+		logger.Warn("Saw status changes when we aren't the leader!")
 	default:
 		if err = r.updateStatus(original, resource); err != nil {
 			logger.Warnw("Failed to update resource status", zap.Error(err))

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
@@ -258,17 +258,22 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		reconcileEvent = rof.ObserveFinalizeKind(ctx, resource)
 	}
 
-	if !r.skipStatusUpdates {
-		// Synchronize the status.
-		if equality.Semantic.DeepEqual(original.Status, resource.Status) {
-			// If we didn't change anything then don't call updateStatus.
-			// This is important because the copy we loaded from the injectionInformer's
-			// cache may be stale and we don't want to overwrite a prior update
-			// to status with this stale state.
-		} else if !isLeader {
-			logger.Warn("Saw status changes when we aren't the leader!")
-			// TODO: Consider logging the diff at Debug?
-		} else if err = r.updateStatus(original, resource); err != nil {
+	// Synchronize the status.
+	switch {
+	case !r.skipStatusUpdates:
+		// This reconciler implementation is configured to skip resource updates.
+		// This may mean this reconciler does not observe spec, but reconciles external changes.
+	case !isLeader:
+		// High-availability reconcilers may have many replicas watching the resource, but only
+		// the elected leader is expected to write modifications.
+		logger.Warn("Saw status changes when we aren't the leader!")
+	case equality.Semantic.DeepEqual(original.Status, resource.Status):
+		// If we didn't change anything then don't call updateStatus.
+		// This is important because the copy we loaded from the injectionInformer's
+		// cache may be stale and we don't want to overwrite a prior update
+		// to status with this stale state.
+	default:
+		if err = r.updateStatus(original, resource); err != nil {
 			logger.Warnw("Failed to update resource status", zap.Error(err))
 			r.Recorder.Eventf(resource, v1.EventTypeWarning, "UpdateFailed",
 				"Failed to update status for %q: %v", resource.Name, err)

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
@@ -260,7 +260,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	// Synchronize the status.
 	switch {
-	case !r.skipStatusUpdates:
+	case r.skipStatusUpdates:
 		// This reconciler implementation is configured to skip resource updates.
 		// This may mean this reconciler does not observe spec, but reconciles external changes.
 	case !isLeader:

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
@@ -263,15 +263,15 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	case r.skipStatusUpdates:
 		// This reconciler implementation is configured to skip resource updates.
 		// This may mean this reconciler does not observe spec, but reconciles external changes.
-	case !isLeader:
-		// High-availability reconcilers may have many replicas watching the resource, but only
-		// the elected leader is expected to write modifications.
-		logger.Warn("Saw status changes when we aren't the leader!")
 	case equality.Semantic.DeepEqual(original.Status, resource.Status):
 		// If we didn't change anything then don't call updateStatus.
 		// This is important because the copy we loaded from the injectionInformer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
+	case !isLeader:
+		// High-availability reconcilers may have many replicas watching the resource, but only
+		// the elected leader is expected to write modifications.
+		logger.Warn("Saw status changes when we aren't the leader!")
 	default:
 		if err = r.updateStatus(original, resource); err != nil {
 			logger.Warnw("Failed to update resource status", zap.Error(err))

--- a/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
@@ -259,7 +259,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	// Synchronize the status.
 	switch {
-	case !r.skipStatusUpdates:
+	case r.skipStatusUpdates:
 		// This reconciler implementation is configured to skip resource updates.
 		// This may mean this reconciler does not observe spec, but reconciles external changes.
 	case !isLeader:

--- a/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
@@ -262,15 +262,15 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	case r.skipStatusUpdates:
 		// This reconciler implementation is configured to skip resource updates.
 		// This may mean this reconciler does not observe spec, but reconciles external changes.
-	case !isLeader:
-		// High-availability reconcilers may have many replicas watching the resource, but only
-		// the elected leader is expected to write modifications.
-		logger.Warn("Saw status changes when we aren't the leader!")
 	case equality.Semantic.DeepEqual(original.Status, resource.Status):
 		// If we didn't change anything then don't call updateStatus.
 		// This is important because the copy we loaded from the injectionInformer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
+	case !isLeader:
+		// High-availability reconcilers may have many replicas watching the resource, but only
+		// the elected leader is expected to write modifications.
+		logger.Warn("Saw status changes when we aren't the leader!")
 	default:
 		if err = r.updateStatus(original, resource); err != nil {
 			logger.Warnw("Failed to update resource status", zap.Error(err))

--- a/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
@@ -257,17 +257,22 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		reconcileEvent = rof.ObserveFinalizeKind(ctx, resource)
 	}
 
-	if !r.skipStatusUpdates {
-		// Synchronize the status.
-		if equality.Semantic.DeepEqual(original.Status, resource.Status) {
-			// If we didn't change anything then don't call updateStatus.
-			// This is important because the copy we loaded from the injectionInformer's
-			// cache may be stale and we don't want to overwrite a prior update
-			// to status with this stale state.
-		} else if !isLeader {
-			logger.Warn("Saw status changes when we aren't the leader!")
-			// TODO: Consider logging the diff at Debug?
-		} else if err = r.updateStatus(original, resource); err != nil {
+	// Synchronize the status.
+	switch {
+	case !r.skipStatusUpdates:
+		// This reconciler implementation is configured to skip resource updates.
+		// This may mean this reconciler does not observe spec, but reconciles external changes.
+	case !isLeader:
+		// High-availability reconcilers may have many replicas watching the resource, but only
+		// the elected leader is expected to write modifications.
+		logger.Warn("Saw status changes when we aren't the leader!")
+	case equality.Semantic.DeepEqual(original.Status, resource.Status):
+		// If we didn't change anything then don't call updateStatus.
+		// This is important because the copy we loaded from the injectionInformer's
+		// cache may be stale and we don't want to overwrite a prior update
+		// to status with this stale state.
+	default:
+		if err = r.updateStatus(original, resource); err != nil {
 			logger.Warnw("Failed to update resource status", zap.Error(err))
 			r.Recorder.Eventf(resource, v1.EventTypeWarning, "UpdateFailed",
 				"Failed to update status for %q: %v", resource.Name, err)

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -435,15 +435,15 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 	case r.skipStatusUpdates:
 		// This reconciler implementation is configured to skip resource updates.
 		// This may mean this reconciler does not observe spec, but reconciles external changes.
-	case !isLeader:
-		// High-availability reconcilers may have many replicas watching the resource, but only
-		// the elected leader is expected to write modifications.
-		logger.Warn("Saw status changes when we aren't the leader!")
 	case {{.equalitySemantic|raw}}.DeepEqual(original.Status, resource.Status):
 		// If we didn't change anything then don't call updateStatus.
 		// This is important because the copy we loaded from the injectionInformer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
+	case !isLeader:
+		// High-availability reconcilers may have many replicas watching the resource, but only
+		// the elected leader is expected to write modifications.
+		logger.Warn("Saw status changes when we aren't the leader!")
 	default:
 		if err = r.updateStatus(original, resource); err != nil {
 			logger.Warnw("Failed to update resource status", zap.Error(err))

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -430,17 +430,22 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 		reconcileEvent = rof.ObserveFinalizeKind(ctx, resource)
 	}
 
-	if !r.skipStatusUpdates {
-		// Synchronize the status.
-		if {{.equalitySemantic|raw}}.DeepEqual(original.Status, resource.Status) {
-			// If we didn't change anything then don't call updateStatus.
-			// This is important because the copy we loaded from the injectionInformer's
-			// cache may be stale and we don't want to overwrite a prior update
-			// to status with this stale state.
-		} else if !isLeader {
-			logger.Warn("Saw status changes when we aren't the leader!")
-			// TODO: Consider logging the diff at Debug?
-		} else if err = r.updateStatus(original, resource); err != nil {
+	// Synchronize the status.
+	switch {
+	case !r.skipStatusUpdates:
+		// This reconciler implementation is configured to skip resource updates.
+		// This may mean this reconciler does not observe spec, but reconciles external changes.
+	case !isLeader:
+		// High-availability reconcilers may have many replicas watching the resource, but only
+		// the elected leader is expected to write modifications.
+		logger.Warn("Saw status changes when we aren't the leader!")
+	case {{.equalitySemantic|raw}}.DeepEqual(original.Status, resource.Status):
+		// If we didn't change anything then don't call updateStatus.
+		// This is important because the copy we loaded from the injectionInformer's
+		// cache may be stale and we don't want to overwrite a prior update
+		// to status with this stale state.
+	default:
+		if err = r.updateStatus(original, resource); err != nil {
 			logger.Warnw("Failed to update resource status", zap.Error(err))
 			r.Recorder.Eventf(resource, {{.corev1EventTypeWarning|raw}}, "UpdateFailed",
 				"Failed to update status for %q: %v", resource.Name, err)

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -432,7 +432,7 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 
 	// Synchronize the status.
 	switch {
-	case !r.skipStatusUpdates:
+	case r.skipStatusUpdates:
 		// This reconciler implementation is configured to skip resource updates.
 		// This may mean this reconciler does not observe spec, but reconciles external changes.
 	case !isLeader:


### PR DESCRIPTION
Slight readability update to https://github.com/knative/pkg/pull/1456

I think this better highlights the checks we do before enacting the status writeback.
Added comments for the additional cases.