### PR TITLE
Deprecate --master flag in favor of --server.

### DIFF
--- a/apiextensions/storageversion/cmd/migrate/config.go
+++ b/apiextensions/storageversion/cmd/migrate/config.go
@@ -31,8 +31,6 @@ import (
 
 func configOrDie() *rest.Config {
 	var (
-		masterURL = flag.String("master", "",
-			"DEPRECATED: Use --server instead. The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 		serverURL = flag.String("server", "",
 			"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 		kubeconfig = flag.String("kubeconfig", "",
@@ -41,12 +39,7 @@ func configOrDie() *rest.Config {
 
 	flag.Parse()
 
-	server := *masterURL
-	if *serverURL != "" {
-		server = *serverURL
-	}
-
-	cfg, err := getConfig(server, *kubeconfig)
+	cfg, err := getConfig(*serverURL, *kubeconfig)
 	if err != nil {
 		panic(fmt.Sprintf("Error building kubeconfig: %v", err))
 	}

--- a/apiextensions/storageversion/cmd/migrate/config.go
+++ b/apiextensions/storageversion/cmd/migrate/config.go
@@ -32,6 +32,8 @@ import (
 func configOrDie() *rest.Config {
 	var (
 		masterURL = flag.String("master", "",
+			"DEPRECATED: Use --server instead. The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+		serverURL = flag.String("server", "",
 			"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 		kubeconfig = flag.String("kubeconfig", "",
 			"Path to a kubeconfig. Only required if out-of-cluster.")
@@ -39,7 +41,12 @@ func configOrDie() *rest.Config {
 
 	flag.Parse()
 
-	cfg, err := getConfig(*masterURL, *kubeconfig)
+	server := *masterURL
+	if *serverURL != "" {
+		server = *serverURL
+	}
+
+	cfg, err := getConfig(server, *kubeconfig)
 	if err != nil {
 		panic(fmt.Sprintf("Error building kubeconfig: %v", err))
 	}
@@ -49,17 +56,17 @@ func configOrDie() *rest.Config {
 
 // getConfig returns a rest.Config to be used for kubernetes client creation.
 // It does so in the following order:
-//   1. Use the passed kubeconfig/masterURL.
+//   1. Use the passed kubeconfig/serverURL.
 //   2. Fallback to the KUBECONFIG environment variable.
 //   3. Fallback to in-cluster config.
 //   4. Fallback to the ~/.kube/config.
-func getConfig(masterURL, kubeconfig string) (*rest.Config, error) {
+func getConfig(serverURL, kubeconfig string) (*rest.Config, error) {
 	if kubeconfig == "" {
 		kubeconfig = os.Getenv("KUBECONFIG")
 	}
 	// If we have an explicit indication of where the kubernetes config lives, read that.
 	if kubeconfig != "" {
-		return clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
+		return clientcmd.BuildConfigFromFlags(serverURL, kubeconfig)
 	}
 	// If not, try the in-cluster config.
 	if c, err := rest.InClusterConfig(); err == nil {

--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -305,8 +305,6 @@ func flush(logger *zap.SugaredLogger) {
 // dies by calling log.Fatalf.
 func ParseAndGetConfigOrDie() *rest.Config {
 	var (
-		masterURL = flag.String("master", "",
-			"DEPRECATED: Use --server instead. The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 		serverURL = flag.String("server", "",
 			"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 		kubeconfig = flag.String("kubeconfig", "",
@@ -315,16 +313,7 @@ func ParseAndGetConfigOrDie() *rest.Config {
 	klog.InitFlags(flag.CommandLine)
 	flag.Parse()
 
-	var server string
-	if *masterURL != "" {
-		log.Println("--master is deprecated, please use --server instead")
-		server = *masterURL
-	}
-	if *serverURL != "" {
-		server = *serverURL
-	}
-
-	cfg, err := GetConfig(server, *kubeconfig)
+	cfg, err := GetConfig(*serverURL, *kubeconfig)
 	if err != nil {
 		log.Fatalf("Error building kubeconfig: %v", err)
 	}


### PR DESCRIPTION
This not only gets rid of the master terminology, but is also actually in-line with how `kubectl` itself behaves. Win everywhere!

/assign @mattmoor 