### PR TITLE
Add helpers for float pointers.

### DIFF
--- a/ptr/ptr.go
+++ b/ptr/ptr.go
@@ -30,6 +30,18 @@ func Int64(i int64) *int64 {
 	return &i
 }
 
+// Float32 is a helper for turning floats into pointers for use in
+// API types that want *float32.
+func Float32(f float32) *float32 {
+	return &f
+}
+
+// Float64 is a helper for turning floats into pointers for use in
+// API types that want *float64.
+func Float64(f float64) *float64 {
+	return &f
+}
+
 // Bool is a helper for turning bools into pointers for use in
 // API types that want *bool.
 func Bool(b bool) *bool {

--- a/ptr/ptr_test.go
+++ b/ptr/ptr_test.go
@@ -21,9 +21,8 @@ import (
 	"time"
 )
 
-const want = 55
-
 func TestInt32(t *testing.T) {
+	const want = 55
 	gotPtr := Int32(want)
 	if want != *gotPtr {
 		t.Errorf("Int32() = &%v, wanted %v", *gotPtr, want)
@@ -31,9 +30,26 @@ func TestInt32(t *testing.T) {
 }
 
 func TestInt64(t *testing.T) {
+	const want = 55
 	gotPtr := Int64(want)
 	if want != *gotPtr {
 		t.Errorf("Int64() = &%v, wanted %v", *gotPtr, want)
+	}
+}
+
+func TestFloat32(t *testing.T) {
+	const want = 1.25
+	gotPtr := Float32(want)
+	if want != *gotPtr {
+		t.Errorf("Float32() = &%v, wanted %v", *gotPtr, want)
+	}
+}
+
+func TestFloat64(t *testing.T) {
+	const want = 1.25
+	gotPtr := Float64(want)
+	if want != *gotPtr {
+		t.Errorf("Float64() = &%v, wanted %v", *gotPtr, want)
 	}
 }
 


### PR DESCRIPTION
As per title, to be able to replace the respective workarounds in code. I got inspired by deprecated protobuf packages mostly, that ship the same wrappers.

/assign @julz 