### PR TITLE
Remove all ClearAll calls from pkg UTs

### DIFF
--- a/configmap/store_test.go
+++ b/configmap/store_test.go
@@ -78,7 +78,6 @@ func TestStoreBadConstructors(t *testing.T) {
 }
 
 func TestStoreWatchConfigs(t *testing.T) {
-	defer ClearAll()
 	store := NewUntypedStore(
 		"name",
 		TestLogger(t),
@@ -99,7 +98,7 @@ func TestStoreWatchConfigs(t *testing.T) {
 	got := watcher.watches
 
 	if diff := cmp.Diff(want, got, sortStrings); diff != "" {
-		t.Errorf("Unexpected configmap watches (-want, +got): %v", diff)
+		t.Errorf("Unexpected configmap watches (-want, +got):\n%s", diff)
 	}
 }
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -736,7 +736,6 @@ func TestEnqueues(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Cleanup(ClearAll)
 			var rl workqueue.RateLimiter = testRateLimiter{t, 100 * time.Millisecond}
 			impl := NewImplFull(&NopReconciler{}, ControllerOptions{WorkQueueName: "Testing", Logger: TestLogger(t), RateLimiter: rl})
 			test.work(impl)
@@ -754,7 +753,6 @@ func TestEnqueues(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Cleanup(ClearAll)
 			impl := NewImplWithStats(&NopReconciler{}, TestLogger(t), "Testing", &FakeStatsReporter{})
 			test.work(impl)
 
@@ -771,7 +769,6 @@ func TestEnqueues(t *testing.T) {
 }
 
 func TestEnqueueAfter(t *testing.T) {
-	t.Cleanup(ClearAll)
 	impl := NewImplWithStats(&NopReconciler{}, TestLogger(t), "Testing", &FakeStatsReporter{})
 	impl.EnqueueAfter(&Resource{
 		ObjectMeta: metav1.ObjectMeta{
@@ -807,7 +804,6 @@ func TestEnqueueAfter(t *testing.T) {
 }
 
 func TestEnqeueKeyAfter(t *testing.T) {
-	t.Cleanup(ClearAll)
 	impl := NewImplWithStats(&NopReconciler{}, TestLogger(t), "Testing", &FakeStatsReporter{})
 	impl.EnqueueKeyAfter(types.NamespacedName{Namespace: "waiting", Name: "for"}, 5*time.Second)
 	impl.EnqueueKeyAfter(types.NamespacedName{Namespace: "the", Name: "waterfall"}, 500*time.Millisecond)
@@ -840,7 +836,6 @@ func (cr *CountingReconciler) Reconcile(context.Context, string) error {
 }
 
 func TestStartAndShutdown(t *testing.T) {
-	t.Cleanup(ClearAll)
 	r := &CountingReconciler{}
 	impl := NewImplWithStats(r, TestLogger(t), "Testing", &FakeStatsReporter{})
 
@@ -900,7 +895,6 @@ func (cr *countingLeaderAwareReconciler) Reconcile(ctx context.Context, key stri
 }
 
 func TestStartAndShutdownWithLeaderAwareNoElection(t *testing.T) {
-	t.Cleanup(ClearAll)
 	promoted := make(chan struct{})
 	r := &countingLeaderAwareReconciler{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
@@ -946,7 +940,6 @@ func TestStartAndShutdownWithLeaderAwareNoElection(t *testing.T) {
 }
 
 func TestStartAndShutdownWithLeaderAwareWithLostElection(t *testing.T) {
-	t.Cleanup(ClearAll)
 	promoted := make(chan struct{})
 	r := &countingLeaderAwareReconciler{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
@@ -1013,7 +1006,6 @@ func TestStartAndShutdownWithLeaderAwareWithLostElection(t *testing.T) {
 }
 
 func TestStartAndShutdownWithWork(t *testing.T) {
-	t.Cleanup(ClearAll)
 	r := &CountingReconciler{}
 	reporter := &FakeStatsReporter{}
 	impl := NewImplWithStats(r, TestLogger(t), "Testing", reporter)
@@ -1090,7 +1082,6 @@ func (er *ErrorReconciler) Reconcile(context.Context, string) error {
 }
 
 func TestStartAndShutdownWithErroringWork(t *testing.T) {
-	t.Cleanup(ClearAll)
 	r := &ErrorReconciler{}
 	reporter := &FakeStatsReporter{}
 	impl := NewImplWithStats(r, TestLogger(t), "Testing", reporter)
@@ -1145,7 +1136,6 @@ func (er *PermanentErrorReconciler) Reconcile(context.Context, string) error {
 }
 
 func TestStartAndShutdownWithPermanentErroringWork(t *testing.T) {
-	t.Cleanup(ClearAll)
 	r := &PermanentErrorReconciler{}
 	reporter := &FakeStatsReporter{}
 	impl := NewImplWithStats(r, TestLogger(t), "Testing", reporter)
@@ -1238,7 +1228,6 @@ func (*dummyStore) List() []interface{} {
 }
 
 func TestImplGlobalResync(t *testing.T) {
-	t.Cleanup(ClearAll)
 	r := &CountingReconciler{}
 	impl := NewImplWithStats(r, TestLogger(t), "Testing", &FakeStatsReporter{})
 

--- a/metrics/config_test.go
+++ b/metrics/config_test.go
@@ -535,7 +535,6 @@ func successTestsInit() {
 func TestGetMetricsConfig(t *testing.T) {
 	for _, test := range errorTests {
 		t.Run(test.name, func(t *testing.T) {
-			defer ClearAll()
 			_, err := createMetricsConfig(test.ops, TestLogger(t))
 			if err == nil || err.Error() != test.expectedErr {
 				t.Errorf("Wanted err: %v, got: %v", test.expectedErr, err)
@@ -546,7 +545,6 @@ func TestGetMetricsConfig(t *testing.T) {
 	successTestsInit()
 	for _, test := range successTests {
 		t.Run(test.name, func(t *testing.T) {
-			defer ClearAll()
 			mc, err := createMetricsConfig(test.ops, TestLogger(t))
 			if err != nil {
 				t.Errorf("Wanted valid config %v, got error %v", test.expectedConfig, err)
@@ -640,7 +638,6 @@ func TestGetMetricsConfig_fromEnv(t *testing.T) {
 			os.Setenv(test.varName, test.varValue)
 			defer os.Unsetenv(test.varName)
 
-			defer ClearAll()
 			mc, err := createMetricsConfig(test.ops, TestLogger(t))
 			if err != nil {
 				t.Errorf("Wanted valid config %v, got error %v", test.expectedConfig, err)
@@ -656,7 +653,6 @@ func TestGetMetricsConfig_fromEnv(t *testing.T) {
 			os.Setenv(test.varName, test.varValue)
 			defer os.Unsetenv(test.varName)
 
-			defer ClearAll()
 			mc, err := createMetricsConfig(test.ops, TestLogger(t))
 			if mc != nil {
 				t.Errorf("Wanted no config, got %v", mc)
@@ -673,7 +669,6 @@ func TestIsNewExporterRequiredFromNilConfig(t *testing.T) {
 	successTestsInit()
 	for _, test := range successTests {
 		t.Run(test.name, func(t *testing.T) {
-			defer ClearAll()
 			mc, err := createMetricsConfig(test.ops, TestLogger(t))
 			if err != nil {
 				t.Errorf("Wanted valid config %v, got error %v", test.expectedConfig, err)
@@ -801,7 +796,6 @@ func TestUpdateExporter(t *testing.T) {
 	successTestsInit()
 	for _, test := range successTests[1:] {
 		t.Run(test.name, func(t *testing.T) {
-			defer ClearAll()
 			UpdateExporter(test.ops, TestLogger(t))
 			mConfig := getCurMetricsConfig()
 			if mConfig == oldConfig {
@@ -816,7 +810,6 @@ func TestUpdateExporter(t *testing.T) {
 
 	for _, test := range errorTests {
 		t.Run(test.name, func(t *testing.T) {
-			defer ClearAll()
 			UpdateExporter(test.ops, TestLogger(t))
 			mConfig := getCurMetricsConfig()
 			if mConfig != oldConfig {
@@ -832,7 +825,6 @@ func TestUpdateExporterFromConfigMapWithOpts(t *testing.T) {
 	successTestsInit()
 	for _, test := range successTests[1:] {
 		t.Run(test.name, func(t *testing.T) {
-			defer ClearAll()
 			opts := ExporterOptions{
 				Component:      test.ops.Component,
 				Domain:         test.ops.Domain,
@@ -856,7 +848,6 @@ func TestUpdateExporterFromConfigMapWithOpts(t *testing.T) {
 	}
 
 	t.Run("ConfigMapSetErr", func(t *testing.T) {
-		defer ClearAll()
 		opts := ExporterOptions{
 			Component:      testComponent,
 			Domain:         servingDomain,
@@ -870,7 +861,6 @@ func TestUpdateExporterFromConfigMapWithOpts(t *testing.T) {
 	})
 
 	t.Run("MissingComponentErr", func(t *testing.T) {
-		defer ClearAll()
 		opts := ExporterOptions{
 			Component:      "",
 			Domain:         servingDomain,
@@ -887,7 +877,6 @@ func TestUpdateExporter_doesNotCreateExporter(t *testing.T) {
 	setCurMetricsConfig(nil)
 	for _, test := range errorTests {
 		t.Run(test.name, func(t *testing.T) {
-			defer ClearAll()
 			UpdateExporter(test.ops, TestLogger(t))
 			mConfig := getCurMetricsConfig()
 			if mConfig != nil {
@@ -1047,7 +1036,6 @@ func TestStackdriverRecord(t *testing.T) {
 
 	for name, data := range testCases {
 		t.Run(name, func(t *testing.T) {
-			defer ClearAll()
 			opts := ExporterOptions{
 				ConfigMap: data.opts,
 				Domain:    "knative.dev/internal/serving",

--- a/webhook/resourcesemantics/validation/validation_deprecated_test.go
+++ b/webhook/resourcesemantics/validation/validation_deprecated_test.go
@@ -489,7 +489,6 @@ func TestStrictValidation(t *testing.T) {
 
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			defer ClearAll()
 			ctx := TestContextWithLogger(t)
 			if tc.strict {
 				ctx = apis.DisallowDeprecated(ctx)

--- a/websocket/connection_test.go
+++ b/websocket/connection_test.go
@@ -339,8 +339,7 @@ func TestDoubleShutdown(t *testing.T) {
 }
 
 func TestDurableConnectionWhenConnectionBreaksDown(t *testing.T) {
-	defer ktesting.ClearAll()
-	testPayload := "test"
+	const testPayload = "test"
 	reconnectChan := make(chan struct{})
 
 	upgrader := websocket.Upgrader{}
@@ -379,9 +378,8 @@ func TestDurableConnectionWhenConnectionBreaksDown(t *testing.T) {
 }
 
 func TestDurableConnectionSendsPingsRegularly(t *testing.T) {
-	defer ktesting.ClearAll()
 	// Reset pongTimeout to something quite short.
-	pongTimeout = 100 * time.Millisecond
+	const pongTimeout = 100 * time.Millisecond
 
 	upgrader := websocket.Upgrader{}
 


### PR DESCRIPTION
We need this in order to deprecate the function.
Serving is already free of those.

/assign @taragu mattmoor @tcnghia 