### PR TITLE
Fix flakes in EnqueueAfter tests

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -756,8 +756,8 @@ const (
 
 func pollQ(q workqueue.RateLimitingInterface, sig chan int) func() (bool, error) {
 	return func() (bool, error) {
-		if q.Len() > 0 {
-			sig <- q.Len()
+		if ql := q.Len(); ql > 0 {
+			sig <- ql
 			return true, nil
 		}
 		return false, nil

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -754,10 +754,10 @@ const (
 	queueCheckTimeout = shortDelay + 500*time.Millisecond
 )
 
-func pollQ(q workqueue.RateLimitingInterface, sig chan struct{}) func() (bool, error) {
+func pollQ(q workqueue.RateLimitingInterface, sig chan int) func() (bool, error) {
 	return func() (bool, error) {
 		if q.Len() > 0 {
-			sig <- struct{}{}
+			sig <- q.Len()
 			return true, nil
 		}
 		return false, nil
@@ -765,7 +765,6 @@ func pollQ(q workqueue.RateLimitingInterface, sig chan struct{}) func() (bool, e
 }
 
 func TestEnqueueAfter(t *testing.T) {
-
 	impl := NewImplWithStats(&nopReconciler{}, TestLogger(t), "Testing", &FakeStatsReporter{})
 	t.Cleanup(func() {
 		impl.WorkQueue().ShutDown()
@@ -795,7 +794,7 @@ func TestEnqueueAfter(t *testing.T) {
 	}, shortDelay)
 
 	// Keep checking the queue length until 'to/fall' gets enqueued, send to channel to indicate success.
-	queuePopulated := make(chan struct{})
+	queuePopulated := make(chan int)
 	ctx, cancel := context.WithTimeout(context.Background(), queueCheckTimeout)
 
 	t.Cleanup(func() {
@@ -807,11 +806,11 @@ func TestEnqueueAfter(t *testing.T) {
 		pollQ(impl.WorkQueue(), queuePopulated), ctx.Done())
 
 	select {
-	case <-queuePopulated:
+	case qlen := <-queuePopulated:
 		if enqueueDelay := time.Since(enqueueTime); enqueueDelay < shortDelay {
 			t.Errorf("Item enqueued within %v, expected at least a %v delay", enqueueDelay, shortDelay)
 		}
-		if got, want := impl.WorkQueue().Len(), 1; got != want {
+		if got, want := qlen, 1; got != want {
 			t.Errorf("|Queue| = %d, want: %d", got, want)
 		}
 
@@ -842,7 +841,7 @@ func TestEnqueueKeyAfter(t *testing.T) {
 	impl.EnqueueKeyAfter(types.NamespacedName{Namespace: "to", Name: "fall"}, shortDelay)
 
 	// Keep checking the queue length until 'to/fall' gets enqueued, send to channel to indicate success.
-	queuePopulated := make(chan struct{})
+	queuePopulated := make(chan int)
 
 	ctx, cancel := context.WithTimeout(context.Background(), queueCheckTimeout)
 
@@ -855,11 +854,11 @@ func TestEnqueueKeyAfter(t *testing.T) {
 		pollQ(impl.WorkQueue(), queuePopulated), ctx.Done())
 
 	select {
-	case <-queuePopulated:
+	case qlen := <-queuePopulated:
 		if enqueueDelay := time.Since(enqueueTime); enqueueDelay < shortDelay {
 			t.Errorf("Item enqueued within %v, expected at least a %v delay", enqueueDelay, shortDelay)
 		}
-		if got, want := impl.WorkQueue().Len(), 1; got != want {
+		if got, want := qlen, 1; got != want {
 			t.Errorf("|Queue| = %d, want: %d", got, want)
 		}
 


### PR DESCRIPTION
Fixes flakes such as https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_pkg/1709/pull-knative-pkg-unit-tests/1305911274105737216.

the [docs for the Len() function in queue package say](https://github.com/kubernetes/client-go/blob/master/util/workqueue/queue.go#L129):

~~~~
// Len returns the current queue length, for informational purposes only. You
// shouldn't e.g. gate a call to Add() or Get() on Len() being a particular
// value, that can't be synchronized properly.
~~~~

Testing locally, when we see the flake we'll then see the correct length immediately after, so it appears to be caused by inconsistent reads. Directly sending the len to the channel when the poll finishes rather than effectively re-polling an extra time in the test seems to fix up the flakes. Since no-one should be using len() other than for information purposes, this solution seems fine. Ran with `-count 100` locally cleanly.