### PR TITLE
Remove the ResourceLock field from the pkg/LE

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -918,7 +918,6 @@ func TestStartAndShutdownWithLeaderAwareWithLostElection(t *testing.T) {
 	}
 	cc := leaderelection.ComponentConfig{
 		Component:     "component",
-		ResourceLock:  "leases",
 		LeaseDuration: 15 * time.Second,
 		RenewDeadline: 10 * time.Second,
 		RetryPeriod:   2 * time.Second,

--- a/leaderelection/config_test.go
+++ b/leaderelection/config_test.go
@@ -30,7 +30,6 @@ import (
 
 func okConfig() *Config {
 	return &Config{
-		ResourceLock:  "leases",
 		Buckets:       1,
 		LeaseDuration: 15 * time.Second,
 		RenewDeadline: 10 * time.Second,
@@ -40,8 +39,7 @@ func okConfig() *Config {
 
 func okData() map[string]string {
 	return map[string]string{
-		"resourceLock": "leases",
-		"buckets":      "1",
+		"buckets": "1",
 		// values in this data come from the defaults suggested in the
 		// code:
 		// https://github.com/kubernetes/client-go/blob/kubernetes-1.16.0/tools/leaderelection/leaderelection.go
@@ -71,12 +69,6 @@ func TestNewConfigMapFromData(t *testing.T) {
 			config.Buckets = 5
 			return config
 		}(),
-	}, {
-		name: "invalid resourceLock",
-		data: kmeta.UnionMaps(okData(), map[string]string{
-			"resourceLock": "flarps",
-		}),
-		err: errors.New(`resourceLock: invalid value "flarps": valid values are "leases"`),
 	}, {
 		name: "invalid leaseDuration",
 		data: kmeta.UnionMaps(okData(), map[string]string{
@@ -142,14 +134,12 @@ func TestGetComponentConfig(t *testing.T) {
 	}{{
 		name: "component enabled",
 		config: Config{
-			ResourceLock:  "leases",
 			LeaseDuration: 15 * time.Second,
 			RenewDeadline: 10 * time.Second,
 			RetryPeriod:   2 * time.Second,
 		},
 		expected: ComponentConfig{
 			Component:     expectedName,
-			ResourceLock:  "leases",
 			LeaseDuration: 15 * time.Second,
 			RenewDeadline: 10 * time.Second,
 			RetryPeriod:   2 * time.Second,

--- a/leaderelection/context.go
+++ b/leaderelection/context.go
@@ -123,7 +123,7 @@ func (b *standardBuilder) buildElector(ctx context.Context, la reconciler.Leader
 			total: b.lec.Buckets,
 		}
 
-		rl, err := resourcelock.New(b.lec.ResourceLock,
+		rl, err := resourcelock.New(KnativeResourceLock,
 			system.Namespace(), // use namespace we are running in
 			bkt.Name(),
 			b.kc.CoreV1(),

--- a/leaderelection/context_test.go
+++ b/leaderelection/context_test.go
@@ -38,7 +38,6 @@ func TestWithBuilder(t *testing.T) {
 	cc := ComponentConfig{
 		Component:     "the-component",
 		Buckets:       1,
-		ResourceLock:  "leases",
 		LeaseDuration: 15 * time.Second,
 		RenewDeadline: 10 * time.Second,
 		RetryPeriod:   2 * time.Second,


### PR DESCRIPTION
we only use a single possible way, so no need to have, parse and validate
field that is in effect a constant.

/assign @dprotaso mattmoor