### PR TITLE
Return from the goroutine if we fail to start the stream

### DIFF
--- a/test/logstream/kubelogs.go
+++ b/test/logstream/kubelogs.go
@@ -83,6 +83,7 @@ func (k *kubelogs) startForPod(pod *corev1.Pod) {
 					defer k.m.Unlock()
 					k.err = err
 				}()
+				return
 			}
 			defer stream.Close()
 			// Read this container's stream.


### PR DESCRIPTION
This causes panics and lotsa flaky tests.
eg. https://github.com/knative/serving/issues/8725

/assign mattmoor @julz 