### PR TITLE
Adding github action to test downstream repos.

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -15,8 +15,6 @@
 name: Downstream
 
 on:
-  push:
-    branches: [ 'master', 'release-*' ]
   pull_request:
     branches: [ 'master', 'release-*' ]
 

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -58,7 +58,7 @@ jobs:
         path: ./src/knative.dev/serving
 
     - name: Test Downstream
-      uses: knative-sandbox/downstream-test-go@v1
+      uses: knative-sandbox/downstream-test-go@v1.0.1
       with:
         upstream-module: knative.dev/${{ github.event.repository.name }}
         downstream-module: knative.dev/serving
@@ -99,7 +99,7 @@ jobs:
         path: ./src/knative.dev/eventing
 
     - name: Test Downstream
-      uses: knative-sandbox/downstream-test-go@v1
+      uses: knative-sandbox/downstream-test-go@v1.0.1
       with:
         upstream-module: knative.dev/${{ github.event.repository.name }}
         downstream-module: knative.dev/eventing
@@ -140,7 +140,7 @@ jobs:
         path: ./src/knative.dev/eventing-contrib
 
     - name: Test Downstream
-      uses: knative-sandbox/downstream-test-go@v1
+      uses: knative-sandbox/downstream-test-go@v1.0.1
       with:
         upstream-module: knative.dev/${{ github.event.repository.name }}
         downstream-module: knative.dev/eventing-contrib
@@ -182,7 +182,7 @@ jobs:
         path: ./src/knative.dev/sample-controller
 
     - name: Test Downstream
-      uses: knative-sandbox/downstream-test-go@v1
+      uses: knative-sandbox/downstream-test-go@v1.0.1
       with:
         upstream-module: knative.dev/${{ github.event.repository.name }}
         downstream-module: knative.dev/sample-controller
@@ -224,7 +224,7 @@ jobs:
         path: ./src/knative.dev/sample-source
 
     - name: Test Downstream
-      uses: knative-sandbox/downstream-test-go@v1
+      uses: knative-sandbox/downstream-test-go@v1.0.1
       with:
         upstream-module: knative.dev/${{ github.event.repository.name }}
         downstream-module: knative.dev/sample-source

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -1,0 +1,88 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Downstream Test
+
+on:
+  push:
+    branches: [ 'master', 'release-*' ]
+  pull_request:
+    branches: [ 'master', 'release-*' ]
+
+jobs:
+
+  downstream:
+    name: Verify Downstream
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/ko/cmd/ko
+        go get github.com/google/go-licenses
+
+    - name: Check upstream repo into onto GOPATH
+      uses: actions/checkout@v2
+      with:
+        path: ./src/knative.dev/${{ github.event.repository.name }}
+
+    - name: Check downstream repo into onto GOPATH
+      uses: actions/checkout@v2
+      with:
+        repository: knative-sandbox/sample-controller     # TODO: gonna hardcode for now.
+        path: ./src/knative.dev/sample-controller         # TODO: gonna hardcode for now.
+
+
+    - name: Replace Downstream with Local Upstream
+      shell: bash
+      run: |
+        pushd ./src/knative.dev/sample-controller         # TODO: gonna hardcode for now.
+        go mod edit -replace knative.dev/${{ github.event.repository.name }}=$GITHUB_WORKSPACE/src/knative.dev/${{ github.event.repository.name }}
+        popd
+
+    - name: Downstream Update Deps
+      shell: bash
+      run: |
+        pushd ./src/knative.dev/sample-controller        # TODO: gonna hardcode for now.
+        ./hack/update-deps.sh
+        popd
+
+    - name:  Downstream Update Codegen
+      shell: bash
+      run: |
+        pushd ./src/knative.dev/sample-controller       # TODO: gonna hardcode for now.
+        ./hack/update-codegen.sh
+        popd
+
+    - name: Test Downstream
+      shell: bash
+      run: |
+        pushd ./src/knative.dev/sample-controller       # TODO: gonna hardcode for now.
+        go test -race ./...
+        popd

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -44,7 +44,6 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        go get github.com/google/ko/cmd/ko
         go get github.com/google/go-licenses
 
     - name: Check upstream repo into onto GOPATH
