### PR TITLE
Assorted linting fixes.

### DIFF
--- a/metrics/exporter_test.go
+++ b/metrics/exporter_test.go
@@ -27,19 +27,10 @@ import (
 const (
 	testNS            = "test"
 	testService       = "test-service"
-	testRoute         = "test-route"
 	testRevision      = "test-revision"
 	testConfiguration = "test-configuration"
 	testContainer     = "test-container"
 	testPod           = "test-pod"
-
-	testBroker              = "test-broker"
-	testEventType           = "test-eventtype"
-	testEventSource         = "test-eventsource"
-	testTrigger             = "test-trigger"
-	testFilterType          = "test-filtertype"
-	testSource              = "test-source"
-	testSourceResourceGroup = "test-source-rg"
 )
 
 func TestMain(m *testing.M) {

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -646,11 +646,11 @@ type stackDriverFake struct {
 	address   string
 	srv       *grpc.Server
 	t         *testing.T
-	published chan stackdriverpb.CreateTimeSeriesRequest
+	published chan *stackdriverpb.CreateTimeSeriesRequest
 }
 
 func (sd *stackDriverFake) start() error {
-	sd.published = make(chan stackdriverpb.CreateTimeSeriesRequest, 100)
+	sd.published = make(chan *stackdriverpb.CreateTimeSeriesRequest, 100)
 	ln, err := net.Listen("tcp", sd.address)
 	if err != nil {
 		return err
@@ -666,7 +666,7 @@ func (sd *stackDriverFake) start() error {
 }
 
 func (sd *stackDriverFake) CreateTimeSeries(ctx context.Context, req *stackdriverpb.CreateTimeSeriesRequest) (*emptypb.Empty, error) {
-	sd.published <- *req
+	sd.published <- req
 	return nil, nil
 }
 
@@ -688,8 +688,7 @@ func (sd *stackDriverFake) GetMetricDescriptor(context.Context, *stackdriverpb.G
 	return nil, fmt.Errorf("Unimplemented")
 }
 func (sd *stackDriverFake) CreateMetricDescriptor(ctx context.Context, req *stackdriverpb.CreateMetricDescriptorRequest) (*metricpb.MetricDescriptor, error) {
-	resp := *req.MetricDescriptor
-	return &resp, nil
+	return req.MetricDescriptor, nil
 }
 func (sd *stackDriverFake) DeleteMetricDescriptor(context.Context, *stackdriverpb.DeleteMetricDescriptorRequest) (*emptypb.Empty, error) {
 	sd.t.Fatalf("DeleteMetricDescriptor")

--- a/metrics/stackdriver_exporter.go
+++ b/metrics/stackdriver_exporter.go
@@ -274,12 +274,6 @@ func sdCustomMetricsRecorder(mc metricsConfig, allowCustomMetrics bool) func(con
 	}
 }
 
-// clientConfig stores the stackdriver configs for cerating additional connections.
-type clientConfig struct {
-	storeConfig *metricsConfig
-	storeLogger *zap.SugaredLogger
-}
-
 // getStackdriverExporterClientOptions creates client options for the opencensus Stackdriver exporter from the given stackdriverClientConfig.
 // On error, an empty array of client options is returned.
 func getStackdriverExporterClientOptions(config *metricsConfig) ([]option.ClientOption, error) {

--- a/metrics/stackdriver_exporter_test.go
+++ b/metrics/stackdriver_exporter_test.go
@@ -39,38 +39,11 @@ import (
 // TODO UTs should move to eventing and serving, as appropriate.
 // 	See https://github.com/knative/pkg/issues/608
 
-var (
-	revisionTestTags = map[string]string{
-		metricskey.LabelNamespaceName: testNS,
-		metricskey.LabelServiceName:   testService,
-		metricskey.LabelRouteName:     testRoute, // Not a label key for knative_revision resource
-		metricskey.LabelRevisionName:  testRevision,
-	}
-	brokerTestTags = map[string]string{
-		metricskey.LabelNamespaceName: testNS,
-		metricskey.LabelBrokerName:    testBroker,
-		metricskey.LabelEventType:     testEventType, // Not a label key for knative_broker resource
-	}
-	triggerTestTags = map[string]string{
-		metricskey.LabelNamespaceName: testNS,
-		metricskey.LabelTriggerName:   testTrigger,
-		metricskey.LabelBrokerName:    testBroker,
-		metricskey.LabelFilterType:    testFilterType, // Not a label key for knative_trigger resource
-	}
-	sourceTestTags = map[string]string{
-		metricskey.LabelNamespaceName: testNS,
-		metricskey.LabelName:          testSource,
-		metricskey.LabelResourceGroup: testSourceResourceGroup,
-		metricskey.LabelEventType:     testEventType,   // Not a label key for knative_source resource
-		metricskey.LabelEventSource:   testEventSource, // Not a label key for knative_source resource
-	}
-
-	testGcpMetadata = gcpMetadata{
-		project:  "test-project",
-		location: "test-location",
-		cluster:  "test-cluster",
-	}
-)
+var testGcpMetadata = gcpMetadata{
+	project:  "test-project",
+	location: "test-location",
+	cluster:  "test-cluster",
+}
 
 func fakeGcpMetadataFunc() *gcpMetadata {
 	// the caller of this function could modify the struct, so we need a copy if we don't want the original modified.

--- a/tracing/http_test.go
+++ b/tracing/http_test.go
@@ -148,7 +148,7 @@ func TestHTTPSpanIgnoringPaths(t *testing.T) {
 			middleware.ServeHTTP(fw, req)
 
 			// Assert our next handler was called
-			if got, want := string(fw.lastWrite), "fake"; got != want {
+			if got, want := fw.lastWrite, "fake"; got != want {
 				t.Errorf("HTTP response: %q, want: %q", got, want)
 			}
 


### PR DESCRIPTION
- Remove unused code.
- Remove unnecessary conversion.
- Prevent copies of structs that contain sync.Mutex.

/assign @vagababov @evankanderson 