### PR TITLE
Make EnsureRecorded part of metricstest

### DIFF
--- a/metrics/metricstest/resource_metrics_test.go
+++ b/metrics/metricstest/resource_metrics_test.go
@@ -21,12 +21,16 @@ limitations under the License.
 package metricstest
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"go.opencensus.io/metric/metricdata"
 	"go.opencensus.io/resource"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 )
 
 func TestMetricEqual(t *testing.T) {
@@ -314,4 +318,54 @@ func TestMetricShortcuts(t *testing.T) {
 			t.Errorf("Metric.Equal() failed (-want +got): %s", diff)
 		}
 	}
+}
+
+func TestMetricFetch(t *testing.T) {
+	count := stats.Int64("count", "Test count metric", stats.UnitBytes)
+	tagKey := tag.MustNewKey("tag")
+	countView := &view.View{
+		Measure:     count,
+		Aggregation: view.Sum(),
+		TagKeys:     []tag.Key{tagKey},
+	}
+
+	view.Register(countView)
+
+	ctx, err := tag.New(context.Background(), tag.Upsert(tagKey, "alpha"))
+	if err != nil {
+		t.Errorf("Unable to create context: %v", err)
+	}
+	stats.Record(ctx, count.M(5))
+	stats.Record(ctx, count.M(3))
+
+	AssertMetric(t, Metric{Name: "count"})
+	AssertNoMetric(t, "other")
+
+	ctx, err = tag.New(ctx, tag.Upsert(tagKey, "beta"))
+	if err != nil {
+		t.Errorf("Unable to create context: %v", err)
+	}
+	stats.Record(ctx, count.M(20))
+	EnsureRecorded()
+	m := GetMetric("count")
+
+	if len(m) != 1 {
+		t.Errorf("Unexpected number of found metrics (%d): %+v", len(m), m)
+	}
+
+	alphaValue, betaValue := int64(8), int64(20)
+
+	want := Metric{
+		Name: "count",
+		Type: metricdata.TypeCumulativeInt64,
+		Unit: metricdata.UnitBytes,
+		Values: []Value{
+			{Tags: map[string]string{"tag": "alpha"}, Int64: &alphaValue},
+			{Tags: map[string]string{"tag": "beta"}, Int64: &betaValue},
+		},
+	}
+	if diff := cmp.Diff(want, m[0]); diff != "" {
+		t.Errorf("Incorrect received metrics (-want +got): %s", diff)
+	}
+
 }

--- a/metrics/metricstest/resource_metrics_test.go
+++ b/metrics/metricstest/resource_metrics_test.go
@@ -338,7 +338,7 @@ func TestMetricFetch(t *testing.T) {
 	stats.Record(ctx, count.M(5))
 	stats.Record(ctx, count.M(3))
 
-	AssertMetric(t, Metric{Name: "count"})
+	AssertMetricExists(t, "count")
 	AssertNoMetric(t, "other")
 
 	ctx, err = tag.New(ctx, tag.Upsert(tagKey, "beta"))

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -47,6 +47,7 @@ import (
 	"google.golang.org/grpc"
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/metrics/metricskey"
+	"knative.dev/pkg/metrics/metricstest"
 	//_ "knative.dev/pkg/metrics/testing"
 )
 
@@ -295,6 +296,7 @@ func TestMetricsExport(t *testing.T) {
 			return UpdateExporter(configForBackend(prometheus), logtesting.TestLogger(t))
 		},
 		validate: func(t *testing.T) {
+			metricstest.EnsureRecorded()
 			resp, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", prometheusPort))
 			if err != nil {
 				t.Fatalf("failed to fetch prometheus metrics: %+v", err)


### PR DESCRIPTION
Call EnsureRecorded automatically in the "Assert" methods.

This should make testing serving/eventing easier.

Increase test coverage.

/assign @jjzeng-seattle 