### PR TITLE
Add a release leads rotation.

### DIFF
--- a/RELEASE-LEADS.md
+++ b/RELEASE-LEADS.md
@@ -1,4 +1,4 @@
-# Release Masters
+# Release Leads
 
 For each release cycle, we dedicate a team of two individuals, one from Eventing
 and one from Serving, to shepherd the release process. Participation is
@@ -37,18 +37,18 @@ in the rotation, feel free to send a PR to remove yourself.
 
 ## Schedule
 
-| Release | Release Date | Serving        | Eventing        |
-|---------|--------------|----------------|-----------------|
-| v0.17   | 2020-08-18   | yanweiguo      | Harwayne        |
-| v0.18   | 2020-09-29   | ZhiminXiang    | n3wscott        |
-| v0.19   | 2020-11-10   | julz           | nachocano       |
-| v0.20   | 2020-12-22   | nak3           | slinkydeveloper |
-| v0.21   | 2021-02-02   | mattmoor       | lionelvillard   |
-| v0.22   | 2021-03-16   | markusthoemmes | evankanderson   |
-| v0.23   | 2021-04-27   | tcnghia        | vaikas          |
-| v0.24   | 2021-06-08   | dprotaso       | matzew          |
-| v0.25   | 2021-07-20   | vagababov      | grantr          |
-| v0.26   | 2021-08-31   | JRBANCEL       | ...             |
+| Release | Release Date | Serving        | Eventing        | Unpin repos | PKG cut      |
+|---------|--------------|----------------|-----------------|-------------|--------------|
+| v0.17   | 2020-08-18   | yanweiguo      | Harwayne        | -           | 2020-08-11   |
+| v0.18   | 2020-09-29   | ZhiminXiang    | n3wscott        | 2020-08-19  | 2020-09-22   |
+| v0.19   | 2020-11-10   | julz           | nachocano       | 2020-09-30  | 2020-11-03   |
+| v0.20   | 2020-12-22   | nak3           | slinkydeveloper | 2020-11-11  | 2020-12-15   |
+| v0.21   | 2021-02-02   | mattmoor       | lionelvillard   | 2020-12-23  | 2021-01-26   |
+| v0.22   | 2021-03-16   | markusthoemmes | evankanderson   | 2020-02-03  | 2021-03-09   |
+| v0.23   | 2021-04-27   | tcnghia        | vaikas          | 2020-03-17  | 2021-04-20   |
+| v0.24   | 2021-06-08   | dprotaso       | matzew          | 2020-04-28  | 2021-06-01   |
+| v0.25   | 2021-07-20   | vagababov      | grantr          | 2020-06-09  | 2021-07-13   |
+| v0.26   | 2021-08-31   | JRBANCEL       | ...             | 2020-07-21  | 2021-08-24   |
 
 # Release instruction
 
@@ -56,30 +56,29 @@ We release the components of Knative every 6 weeks. All of these components must
 be moved to the latest "release" of all shared dependencies prior to each
 release.
 
-## 5 weeks prior to the release
+## First week of the rotation
 
