### PR TITLE
Inject the config into the context.

### DIFF
--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -190,6 +190,8 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 	if cfg.Burst == 0 {
 		cfg.Burst = len(ctors) * rest.DefaultBurst
 	}
+	ctx = injection.WithConfig(ctx, cfg)
+
 	ctx, informers := injection.Default.SetupInformers(ctx, cfg)
 
 	logger, atomicLevel := SetupLoggerOrDie(ctx, component)


### PR DESCRIPTION
Inject the config into the context.

This seems to have been accidentally removed in #1476 and is a problem for knative/operator#230.