### PR TITLE
Disable GC to reduce test flakiness

### DIFF
--- a/metrics/memstats_test.go
+++ b/metrics/memstats_test.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"context"
 	"runtime"
+	"runtime/debug"
 	"testing"
 	"time"
 
@@ -28,6 +29,8 @@ import (
 )
 
 func TestMemStatsMetrics(t *testing.T) {
+	oldV := debug.SetGCPercent(-1)
+	t.Cleanup(func() { debug.SetGCPercent(oldV) })
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 


### PR DESCRIPTION
At least twice I saw this report +1 over what we expect, which I attribute
to actual GC being collected.
E.g. https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_pkg/1580/pull-knative-pkg-unit-tests/1290650655098146816
So disable GC for the duration of this test

/assign @evankanderson mattmoor