### PR TITLE
Add a func to return a connection which has been established

### DIFF
--- a/websocket/connection_test.go
+++ b/websocket/connection_test.go
@@ -420,14 +420,15 @@ func TestDurableConnectionSendsPingsRegularly(t *testing.T) {
 }
 
 func TestNewDurableSendingConnectionGuaranteed(t *testing.T) {
+	// Unhappy case.
 	logger := ktesting.TestLogger(t)
 	if NewDurableSendingConnectionGuaranteed("ws://somewhere.not.exist", time.Second, logger) != nil {
 		t.Error("Unexpected connection from NewDurableSendingConnectionGuaranteed")
 	}
 
+	// Happy case.
 	const testPayload = "test"
 	reconnectChan := make(chan struct{})
-
 	upgrader := websocket.Upgrader{}
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c, err := upgrader.Upgrade(w, r, nil)

--- a/websocket/connection_test.go
+++ b/websocket/connection_test.go
@@ -422,8 +422,9 @@ func TestDurableConnectionSendsPingsRegularly(t *testing.T) {
 func TestNewDurableSendingConnectionGuaranteed(t *testing.T) {
 	// Unhappy case.
 	logger := ktesting.TestLogger(t)
-	if NewDurableSendingConnectionGuaranteed("ws://somewhere.not.exist", time.Second, logger) != nil {
-		t.Error("Unexpected connection from NewDurableSendingConnectionGuaranteed")
+	_, err := NewDurableSendingConnectionGuaranteed("ws://somewhere.not.exist", time.Second, logger)
+	if got, want := err.Error(), ErrConnectionNotEstablished.Error(); got != want {
+		t.Errorf("Got error: %v, want error: %v", got, want)
 	}
 
 	// Happy case.
@@ -443,7 +444,10 @@ func TestNewDurableSendingConnectionGuaranteed(t *testing.T) {
 	defer s.Close()
 
 	target := "ws" + strings.TrimPrefix(s.URL, "http")
-	conn := NewDurableSendingConnectionGuaranteed(target, time.Second, logger)
+	conn, err := NewDurableSendingConnectionGuaranteed(target, time.Second, logger)
+	if err != nil {
+		t.Errorf("Got error from NewDurableSendingConnectionGuaranteed: %v", err)
+	}
 	defer conn.Shutdown()
 
 	// Sending the message immediately should be fine as the connection has been established.


### PR DESCRIPTION
`NewDurableSendingConnection` creates a managed connection which is connecting asynchronously. We have to wait the connection to be established before sending message.

Proposed to add a function `NewDurableSendingConnectionGuaranteed` to return a connection which can be used immediately by wrapping a wait.

Also remove `IsEstablished` as we can use `Status` instead. Its downstream usage has been removed.

/assign @vagababov 