### PR TITLE
Teach the spoofing client to support NodePort.

### DIFF
--- a/test/ingress/ingress.go
+++ b/test/ingress/ingress.go
@@ -33,7 +33,12 @@ const (
 )
 
 // GetIngressEndpoint gets the ingress public IP or hostname.
-func GetIngressEndpoint(ctx context.Context, kubeClientset *kubernetes.Clientset, endpointOverride string) (string, func(string) string, error) {
+// address - is the endpoint to which we should actually connect.
+// portMap - translates the request's port to the port on address to which the caller
+//    should connect.  This is used when the resolution to address goes through some
+//    sort of port-mapping, e.g. Kubernetes node ports.
+// err - an error when address/portMap cannot be established.
+func GetIngressEndpoint(ctx context.Context, kubeClientset *kubernetes.Clientset, endpointOverride string) (address string, portMap func(string) string, err error) {
 	ingressName := istioIngressName
 	if gatewayOverride := os.Getenv("GATEWAY_OVERRIDE"); gatewayOverride != "" {
 		ingressName = gatewayOverride

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -26,7 +26,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -110,7 +109,7 @@ func New(
 	requestInterval time.Duration,
 	requestTimeout time.Duration,
 	opts ...TransportOption) (*SpoofingClient, error) {
-	endpoint, err := ResolveEndpoint(ctx, kubeClientset, domain, resolvable, endpointOverride)
+	endpoint, mapper, err := ResolveEndpoint(ctx, kubeClientset, domain, resolvable, endpointOverride)
 	if err != nil {
 		return nil, fmt.Errorf("failed get the cluster endpoint: %w", err)
 	}
@@ -119,13 +118,13 @@ func New(
 	logf("Spoofing %s -> %s", domain, endpoint)
 	transport := &http.Transport{
 		DialContext: func(ctx context.Context, network, addr string) (conn net.Conn, e error) {
-			spoofed := addr
-			if i := strings.LastIndex(addr, ":"); i != -1 && domain == addr[:i] {
-				// The original hostname:port is spoofed by replacing the hostname by the value
-				// returned by ResolveEndpoint.
-				spoofed = endpoint + ":" + addr[i+1:]
+			_, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
 			}
-			return dialContext(ctx, network, spoofed)
+			// The original hostname:port is spoofed by replacing the hostname by the value
+			// returned by ResolveEndpoint.
+			return dialContext(ctx, network, net.JoinHostPort(endpoint, mapper(port)))
 		},
 	}
 
@@ -150,17 +149,14 @@ func New(
 
 // ResolveEndpoint resolves the endpoint address considering whether the domain is resolvable and taking into
 // account whether the user overrode the endpoint address externally
-func ResolveEndpoint(ctx context.Context, kubeClientset *kubernetes.Clientset, domain string, resolvable bool, endpointOverride string) (string, error) {
+func ResolveEndpoint(ctx context.Context, kubeClientset *kubernetes.Clientset, domain string, resolvable bool, endpointOverride string) (string, func(string) string, error) {
+	id := func(in string) string { return in }
 	// If the domain is resolvable, it can be used directly
 	if resolvable {
-		return domain, nil
-	}
-	// If an override is provided, use it
-	if endpointOverride != "" {
-		return endpointOverride, nil
+		return domain, id, nil
 	}
 	// Otherwise, use the actual cluster endpoint
-	return ingress.GetIngressEndpoint(ctx, kubeClientset)
+	return ingress.GetIngressEndpoint(ctx, kubeClientset, endpointOverride)
 }
 
 // Do dispatches to the underlying http.Client.Do, spoofing domains as needed


### PR DESCRIPTION
This is loosely based on similar logic that I added to kingress conformance testing here:
https://github.com/knative/networking/blob/611f989aa593e513688d0f0047701e8352571ac4/test/conformance/ingress/util.go#L904-L912

The basic idea is that in our custom dialer we look at the requested port and translate that to the service's NodePort when present.

This is in support of running Serving's e2e testing on top of KinD environments without service `type: LoadBalancer`.


/hold

This needs to be staged as there are a few breaking changes to Serving that need to be fixed.