@@ -55,34 +54,34 @@ jobs:
     - name: Check downstream repo into onto GOPATH
       uses: actions/checkout@v2
       with:
-        repository: knative-sandbox/sample-controller     # TODO: gonna hardcode for now.
-        path: ./src/knative.dev/sample-controller         # TODO: gonna hardcode for now.
+        repository: knative/eventing             # TODO: gonna hardcode for now.
+        path: ./src/knative.dev/eventing         # TODO: gonna hardcode for now.
 
 
     - name: Replace Downstream with Local Upstream
       shell: bash
       run: |
-        pushd ./src/knative.dev/sample-controller         # TODO: gonna hardcode for now.
+        pushd ./src/knative.dev/eventing        # TODO: gonna hardcode for now.
         go mod edit -replace knative.dev/${{ github.event.repository.name }}=$GITHUB_WORKSPACE/src/knative.dev/${{ github.event.repository.name }}
         popd
 
     - name: Downstream Update Deps
       shell: bash
       run: |
-        pushd ./src/knative.dev/sample-controller        # TODO: gonna hardcode for now.
+        pushd ./src/knative.dev/eventing        # TODO: gonna hardcode for now.
         ./hack/update-deps.sh
         popd
 
     - name:  Downstream Update Codegen
       shell: bash
       run: |
-        pushd ./src/knative.dev/sample-controller       # TODO: gonna hardcode for now.
+        pushd ./src/knative.dev/eventing       # TODO: gonna hardcode for now.
         ./hack/update-codegen.sh
         popd
 
     - name: Test Downstream
       shell: bash
       run: |
-        pushd ./src/knative.dev/sample-controller       # TODO: gonna hardcode for now.
+        pushd ./src/knative.dev/eventing       # TODO: gonna hardcode for now.
         go test -race ./...
         popd

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -24,7 +24,7 @@ jobs:
     name: Serving
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.14.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}
@@ -65,7 +65,7 @@ jobs:
     name: Eventing
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.14.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}
@@ -106,7 +106,7 @@ jobs:
     name: Eventing Contrib
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.14.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}
@@ -148,7 +148,7 @@ jobs:
     name: Sample Controller
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.14.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}
@@ -190,7 +190,7 @@ jobs:
     name: Sample Source
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.14.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Downstream Test
+name: Downstream Eventing
 
 on:
   push:
@@ -46,10 +46,19 @@ jobs:
       run: |
         go get github.com/google/go-licenses
 
-    - name: Test Downstream
-      uses: knative-sandbox/downstream-test-go@v1.0.0
+    - name: Checkout Upstream
+      uses: actions/checkout@v2
       with:
-        upstream-module: knative.dev/pkg
-        downstream-repository: knative/eventing
-        downstream-module: knative.dev/eventing
+        path: ./src/knative.dev/${{ github.event.repository.name }}
 
+    - name: Checkout Downstream
+      uses: actions/checkout@v2
+      with:
+        repository: knative/eventing
+        path: ./src/knative.dev/eventing
+
+    - name: Test Downstream
+      uses: knative-sandbox/downstream-test-go@v1.0.1
+      with:
+        upstream-module: knative.dev/${{ github.event.repository.name }}
+        downstream-module: knative.dev/eventing

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -58,7 +58,7 @@ jobs:
         path: ./src/knative.dev/serving
 
     - name: Test Downstream
-      uses: knative-sandbox/downstream-test-go@v1.0.1
+      uses: knative-sandbox/downstream-test-go@v1
       with:
         upstream-module: knative.dev/${{ github.event.repository.name }}
         downstream-module: knative.dev/serving
@@ -99,7 +99,7 @@ jobs:
         path: ./src/knative.dev/eventing
 
     - name: Test Downstream
-      uses: knative-sandbox/downstream-test-go@v1.0.1
+      uses: knative-sandbox/downstream-test-go@v1
       with:
         upstream-module: knative.dev/${{ github.event.repository.name }}
         downstream-module: knative.dev/eventing
