### PR TITLE
Add a method to set possible maxidle params on the transport.

### DIFF
--- a/network/prober/prober_test.go
+++ b/network/prober/prober_test.go
@@ -77,7 +77,7 @@ func TestDoServing(t *testing.T) {
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := Do(context.Background(), network.NewAutoTransport(), ts.URL, WithHeader(network.ProbeHeaderName, test.headerValue), ExpectsBody(systemName), ExpectsStatusCodes([]int{http.StatusOK}))
+			got, err := Do(context.Background(), network.NewProberTransport(), ts.URL, WithHeader(network.ProbeHeaderName, test.headerValue), ExpectsBody(systemName), ExpectsStatusCodes([]int{http.StatusOK}))
 			if want := test.want; got != want {
 				t.Errorf("Got = %v, want: %v", got, want)
 			}
@@ -107,7 +107,7 @@ func TestBlackHole(t *testing.T) {
 }
 
 func TestBadURL(t *testing.T) {
-	_, err := Do(context.Background(), network.NewAutoTransport(), ":foo", ExpectsStatusCodes([]int{http.StatusOK}))
+	_, err := Do(context.Background(), network.NewProberTransport(), ":foo", ExpectsStatusCodes([]int{http.StatusOK}))
 	if err == nil {
 		t.Error("Do did not return an error")
 	}

--- a/network/transports.go
+++ b/network/transports.go
@@ -92,7 +92,7 @@ func dialBackOffHelper(ctx context.Context, network, address string, bo wait.Bac
 	return nil, fmt.Errorf("timed out dialing after %.2fs", elapsed.Seconds())
 }
 
-func newHTTPTransport(disableKeepAlives bool) http.RoundTripper {
+func newHTTPTransport(disableKeepAlives bool, maxIdle, maxIdlePerHost int) http.RoundTripper {
 	return &http.Transport{
 		// Those match net/http/transport.go
 		Proxy:                 http.ProxyFromEnvironment,
@@ -103,8 +103,8 @@ func newHTTPTransport(disableKeepAlives bool) http.RoundTripper {
 
 		// Those are bespoke.
 		DialContext:         DialWithBackOff,
-		MaxIdleConns:        1000,
-		MaxIdleConnsPerHost: 100,
+		MaxIdleConns:        maxIdle,
+		MaxIdleConnsPerHost: maxIdlePerHost,
 	}
 }
 
@@ -112,17 +112,17 @@ func newHTTPTransport(disableKeepAlives bool) http.RoundTripper {
 // since it will not cache connections.
 func NewProberTransport() http.RoundTripper {
 	return newAutoTransport(
-		newHTTPTransport(true /*disable keep-alives*/),
+		newHTTPTransport(true /*disable keep-alives*/, 0, 0 /*no caching*/),
 		NewH2CTransport())
 }
 
 // NewAutoTransport creates a RoundTripper that can use appropriate transport
 // based on the request's HTTP version.
-func NewAutoTransport() http.RoundTripper {
+func NewAutoTransport(maxIdle, maxIdlePerHost int) http.RoundTripper {
 	return newAutoTransport(
-		newHTTPTransport(false /*disable keep-alives*/),
+		newHTTPTransport(false /*disable keep-alives*/, maxIdle, maxIdlePerHost),
 		NewH2CTransport())
 }
 
 // AutoTransport uses h2c for HTTP2 requests and falls back to `http.DefaultTransport` for all others
-var AutoTransport = NewAutoTransport()
+var AutoTransport = NewAutoTransport(1000, 100)

--- a/network/transports_test.go
+++ b/network/transports_test.go
@@ -41,23 +41,19 @@ func TestHTTPRoundTripper(t *testing.T) {
 		label      string
 		protoMajor int
 		want       string
-	}{
-		{
-			label:      "use default transport for HTTP1",
-			protoMajor: 1,
-			want:       "v1",
-		},
-		{
-			label:      "use h2c transport for HTTP2",
-			protoMajor: 2,
-			want:       "v2",
-		},
-		{
-			label:      "use default transport for all others",
-			protoMajor: 99,
-			want:       "v1",
-		},
-	}
+	}{{
+		label:      "use default transport for HTTP1",
+		protoMajor: 1,
+		want:       "v1",
+	}, {
+		label:      "use h2c transport for HTTP2",
+		protoMajor: 2,
+		want:       "v2",
+	}, {
+		label:      "use default transport for all others",
+		protoMajor: 99,
+		want:       "v1",
+	}}
 
 	for _, e := range examples {
 		t.Run(e.label, func(t *testing.T) {
@@ -100,7 +96,7 @@ func TestDialWithBackoff(t *testing.T) {
 
 	c, err = DialWithBackOff(context.Background(), "tcp4", strings.TrimPrefix(s.URL, "http://"))
 	if err != nil {
-		t.Fatalf("dial error = %v, want nil", err)
+		t.Fatal("Dial error =", err)
 	}
 	c.Close()
 }


### PR DESCRIPTION
This method is not used anywhere outside pkg right now, so it's a safe change.
This will permit activator to set desired maxidle params and cache more connection for better performance

/assign @tcnghia mattmoor
/cc @julz @markusthoemmes 