### PR TITLE
Replace init with sync.Once

### DIFF
--- a/test/logstream/interface.go
+++ b/test/logstream/interface.go
@@ -18,6 +18,7 @@ package logstream
 
 import (
 	"os"
+	"sync"
 
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/test"
@@ -31,6 +32,18 @@ type Canceler func()
 // `test.ObjectNameForTest(t)` to `t.Log`.  It returns a Canceler, which must
 // be called before the test completes.
 func Start(t test.TLegacy) Canceler {
+	// Do this lazily to make import ordering less important.
+	once.Do(func() {
+		ns := os.Getenv(system.NamespaceEnvKey)
+		if ns != "" {
+			// If SYSTEM_NAMESPACE is set, then start the stream.
+			stream = &kubelogs{namespace: ns}
+		} else {
+			// Otherwise set up a null stream.
+			stream = &null{}
+		}
+	})
+
 	return stream.Start(t)
 }
 
@@ -38,15 +51,7 @@ type streamer interface {
 	Start(t test.TLegacy) Canceler
 }
 
-var stream streamer
-
-func init() {
-	ns := os.Getenv(system.NamespaceEnvKey)
-	if ns != "" {
-		// If SYSTEM_NAMESPACE is set, then start the stream.
-		stream = &kubelogs{namespace: ns}
-	} else {
-		// Otherwise set up a null stream.
-		stream = &null{}
-	}
-}
+var (
+	stream streamer
+	once   sync.Once
+)

--- a/test/logstream/interface.go
+++ b/test/logstream/interface.go
@@ -34,8 +34,7 @@ type Canceler func()
 func Start(t test.TLegacy) Canceler {
 	// Do this lazily to make import ordering less important.
 	once.Do(func() {
-		ns := os.Getenv(system.NamespaceEnvKey)
-		if ns != "" {
+		if ns := os.Getenv(system.NamespaceEnvKey); ns != "" {
 			// If SYSTEM_NAMESPACE is set, then start the stream.
 			stream = &kubelogs{namespace: ns}
 		} else {

--- a/test/logstream/null.go
+++ b/test/logstream/null.go
@@ -24,5 +24,6 @@ var _ streamer = (*null)(nil)
 
 // Start implements streamer
 func (*null) Start(t test.TLegacy) Canceler {
+	t.Log("logstream was requested, but SYSTEM_NAMESPACE was unset.")
 	return func() {}
 }


### PR DESCRIPTION
This makes things insensitive to link ordering.

Also add clarity when the null logstream is being used.