@@ -140,7 +140,7 @@ jobs:
         path: ./src/knative.dev/eventing-contrib
 
     - name: Test Downstream
-      uses: knative-sandbox/downstream-test-go@v1.0.1
+      uses: knative-sandbox/downstream-test-go@v1
       with:
         upstream-module: knative.dev/${{ github.event.repository.name }}
         downstream-module: knative.dev/eventing-contrib
@@ -182,7 +182,7 @@ jobs:
         path: ./src/knative.dev/sample-controller
 
     - name: Test Downstream
-      uses: knative-sandbox/downstream-test-go@v1.0.1
+      uses: knative-sandbox/downstream-test-go@v1
       with:
         upstream-module: knative.dev/${{ github.event.repository.name }}
         downstream-module: knative.dev/sample-controller
@@ -224,7 +224,7 @@ jobs:
         path: ./src/knative.dev/sample-source
 
     - name: Test Downstream
-      uses: knative-sandbox/downstream-test-go@v1.0.1
+      uses: knative-sandbox/downstream-test-go@v1
       with:
         upstream-module: knative.dev/${{ github.event.repository.name }}
         downstream-module: knative.dev/sample-source

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Downstream Eventing
+name: Downstream
 
 on:
   push:
@@ -22,8 +22,8 @@ on:
 
 jobs:
 
-  downstream:
-    name: Downstream Eventing
+  downstream-eventing:
+    name: Eventing
     strategy:
       matrix:
         go-version: [1.15.x]
@@ -62,3 +62,44 @@ jobs:
       with:
         upstream-module: knative.dev/${{ github.event.repository.name }}
         downstream-module: knative.dev/eventing
+
+  downstream-serving:
+    name: Serving
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/go-licenses
+
+    - name: Checkout Upstream
+      uses: actions/checkout@v2
+      with:
+        path: ./src/knative.dev/${{ github.event.repository.name }}
+
+    - name: Checkout Downstream
+      uses: actions/checkout@v2
+      with:
+        repository: knative/serving
+        path: ./src/knative.dev/serving
+
+    - name: Test Downstream
+      uses: knative-sandbox/downstream-test-go@v1.0.1
+      with:
+        upstream-module: knative.dev/${{ github.event.repository.name }}
+        downstream-module: knative.dev/serving

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -22,6 +22,47 @@ on:
 
 jobs:
 
+  downstream-serving:
+    name: Serving
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/go-licenses
+
+    - name: Checkout Upstream
+      uses: actions/checkout@v2
+      with:
+        path: ./src/knative.dev/${{ github.event.repository.name }}
+
+    - name: Checkout Downstream
+      uses: actions/checkout@v2
+      with:
+        repository: knative/serving
+        path: ./src/knative.dev/serving
+
+    - name: Test Downstream
+      uses: knative-sandbox/downstream-test-go@v1.0.1
+      with:
+        upstream-module: knative.dev/${{ github.event.repository.name }}
+        downstream-module: knative.dev/serving
+
   downstream-eventing:
     name: Eventing
     strategy:
@@ -63,8 +104,8 @@ jobs:
         upstream-module: knative.dev/${{ github.event.repository.name }}
         downstream-module: knative.dev/eventing
 
-  downstream-serving:
-    name: Serving
+  downstream-eventing-contrib:
+    name: Eventing Contrib
     strategy:
       matrix:
         go-version: [1.15.x]
@@ -95,11 +136,97 @@ jobs:
     - name: Checkout Downstream
       uses: actions/checkout@v2
       with:
-        repository: knative/serving
-        path: ./src/knative.dev/serving
+        repository: knative/eventing-contrib
+        path: ./src/knative.dev/eventing-contrib
 
     - name: Test Downstream
       uses: knative-sandbox/downstream-test-go@v1.0.1
       with:
         upstream-module: knative.dev/${{ github.event.repository.name }}
