### PR TITLE
Wait longer for metrics collection to settle for OpenCensus

### DIFF
--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -337,7 +337,7 @@ testComponent_testing_value{project="p1",revision="r2"} 1
 			UnregisterResourceView(gaugeView, resourceCounter)
 			FlushExporter()
 
-			time.Sleep(time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 			ocFake.srv.Stop() // Force close connections
 			records := []metricExtract{}
 			for record := range ocFake.published {


### PR DESCRIPTION
I'm seeing [some flakiness](https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-pkg-continuous/1285092827042156545) in `TestMetricsExport/OpenCensus` which looks like:

```
    TestMetricsExport/OpenCensus: resource_view_test.go:359: Unexpected OpenCensus exports (-want +got):
          []metrics.metricExtract(Inverse(Sort, []string{
          	"global_export_counts<>:2",
          	"resource_global_export_count<>:2",
        - 	`testing/value<project="p1",revision="r1">:0`,
          	`testing/value<project="p1",revision="r2">:1`,
          }))
```

I can't seem to repro locally, but I'm strongly guessing this is timing related and a slightly longer wait will allow all the RPCs to complete.