### PR TITLE
Avoid copying object if TypeMeta is already correct.

### DIFF
--- a/controller/helper.go
+++ b/controller/helper.go
@@ -26,7 +26,7 @@ import (
 // Callback is a function that is passed to an informer's event handler.
 type Callback func(interface{})
 
-// EnsureTypeMeta augments the passed in callback, ensuring that all objects that pass
+// EnsureTypeMeta augments the passed-in callback, ensuring that all objects that pass
 // through this callback have their TypeMeta set according to the provided GVK.
 func EnsureTypeMeta(f Callback, gvk schema.GroupVersionKind) Callback {
 	apiVersion, kind := gvk.ToAPIVersionAndKind()
@@ -49,7 +49,7 @@ func EnsureTypeMeta(f Callback, gvk schema.GroupVersionKind) Callback {
 			return
 		}
 
-		// We need to populated TypeMeta, but cannot trample the
+		// We need to populate TypeMeta, but cannot trample the
 		// informer's copy.
 		copy := typed.DeepCopyObject()
 

--- a/controller/helper.go
+++ b/controller/helper.go
@@ -23,8 +23,11 @@ import (
 	"knative.dev/pkg/kmeta"
 )
 
+// Callback is a function that is passed to an informer's event handler.
 type Callback func(interface{})
 
+// EnsureTypeMeta augments the passed in callback, ensuring that all objects that pass
+// through this callback have their TypeMeta set according to the provided GVK.
 func EnsureTypeMeta(f Callback, gvk schema.GroupVersionKind) Callback {
 	apiVersion, kind := gvk.ToAPIVersionAndKind()
 
@@ -34,12 +37,23 @@ func EnsureTypeMeta(f Callback, gvk schema.GroupVersionKind) Callback {
 			// TODO: We should consider logging here.
 			return
 		}
+
+		accessor, err := meta.TypeAccessor(typed)
+		if err != nil {
+			return
+		}
+
+		// If TypeMeta is already what we want, exit early.
+		if accessor.GetAPIVersion() == apiVersion && accessor.GetKind() == kind {
+			f(typed)
+			return
+		}
+
 		// We need to populated TypeMeta, but cannot trample the
 		// informer's copy.
-		// TODO(mattmoor): Avoid the copy if TypeMeta is set.
 		copy := typed.DeepCopyObject()
 
-		accessor, err := meta.TypeAccessor(copy)
+		accessor, err = meta.TypeAccessor(copy)
 		if err != nil {
 			return
 		}

--- a/controller/helper_test.go
+++ b/controller/helper_test.go
@@ -44,8 +44,30 @@ func TestEnsureTypeMeta(t *testing.T) {
 		name: "not a runtime.Object",
 		obj:  struct{}{},
 	}, {
-		name: "called with type meta",
+		name: "called without type meta",
 		obj: &Resource{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "thing",
+			},
+		},
+		want: &Resource{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: apiVersion,
+				Kind:       kind,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "thing",
+			},
+		},
+	}, {
+		name: "called with correct type meta",
+		obj: &Resource{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: apiVersion,
+				Kind:       kind,
+			},
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "default",
 				Name:      "thing",

--- a/controller/helper_test.go
+++ b/controller/helper_test.go
@@ -62,6 +62,28 @@ func TestEnsureTypeMeta(t *testing.T) {
 			},
 		},
 	}, {
+		name: "called with wrong type meta",
+		obj: &Resource{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "foo",
+				Kind:       "bar",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "thing",
+			},
+		},
+		want: &Resource{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: apiVersion,
+				Kind:       kind,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "thing",
+			},
+		},
+	}, {
 		name: "called with deleted obj",
 		obj: cache.DeletedFinalStateUnknown{
 			Key: "default/thing",


### PR DESCRIPTION
As per title. This short-circuits the copy code if the TypeMeta is already correct. Less allocations and stuff :slightly_smiling_face: 

/assign @mattmoor 