### PR TITLE
Make sure metrics tests are re-entrant

### DIFF
--- a/metrics/metricstest/metricstest.go
+++ b/metrics/metricstest/metricstest.go
@@ -118,9 +118,31 @@ func CheckDistributionCount(t test.T, name string, wantTags map[string]string, e
 
 }
 
+// GetLastValueData returns the last value for the given metric, verifying tags.
+func GetLastValueData(t test.T, name string, tags map[string]string) float64 {
+	t.Helper()
+	return GetLastValueDataWithMeter(t, name, tags, nil)
+}
+
+// GetLastValueDataWithMeter returns the last value of the given metric using meter, verifying tags.
+func GetLastValueDataWithMeter(t test.T, name string, tags map[string]string, meter view.Meter) float64 {
+	t.Helper()
+	if row := lastRow(t, name, meter); row != nil {
+		checkRowTags(t, row, name, tags)
+
+		s, ok := row.Data.(*view.LastValueData)
+		if !ok {
+			t.Error("want LastValueData", "metric", name, "got", reflect.TypeOf(row.Data))
+		}
+		return s.Value
+	}
+	return 0
+}
+
 // CheckLastValueData checks the view with a name matching string name to verify that the LastValueData stats
 // reported are tagged with the tags in wantTags and that wantValue matches reported last value.
 func CheckLastValueData(t test.T, name string, wantTags map[string]string, wantValue float64) {
+	t.Helper()
 	CheckLastValueDataWithMeter(t, name, wantTags, wantValue, nil)
 }
 

--- a/metrics/metricstest/metricstest.go
+++ b/metrics/metricstest/metricstest.go
@@ -151,14 +151,8 @@ func CheckLastValueData(t test.T, name string, wantTags map[string]string, wantV
 // the tags in wantTags and that wantValue matches the last reported value.
 func CheckLastValueDataWithMeter(t test.T, name string, wantTags map[string]string, wantValue float64, meter view.Meter) {
 	t.Helper()
-	if row := lastRow(t, name, meter); row != nil {
-		checkRowTags(t, row, name, wantTags)
-
-		if s, ok := row.Data.(*view.LastValueData); !ok {
-			t.Error("want LastValueData", "metric", name, "got", reflect.TypeOf(row.Data))
-		} else if s.Value != wantValue {
-			t.Error("Reporter.Report() wrong value", "metric", name, "got", s.Value, "want", wantValue)
-		}
+	if v := GetLastValueDataWithMeter(t, name, wantTags, meter); v != wantValue {
+		t.Error("Reporter.Report() wrong value", "metric", name, "got", v, "want", wantValue)
 	}
 }
 


### PR DESCRIPTION
Currently they are not. 'go test -count=2' will miserably fail.
So ensure they are. Also add a helper to return current value (this might be a better way than trying to jump through hoops to erase everything).

Other minor nits.

/assign @evankanderson @yanweiguo 