### PR TITLE
Harden the drain tests more

### DIFF
--- a/network/handlers/drain.go
+++ b/network/handlers/drain.go
@@ -38,6 +38,8 @@ func (s *sysTimer) tickChan() <-chan time.Time {
 	return s.Timer.C
 }
 
+// This constructor is overridden in tests to control the progress
+// of time in the test.
 var newTimer = func(d time.Duration) timer {
 	return &sysTimer{
 		time.NewTimer(d),

--- a/network/handlers/drain_test.go
+++ b/network/handlers/drain_test.go
@@ -25,6 +25,44 @@ import (
 	"knative.dev/pkg/network"
 )
 
+type mockTimer struct {
+	now        time.Time // our current time.
+	deadline   time.Time // when we're supposed to fire
+	c          chan time.Time
+	resetCalls int
+	stopped    bool
+}
+
+func (mt *mockTimer) advance(d time.Duration) {
+	mt.now = mt.now.Add(d)
+	if !mt.now.Before(mt.deadline) {
+		mt.stopped = true
+		mt.c <- mt.now
+	}
+}
+
+func (mt *mockTimer) Reset(d time.Duration) bool {
+	mt.resetCalls++
+	if mt.stopped {
+		mt.now = time.Now()
+		mt.deadline = mt.now.Add(d)
+		mt.stopped = false
+	}
+	return !mt.stopped
+}
+
+func (mt *mockTimer) Stop() bool {
+	if mt.stopped {
+		return false
+	}
+	mt.stopped = true
+	return true
+}
+
+func (mt *mockTimer) tickChan() <-chan time.Time {
+	return mt.c
+}
+
 func TestDrainMechanics(t *testing.T) {
 	var (
 		w     http.ResponseWriter
@@ -38,6 +76,22 @@ func TestDrainMechanics(t *testing.T) {
 
 	inner := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
 
+	// We need init channel to signal the main thread that the drain
+	// has been initialized in the background thread.
+	init := make(chan struct{})
+	nt := newTimer
+	t.Cleanup(func() {
+		newTimer = nt
+	})
+	mt := &mockTimer{
+		c: make(chan time.Time),
+	}
+	newTimer = func(d time.Duration) timer {
+		defer close(init)
+		mt.now = time.Now()
+		mt.deadline = mt.now.Add(d)
+		return mt
+	}
 	drainer := &Drainer{
 		Inner:       inner,
 		QuietPeriod: 100 * time.Millisecond,
@@ -55,7 +109,7 @@ func TestDrainMechanics(t *testing.T) {
 		t.Errorf("Probe status = %d, wanted %d", got, want)
 	}
 
-	// Start to drain, and cancel the context when it returns.
+	// Start to drain, and close the channel when it returns.
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -63,13 +117,19 @@ func TestDrainMechanics(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(40 * time.Millisecond):
-		// Drain is blocking.
 	case <-done:
 		t.Error("Drain terminated prematurely.")
+	case <-init:
+		// OK.
 	}
+	mt.advance(40 * time.Millisecond)
+
 	// Now send a request to reset things.
+	rc := mt.resetCalls
 	drainer.ServeHTTP(w, req)
+	if mt.resetCalls != rc+1 {
+		t.Errorf("ResetCalls = %d, want: %d", mt.resetCalls, rc+1)
+	}
 
 	// Check for 503 as a probe response when shutting down.
 	resp = httptest.NewRecorder()
@@ -77,19 +137,28 @@ func TestDrainMechanics(t *testing.T) {
 	if got, want := resp.Code, http.StatusServiceUnavailable; got != want {
 		t.Errorf("Probe status = %d, wanted %d", got, want)
 	}
+	// Verify no reset was called.
+	if mt.resetCalls != rc+1 {
+		t.Errorf("ResetCalls = %d, want: %d", mt.resetCalls, rc+1)
+	}
 
 	for i := 0; i < 3; i++ {
+		mt.advance(40 * time.Millisecond)
 		select {
-		case <-time.After(40 * time.Millisecond):
-			// Drain is blocking.
 		case <-done:
 			t.Error("Drain terminated prematurely.")
+		default:
+			// OK
 		}
 		// For the last one we don't want to reset the drain timer.
 		if i < 2 {
 			drainer.ServeHTTP(w, req)
 		}
 	}
+	if mt.resetCalls != rc+3 {
+		t.Errorf("ResetCalls = %d, want: %d", mt.resetCalls, rc+1)
+	}
+
 	// Probing does not reset the clock.
 	// Check for 503 on a probe when shutting down.
 	resp = httptest.NewRecorder()
@@ -116,13 +185,22 @@ func TestDrainMechanics(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(80 * time.Millisecond):
-		t.Error("Timed out waiting for Drain to return.")
 	case <-done:
 	case <-done1:
 	case <-done2:
 	case <-done3:
-		// Once the first context is cancelled, check that all of them are cancelled.
+	default:
+		// Expected.
+	}
+
+	mt.advance(61 * time.Millisecond)
+	select {
+	case <-done:
+	case <-done1:
+	case <-done2:
+	case <-done3:
+	case <-time.After(time.Second): // We can't use default here, since it will race the tick in the drainer.
+		t.Error("Drains should have happened!")
 	}
 
 	// Check that a 4th and final one after things complete finishes instantly.
@@ -132,14 +210,12 @@ func TestDrainMechanics(t *testing.T) {
 		drainer.Drain()
 	}()
 
-	// Give the test a short window to launch and execute the go routine.
-	time.Sleep(5 * time.Millisecond)
-
+	// We need to ensure all the go routines complete, so give them ample time.
 	for idx, dch := range []chan struct{}{done, done1, done2, done3, done4} {
 		select {
 		case <-dch:
 			// Should be done.
-		default:
+		case <-time.After(time.Second):
 			t.Errorf("Drain[%d] did not complete.", idx)
 		}
 	}

--- a/network/handlers/drain_test.go
+++ b/network/handlers/drain_test.go
@@ -75,8 +75,8 @@ func TestDrainMechanics(t *testing.T) {
 	)
 
 	const (
-		timeout   = 100 * time.Millisecond
-		razorThin = timeout - time.Nanosecond
+		timeout = 100 * time.Millisecond
+		epsilon = time.Nanosecond
 	)
 
 	inner := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
@@ -129,7 +129,7 @@ func TestDrainMechanics(t *testing.T) {
 	case <-init:
 		// OK.
 	}
-	mt.advance(razorThin)
+	mt.advance(timeout - epsilon)
 
 	// Now send a request to reset things.
 	rc := mt.resetCalls
@@ -151,7 +151,7 @@ func TestDrainMechanics(t *testing.T) {
 	rc++
 
 	for i := 0; i < 3; i++ {
-		mt.advance(razorThin)
+		mt.advance(timeout - epsilon)
 		select {
 		case <-done:
 			t.Error("Drain terminated prematurely.")


### PR DESCRIPTION
- introduce synthetic timer that gives us the capability to actually trigger events in the drain itself
- unfortunately we still need time.After calls in the test due to the timing for go routines to finish (they race the default: case and lose).

OTOH, the happy runs take virtually no time now.
```
>rt -count=2200
PASS
ok      knative.dev/pkg/network/handlers        1.414s
```

/assign mattmoor