### PR TITLE
Make test override pongTimeout correctly.

### DIFF
--- a/websocket/connection_test.go
+++ b/websocket/connection_test.go
@@ -379,7 +379,7 @@ func TestDurableConnectionWhenConnectionBreaksDown(t *testing.T) {
 
 func TestDurableConnectionSendsPingsRegularly(t *testing.T) {
 	// Reset pongTimeout to something quite short.
-	const pongTimeout = 100 * time.Millisecond
+	pongTimeout = 100 * time.Millisecond
 
 	upgrader := websocket.Upgrader{}
 

--- a/websocket/connection_test.go
+++ b/websocket/connection_test.go
@@ -379,7 +379,11 @@ func TestDurableConnectionWhenConnectionBreaksDown(t *testing.T) {
 
 func TestDurableConnectionSendsPingsRegularly(t *testing.T) {
 	// Reset pongTimeout to something quite short.
+	pingTimeoutBackup := pongTimeout
 	pongTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		pongTimeout = pingTimeoutBackup
+	})
 
 	upgrader := websocket.Upgrader{}
 


### PR DESCRIPTION
This was erroneously changed in https://github.com/knative/pkg/commit/34838c4559697a4502141537a368fac1e09fccd4#diff-6c7213643bc6f930dd8cdc16121ccbc8. It's actually supposed to override the global var.