### PR TITLE
Reduce delays in controller tests

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1450,10 +1450,10 @@ func TestStartInformersEventualSuccess(t *testing.T) {
 	}()
 
 	select {
-	case err := <-errCh:
-		t.Errorf("Unexpected send on errCh: %v", err)
-	case <-time.After(1 * time.Second):
+	case <-time.After(50 * time.Millisecond):
 		// Wait a brief period to ensure nothing is sent.
+	case err := <-errCh:
+		t.Fatal("Unexpected send on errCh:", err)
 	}
 
 	// Let the Sync complete.
@@ -1481,10 +1481,10 @@ func TestStartInformersFailure(t *testing.T) {
 	}()
 
 	select {
-	case err := <-errCh:
-		t.Errorf("Unexpected send on errCh: %v", err)
-	case <-time.After(1 * time.Second):
+	case <-time.After(50 * time.Millisecond):
 		// Wait a brief period to ensure nothing is sent.
+	case err := <-errCh:
+		t.Fatal("Unexpected send on errCh:", err)
 	}
 
 	// Now close the stopCh and we should see an error sent.
@@ -1537,10 +1537,10 @@ func TestRunInformersEventualSuccess(t *testing.T) {
 	}()
 
 	select {
-	case err := <-errCh:
-		t.Fatalf("Unexpected send on errCh: %v", err)
-	case <-time.After(1 * time.Second):
+	case <-time.After(50 * time.Millisecond):
 		// Wait a brief period to ensure nothing is sent.
+	case err := <-errCh:
+		t.Fatal("Unexpected send on errCh:", err)
 	}
 
 	// Let the Sync complete.
@@ -1571,10 +1571,10 @@ func TestRunInformersFailure(t *testing.T) {
 	}()
 
 	select {
-	case err := <-errCh:
-		t.Errorf("Unexpected send on errCh: %v", err)
-	case <-time.After(1 * time.Second):
+	case <-time.After(50 * time.Millisecond):
 		// Wait a brief period to ensure nothing is sent.
+	case err := <-errCh:
+		t.Fatal("Unexpected send on errCh:", err)
 	}
 
 	// Now close the stopCh and we should see an error sent.

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1343,9 +1343,10 @@ func TestImplGlobalResync(t *testing.T) {
 	impl.GlobalResync(&dummyInformer{})
 
 	// The global resync delays enqueuing things by a second with a jitter that
-	// goes up to len(dummyObjs) times a second.
+	// goes up to len(dummyObjs) times a second: time.Duration(1+len(dummyObjs)) * time.Second.
+	// In this test, the fast lane is empty, so we can assume immediate enqueuing.
 	select {
-	case <-time.After((1 + 3) * time.Second):
+	case <-time.After(50 * time.Millisecond):
 		// We don't expect completion before the context is cancelled.
 	case <-doneCh:
 		t.Error("StartAll finished early.")

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -435,7 +435,7 @@ func (t testRateLimiter) NumRequeues(interface{}) int    { return 0 }
 
 var _ workqueue.RateLimiter = (*testRateLimiter)(nil)
 
-func TestEnqueues(t *testing.T) {
+func TestEnqueue(t *testing.T) {
 	tests := []struct {
 		name      string
 		work      func(*Impl)
@@ -741,8 +741,6 @@ func TestEnqueues(t *testing.T) {
 			impl := NewImplFull(&NopReconciler{}, ControllerOptions{WorkQueueName: "Testing", Logger: TestLogger(t), RateLimiter: rl})
 			test.work(impl)
 
-			// The rate limit on our queue delays when things are added to the queue.
-			time.Sleep(150 * time.Millisecond)
 			impl.WorkQueue().ShutDown()
 			gotQueue := drainWorkQueue(impl.WorkQueue())
 
@@ -758,8 +756,6 @@ func TestEnqueues(t *testing.T) {
 			impl := NewImplWithStats(&NopReconciler{}, TestLogger(t), "Testing", &FakeStatsReporter{})
 			test.work(impl)
 
-			// The rate limit on our queue delays when things are added to the queue.
-			time.Sleep(50 * time.Millisecond)
 			impl.WorkQueue().ShutDown()
 			gotQueue := drainWorkQueue(impl.WorkQueue())
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -770,7 +770,7 @@ func TestEnqueue(t *testing.T) {
 func TestEnqueueAfter(t *testing.T) {
 	const (
 		// longDelay is longer than we expect the test to run.
-		longDelay = 1 * time.Minute
+		longDelay = time.Minute
 		// shortDelay is short enough for the test to execute quickly, but long
 		// enough to reasonably delay the enqueuing of an item.
 		shortDelay = 50 * time.Millisecond
@@ -847,7 +847,7 @@ func TestEnqueueAfter(t *testing.T) {
 func TestEnqueueKeyAfter(t *testing.T) {
 	const (
 		// longDelay is longer than we expect the test to run.
-		longDelay = 1 * time.Minute
+		longDelay = time.Minute
 		// shortDelay is short enough for the test to execute quickly, but long
 		// enough to reasonably delay the enqueuing of an item.
 		shortDelay = 50 * time.Millisecond


### PR DESCRIPTION
A series of tweaks to reduce unnecessary pauses in `controller` tests. Most of them related to excessive Sleeps.

Each commit corresponds to 1 test suite. See individual commit messages for details.

Closes #1364