### PR TITLE
filter "control-plane" labeled namespaces out of our webhooks

### DIFF
--- a/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/webhook/resourcesemantics/defaulting/defaulting.go
@@ -186,6 +186,9 @@ func (ac *reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 			MatchExpressions: []metav1.LabelSelectorRequirement{{
 				Key:      "webhooks.knative.dev/exclude",
 				Operator: metav1.LabelSelectorOpDoesNotExist,
+			},{
+				Key:      "control-plane",
+				Operator: metav1.LabelSelectorOpDoesNotExist,
 			}},
 		}
 		webhook.Webhooks[i].ClientConfig.CABundle = caCert

--- a/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/webhook/resourcesemantics/defaulting/defaulting.go
@@ -186,7 +186,9 @@ func (ac *reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 			MatchExpressions: []metav1.LabelSelectorRequirement{{
 				Key:      "webhooks.knative.dev/exclude",
 				Operator: metav1.LabelSelectorOpDoesNotExist,
-			},{
+			}, {
+				// "control-plane" is added to support Azure's AKS, otherwise the controllers fight.
+				// See knative/pkg#1590 for details.
 				Key:      "control-plane",
 				Operator: metav1.LabelSelectorOpDoesNotExist,
 			}},

--- a/webhook/resourcesemantics/defaulting/table_test.go
+++ b/webhook/resourcesemantics/defaulting/table_test.go
@@ -66,6 +66,9 @@ func TestReconcile(t *testing.T) {
 		MatchExpressions: []metav1.LabelSelectorRequirement{{
 			Key:      "webhooks.knative.dev/exclude",
 			Operator: metav1.LabelSelectorOpDoesNotExist,
+		}, {
+			Key:      "control-plane",
+			Operator: metav1.LabelSelectorOpDoesNotExist,
 		}},
 	}
 

--- a/webhook/resourcesemantics/validation/reconcile_config.go
+++ b/webhook/resourcesemantics/validation/reconcile_config.go
@@ -149,6 +149,9 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 			MatchExpressions: []metav1.LabelSelectorRequirement{{
 				Key:      "webhooks.knative.dev/exclude",
 				Operator: metav1.LabelSelectorOpDoesNotExist,
+			},{
+				Key:      "control-plane",
+				Operator: metav1.LabelSelectorOpDoesNotExist,
 			}},
 		}
 		webhook.Webhooks[i].ClientConfig.CABundle = caCert

--- a/webhook/resourcesemantics/validation/reconcile_config.go
+++ b/webhook/resourcesemantics/validation/reconcile_config.go
@@ -149,7 +149,9 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 			MatchExpressions: []metav1.LabelSelectorRequirement{{
 				Key:      "webhooks.knative.dev/exclude",
 				Operator: metav1.LabelSelectorOpDoesNotExist,
-			},{
+			}, {
+				// "control-plane" is added to support Azure's AKS, otherwise the controllers fight.
+				// See knative/pkg#1590 for details.
 				Key:      "control-plane",
 				Operator: metav1.LabelSelectorOpDoesNotExist,
 			}},

--- a/webhook/resourcesemantics/validation/reconcile_config_test.go
+++ b/webhook/resourcesemantics/validation/reconcile_config_test.go
@@ -66,6 +66,9 @@ func TestReconcile(t *testing.T) {
 		MatchExpressions: []metav1.LabelSelectorRequirement{{
 			Key:      "webhooks.knative.dev/exclude",
 			Operator: metav1.LabelSelectorOpDoesNotExist,
+		}, {
+			Key:      "control-plane",
+			Operator: metav1.LabelSelectorOpDoesNotExist,
 		}},
 	}
 


### PR DESCRIPTION
fixes: #1590 