### PR TITLE
Enhance error message on failure to update _example.

### DIFF
--- a/webhook/configmaps/configmaps.go
+++ b/webhook/configmaps/configmaps.go
@@ -200,8 +200,8 @@ func (ac *reconciler) validate(ctx context.Context, req *admissionv1.AdmissionRe
 		if hasExampleData && hasExampleChecksumAnnotation &&
 			exampleChecksum != configmap.Checksum(exampleData) {
 			return fmt.Errorf(
-				"%q modified, you likely wanted to create an unindented configuration",
-				configmap.ExampleKey)
+				"the update modifies a key in %q which is probably not what you want. Instead, copy the respective setting to the top-level of the ConfigMap, directly below %q",
+				configmap.ExampleKey, "data")
 		}
 
 		inputs := []reflect.Value{

--- a/webhook/configmaps/configmaps_test.go
+++ b/webhook/configmaps/configmaps_test.go
@@ -255,7 +255,7 @@ func TestDenyInvalidUpdateConfigMapExample(t *testing.T) {
 
 	resp := ac.Admit(ctx, createCreateConfigMapRequest(ctx, t, r))
 
-	ExpectFailsWith(t, resp, fmt.Sprintf("%q modified", configmap.ExampleKey))
+	ExpectFailsWith(t, resp, fmt.Sprintf("a key in %q", configmap.ExampleKey))
 }
 
 type config struct {


### PR DESCRIPTION
We still see users frequently struggle with this and the error message seemingly doesn't help them. This gives a more explicit description of what the user can do to fix the situation.

/assign @mattmoor @vagababov 