### PR TITLE
Use two lane queue instead of the regular workqueue

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -213,12 +213,9 @@ func NewImpl(r Reconciler, logger *zap.SugaredLogger, workQueueName string) *Imp
 func NewImplWithStats(r Reconciler, logger *zap.SugaredLogger, workQueueName string, reporter StatsReporter) *Impl {
 	logger = logger.Named(workQueueName)
 	return &Impl{
-		Name:       workQueueName,
-		Reconciler: r,
-		WorkQueue: workqueue.NewNamedRateLimitingQueue(
-			workqueue.DefaultControllerRateLimiter(),
-			workQueueName,
-		),
+		Name:          workQueueName,
+		Reconciler:    r,
+		WorkQueue:     newTwoLaneWorkQueue(workQueueName),
 		logger:        logger,
 		statsReporter: reporter,
 	}

--- a/controller/two_lane_queue_test.go
+++ b/controller/two_lane_queue_test.go
@@ -75,7 +75,7 @@ func TestDoubleKey(t *testing.T) {
 	select {
 	case <-sentinel:
 		t.Error("The sentinel should not have fired")
-	case <-time.After(400 * time.Millisecond):
+	case <-time.After(600 * time.Millisecond):
 		// Expected.
 	}
 	// This should permit the re-reading of the same key.

--- a/controller/two_lane_queue_test.go
+++ b/controller/two_lane_queue_test.go
@@ -75,7 +75,7 @@ func TestDoubleKey(t *testing.T) {
 	select {
 	case <-sentinel:
 		t.Error("The sentinel should not have fired")
-	case <-time.After(200 * time.Millisecond):
+	case <-time.After(400 * time.Millisecond):
 		// Expected.
 	}
 	// This should permit the re-reading of the same key.

--- a/webhook/resourcesemantics/defaulting/table_test.go
+++ b/webhook/resourcesemantics/defaulting/table_test.go
@@ -19,6 +19,7 @@ package defaulting
 import (
 	"context"
 	"testing"
+	"time"
 
 	kubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	_ "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret/fake"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientgotesting "k8s.io/client-go/testing"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -368,7 +370,10 @@ func TestNew(t *testing.T) {
 		t.Errorf("Promote() = %v", err)
 	}
 
-	if want, got := 1, c.WorkQueue.Len(); want != got {
-		t.Errorf("WorkQueue.Len() = %d, wanted %d", got, want)
+	// Queue has async moving parts so if we check at the wrong moment, this might still be 0.
+	if wait.PollImmediate(10*time.Millisecond, 250*time.Millisecond, func() (bool, error) {
+		return c.WorkQueue.Len() == 1, nil
+	}) != nil {
+		t.Error("Queue length was never 1")
 	}
 }

--- a/webhook/resourcesemantics/validation/validation_admit_test.go
+++ b/webhook/resourcesemantics/validation/validation_admit_test.go
@@ -661,6 +661,7 @@ func NewTestResourceAdmissionController(t *testing.T) *reconciler {
 		t.Errorf("Promote() = %v", err)
 	}
 
+	// Queue has async moving parts so if we check at the wrong moment, this might still be 0.
 	if wait.PollImmediate(10*time.Millisecond, 250*time.Millisecond, func() (bool, error) {
 		return c.WorkQueue.Len() == 1, nil
 	}) != nil {

--- a/webhook/resourcesemantics/validation/validation_admit_test.go
+++ b/webhook/resourcesemantics/validation/validation_admit_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	// Injection stuff
 	_ "knative.dev/pkg/client/injection/kube/client/fake"
@@ -35,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/system"
@@ -659,8 +661,10 @@ func NewTestResourceAdmissionController(t *testing.T) *reconciler {
 		t.Errorf("Promote() = %v", err)
 	}
 
-	if want, got := 1, c.WorkQueue.Len(); want != got {
-		t.Errorf("WorkQueue.Len() = %d, wanted %d", got, want)
+	if wait.PollImmediate(10*time.Millisecond, 250*time.Millisecond, func() (bool, error) {
+		return c.WorkQueue.Len() == 1, nil
+	}) != nil {
+		t.Error("Queue length was never 1")
 	}
 
 	return c.Reconciler.(*reconciler)


### PR DESCRIPTION
- we need to poll for len in the webhook tests because we have async propagation now, and check at the wrong time will be not correct.
- otherwise just a drop in replacement.

/assign @mattmoor 