### PR TITLE
Fixes a race in the logstream.

### DIFF
--- a/test/logstream/kubelogs.go
+++ b/test/logstream/kubelogs.go
@@ -112,7 +112,7 @@ func (k *kubelogs) watchPods(t test.TLegacy) {
 		return
 	}
 	eg := errgroup.Group{}
-	go func() {
+	eg.Go(func() error {
 		watchedPods := sets.NewString()
 		for ev := range wi.ResultChan() {
 			p := ev.Object.(*corev1.Pod)
@@ -130,7 +130,8 @@ func (k *kubelogs) watchPods(t test.TLegacy) {
 				}
 			}
 		}
-	}()
+		return nil
+	})
 	// Monitor the error group in the background and surface an error on the kubelogs
 	// in case anything had an active stream open.
 	go func() {


### PR DESCRIPTION
`eg.Wait` cannot be called before `eg.Go` without tripping Go's race detection.

Internally errgroup uses sync.Wait, which has [the following](https://godoc.org/sync#WaitGroup.Add) warning:

> Note that calls with a positive delta that occur when the counter is zero must happen before a Wait

When `eg.Go` isn't clearly called prior to `eg.Wait` the read of the error field in `eg.Wait` races with the
assignment of the error field in the once of `eg.Go`.