### PR TITLE
Use http.Transport.Clone in preference to copy-pasting defaults

### DIFF
--- a/network/transports.go
+++ b/network/transports.go
@@ -93,19 +93,12 @@ func dialBackOffHelper(ctx context.Context, network, address string, bo wait.Bac
 }
 
 func newHTTPTransport(disableKeepAlives bool, maxIdle, maxIdlePerHost int) http.RoundTripper {
-	return &http.Transport{
-		// Those match net/http/transport.go
-		Proxy:                 http.ProxyFromEnvironment,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		DisableKeepAlives:     disableKeepAlives,
-
-		// Those are bespoke.
-		DialContext:         DialWithBackOff,
-		MaxIdleConns:        maxIdle,
-		MaxIdleConnsPerHost: maxIdlePerHost,
-	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = DialWithBackOff
+	transport.MaxIdleConns = maxIdle
+	transport.MaxIdleConnsPerHost = maxIdlePerHost
+	transport.ForceAttemptHTTP2 = false
+	return transport
 }
 
 // NewProberTransport creates a RoundTripper that is useful for probing,

--- a/network/transports.go
+++ b/network/transports.go
@@ -95,6 +95,7 @@ func dialBackOffHelper(ctx context.Context, network, address string, bo wait.Bac
 func newHTTPTransport(disableKeepAlives bool, maxIdle, maxIdlePerHost int) http.RoundTripper {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.DialContext = DialWithBackOff
+	transport.DisableKeepAlives = disableKeepAlives
 	transport.MaxIdleConns = maxIdle
 	transport.MaxIdleConnsPerHost = maxIdlePerHost
 	transport.ForceAttemptHTTP2 = false


### PR DESCRIPTION
Same as https://github.com/knative/serving/pull/9488.

Since go 1.13 http.Transport has a Clone method (more context in https://github.com/golang/go/issues/26013) which means we can inherit and override the defaults rather than re-stating them. This also makes it clear that we're overriding the http.DefaultTransport default for ForceAttemptHTTP2 here, which we are.

/assign @markusthoemmes @vagababov 