### PR TITLE
Remove patch detail for webhook being logged on info

### DIFF
--- a/logging/logkey/constants.go
+++ b/logging/logkey/constants.go
@@ -62,19 +62,4 @@ const (
 	// GitHubCommitID is the key used to represent the GitHub Commit ID where the
 	// Knative component was built from in logs
 	GitHubCommitID = "commit"
-
-	// AdmissionReviewUID is the key used to represent the admission review
-	// request/response UID in logs
-	AdmissionReviewUID = "admissionreview/uid"
-
-	// AdmissionReviewAllowed is the key used to represent whether or not
-	// the admission request was permitted in logs
-	AdmissionReviewAllowed = "admissionreview/allowed"
-
-	// AdmissionReviewResult is the key used to represent extra details into
-	// why an admission request was denied in logs
-	AdmissionReviewResult = "admissionreview/result"
-
-	// AdmissionReviewPatchType is the key used to represent the type of Patch in logs
-	AdmissionReviewPatchType = "admissionreview/patchtype"
 )

--- a/logging/logkey/constants.go
+++ b/logging/logkey/constants.go
@@ -62,4 +62,19 @@ const (
 	// GitHubCommitID is the key used to represent the GitHub Commit ID where the
 	// Knative component was built from in logs
 	GitHubCommitID = "commit"
+
+	// AdmissionReviewUID is the key used to represent the admission review
+	// request/response UID in logs
+	AdmissionReviewUID = "knative.dev/admissionreview/uid"
+
+	// AdmissionReviewAllowed is the key used to represent whether or not
+	// the admission request was permitted in logs
+	AdmissionReviewAllowed = "knative.dev/admissionreview/allowed"
+
+	// AdmissionReviewResult is the key used to represent extra details into
+	// why an admission request was denied in logs
+	AdmissionReviewResult = "knative.dev/admissionreview/result"
+
+	// AdmissionReviewPatchType is the key used to represent the type of Patch in logs
+	AdmissionReviewPatchType = "knative.dev/admissionreview/patchtype"
 )

--- a/logging/logkey/constants.go
+++ b/logging/logkey/constants.go
@@ -65,16 +65,16 @@ const (
 
 	// AdmissionReviewUID is the key used to represent the admission review
 	// request/response UID in logs
-	AdmissionReviewUID = "knative.dev/admissionreview/uid"
+	AdmissionReviewUID = "admissionreview/uid"
 
 	// AdmissionReviewAllowed is the key used to represent whether or not
 	// the admission request was permitted in logs
-	AdmissionReviewAllowed = "knative.dev/admissionreview/allowed"
+	AdmissionReviewAllowed = "admissionreview/allowed"
 
 	// AdmissionReviewResult is the key used to represent extra details into
 	// why an admission request was denied in logs
-	AdmissionReviewResult = "knative.dev/admissionreview/result"
+	AdmissionReviewResult = "admissionreview/result"
 
 	// AdmissionReviewPatchType is the key used to represent the type of Patch in logs
-	AdmissionReviewPatchType = "knative.dev/admissionreview/patchtype"
+	AdmissionReviewPatchType = "admissionreview/patchtype"
 )

--- a/webhook/admission.go
+++ b/webhook/admission.go
@@ -129,7 +129,7 @@ func admissionHandler(rootLogger *zap.SugaredLogger, stats StatsReporter, c Admi
 			AdmissionReviewResult, reviewResponse.Result.String())
 
 		logger.Infof("remote admission controller audit annotations=%#v", reviewResponse.AuditAnnotations)
