### PR TITLE
Allow reconcilers to watch more than once config store

### DIFF
--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
@@ -101,10 +101,11 @@ type reconcilerImpl struct {
 	Recorder record.EventRecorder
 
 	// configStore allows for decorating a context with config maps.
+	// [deprecated] in favor of configStores
 	// +optional
 	configStore reconciler.ConfigStore
 
-	// configStore allows for decorating a context with config maps.
+	// configStores allows for decorating a context with config maps.
 	// +optional
 	configStores []reconciler.ConfigStore
 
@@ -201,13 +202,13 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	}
 
 	// If configStore is set, attach the frozen configuration to the context.
-	for _, cs := range r.configStores {
-		ctx = cs.ToContext(ctx)
-	}
-
-	// If configStore is set, attach the frozen configuration to the context.
 	if r.configStore != nil {
 		ctx = r.configStore.ToContext(ctx)
+	}
+
+	// Attach the frozen configuration to the context.
+	for _, cs := range r.configStores {
+		ctx = cs.ToContext(ctx)
 	}
 
 	// Add the recorder to context.

--- a/client/injection/kube/reconciler/apps/v1/deployment/reconciler.go
+++ b/client/injection/kube/reconciler/apps/v1/deployment/reconciler.go
@@ -101,8 +101,13 @@ type reconcilerImpl struct {
 	Recorder record.EventRecorder
 
 	// configStore allows for decorating a context with config maps.
+	// [deprecated] in favor of configStores
 	// +optional
 	configStore reconciler.ConfigStore
+
+	// configStores allows for decorating a context with config maps.
+	// +optional
+	configStores []reconciler.ConfigStore
 
 	// reconciler is the implementation of the business logic of the resource.
 	reconciler Interface
@@ -162,6 +167,9 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client kubern
 		if opts.ConfigStore != nil {
 			rec.configStore = opts.ConfigStore
 		}
+		if len(opts.ConfigStores) != 0 {
+			rec.configStores = opts.ConfigStores
+		}
 		if opts.FinalizerName != "" {
 			rec.finalizerName = opts.FinalizerName
 		}
@@ -196,6 +204,11 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	// If configStore is set, attach the frozen configuration to the context.
 	if r.configStore != nil {
 		ctx = r.configStore.ToContext(ctx)
+	}
+
+	// Attach the frozen configuration to the context.
+	for _, cs := range r.configStores {
+		ctx = cs.ToContext(ctx)
 	}
 
 	// Add the recorder to context.

--- a/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
@@ -100,8 +100,13 @@ type reconcilerImpl struct {
 	Recorder record.EventRecorder
 
 	// configStore allows for decorating a context with config maps.
+	// [deprecated] in favor of configStores
 	// +optional
 	configStore reconciler.ConfigStore
+
+	// configStores allows for decorating a context with config maps.
+	// +optional
+	configStores []reconciler.ConfigStore
 
 	// reconciler is the implementation of the business logic of the resource.
 	reconciler Interface
@@ -161,6 +166,9 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client kubern
 		if opts.ConfigStore != nil {
 			rec.configStore = opts.ConfigStore
 		}
+		if len(opts.ConfigStores) != 0 {
+			rec.configStores = opts.ConfigStores
+		}
 		if opts.FinalizerName != "" {
 			rec.finalizerName = opts.FinalizerName
 		}
@@ -195,6 +203,11 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	// If configStore is set, attach the frozen configuration to the context.
 	if r.configStore != nil {
 		ctx = r.configStore.ToContext(ctx)
+	}
+
+	// Attach the frozen configuration to the context.
+	for _, cs := range r.configStores {
+		ctx = cs.ToContext(ctx)
 	}
 
 	// Add the recorder to context.

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -265,12 +265,13 @@ type reconcilerImpl struct {
 	Recorder {{.recordEventRecorder|raw}}
 
 	// configStore allows for decorating a context with config maps.
+	// [deprecated] in favor of configStores
 	// +optional
 	configStore {{.reconcilerConfigStore|raw}}
 
-	// configStore allows for decorating a context with config maps.
+	// configStores allows for decorating a context with config maps.
 	// +optional
-	configStores {{.reconcilerConfigStores|raw}}
+	configStores []{{.reconcilerConfigStore|raw}}
 
 	// reconciler is the implementation of the business logic of the resource.
 	reconciler Interface
@@ -336,10 +337,10 @@ func NewReconciler(ctx {{.contextContext|raw}}, logger *{{.zapSugaredLogger|raw}
 
 	for _, opts := range options {
 		if opts.ConfigStore != nil {
-			rec.configStore = {{.reconcilerConfigStore|raw}}
+			rec.configStore = opts.ConfigStore
 		}
 		if len(opts.ConfigStores) != 0 {
-			rec.configStores = {{.reconcilerConfigStores|raw}}
+			rec.configStores = opts.ConfigStores
 		}
 		if opts.FinalizerName != "" {
 			rec.finalizerName = opts.FinalizerName
@@ -379,7 +380,7 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 		ctx = r.configStore.ToContext(ctx)
 	}
 
-	// If configStore is set, attach the frozen configuration to the context.
+	// Attach the frozen configuration to the context.
 	for _, cs := range r.configStores {
 		ctx = cs.ToContext(ctx)
 	}

--- a/controller/options.go
+++ b/controller/options.go
@@ -22,7 +22,12 @@ import "knative.dev/pkg/reconciler"
 // on implementation.
 type Options struct {
 	// ConfigStore is used to attach the frozen configuration to the context.
+	// [Deprecated]: Use ConfigStores instead.
+	//               This will be removed once downstream references are addressed.
 	ConfigStore reconciler.ConfigStore
+
+	// ConfigStore is used to attach the frozen configuration to the context.
+	ConfigStores []reconciler.ConfigStore
 
 	// FinalizerName is the name of the finalizer this reconciler uses. This
 	// overrides a default finalizer name assigned by the generator if needed.


### PR DESCRIPTION
## Proposed Change
- Create a list of config stores in Controller Options
    - Implementers may snapshot many config stores and attach to config
    - Use case: serving garbage collection has its own config and will listen to the features config

- The existing single option is left for backwards-compatibility for consumers of /pkg. We can update downstream over time to use the new field before removing.
