### PR TITLE
Add a helper func for BucketSet

### DIFF
--- a/hash/bucketer.go
+++ b/hash/bucketer.go
@@ -111,6 +111,11 @@ func (bs *BucketSet) Owner(key string) string {
 	return ret
 }
 
+// HasBucket returns true if this BucketSet has the given bucket name.
+func (bs *BucketSet) HasBucket(bkt string) bool {
+	return bs.buckets.Has(bkt)
+}
+
 // BucketList returns the bucket names of this BucketSet in random order.
 func (bs *BucketSet) BucketList() []string {
 	bs.mu.RLock()

--- a/hash/bucketer_test.go
+++ b/hash/bucketer_test.go
@@ -118,6 +118,16 @@ func TestBucketSetBuckets(t *testing.T) {
 	}
 }
 
+func TestBucketSetHasBucket(t *testing.T) {
+	bs := NewBucketSet(sets.NewString(thisBucket, "aguacero", "chaparrón"))
+	if !bs.HasBucket(thisBucket) {
+		t.Errorf("HasBucket(%v) = false", thisBucket)
+	}
+	if bs.HasBucket(otherBucket) {
+		t.Errorf("HasBucket(%v) = true", otherBucket)
+	}
+}
+
 func TestBucketHas(t *testing.T) {
 	bs := NewBucketSet(buckets)
 	b := Bucket{


### PR DESCRIPTION
Add `BucketSet.HasBucket` func to get whether the BucketSet has the given BucketName. This will be used to filter endpoints created for leader election buckets.

/assign @vagababov 