-		logger.Debugf("AdmissionReview patch body=%s", string(reviewResponse.Patch))
+		logger.Debugf("AdmissionReview patch={ type: %s, body: %s }", patchType, string(reviewResponse.Patch))
 
 		if err := json.NewEncoder(w).Encode(response); err != nil {
 			http.Error(w, fmt.Sprintf("could not encode response: %v", err), http.StatusInternalServerError)

--- a/webhook/admission.go
+++ b/webhook/admission.go
@@ -101,9 +101,12 @@ func admissionHandler(rootLogger *zap.SugaredLogger, stats StatsReporter, c Admi
 			patchType = string(*reviewResponse.PatchType)
 		}
 
-		logger.Infof("AdmissionReview for %#v: %s/%s response={ UID: %#v, Allowed: %t, Status: %#v, Patch: %s, PatchType: %s, AuditAnnotations: %#v}",
+		logger.Infof("AdmissionReview for %#v: %s/%s response={ UID: %#v, Allowed: %t, Status: %#v, PatchType: %s, AuditAnnotations: %#v}",
 			review.Request.Kind, review.Request.Namespace, review.Request.Name,
-			reviewResponse.UID, reviewResponse.Allowed, reviewResponse.Result, string(reviewResponse.Patch), patchType, reviewResponse.AuditAnnotations)
+			reviewResponse.UID, reviewResponse.Allowed, reviewResponse.Result, patchType, reviewResponse.AuditAnnotations)
+		logger.Debugf("AdmissionReview for %#v: %s/%s patch=%s",
+			review.Request.Kind, review.Request.Namespace, review.Request.Name,
+			string(reviewResponse.Patch))
 
 		if !reviewResponse.Allowed || reviewResponse.PatchType != nil || response.Response == nil {
 			response.Response = reviewResponse

--- a/webhook/admission.go
+++ b/webhook/admission.go
@@ -78,13 +78,13 @@ func admissionHandler(rootLogger *zap.SugaredLogger, stats StatsReporter, c Admi
 		}
 
 		logger = logger.With(
-			zap.String(logkey.Kind, review.Request.Kind.String()),
-			zap.String(logkey.Namespace, review.Request.Namespace),
-			zap.String(logkey.Name, review.Request.Name),
-			zap.String(logkey.Operation, string(review.Request.Operation)),
-			zap.String(logkey.Resource, review.Request.Resource.String()),
-			zap.String(logkey.SubResource, review.Request.SubResource),
-			zap.String(logkey.UserInfo, fmt.Sprint(review.Request.UserInfo)))
+			logkey.Kind, review.Request.Kind.String(),
+			logkey.Namespace, review.Request.Namespace,
+			logkey.Name, review.Request.Name,
+			logkey.Operation, string(review.Request.Operation),
+			logkey.Resource, review.Request.Resource.String(),
+			logkey.SubResource, review.Request.SubResource,
+			logkey.UserInfo, fmt.Sprint(review.Request.UserInfo))
 
 		ctx := logging.WithLogger(r.Context(), logger)
 
@@ -107,10 +107,10 @@ func admissionHandler(rootLogger *zap.SugaredLogger, stats StatsReporter, c Admi
 		response.Response.UID = review.Request.UID
 
 		logger = logger.With(
-			zap.String(logkey.AdmissionReviewUID, string(reviewResponse.UID)),
-			zap.Bool(logkey.AdmissionReviewAllowed, reviewResponse.Allowed),
-			zap.String(logkey.AdmissionReviewResult, reviewResponse.Result.String()),
-			zap.String(logkey.AdmissionReviewPatchType, patchType))
+			logkey.AdmissionReviewUID, string(reviewResponse.UID),
+			logkey.AdmissionReviewAllowed, reviewResponse.Allowed,
+			logkey.AdmissionReviewResult, reviewResponse.Result.String(),
+			logkey.AdmissionReviewPatchType, patchType)
 
 		logger.Infof("remote admission controller audit annotations=%#v", reviewResponse.AuditAnnotations)
 		logger.Debugf("AdmissionReview patch body=%s", string(reviewResponse.Patch))

--- a/webhook/admission.go
+++ b/webhook/admission.go
@@ -30,6 +30,23 @@ import (
 	"knative.dev/pkg/logging/logkey"
 )
 
+const (
+	// AdmissionReviewUID is the key used to represent the admission review
+	// request/response UID in logs
+	AdmissionReviewUID = "admissionreview/uid"
+
+	// AdmissionReviewAllowed is the key used to represent whether or not
+	// the admission request was permitted in logs
+	AdmissionReviewAllowed = "admissionreview/allowed"
+
+	// AdmissionReviewResult is the key used to represent extra details into
+	// why an admission request was denied in logs
+	AdmissionReviewResult = "admissionreview/result"
+
+	// AdmissionReviewPatchType is the key used to represent the type of Patch in logs
+	AdmissionReviewPatchType = "admissionreview/patchtype"
+)
+
 // AdmissionController provides the interface for different admission controllers
 type AdmissionController interface {
 	// Path returns the path that this particular admission controller serves on.
@@ -107,10 +124,9 @@ func admissionHandler(rootLogger *zap.SugaredLogger, stats StatsReporter, c Admi
 		response.Response.UID = review.Request.UID
 
 		logger = logger.With(
-			logkey.AdmissionReviewUID, string(reviewResponse.UID),
-			logkey.AdmissionReviewAllowed, reviewResponse.Allowed,
-			logkey.AdmissionReviewResult, reviewResponse.Result.String(),
-			logkey.AdmissionReviewPatchType, patchType)
+			AdmissionReviewUID, string(reviewResponse.UID),
+			AdmissionReviewAllowed, reviewResponse.Allowed,
+			AdmissionReviewResult, reviewResponse.Result.String())
 
 		logger.Infof("remote admission controller audit annotations=%#v", reviewResponse.AuditAnnotations)
 		logger.Debugf("AdmissionReview patch body=%s", string(reviewResponse.Patch))


### PR DESCRIPTION
It might contain the sensitive data, so print it to debug log.

Fixes: #1397
