### PR TITLE
add a json tag to volatile_time

### DIFF
--- a/apis/volatile_time.go
+++ b/apis/volatile_time.go
@@ -29,7 +29,7 @@ import (
 // Note, go-cmp will still return inequality, see unit test if you
 // need this behavior for go-cmp.
 type VolatileTime struct {
-	Inner metav1.Time
+	Inner metav1.Time `json:",inline"`
 }
 
 // MarshalJSON implements the json.Marshaler interface.


### PR DESCRIPTION
Fixes #1426

-Adds inline to the .inner structure for VolatileTime
- Note marshall/unmarshall are implemented already to bypass the default, but this will help users who may be using the tags for codegen