### PR TITLE
Use real synchronization to make sure we get four exports in the OpenCensus test

### DIFF
--- a/metrics/opencensus_exporter.go
+++ b/metrics/opencensus_exporter.go
@@ -52,11 +52,15 @@ func newOpenCensusExporter(config *metricsConfig, logger *zap.SugaredLogger) (vi
 	}
 	logger.Infow("Created OpenCensus exporter with config:", zap.Any("config", *config))
 	view.RegisterExporter(e)
-	return e, getFactory(opts), nil
+	return e, getFactory(e, opts), nil
 }
 
-func getFactory(stored []ocagent.ExporterOption) ResourceExporterFactory {
+func getFactory(defaultExporter view.Exporter, stored []ocagent.ExporterOption) ResourceExporterFactory {
 	return func(r *resource.Resource) (view.Exporter, error) {
+		if r == nil || (r.Type == "" && len(r.Labels) == 0) {
+			// Don't create duplicate exporters for the default exporter.
+			return defaultExporter, nil
+		}
 		opts := append(stored, ocagent.WithResourceDetector(
 			func(context.Context) (*resource.Resource, error) {
 				return r, nil

--- a/metrics/resource_view.go
+++ b/metrics/resource_view.go
@@ -177,6 +177,21 @@ func flushResourceExporters() {
 	}
 }
 
+// ClearMetersForTest clears the internal set of metrics being exported,
+// including cleaning up background threads.
+func ClearMetersForTest() {
+	allMeters.lock.Lock()
+	defer allMeters.lock.Unlock()
+
+	for k, meter := range allMeters.meters {
+		if k == "" {
+			continue
+		}
+		meter.m.Stop()
+		delete(allMeters.meters, k)
+	}
+}
+
 func meterExporterForResource(r *resource.Resource) *meterExporter {
 	key := resourceToKey(r)
 	mE := allMeters.meters[key]

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	sd "contrib.go.opencensus.io/exporter/stackdriver"
 	ocmetrics "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
@@ -326,7 +325,7 @@ testComponent_testing_value{project="p1",revision="r2"} 1
 	}, {
 		name: "OpenCensus",
 		init: func() error {
-			if err := ocFake.start(); err != nil {
+			if err := ocFake.start(len(expected)); err != nil {
 				return err
 			}
 			t.Logf("Created exporter at %s", ocFake.address)
@@ -341,8 +340,6 @@ testComponent_testing_value{project="p1",revision="r2"} 1
 			UnregisterResourceView(gaugeView, resourceCounter)
 			FlushExporter()
 
-			time.Sleep(10 * time.Millisecond)
-			ocFake.srv.Stop() // Force close connections
 			records := []metricExtract{}
 			for record := range ocFake.published {
 				for _, m := range record.Metrics {
@@ -599,11 +596,12 @@ func TestStackDriverExports(t *testing.T) {
 type openCensusFake struct {
 	address   string
 	srv       *grpc.Server
+	exports   sync.WaitGroup
 	wg        sync.WaitGroup
 	published chan ocmetrics.ExportMetricsServiceRequest
 }
 
-func (oc *openCensusFake) start() error {
+func (oc *openCensusFake) start(expectedMetrics int) error {
 	ln, err := net.Listen("tcp", oc.address)
 	if err != nil {
 		return err
@@ -619,7 +617,14 @@ func (oc *openCensusFake) start() error {
 		oc.wg.Wait()
 		close(oc.published)
 	}()
+	oc.exports.Add(expectedMetrics)
+	go oc.stop()
 	return nil
+}
+
+func (oc *openCensusFake) stop() {
+	oc.exports.Wait()
+	oc.srv.Stop()
 }
 
 func (oc *openCensusFake) Export(stream ocmetrics.MetricsService_ExportServer) error {
@@ -643,6 +648,7 @@ func (oc *openCensusFake) Export(stream ocmetrics.MetricsService_ExportServer) e
 				in.Resource = streamResource
 			}
 			oc.published <- *in
+			oc.exports.Done()
 		}
 	}
 }


### PR DESCRIPTION
Somehow, the timing on my machine always "wins" this race even without the sleep, but switch from a 10ms sleep to real `sync.WaitGroup`s since the race can apparently be lost, making the test flaky: https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_pkg/1588/pull-knative-pkg-unit-tests/1291443127265005569

/assign @vagababov 