### PR TITLE
Fix the logkey.Key tagging in Enqueue.

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -262,7 +262,7 @@ func (c *Impl) EnqueueAfter(obj interface{}, after time.Duration) {
 // and enqueues that key in the slow lane.
 func (c *Impl) EnqueueSlowKey(key types.NamespacedName) {
 	c.workQueue.SlowLane().Add(key)
-	c.logger.With(zap.Object(logkey.Key, logging.NamespacedName(key))).
+	c.logger.With(zap.String(logkey.Key, key.String())).
 		Debugf("Adding to the slow queue %s (depth(total/slow): %d/%d)",
 			safeKey(key), c.workQueue.Len(), c.workQueue.SlowLane().Len())
 }
@@ -390,7 +390,7 @@ func (c *Impl) EnqueueNamespaceOf(obj interface{}) {
 // EnqueueKey takes a namespace/name string and puts it onto the work queue.
 func (c *Impl) EnqueueKey(key types.NamespacedName) {
 	c.workQueue.Add(key)
-	c.logger.With(zap.Object(logkey.Key, logging.NamespacedName(key))).
+	c.logger.With(zap.String(logkey.Key, key.String())).
 		Debugf("Adding to queue %s (depth: %d)", safeKey(key), c.workQueue.Len())
 }
 
@@ -406,7 +406,7 @@ func (c *Impl) MaybeEnqueueBucketKey(bkt reconciler.Bucket, key types.Namespaced
 // the work queue after given delay.
 func (c *Impl) EnqueueKeyAfter(key types.NamespacedName, delay time.Duration) {
 	c.workQueue.AddAfter(key, delay)
-	c.logger.With(zap.Object(logkey.Key, logging.NamespacedName(key))).
+	c.logger.With(zap.String(logkey.Key, key.String())).
 		Debugf("Adding to queue %s (delay: %v, depth: %d)", safeKey(key), delay, c.workQueue.Len())
 }
 


### PR DESCRIPTION
Debugging https://github.com/knative-sandbox/net-contour/issues/214 I noticed the logging was showing up as:

```
"knative.dev/key":{"knative.dev/key":"serving-tests/service-create-and-update-teaoccuu"}
```