### PR TITLE
fix nil pointer

### DIFF
--- a/test/logstream/kubelogs.go
+++ b/test/logstream/kubelogs.go
@@ -83,6 +83,7 @@ func (k *kubelogs) startForPod(pod *corev1.Pod) {
 					defer k.m.Unlock()
 					k.err = err
 				}()
+				return
 			}
 			defer stream.Close()
 			// Read this container's stream.


### PR DESCRIPTION
if we don't return the use of `stream` causes a panic

From: https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1292853671020728321

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1e88beb]

goroutine 104 [running]:
knative.dev/pkg/test/logstream.(*kubelogs).startForPod.func1(0xc0014ccf20, 0xe, 0xc0000e14a0, 0xc0018806f0, 0x24, 0xc001616d20, 0x1f, 0xc001984170)
	/home/prow/go/src/knative.dev/serving/vendor/knative.dev/pkg/test/logstream/kubelogs.go:87 +0x27b
created by knative.dev/pkg/test/logstream.(*kubelogs).startForPod
	/home/prow/go/src/knative.dev/serving/vendor/knative.dev/pkg/test/logstream/kubelogs.go:69 +0x286
```