### PR TITLE
Fix the the request logging boolean toggle

### DIFF
--- a/metrics/config_observability.go
+++ b/metrics/config_observability.go
@@ -28,6 +28,8 @@ import (
 const (
 	// The following is used to set the default log url template
 	DefaultLogURLTemplate = "http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))"
+	// DefaultRequestLogTemplate is the default format for emitting request logs.
+	DefaultRequestLogTemplate = `{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}`
 
 	// The following is used to set the default metrics backend
 	defaultRequestMetricsBackend = "prometheus"
@@ -74,6 +76,7 @@ type ObservabilityConfig struct {
 func defaultConfig() *ObservabilityConfig {
 	return &ObservabilityConfig{
 		LoggingURLTemplate:    DefaultLogURLTemplate,
+		RequestLogTemplate:    DefaultRequestLogTemplate,
 		RequestMetricsBackend: defaultRequestMetricsBackend,
 	}
 }

--- a/metrics/config_observability.go
+++ b/metrics/config_observability.go
@@ -17,8 +17,8 @@ limitations under the License.
 package metrics
 
 import (
+	"fmt"
 	"os"
-	"strings"
 	texttemplate "text/template"
 
 	corev1 "k8s.io/api/core/v1"
@@ -33,7 +33,9 @@ const (
 	defaultRequestMetricsBackend = "prometheus"
 
 	// The env var name for config-observability
-	configMapNameEnv = "CONFIG_OBSERVABILITY_NAME"
+	configMapNameEnv  = "CONFIG_OBSERVABILITY_NAME"
+	reqLogTemplateKey = "logging.request-log-template"
+	enableReqLogKey   = "logging.enable-request-log"
 )
 
 // ObservabilityConfig contains the configuration defined in the observability ConfigMap.
@@ -83,7 +85,8 @@ func NewObservabilityConfigFromConfigMap(configMap *corev1.ConfigMap) (*Observab
 	if err := cm.Parse(configMap.Data,
 		cm.AsBool("logging.enable-var-log-collection", &oc.EnableVarLogCollection),
 		cm.AsString("logging.revision-url-template", &oc.LoggingURLTemplate),
-		cm.AsString("logging.request-log-template", &oc.RequestLogTemplate),
+		cm.AsString(reqLogTemplateKey, &oc.RequestLogTemplate),
+		cm.AsBool(enableReqLogKey, &oc.EnableRequestLog),
 		cm.AsBool("logging.enable-probe-request-log", &oc.EnableProbeRequestLog),
 		cm.AsString("metrics.request-metrics-backend-destination", &oc.RequestMetricsBackend),
 		cm.AsBool("profiling.enable", &oc.EnableProfiling),
@@ -92,15 +95,8 @@ func NewObservabilityConfigFromConfigMap(configMap *corev1.ConfigMap) (*Observab
 		return nil, err
 	}
 
-	if raw, ok := configMap.Data["logging.enable-request-log"]; ok {
-		if strings.EqualFold(raw, "true") && oc.RequestLogTemplate != "" {
-			oc.EnableRequestLog = true
-		}
-	} else if oc.RequestLogTemplate != "" {
-		// TODO: remove this after 0.17 cuts, this is meant only for smooth transition to the new flag.
-		// Once 0.17 cuts we should set a proper default value and users will need to set the flag explicitly
-		// to enable request logging.
-		oc.EnableRequestLog = true
+	if oc.RequestLogTemplate == "" && oc.EnableRequestLog {
+		return nil, fmt.Errorf("%q was set to true, but no %q was specified", enableReqLogKey, reqLogTemplateKey)
 	}
 
 	if oc.RequestLogTemplate != "" {

--- a/metrics/config_observability_test.go
+++ b/metrics/config_observability_test.go
@@ -73,9 +73,10 @@ func TestObservabilityConfiguration(t *testing.T) {
 		},
 		data: map[string]string{
 			"logging.enable-probe-request-log":            "true",
-			"logging.enable-var-log-collection":           "true",
-			"logging.revision-url-template":               "https://logging.io",
 			"logging.enable-request-log":                  "false",
+			"logging.enable-var-log-collection":           "true",
+			"logging.request-log-template":                "",
+			"logging.revision-url-template":               "https://logging.io",
 			"metrics.request-metrics-backend-destination": "stackdriver",
 			"profiling.enable":                            "true",
 		},
@@ -84,9 +85,10 @@ func TestObservabilityConfiguration(t *testing.T) {
 		wantErr: true,
 		data: map[string]string{
 			"logging.enable-probe-request-log":            "true",
-			"logging.enable-var-log-collection":           "true",
-			"logging.revision-url-template":               "https://logging.io",
 			"logging.enable-request-log":                  "true",
+			"logging.enable-var-log-collection":           "true",
+			"logging.request-log-template":                "",
+			"logging.revision-url-template":               "https://logging.io",
 			"metrics.request-metrics-backend-destination": "stackdriver",
 			"profiling.enable":                            "true",
 		},
@@ -110,10 +112,10 @@ func TestObservabilityConfiguration(t *testing.T) {
 			"profiling.enable":                            "true",
 		},
 	}, {
-		name:    "observability configuration with collector address",
-		wantErr: false,
+		name: "observability configuration with collector address",
 		wantConfig: &ObservabilityConfig{
 			LoggingURLTemplate:      DefaultLogURLTemplate,
+			RequestLogTemplate:      DefaultRequestLogTemplate,
 			RequestMetricsBackend:   "opencensus",
 			MetricsCollectorAddress: "otel:55678",
 		},

--- a/metrics/config_observability_test.go
+++ b/metrics/config_observability_test.go
@@ -32,13 +32,12 @@ func TestObservabilityConfiguration(t *testing.T) {
 		wantErr    bool
 		wantConfig *ObservabilityConfig
 	}{{
-		name:    "observability configuration with all inputs",
-		wantErr: false,
+		name: "observability configuration with all inputs",
 		wantConfig: &ObservabilityConfig{
 			EnableProbeRequestLog:  true,
 			EnableProfiling:        true,
-			EnableRequestLog:       false,
 			EnableVarLogCollection: true,
+			EnableRequestLog:       true,
 			LoggingURLTemplate:     "https://logging.io",
 			RequestLogTemplate:     `{"requestMethod": "{{.Request.Method}}"}`,
 			RequestMetricsBackend:  "stackdriver",
@@ -48,31 +47,27 @@ func TestObservabilityConfiguration(t *testing.T) {
 			"logging.enable-var-log-collection":           "true",
 			"logging.request-log-template":                `{"requestMethod": "{{.Request.Method}}"}`,
 			"logging.revision-url-template":               "https://logging.io",
-			"logging.enable-request-log":                  "false",
+			"logging.enable-request-log":                  "true",
 			"metrics.request-metrics-backend-destination": "stackdriver",
 			"profiling.enable":                            "true",
 		},
 	}, {
 		name:       "observability config with no map",
-		wantErr:    false,
 		wantConfig: defaultConfig(),
 	}, {
-		name:       "invalid request log template",
-		wantErr:    true,
-		wantConfig: nil,
+		name:    "invalid request log template",
+		wantErr: true,
 		data: map[string]string{
 			"logging.request-log-template": `{{ something }}`,
 		},
 	}, {
-		name:    "observability configuration with request log set and with template not set",
+		name:    "observability configuration with request log and template not set",
 		wantErr: false,
 		wantConfig: &ObservabilityConfig{
 			EnableProbeRequestLog:  true,
 			EnableProfiling:        true,
-			EnableRequestLog:       false,
 			EnableVarLogCollection: true,
 			LoggingURLTemplate:     "https://logging.io",
-			RequestLogTemplate:     "",
 			RequestMetricsBackend:  "stackdriver",
 		},
 		data: map[string]string{
@@ -84,12 +79,22 @@ func TestObservabilityConfiguration(t *testing.T) {
 			"profiling.enable":                            "true",
 		},
 	}, {
+		name:    "observability configuration with request log set and template not set",
+		wantErr: true,
+		data: map[string]string{
+			"logging.enable-probe-request-log":            "true",
+			"logging.enable-var-log-collection":           "true",
+			"logging.revision-url-template":               "https://logging.io",
+			"logging.enable-request-log":                  "true",
+			"metrics.request-metrics-backend-destination": "stackdriver",
+			"profiling.enable":                            "true",
+		},
+	}, {
 		name:    "observability configuration with request log not set and with template set",
 		wantErr: false,
 		wantConfig: &ObservabilityConfig{
 			EnableProbeRequestLog:  true,
 			EnableProfiling:        true,
-			EnableRequestLog:       true,
 			EnableVarLogCollection: true,
 			LoggingURLTemplate:     "https://logging.io",
 			RequestLogTemplate:     `{"requestMethod": "{{.Request.Method}}"}`,
@@ -107,12 +112,7 @@ func TestObservabilityConfiguration(t *testing.T) {
 		name:    "observability configuration with collector address",
 		wantErr: false,
 		wantConfig: &ObservabilityConfig{
-			EnableProbeRequestLog:   false,
-			EnableProfiling:         false,
-			EnableRequestLog:        false,
-			EnableVarLogCollection:  false,
 			LoggingURLTemplate:      DefaultLogURLTemplate,
-			RequestLogTemplate:      "",
 			RequestMetricsBackend:   "opencensus",
 			MetricsCollectorAddress: "otel:55678",
 		},

--- a/metrics/config_observability_test.go
+++ b/metrics/config_observability_test.go
@@ -62,8 +62,26 @@ func TestObservabilityConfiguration(t *testing.T) {
 			"logging.request-log-template": `{{ something }}`,
 		},
 	}, {
-		name:    "observability configuration with request log and template not set",
-		wantErr: false,
+		name: "observability configuration with request log set and template default",
+		data: map[string]string{
+			"logging.enable-probe-request-log":            "true",
+			"logging.enable-request-log":                  "true",
+			"logging.enable-var-log-collection":           "true",
+			"logging.revision-url-template":               "https://logging.io",
+			"metrics.request-metrics-backend-destination": "stackdriver",
+			"profiling.enable":                            "true",
+		},
+		wantConfig: &ObservabilityConfig{
+			EnableProbeRequestLog:  true,
+			EnableProfiling:        true,
+			EnableRequestLog:       true,
+			EnableVarLogCollection: true,
+			LoggingURLTemplate:     "https://logging.io",
+			RequestLogTemplate:     DefaultRequestLogTemplate,
+			RequestMetricsBackend:  "stackdriver",
+		},
+	}, {
+		name: "observability configuration with request log and template not set",
 		wantConfig: &ObservabilityConfig{
 			EnableProbeRequestLog:  true,
 			EnableProfiling:        true,


### PR DESCRIPTION
Since we have cut the 0.17, we can go for the proper toggle setup:

- if request logging is on — template must be present and the logging will be on
- if the request of logging is off — template can be present, but will not affect whether the request logs will be collected

Really
Fixes https://github.com/knative/serving/issues/8644

/assign @yanweiguo @julz 