### PR TITLE
Remove resourceToKey map

### DIFF
--- a/metrics/resource_view.go
+++ b/metrics/resource_view.go
@@ -50,10 +50,7 @@ type ResourceExporterFactory func(*resource.Resource) (view.Exporter, error)
 type meters struct {
 	meters  map[string]*meterExporter
 	factory ResourceExporterFactory
-	// Cache of Resource pointers from metricskey to Meters, to avoid
-	// unnecessary stringify operations
-	resourceToKey map[*resource.Resource]string
-	lock          sync.Mutex
+	lock    sync.Mutex
 }
 
 // Lock regime: lock allMeters before resourceViews. The critical path is in
@@ -61,8 +58,7 @@ type meters struct {
 // resourceViews if a new meter needs to be created.
 var resourceViews = storedViews{}
 var allMeters = meters{
-	meters:        map[string]*meterExporter{"": &defaultMeter},
-	resourceToKey: map[*resource.Resource]string{nil: ""},
+	meters: map[string]*meterExporter{"": &defaultMeter},
 }
 
 // RegisterResourceView is similar to view.Register(), except that it will
@@ -169,12 +165,7 @@ func flushResourceExporters() {
 }
 
 func meterExporterForResource(r *resource.Resource) *meterExporter {
-	key, ok := allMeters.resourceToKey[r]
-	if !ok {
-		key = resourceToKey(r)
-		allMeters.resourceToKey[r] = key
-	}
-
+	key := resourceToKey(r)
 	mE := allMeters.meters[key]
 	if mE == nil {
 		mE = &meterExporter{}
@@ -234,6 +225,9 @@ func optionForResource(r *resource.Resource) (stats.Options, error) {
 }
 
 func resourceToKey(r *resource.Resource) string {
+	if r == nil {
+		return ""
+	}
 	var s strings.Builder
 	l := len(r.Type)
 	kvs := make([]string, 0, len(r.Labels))


### PR DESCRIPTION
There is currently no mechanism to resolve a resource to a unique pointer causing this map to leak
memory.