-        downstream-module: knative.dev/serving
+        downstream-module: knative.dev/eventing-contrib
+
+
+  downstream-sample-controller:
+    name: Sample Controller
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/go-licenses
+
+    - name: Checkout Upstream
+      uses: actions/checkout@v2
+      with:
+        path: ./src/knative.dev/${{ github.event.repository.name }}
+
+    - name: Checkout Downstream
+      uses: actions/checkout@v2
+      with:
+        repository: knative-sandbox/sample-controller
+        path: ./src/knative.dev/sample-controller
+
+    - name: Test Downstream
+      uses: knative-sandbox/downstream-test-go@v1.0.1
+      with:
+        upstream-module: knative.dev/${{ github.event.repository.name }}
+        downstream-module: knative.dev/sample-controller
+
+
+  downstream-sample-source:
+    name: Sample Source
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/go-licenses
+
+    - name: Checkout Upstream
+      uses: actions/checkout@v2
+      with:
+        path: ./src/knative.dev/${{ github.event.repository.name }}
+
+    - name: Checkout Downstream
+      uses: actions/checkout@v2
+      with:
+        repository: knative-sandbox/sample-source
+        path: ./src/knative.dev/sample-source
+
+    - name: Test Downstream
+      uses: knative-sandbox/downstream-test-go@v1.0.1
+      with:
+        upstream-module: knative.dev/${{ github.event.repository.name }}
+        downstream-module: knative.dev/sample-source
+
+

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -23,7 +23,7 @@ on:
 jobs:
 
   downstream:
-    name: Verify Downstream
+    name: Downstream Eventing
     strategy:
       matrix:
         go-version: [1.15.x]
@@ -46,42 +46,10 @@ jobs:
       run: |
         go get github.com/google/go-licenses
 
-    - name: Check upstream repo into onto GOPATH
-      uses: actions/checkout@v2
-      with:
-        path: ./src/knative.dev/${{ github.event.repository.name }}
-
-    - name: Check downstream repo into onto GOPATH
-      uses: actions/checkout@v2
-      with:
-        repository: knative/eventing             # TODO: gonna hardcode for now.
-        path: ./src/knative.dev/eventing         # TODO: gonna hardcode for now.
-
-
-    - name: Replace Downstream with Local Upstream
-      shell: bash
-      run: |
-        pushd ./src/knative.dev/eventing        # TODO: gonna hardcode for now.
-        go mod edit -replace knative.dev/${{ github.event.repository.name }}=$GITHUB_WORKSPACE/src/knative.dev/${{ github.event.repository.name }}
-        popd
-
-    - name: Downstream Update Deps
-      shell: bash
-      run: |
-        pushd ./src/knative.dev/eventing        # TODO: gonna hardcode for now.
-        ./hack/update-deps.sh
-        popd
-
-    - name:  Downstream Update Codegen
-      shell: bash
-      run: |
-        pushd ./src/knative.dev/eventing       # TODO: gonna hardcode for now.
-        ./hack/update-codegen.sh
-        popd
-
     - name: Test Downstream
-      shell: bash
-      run: |
-        pushd ./src/knative.dev/eventing       # TODO: gonna hardcode for now.
-        go test -race ./...
-        popd
+      uses: knative-sandbox/downstream-test-go@v1.0.0
+      with:
+        upstream-module: knative.dev/pkg
+        downstream-repository: knative/eventing
+        downstream-module: knative.dev/eventing
+

--- a/.github/workflows/knative-verify.yaml
+++ b/.github/workflows/knative-verify.yaml
@@ -53,7 +53,6 @@ jobs:
     - name: Check out code onto GOPATH
       uses: actions/checkout@v2
       with:
-        fetch-depth: 1
         path: ./src/knative.dev/${{ github.event.repository.name }}
 
     - name: Update Codegen


### PR DESCRIPTION
Integrate the knative-sandbox/downstream-test-go action that takes two repos that are checked out and upgrades the downstream with an upstream module, and then runs the standard knative repo update-codegen and runs the unit tests.

This PR makes it an FYI that any future PR will test on the following:

- Serving
- Eventing
- Eventing Contrib
- Sample Controller
- Sample Source