### PR TITLE
Remove logging from pod watcher to avoid race conditions.

### DIFF
--- a/test/logstream/kubelogs.go
+++ b/test/logstream/kubelogs.go
@@ -113,16 +113,13 @@ func (k *kubelogs) watchPods(t test.TLegacy) {
 				watchedPods.Delete(p.Name)
 			case watch.Added, watch.Modified:
 				if watchedPods.Has(p.Name) {
-					t.Log("Already watching pod", p.Name)
 					continue
 				}
 				if podIsReady(p) {
-					t.Log("Watching logs for pod: ", p.Name)
 					watchedPods.Insert(p.Name)
 					k.startForPod(&eg, p)
 					continue
 				}
-				t.Log("Pod is not yet ready: ", p.Name)
 			}
 		}
 	}()


### PR DESCRIPTION
These cause a race condition as can be seen in https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1283612572876017666.

They capture `t` far beyond the test's lifetime (this is `t` of the test that first initializes the logstream).

If we alternatively think that those logs are valuable, we should probably run through the set of active tests and log it to each of them. I didn't think they're all too important to the test output though.