### PR TITLE
Remove ha.ExtractDeployment dependency.

### DIFF
--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -41,7 +41,7 @@ func countingRFind(wr rune, wc int) func(rune) bool {
 	}
 }
 
-func ExtractDeployment(pod string) string {
+func extractDeployment(pod string) string {
 	if x := strings.LastIndexFunc(pod, countingRFind('-', 2)); x != -1 {
 		return pod[:x]
 	}
@@ -63,7 +63,7 @@ func GetLeaders(t *testing.T, client *test.KubeClient, deploymentName, namespace
 		pod := strings.SplitN(*lease.Spec.HolderIdentity, "_", 2)[0]
 
 		// Deconstruct the pod name and look for the deployment.  This won't work for very long deployment names.
-		if ExtractDeployment(pod) != deploymentName {
+		if extractDeployment(pod) != deploymentName {
 			continue
 		}
 		ret = append(ret, pod)

--- a/test/ha/ha_test.go
+++ b/test/ha/ha_test.go
@@ -20,10 +20,10 @@ import "testing"
 
 func TestExtractDeployment(t *testing.T) {
 	const want = "gke-cluster-michigan-pool-2"
-	if got := ExtractDeployment("gke-cluster-michigan-pool-2-03f384a0-2zu1"); got != want {
+	if got := extractDeployment("gke-cluster-michigan-pool-2-03f384a0-2zu1"); got != want {
 		t.Errorf("Deployment = %q, want: %q", got, want)
 	}
-	if got := ExtractDeployment("a-b"); got != "" {
+	if got := extractDeployment("a-b"); got != "" {
 		t.Errorf("Deployment = %q, want empty string", got)
 	}
 }


### PR DESCRIPTION
This was part of the review feedback, but it inadvertently introduced a dependency that redefined a flag causing the duck to crash loop.

This copies the function instead of pulling in the dependency.