### PR TITLE
Add IsEstablished method to ManagedConnection to expose whether the connection has been established

### DIFF
--- a/websocket/connection.go
+++ b/websocket/connection.go
@@ -327,3 +327,11 @@ func (c *ManagedConnection) Shutdown() error {
 	c.processingWg.Wait()
 	return err
 }
+
+// IsEstablished returns true the websocket connection has been established.
+func (c *ManagedConnection) IsEstablished() bool {
+	c.connectionLock.RLock()
+	defer c.connectionLock.RUnlock()
+
+	return c.connection != nil
+}

--- a/websocket/connection_test.go
+++ b/websocket/connection_test.go
@@ -418,3 +418,17 @@ func TestDurableConnectionSendsPingsRegularly(t *testing.T) {
 		<-pingReceived
 	}
 }
+
+func TestIsEstablished(t *testing.T) {
+	c := &ManagedConnection{}
+	if got, want := c.IsEstablished(), false; got != want {
+		t.Errorf("IsEstablished() = %v, want = %v", got, want)
+	}
+
+	c.connection = &inspectableConnection{
+		writeMessageCalls: make(chan struct{}, 1),
+	}
+	if got, want := c.IsEstablished(), true; got != want {
+		t.Errorf("IsEstablished() = %v, want = %v", got, want)
+	}
+}


### PR DESCRIPTION
When using a ManagedConnection for unit test, this function can help us know whether the connection has been established so that we can start sending message. Instead of sending message and checking whether it succeeds or not, checking the return of this function is easier.