### PR TITLE
Use quotation marks for generated checksums

### DIFF
--- a/configmap/hash-gen/main.go
+++ b/configmap/hash-gen/main.go
@@ -85,9 +85,10 @@ func process(data []byte) ([]byte, error) {
 	if existingAnnotation != nil {
 		existingAnnotation.Value = checksum
 	} else {
+		sumNode := strNode(checksum)
+		sumNode.Style = yaml.DoubleQuotedStyle
 		annotations.Content = append(annotations.Content,
-			strNode(configmap.ExampleChecksumAnnotation),
-			strNode(checksum))
+			strNode(configmap.ExampleChecksumAnnotation), sumNode)
 	}
 
 	var buffer bytes.Buffer

--- a/configmap/hash-gen/testdata/add_want.yaml
+++ b/configmap/hash-gen/testdata/add_want.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: 05d48218
+    knative.dev/example-checksum: "05d48218"
 data:
   leave-me: "alone"
   _example: |

--- a/configmap/hash-gen/testdata/update.yaml
+++ b/configmap/hash-gen/testdata/update.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: bla
+    knative.dev/example-checksum: "bla"
 data:
   leave-me: "alone"
   _example: |

--- a/configmap/hash-gen/testdata/update_want.yaml
+++ b/configmap/hash-gen/testdata/update_want.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: 05d48218
+    knative.dev/example-checksum: "05d48218"
 data:
   leave-me: "alone"
   _example: |


### PR DESCRIPTION
* If you win the hashcode lottery and get a checksum that is all numeric, this parses as an int instead of a string and fails.
    * Quotes ensure proper parsing
    * This was mysterious and confusing in: #8582