### PR TITLE
Remove resource_name tag from webhook stats

### DIFF
--- a/webhook/stats_reporter.go
+++ b/webhook/stats_reporter.go
@@ -55,7 +55,6 @@ var (
 	resourceGroupKey     = tag.MustNewKey("resource_group")
 	resourceVersionKey   = tag.MustNewKey("resource_version")
 	resourceResourceKey  = tag.MustNewKey("resource_resource")
-	resourceNameKey      = tag.MustNewKey("resource_name")
 	resourceNamespaceKey = tag.MustNewKey("resource_namespace")
 	admissionAllowedKey  = tag.MustNewKey("admission_allowed")
 )
@@ -93,7 +92,6 @@ func (r *reporter) ReportRequest(req *admissionv1.AdmissionRequest, resp *admiss
 		tag.Insert(resourceGroupKey, req.Resource.Group),
 		tag.Insert(resourceVersionKey, req.Resource.Version),
 		tag.Insert(resourceResourceKey, req.Resource.Resource),
-		tag.Insert(resourceNameKey, req.Name),
 		tag.Insert(resourceNamespaceKey, req.Namespace),
 		tag.Insert(admissionAllowedKey, strconv.FormatBool(resp.Allowed)),
 	)
@@ -117,7 +115,6 @@ func RegisterMetrics() {
 		resourceVersionKey,
 		resourceResourceKey,
 		resourceNamespaceKey,
-		resourceNameKey,
 		admissionAllowedKey}
 
 	if err := view.Register(

--- a/webhook/stats_reporter_test.go
+++ b/webhook/stats_reporter_test.go
@@ -54,7 +54,6 @@ func TestWebhookStatsReporter(t *testing.T) {
 		resourceGroupKey.Name():     req.Resource.Group,
 		resourceVersionKey.Name():   req.Resource.Version,
 		resourceResourceKey.Name():  req.Resource.Resource,
-		resourceNameKey.Name():      req.Name,
 		resourceNamespaceKey.Name(): req.Namespace,
 		admissionAllowedKey.Name():  strconv.FormatBool(resp.Allowed),
 	}


### PR DESCRIPTION
Proposed in relation to https://github.com/tektoncd/pipeline/issues/2872.

Motivation: Common use cases for this webhook involve using Kubernetes's generateName API to randomise resource names (this is a good idea in Tekton pipelines, for example, where there are uniqueness constraints. That means that the webhook metrics here end up with very high cardinality, which makes Prometheus fall over. Even without generateName, it is possible to shoot oneself in the foot this way. 

This commit just removes the resource_name label altogether.