### PR TITLE
Reorder statements for more precise behavior

### DIFF
--- a/controller/two_lane_queue.go
+++ b/controller/two_lane_queue.go
@@ -72,8 +72,8 @@ func process(q workqueue.Interface, ch chan interface{}) {
 		if d {
 			break
 		}
-		ch <- i
 		q.Done(i)
+		ch <- i
 	}
 }
 


### PR DESCRIPTION
So we have a Len() race here. Before we could have len=2, now we can have len=0. I don't know which one's better/worse, but I prefer 0.
Also harden the test to not flake.
/assign mattmoor