### PR TITLE
Assorted tweaks to actions.

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -15,8 +15,10 @@
 name: Build
 
 on:
+  push:
+    branches: [ 'master', 'release-*' ]
   pull_request:
-    branches: [ master ]
+    branches: [ 'master', 'release-*' ]
 
 jobs:
 
@@ -24,13 +26,10 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.15.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}
-
-    env:
-      GOPATH: ${{ github.workspace }}
 
     steps:
 
@@ -40,14 +39,13 @@ jobs:
           go-version: ${{ matrix.go-version }}
         id: go
 
-      - name: Check out code onto GOPATH
+      - name: Check out code
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
-          path: ./src/knative.dev/${{ github.event.repository.name }}
 
       - name: Vet
-        run: go vet knative.dev/${{ github.event.repository.name }}/...
+        run: go vet ./...
 
       - name: Build
-        run: go build -v knative.dev/${{ github.event.repository.name }}/...
+        run: go build -v ./...

--- a/.github/workflows/go-style.yaml
+++ b/.github/workflows/go-style.yaml
@@ -15,8 +15,10 @@
 name: Code Style
 
 on:
+  push:
+    branches: [ 'master', 'release-*' ]
   pull_request:
-    branches: [ master ]
+    branches: [ 'master', 'release-*' ]
 
 jobs:
 
@@ -24,36 +26,30 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
 
-    env:
-      GOPATH: ${{ github.workspace }}
-
     steps:
 
-      - name: Set up Go 1.14.x
+      - name: Set up Go 1.15.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.x
+          go-version: 1.15.x
         id: go
 
-      - name: Check out code onto GOPATH
+      - name: Check out code
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
-          path: ./src/knative.dev/${{ github.event.repository.name }}
 
-      # TODO: add pretter step
+      # TODO: add prettier step
+      # TODO: add goimports step
 
       - name: Go Format
         shell: bash
         run: |
-          pushd ./src/knative.dev/${{ github.event.repository.name }}
           gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -type f -name '*.go' -print)
-          popd
 
       - name: Verify
         shell: bash
         run: |
-          pushd ./src/knative.dev/${{ github.event.repository.name }}
           if [[ $(git diff-index --name-only HEAD --) ]]; then
               echo "Found diffs in:"
               git diff-index --name-only HEAD --
@@ -61,4 +57,3 @@ jobs:
               exit 1
           fi
           echo "${{ github.repository }} is formatted correctly."
-          popd

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -15,8 +15,10 @@
 name: Test
 
 on:
+  push:
+    branches: [ 'master', 'release-*' ]
   pull_request:
-    branches: [ master ]
+    branches: [ 'master', 'release-*' ]
 
 jobs:
 
@@ -24,13 +26,10 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.15.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}
-
-    env:
-      GOPATH: ${{ github.workspace }}
 
     steps:
 
@@ -40,11 +39,10 @@ jobs:
           go-version: ${{ matrix.go-version }}
         id: go
 
-      - name: Check out code onto GOPATH
+      - name: Check out code
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
-          path: ./src/knative.dev/${{ github.event.repository.name }}
 
       - name: Test
-        run: go test -race knative.dev/${{ github.event.repository.name }}/...
+        run: go test -race ./...

--- a/.github/workflows/go-verify.yaml
+++ b/.github/workflows/go-verify.yaml
@@ -15,8 +15,10 @@
 name: Verify
 
 on:
+  push:
+    branches: [ 'master', 'release-*' ]
   pull_request:
-    branches: [ master ]
+    branches: [ 'master', 'release-*' ]
 
 jobs:
 
@@ -24,7 +26,7 @@ jobs:
     name: Verify Deps and Codegen
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.15.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
Drop GOPATH from all except verify (codegen needs it), and change directories to just use workspace.

Switch to Go 1.15 (go.mod actually controls what's used IIUC).