### PR TITLE
Alter URIFromObjectReference to return apierrs

### DIFF
--- a/resolver/addressable_resolver.go
+++ b/resolver/addressable_resolver.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -137,16 +138,17 @@ func (r *URIResolver) URIFromKReference(ref *duckv1.KReference, parent interface
 // URIFromObjectReference resolves an ObjectReference to a URI string.
 func (r *URIResolver) URIFromObjectReference(ref *corev1.ObjectReference, parent interface{}) (*apis.URL, error) {
 	if ref == nil {
-		return nil, errors.New("ref is nil")
+		return nil, apierrs.NewBadRequest(fmt.Sprintf("ref is nil"))
 	}
 
+	gvr, _ := meta.UnsafeGuessKindToResource(ref.GroupVersionKind())
 	if err := r.tracker.TrackReference(tracker.Reference{
 		APIVersion: ref.APIVersion,
 		Kind:       ref.Kind,
 		Namespace:  ref.Namespace,
 		Name:       ref.Name,
 	}, parent); err != nil {
-		return nil, fmt.Errorf("failed to track %+v: %w", ref, err)
+		return nil, apierrs.NewNotFound(gvr.GroupResource(), ref.Name)
 	}
 
 	// K8s Services are special cased. They can be called, even though they do not satisfy the
@@ -161,30 +163,29 @@ func (r *URIResolver) URIFromObjectReference(ref *corev1.ObjectReference, parent
 		return url, nil
 	}
 
-	gvr, _ := meta.UnsafeGuessKindToResource(ref.GroupVersionKind())
 	_, lister, err := r.informerFactory.Get(gvr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get lister for %+v: %w", gvr, err)
+		return nil, apierrs.NewNotFound(gvr.GroupResource(), "Lister")
 	}
 
 	obj, err := lister.ByNamespace(ref.Namespace).Get(ref.Name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get ref %+v: %w", ref, err)
+		return nil, apierrs.NewNotFound(gvr.GroupResource(), ref.Name)
 	}
 
 	addressable, ok := obj.(*duckv1.AddressableType)
 	if !ok {
-		return nil, fmt.Errorf("%+v (%T) is not an AddressableType", ref, ref)
+		return nil, apierrs.NewBadRequest(fmt.Sprintf("%+v (%T) is not an AddressableType", ref, ref))
 	}
 	if addressable.Status.Address == nil {
-		return nil, fmt.Errorf("address not set for %+v", ref)
+		return nil, apierrs.NewBadRequest(fmt.Sprintf("address not set for %+v", ref))
 	}
 	url := addressable.Status.Address.URL
 	if url == nil {
-		return nil, fmt.Errorf("URL missing in address of %+v", ref)
+		return nil, apierrs.NewBadRequest(fmt.Sprintf("URL missing in address of %+v", ref))
 	}
 	if url.Host == "" {
-		return nil, fmt.Errorf("hostname missing in address of %+v", ref)
+		return nil, apierrs.NewBadRequest(fmt.Sprintf("hostname missing in address of %+v", ref))
 	}
 	return url, nil
 }

--- a/resolver/addressable_resolver.go
+++ b/resolver/addressable_resolver.go
@@ -138,7 +138,7 @@ func (r *URIResolver) URIFromKReference(ref *duckv1.KReference, parent interface
 // URIFromObjectReference resolves an ObjectReference to a URI string.
 func (r *URIResolver) URIFromObjectReference(ref *corev1.ObjectReference, parent interface{}) (*apis.URL, error) {
 	if ref == nil {
-		return nil, apierrs.NewBadRequest(fmt.Sprintf("ref is nil"))
+		return nil, apierrs.NewBadRequest("ref is nil")
 	}
 
 	gvr, _ := meta.UnsafeGuessKindToResource(ref.GroupVersionKind())

--- a/resolver/addressable_resolver_test.go
+++ b/resolver/addressable_resolver_test.go
@@ -328,7 +328,7 @@ func TestGetURIDestinationV1Beta1(t *testing.T) {
 			wantErr: fmt.Sprintf("address not set for %+v", getUnaddressableRef()),
 		}, "notFound": {
 			dest:    duckv1beta1.Destination{Ref: getUnaddressableRef()},
-			wantErr: fmt.Sprintf("failed to get ref %+v: %s %q not found", getUnaddressableRef(), unaddressableResource, unaddressableName),
+			wantErr: fmt.Sprintf("%s %q not found", unaddressableResource, unaddressableName),
 		}}
 
 	for n, tc := range tests {
@@ -510,7 +510,7 @@ func TestGetURIDestinationV1(t *testing.T) {
 			wantErr: fmt.Sprintf("address not set for %+v", getUnaddressableRef()),
 		}, "notFound": {
 			dest:    duckv1.Destination{Ref: getUnaddressableKnativeRef()},
-			wantErr: fmt.Sprintf("failed to get ref %+v: %s %q not found", getUnaddressableRef(), unaddressableResource, unaddressableName),
+			wantErr: fmt.Sprintf("%s %q not found", unaddressableResource, unaddressableName),
 		}}
 
 	for n, tc := range tests {
@@ -548,12 +548,11 @@ func TestURIFromObjectReferenceErrors(t *testing.T) {
 	}{"nil": {
 		wantErr: "ref is nil",
 	}, "fail tracker with bad object": {
-		ref: getInvalidObjectReference(),
-		wantErr: fmt.Sprintf(`failed to track %+v: invalid Reference:
-Namespace: a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')`, getInvalidObjectReference()),
+		ref:     getInvalidObjectReference(),
+		wantErr: `sinks.duck.knative.dev "testsink" not found`,
 	}, "fail get": {
 		ref:     getAddressableRef(),
-		wantErr: fmt.Sprintf(`failed to get ref %+v: sinks.duck.knative.dev "testsink" not found`, getAddressableRef()),
+		wantErr: `sinks.duck.knative.dev "testsink" not found`,
 	}}
 
 	for n, tc := range tests {

--- a/webhook/psbinding/reconciler.go
+++ b/webhook/psbinding/reconciler.go
@@ -361,7 +361,7 @@ func (r *BaseReconciler) ReconcileSubject(ctx context.Context, fb Bindable, muta
 	if r.WithContext != nil {
 		ctx, err = r.WithContext(ctx, fb)
 		if err != nil {
-			return apierrs.NewNotFound(gvr.GroupResource(), subject.Name)
+			return err
 		}
 	}
 

--- a/webhook/psbinding/reconciler.go
+++ b/webhook/psbinding/reconciler.go
@@ -361,7 +361,7 @@ func (r *BaseReconciler) ReconcileSubject(ctx context.Context, fb Bindable, muta
 	if r.WithContext != nil {
 		ctx, err = r.WithContext(ctx, fb)
 		if err != nil {
-			return err
+			return apierrs.NewNotFound(gvr.GroupResource(), subject.Name)
 		}
 	}
 


### PR DESCRIPTION
This allows for reconcile deletion to properly remove finalizer and
delete sinkbinding

Followup from #1647