### PR TITLE
Print loglines from chaosduck to all tests.

### DIFF
--- a/test/logstream/kubelogs.go
+++ b/test/logstream/kubelogs.go
@@ -77,7 +77,13 @@ func (k *kubelogs) startForPod(eg *errgroup.Group, pod *corev1.Pod) {
 			// Read this container's stream.
 			scanner := bufio.NewScanner(stream)
 			for scanner.Scan() {
-				k.handleLine(scanner.Bytes(), pn)
+				// Specialcase logs from chaosduck to be able to easily see when pods
+				// have been killed throughout all tests.
+				if cn == "chaosduck" {
+					k.handleGenericLine(scanner.Bytes(), pn)
+				} else {
+					k.handleLine(scanner.Bytes(), pn)
+				}
 			}
 			// Pods get killed with chaos duck, so logs might end
 			// before the test does. So don't report an error here.
@@ -184,7 +190,7 @@ func (k *kubelogs) handleLine(l []byte, pod string) {
 		if site == "" {
 			site = line.Caller
 		}
-		// E 15:04:05.000 [route-controller] [default/testroute-xyz] this is my message
+		// E 15:04:05.000 webhook-699b7b668d-9smk2 [route-controller] [default/testroute-xyz] this is my message
 		msg := fmt.Sprintf("%s %s %s [%s] [%s] %s",
 			strings.ToUpper(string(line.Level[0])),
 			line.Timestamp.Format(timeFormat),
@@ -198,6 +204,18 @@ func (k *kubelogs) handleLine(l []byte, pod string) {
 		}
 
 		logf(msg)
+	}
+}
+
+// handleGenericLine prints the given logline to all active tests as it cannot be parsed
+// and/or doesn't contain any correlation data (like the chaosduck for example).
+func (k *kubelogs) handleGenericLine(l []byte, pod string) {
+	k.m.RLock()
+	defer k.m.RUnlock()
+
+	for _, logf := range k.keys {
+		// I 15:04:05.000 webhook-699b7b668d-9smk2 this is my message
+		logf(fmt.Sprintf("I %s %s %s", time.Now().Format(timeFormat), pod, string(l)))
 	}
 }
 


### PR DESCRIPTION
To enhance debuggability in flaky tests that are suspicious to be chaos induced.

/assign @vagababov @mattmoor 