### PR TITLE
Add more time for the checks

### DIFF
--- a/controller/two_lane_queue_test.go
+++ b/controller/two_lane_queue_test.go
@@ -75,17 +75,12 @@ func TestDoubleKey(t *testing.T) {
 	select {
 	case <-sentinel:
 		t.Error("The sentinel should not have fired")
-	case <-time.After(200 * time.Millisecond):
+	case <-time.After(500 * time.Millisecond):
 		// Expected.
 	}
 	// This should permit the re-reading of the same key.
 	q.Done(k)
-	select {
-	case <-sentinel:
-		// Expected.
-	case <-time.After(200 * time.Millisecond):
-		t.Error("The item was not processed as expected")
-	}
+	<-sentinel
 }
 
 func TestOrder(t *testing.T) {


### PR DESCRIPTION
On the prow clusters which are usually strapped for CPU this fails due to wrong order of things.
So the final check should just wait for the channel to close rather than race a timer.