### PR TITLE
Completely skip metric reporting if backend is 'none'.

### DIFF
--- a/metrics/config.go
+++ b/metrics/config.go
@@ -156,9 +156,9 @@ func NewStackdriverClientConfigFromMap(config map[string]string) *StackdriverCli
 // record applies the `ros` Options to each measurement in `mss` and then records the resulting
 // measurements in the metricsConfig's designated backend.
 func (mc *metricsConfig) record(ctx context.Context, mss []stats.Measurement, ros ...stats.Options) error {
-	if mc == nil {
-		// Don't record data points if the metric config is not initialized yet.
-		// At this point, it's unclear whether should record or not.
+	if mc == nil || mc.backendDestination == none {
+		// Don't record data points if the metric config is not initialized yet or if
+		// the defined backend is "none" explicitly.
 		return nil
 	}
 

--- a/metrics/record_test.go
+++ b/metrics/record_test.go
@@ -148,6 +148,10 @@ func testRecord(t *testing.T, measure *stats.Int64Measure, shouldReportCases []c
 	}, {
 		name:        "empty metricsConfig",
 		measurement: measure.M(4),
+	}, {
+		name:          "none backend",
+		metricsConfig: &metricsConfig{backendDestination: none},
+		measurement:   measure.M(4),
 	}}
 
 	for _, test := range shouldNotReportCases {


### PR DESCRIPTION
There's no point in even producing the metrics if they are not being surfaced in any way anyway.

/assign @vagababov @evankanderson 