### PR TITLE
Fix the flaky test.

### DIFF
--- a/controller/stats_reporter_test.go
+++ b/controller/stats_reporter_test.go
@@ -38,7 +38,6 @@ func TestNewStatsReporterErrors(t *testing.T) {
 		if err == nil {
 			t.Errorf("Expected err to not be nil for value %q, got nil", v)
 		}
-
 	}
 }
 


### PR DESCRIPTION
The test assumes the threads would schedule in particular way, but they don't.
But what we really care to check is that we thread in the proper RL and it works.
We don't need to check that underlying queue impl works, that's done in its own tests.
So just verify these two things.

/assign mattmoor