### PR TITLE
Added logging of port forwarding stdout/stderr

### DIFF
--- a/test/logging/logger_writer.go
+++ b/test/logging/logger_writer.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package logging
+
+import (
+	"bytes"
+	"io"
+	"strings"
+)
+
+type loggerWriter struct {
+	prepend string
+	logf    FormatLogger
+
+	buf bytes.Buffer
+}
+
+func NewLoggerWriter(prepend string, logf FormatLogger) io.Writer {
+	return &loggerWriter{
+		prepend: prepend,
+		logf:    logf,
+	}
+}
+
+func (l *loggerWriter) Write(p []byte) (n int, err error) {
+	s := string(p)
+	splitted := strings.Split(s, "\n")
+
+	// Get the remaining of the previous write
+	splitted[0] = l.buf.String() + splitted[0]
+	l.buf.Reset()
+
+	// Write out the lines
+	for i := 0; i < len(splitted)-1; i++ {
+		l.logf(l.prepend + splitted[i])
+	}
+
+	n, err = l.buf.WriteString(splitted[len(splitted)-1])
+	return
+}

--- a/test/logging/logger_writer_test.go
+++ b/test/logging/logger_writer_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package logging
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoggerWriter(t *testing.T) {
+	var strs []string
+	fn := FormatLogger(func(template string, args ...interface{}) {
+		strs = append(strs, template)
+	})
+
+	loggerWriter := NewLoggerWriter("hello: ", fn)
+	_, err := loggerWriter.Write([]byte("aaaa"))
+	if err != nil {
+		t.Fatalf("Error while writing: %v", err)
+	}
+	_, err = loggerWriter.Write([]byte("bbb\nbbb\nbbb"))
+	if err != nil {
+		t.Fatalf("Error while writing: %v", err)
+	}
+	_, err = loggerWriter.Write([]byte("\nccc\n"))
+	if err != nil {
+		t.Fatalf("Error while writing: %v", err)
+	}
+	_, err = loggerWriter.Write([]byte("ddd\n"))
+	if err != nil {
+		t.Fatalf("Error while writing: %v", err)
+	}
+
+	actual := strings.Join(strs, "-")
+	expected := "hello: aaaabbb-hello: bbb-hello: bbb-hello: ccc-hello: ddd"
+	if actual != expected {
+		t.Fatalf("expected: %s, actual: %s", expected, actual)
+	}
+
+}

--- a/test/monitoring/monitoring.go
+++ b/test/monitoring/monitoring.go
@@ -18,6 +18,7 @@ package monitoring
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -59,10 +60,10 @@ func Cleanup(pid int) error {
 }
 
 // PortForward sets up local port forward to the pod specified by the "app" label in the given namespace
-func PortForward(logf logging.FormatLogger, podList *v1.PodList, localPort, remotePort int, namespace string) (int, error) {
+func PortForward(logf logging.FormatLogger, podList *v1.PodList, localPort, remotePort int, namespace string, stdout io.Writer, stderr io.Writer) (int, error) {
 	podName := podList.Items[0].Name
 	portFwdCmd := fmt.Sprintf("kubectl port-forward %s %d:%d -n %s", podName, localPort, remotePort, namespace)
-	portFwdProcess, err := executeCmdBackground(logf, portFwdCmd)
+	portFwdProcess, err := executeCmdBackground(logf, stdout, stderr, portFwdCmd)
 
 	if err != nil {
 		return 0, fmt.Errorf("failed to port forward: %w", err)
@@ -73,11 +74,13 @@ func PortForward(logf logging.FormatLogger, podList *v1.PodList, localPort, remo
 }
 
 // RunBackground starts a background process and returns the Process if succeed
-func executeCmdBackground(logf logging.FormatLogger, format string, args ...interface{}) (*os.Process, error) {
+func executeCmdBackground(logf logging.FormatLogger, stdout io.Writer, stderr io.Writer, format string, args ...interface{}) (*os.Process, error) {
 	cmd := fmt.Sprintf(format, args...)
 	logf("Executing command: %s", cmd)
 	parts := strings.Split(cmd, " ")
 	c := exec.Command(parts[0], parts[1:]...) // #nosec
+	c.Stdout = stdout
+	c.Stderr = stderr
 	if err := c.Start(); err != nil {
 		return nil, fmt.Errorf("%s command failed: %w", cmd, err)
 	}

--- a/test/prometheus/prometheus.go
+++ b/test/prometheus/prometheus.go
@@ -64,7 +64,15 @@ func (p *PromProxy) Setup(kubeClientset *kubernetes.Clientset, logf logging.Form
 			return
 		}
 
-		p.processID, err = monitoring.PortForward(logf, promPods, prometheusPort, prometheusPort, p.Namespace)
+		p.processID, err = monitoring.PortForward(
+			logf,
+			promPods,
+			prometheusPort,
+			prometheusPort,
+			p.Namespace,
+			logging.NewLoggerWriter("prometheus-port-forward-stdout", logf),
+			logging.NewLoggerWriter("prometheus-port-forward-stderr", logf),
+		)
 		if err != nil {
 			logf("Error starting kubectl port-forward command: %v", err)
 			return

--- a/test/zipkin/util.go
+++ b/test/zipkin/util.go
@@ -126,7 +126,15 @@ func SetupZipkinTracing(kubeClientset *kubernetes.Clientset, logf logging.Format
 			return
 		}
 
-		zipkinPortForwardPID, e = monitoring.PortForward(logf, zipkinPods, ZipkinPort, zipkinRemotePort, zipkinNamespace)
+		zipkinPortForwardPID, e = monitoring.PortForward(
+			logf,
+			zipkinPods,
+			ZipkinPort,
+			zipkinRemotePort,
+			zipkinNamespace,
+			logging.NewLoggerWriter("zipkin-port-forward-stdout", logf),
+			logging.NewLoggerWriter("zipkin-port-forward-stderr", logf),
+		)
 		if e != nil {
 			err = fmt.Errorf("error starting kubectl port-forward command: %w", err)
 			return


### PR DESCRIPTION
This change modifies the signature of `PortForwarding` to include an stdout/stderr `io.Writer`. It also provides a writer that can be built from a logging function

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>