### PR TITLE
Make mako stub results reader cross-platform

### DIFF
--- a/test/mako/stub-sidecar/read_results.sh
+++ b/test/mako/stub-sidecar/read_results.sh
@@ -52,13 +52,13 @@ while [[ -n "$isfree" ]]; do
   isfree=$(lsof -i TCP:$port)
 done
 
-for i in $(seq $RETRIES); do
-  kubectl port-forward -n "$MAKO_STUB_NAMESPACE" "$MAKO_STUB_POD_NAME" $port:$MAKO_STUB_PORT &
+for _ in $(seq "$RETRIES"); do
+  kubectl port-forward -n "$MAKO_STUB_NAMESPACE" "$MAKO_STUB_POD_NAME" $port:"$MAKO_STUB_PORT" &
   PORT_FORWARD_PID=$!
 
   sleep 10
 
-  curl --connect-timeout $TIMEOUT "http://localhost:$port/results" > $OUTPUT_FILE
+  curl --connect-timeout "$TIMEOUT" "http://localhost:$port/results" > "$OUTPUT_FILE"
   curl_exit_status=$?
 
   kill $PORT_FORWARD_PID
@@ -67,7 +67,7 @@ for i in $(seq $RETRIES); do
   if [ 0 -eq $curl_exit_status ]; then
     exit 0
   else
-    sleep $RETRIES_INTERVAL
+    sleep "$RETRIES_INTERVAL"
   fi
 
 done

--- a/test/mako/stub-sidecar/read_results.sh
+++ b/test/mako/stub-sidecar/read_results.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Knative Authors
 #
@@ -26,6 +26,7 @@ check_command_exists() {
 
 check_command_exists kubectl
 check_command_exists curl
+check_command_exists lsof
 
 if [[ $# -lt 7 ]]
 then
@@ -44,11 +45,11 @@ OUTPUT_FILE="$7"
 # Find port ready to use
 
 port=10000
-isfree=$(netstat -tapln | grep $port)
+isfree=$(lsof -i TCP:$port)
 
 while [[ -n "$isfree" ]]; do
   port=$((port + 1))
-  isfree=$(netstat -tapln | grep $port)
+  isfree=$(lsof -i TCP:$port)
 done
 
 for i in $(seq $RETRIES); do


### PR DESCRIPTION
The original mako stub `read_results.sh` script relies on `netstat` options which are not available on Mac, in order to find a free TCP port, which makes it impossible to launch some performance tests on Mac. This change instead uses the cross-platform utility `lsof` and portable bash environment for convenience.