-###  Make sure you are in the release-masters OWNER_ALIASES
-
-- [knative-sandbox/net-certmanager](https://github.com/knative-sandbox/net-certmanager)
-- [knative-sandbox/net-contour](https://github.com/knative-sandbox/net-contour)
-- [knative-sandbox/net-http01](https://github.com/knative-sandbox/net-http01)
-- [knative-sandbox/net-istio](https://github.com/knative-sandbox/net-istio)
-- [knative-sandbox/net-kourier](https://github.com/knative-sandbox/net-kourier)
-- [knative/caching](https://github.com/knative/caching)
-- [knative/client](https://github.com/knative/client)
-- [knative/eventing-contrib](https://github.com/knative/eventing-contrib)
-- [knative/eventing](https://github.com/knative/eventing)
-- [knative/networking](https://github.com/knative/networking)
-- [knative/operator](https://github.com/knative/operator)
-- [knative/pkg](https://github.com/knative/pkg)
-- [knative/serving](https://github.com/knative/serving)
-- [knative/serving](https://github.com/knative/serving)
-- [knative/test-infra](https://github.com/knative/test-infra)
+###  Make sure you have the right permission
+TBD after we add a Peribolos role.
 
 ### Revert all pins to pin master branches again
 
 Revert all pins in all repositories to pin the **master** branches again, run
 `hack/update-deps.sh --upgrade` and PR the changes.
+
+You should only need to do this for `knative/{serving,eventing-contrib,eventing}` and `knative-sandbox/net-{istio,contour,kourier,http01,certmanager}`. However, you may want to double check `knative/{pkg,caching,networking}` as well in case the previous release leads missed a step during their last rotation.
+
+Example PRs:
+
+* [knative/serving](https://github.com/knative/serving/pull/8579)
+* [knative/eventing](https://github.com/knative/eventing/pull/3546)
+* [knative/eventing-contrib](https://github.com/knative/eventing-contrib/pull/1272)
+* [knative-sandbox/net-istio](https://github.com/knative-sandbox/net-istio/pull/172)
+* [knative-sandbox/net-contour](https://github.com/knative-sandbox/net-contour/pull/154)
+* [knative-sandbox/net-kourier](https://github.com/knative-sandbox/net-kourier/pull/84)
+* [knative-sandbox/net-http01](https://github.com/knative-sandbox/net-http01/pull/42)
+* [knative-sandbox/net-certmanager](https://github.com/knative-sandbox/net-certmanager/pull/39)
+
 
 ## 14 days prior to the release
 

--- a/RELEASE-LEADS.md
+++ b/RELEASE-LEADS.md
@@ -65,7 +65,13 @@ release.
 ## First week of the rotation
 
 ###  Make sure you have the right permission
-TBD after we add a Peribolos role.
+
+Check to make sure you already are in the "Knative Release Leads" team in
+https://github.com/knative/community/blob/master/peribolos/knative.yaml and
+https://github.com/knative/community/blob/master/peribolos/knative-sandbox.yaml
+. If not, send a PR like [this
+one](https://github.com/knative/community/pull/209) to grant yourself some super
+power.
 
 ### Revert all pins to pin master branches again
 
@@ -254,6 +260,10 @@ remaining repositories (except `operator`):
 Release automation will automatically pick up the branches and will likewise
 create the respective tags.
 
-### Ping and remind the next release masters on the rotation
+## Right after the release
+
+Send a PR like [this one](https://github.com/knative/community/pull/209) to
+grant ACLs for the next release leads, and to remove yourself from the
+rotation. Include the next release leads in the PR as a reminder.
 
 ---

--- a/RELEASE-LEADS.md
+++ b/RELEASE-LEADS.md
@@ -13,6 +13,9 @@ if you are contributing on personal capacity and do not have time to contribute
 in the rotation, feel free to send a PR to remove yourself.
 
 ## Serving roster
+
+This roster is seeded with all approvers from Serving workgroups.
+
 - dprotaso
 - julz
 - JRBANCEL
@@ -25,6 +28,9 @@ in the rotation, feel free to send a PR to remove yourself.
 - ZhiminXiang
 
 ## Eventing roster
+
+This roster is seeded with all approvers from Eventing workgroups.
+
 - evankanderson
 - grantr
 - Harwayne

--- a/RELEASE-MASTERS.md
+++ b/RELEASE-MASTERS.md
@@ -1,10 +1,85 @@
-# Releasing Knative
+# Release Masters
+
+For each release cycle, we dedicate a team of two individuals, one from Eventing
+and one from Serving, to shepherd the release process. Participation is
+voluntary and based on good faith. We are only expected to participate during
+our local office hour.
+
+# Roster
+
+We seed this rotation with all approvers from all the Serving and Eventing
+workgroups, excluding productivity. If you are no longer active in Knative, or
+if you are contributing on personal capacity and do not have time to contribute
+in the rotation, feel free to send a PR to remove yourself.
+
+## Serving roster
+- dprotaso
+- julz
+- JRBANCEL
+- markusthoemmes
+- mattmoor
+- nak3
+- tcnghia
+- vagababov
+- yanweiguo
+- ZhiminXiang
+
+## Eventing roster
+- evankanderson
+- grantr
+- Harwayne
+- lionelvillard
+- matzew
+- n3wscott
+- nachocano
+- slinkydeveloper
+- vaikas
+
+## Schedule
+
+| Release | Release Date | Serving        | Eventing        |
+|---------|--------------|----------------|-----------------|
+| v0.17   | 2020-08-18   | yanweiguo      | Harwayne        |
+| v0.18   | 2020-09-29   | ZhiminXiang    | n3wscott        |
+| v0.19   | 2020-11-10   | julz           | nachocano       |
+| v0.20   | 2020-12-22   | nak3           | slinkydeveloper |
+| v0.21   | 2021-02-02   | mattmoor       | lionelvillard   |
+| v0.22   | 2021-03-16   | markusthoemmes | evankanderson   |
+| v0.23   | 2021-04-27   | tcnghia        | vaikas          |
+| v0.24   | 2021-06-08   | dprotaso       | matzew          |
+| v0.25   | 2021-07-20   | vagababov      | grantr          |
+| v0.26   | 2021-08-31   | JRBANCEL       | ...             |
+
+# Release instruction
 
 We release the components of Knative every 6 weeks. All of these components must
 be moved to the latest "release" of all shared dependencies prior to each
 release.
 
----
+## 5 weeks prior to the release
+
+###  Make sure you are in the release-masters OWNER_ALIASES
+
+- [knative-sandbox/eventing-contrib](https://github.com/knative-sandbox/eventing-contrib)
+- [knative-sandbox/net-certmanager](https://github.com/knative-sandbox/net-certmanager)
+- [knative-sandbox/net-contour](https://github.com/knative-sandbox/net-contour)
+- [knative-sandbox/net-http01](https://github.com/knative-sandbox/net-http01)
+- [knative-sandbox/net-istio](https://github.com/knative-sandbox/net-istio)
+- [knative-sandbox/net-kourier](https://github.com/knative-sandbox/net-kourier)
+- [knative-sandbox/networking](https://github.com/knative-sandbox/networking)
+- [knative/caching](https://github.com/knative/caching)
+- [knative/client](https://github.com/knative/client)
+- [knative/eventing](https://github.com/knative/eventing)
+- [knative/operator](https://github.com/knative/operator)
+- [knative/pkg](https://github.com/knative/pkg)
+- [knative/serving](https://github.com/knative/serving)
+- [knative/serving](https://github.com/knative/serving)
+- [knative/test-infra](https://github.com/knative/test-infra)
+
+### Revert all pins to pin master branches again
+
+Revert all pins in all repositories to pin the **master** branches again, run
+`hack/update-deps.sh --upgrade` and PR the changes.
 
 ## 14 days prior to the release
 
@@ -95,13 +170,13 @@ index b277dd3ff..1989885ce 100755
 The downstream repositories this needs to happen on are:
 
 - [knative/client](https://github.com/knative/client)
-- [knative/eventing-contrib](https://github.com/knative/eventing-contrib)
+- [knative-sandbox/eventing-contrib](https://github.com/knative-sandbox/eventing-contrib)
 - [knative/eventing](https://github.com/knative/eventing)
-- [knative/net-certmanager](https://github.com/knative/net-certmanager)
-- [knative/net-contour](https://github.com/knative/net-contour)
-- [knative/net-http01](https://github.com/knative/net-http01)
-- [knative/net-istio](https://github.com/knative/net-istio)
-- [knative/net-kourier](https://github.com/knative/net-kourier)
+- [knative-sandbox/net-certmanager](https://github.com/knative-sandbox/net-certmanager)
+- [knative-sandbox/net-contour](https://github.com/knative-sandbox/net-contour)
+- [knative-sandbox/net-http01](https://github.com/knative-sandbox/net-http01)
+- [knative-sandbox/net-istio](https://github.com/knative-sandbox/net-istio)
+- [knative-sandbox/net-kourier](https://github.com/knative-sandbox/net-kourier)
 - [knative/operator](https://github.com/knative/operator)
 - [knative/serving](https://github.com/knative/serving)
 
@@ -144,16 +219,16 @@ to be pinned in all repositories that depend on them.
 
 For **serving** that is:
 
-- [knative/eventing-contrib](https://github.com/knative/eventing-contrib)
-- [knative/net-certmanager](https://github.com/knative/net-certmanager)
-- [knative/net-contour](https://github.com/knative/net-contour)
-- [knative/net-http01](https://github.com/knative/net-http01)
-- [knative/net-istio](https://github.com/knative/net-istio)
-- [knative/net-kourier](https://github.com/knative/net-kourier)
+- [knative-sandbox/eventing-contrib](https://github.com/knative-sandbox/eventing-contrib)
+- [knative-sandbox/net-certmanager](https://github.com/knative-sandbox/net-certmanager)
+- [knative-sandbox/net-contour](https://github.com/knative-sandbox/net-contour)
+- [knative-sandbox/net-http01](https://github.com/knative-sandbox/net-http01)
+- [knative-sandbox/net-istio](https://github.com/knative-sandbox/net-istio)
+- [knative-sandbox/net-kourier](https://github.com/knative-sandbox/net-kourier)
 
 For **eventing** that is:
 
-- [knative/eventing-contrib](https://github.com/knative/eventing-contrib)
+- [knative-sandbox/eventing-contrib](https://github.com/knative-sandbox/eventing-contrib)
 
 The pins are similar to step 5 above, but now we're pinning `serving` and
 `eventing` respectively. Again, the pin PRs are sent against the **master**
@@ -164,25 +239,16 @@ branch of each repository respectively.
 After the pin PRs are merged, cut the `release-x.y` branch in each of the
 remaining repositories (except `operator`):
 
-- [knative/eventing-contrib](https://github.com/knative/eventing-contrib)
-- [knative/net-certmanager](https://github.com/knative/net-certmanager)
-- [knative/net-contour](https://github.com/knative/net-contour)
-- [knative/net-http01](https://github.com/knative/net-http01)
-- [knative/net-istio](https://github.com/knative/net-istio)
-- [knative/net-kourier](https://github.com/knative/net-kourier)
+- [knative-sandbox/eventing-contrib](https://github.com/knative-sandbox/eventing-contrib)
+- [knative-sandbox/net-certmanager](https://github.com/knative-sandbox/net-certmanager)
+- [knative-sandbox/net-contour](https://github.com/knative-sandbox/net-contour)
+- [knative-sandbox/net-http01](https://github.com/knative-sandbox/net-http01)
+- [knative-sandbox/net-istio](https://github.com/knative-sandbox/net-istio)
+- [knative-sandbox/net-kourier](https://github.com/knative-sandbox/net-kourier)
 
 Release automation will automatically pick up the branches and will likewise
 create the respective tags.
 
----
-
-## After the release
-
-### Revert all pins to pin master branches again
-
-Revert all pins in all repositories to pin the **master** branches again, run
-`hack/update-deps.sh --upgrade` and PR the changes.
-
-### Change this file to reflect new modification to the release if applicable
+### Ping and remind the next release masters on the rotation
 
 ---

--- a/RELEASE-MASTERS.md
+++ b/RELEASE-MASTERS.md
@@ -60,16 +60,16 @@ release.
 
 ###  Make sure you are in the release-masters OWNER_ALIASES
 
-- [knative-sandbox/eventing-contrib](https://github.com/knative-sandbox/eventing-contrib)
 - [knative-sandbox/net-certmanager](https://github.com/knative-sandbox/net-certmanager)
 - [knative-sandbox/net-contour](https://github.com/knative-sandbox/net-contour)
 - [knative-sandbox/net-http01](https://github.com/knative-sandbox/net-http01)
 - [knative-sandbox/net-istio](https://github.com/knative-sandbox/net-istio)
 - [knative-sandbox/net-kourier](https://github.com/knative-sandbox/net-kourier)
-- [knative-sandbox/networking](https://github.com/knative-sandbox/networking)
 - [knative/caching](https://github.com/knative/caching)
 - [knative/client](https://github.com/knative/client)
+- [knative/eventing-contrib](https://github.com/knative-sandbox/eventing-contrib)
 - [knative/eventing](https://github.com/knative/eventing)
+- [knative/networking](https://github.com/knative/networking)
 - [knative/operator](https://github.com/knative/operator)
 - [knative/pkg](https://github.com/knative/pkg)
 - [knative/serving](https://github.com/knative/serving)
@@ -170,7 +170,7 @@ index b277dd3ff..1989885ce 100755
 The downstream repositories this needs to happen on are:
 
 - [knative/client](https://github.com/knative/client)
-- [knative-sandbox/eventing-contrib](https://github.com/knative-sandbox/eventing-contrib)
+- [knative/eventing-contrib](https://github.com/knative/eventing-contrib)
 - [knative/eventing](https://github.com/knative/eventing)
 - [knative-sandbox/net-certmanager](https://github.com/knative-sandbox/net-certmanager)
 - [knative-sandbox/net-contour](https://github.com/knative-sandbox/net-contour)
@@ -219,16 +219,16 @@ to be pinned in all repositories that depend on them.
 
 For **serving** that is:
 
-- [knative-sandbox/eventing-contrib](https://github.com/knative-sandbox/eventing-contrib)
 - [knative-sandbox/net-certmanager](https://github.com/knative-sandbox/net-certmanager)
 - [knative-sandbox/net-contour](https://github.com/knative-sandbox/net-contour)
 - [knative-sandbox/net-http01](https://github.com/knative-sandbox/net-http01)
 - [knative-sandbox/net-istio](https://github.com/knative-sandbox/net-istio)
 - [knative-sandbox/net-kourier](https://github.com/knative-sandbox/net-kourier)
+- [knative/eventing-contrib](https://github.com/knative/eventing-contrib)
 
 For **eventing** that is:
 
-- [knative-sandbox/eventing-contrib](https://github.com/knative-sandbox/eventing-contrib)
+- [knative/eventing-contrib](https://github.com/knative/eventing-contrib)
 
 The pins are similar to step 5 above, but now we're pinning `serving` and
 `eventing` respectively. Again, the pin PRs are sent against the **master**
@@ -239,12 +239,12 @@ branch of each repository respectively.
 After the pin PRs are merged, cut the `release-x.y` branch in each of the
 remaining repositories (except `operator`):
 
-- [knative-sandbox/eventing-contrib](https://github.com/knative-sandbox/eventing-contrib)
 - [knative-sandbox/net-certmanager](https://github.com/knative-sandbox/net-certmanager)
 - [knative-sandbox/net-contour](https://github.com/knative-sandbox/net-contour)
 - [knative-sandbox/net-http01](https://github.com/knative-sandbox/net-http01)
 - [knative-sandbox/net-istio](https://github.com/knative-sandbox/net-istio)
 - [knative-sandbox/net-kourier](https://github.com/knative-sandbox/net-kourier)
+- [knative/eventing-contrib](https://github.com/knative/eventing-contrib)
 
 Release automation will automatically pick up the branches and will likewise
 create the respective tags.

--- a/RELEASE-MASTERS.md
+++ b/RELEASE-MASTERS.md
@@ -67,7 +67,7 @@ release.
 - [knative-sandbox/net-kourier](https://github.com/knative-sandbox/net-kourier)
 - [knative/caching](https://github.com/knative/caching)
 - [knative/client](https://github.com/knative/client)
-- [knative/eventing-contrib](https://github.com/knative-sandbox/eventing-contrib)
+- [knative/eventing-contrib](https://github.com/knative/eventing-contrib)
 - [knative/eventing](https://github.com/knative/eventing)
 - [knative/networking](https://github.com/knative/networking)
 - [knative/operator](https://github.com/knative/operator)


### PR DESCRIPTION
Seed a release master rotation from Serving and Eventing approvers using https://www.random.org/lists/ 

Part of https://github.com/knative/serving/issues/8005

See https://docs.google.com/document/d/1woxDpdw6TrwwF-Y987OYVUFrSgGpyBiR3U8ehf0BX9o/edit# 