### PR TITLE
Add TTL expiry for items in allMeters.meters map

### DIFF
--- a/metrics/resource_view.go
+++ b/metrics/resource_view.go
@@ -29,6 +29,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+	"k8s.io/apimachinery/pkg/util/clock"
 )
 
 type storedViews struct {
@@ -40,6 +41,7 @@ type meterExporter struct {
 	m view.Meter    // NOTE: DO NOT RETURN THIS DIRECTLY; the view.Meter will not work for the empty Resource
 	o stats.Options // Cache the option to reduce allocations
 	e view.Exporter
+	t time.Time // Time when last access occurred
 }
 
 // ResourceExporterFactory provides a hook for producing separate view.Exporters
@@ -48,17 +50,70 @@ type meterExporter struct {
 // Tags are.
 type ResourceExporterFactory func(*resource.Resource) (view.Exporter, error)
 type meters struct {
-	meters  map[string]*meterExporter
-	factory ResourceExporterFactory
-	lock    sync.Mutex
+	meters         map[string]*meterExporter
+	factory        ResourceExporterFactory
+	lock           sync.Mutex
+	clock          clock.Clock
+	ticker         clock.Ticker
+	tickerStopChan chan struct{}
 }
 
 // Lock regime: lock allMeters before resourceViews. The critical path is in
 // optionForResource, which must lock allMeters, but only needs to lock
 // resourceViews if a new meter needs to be created.
-var resourceViews = storedViews{}
-var allMeters = meters{
-	meters: map[string]*meterExporter{"": &defaultMeter},
+var (
+	resourceViews = storedViews{}
+	allMeters     = meters{
+		meters: map[string]*meterExporter{"": &defaultMeter},
+		clock:  clock.Clock(clock.RealClock{}),
+	}
+
+	cleanupOnce                = new(sync.Once)
+	meterExporterScanFrequency = 1 * time.Minute
+	maxMeterExporterAge        = 10 * time.Minute
+)
+
+// cleanup looks through allMeter's meterExporter and prunes any that were last visited
+// more than maxMeterExporterAge ago. This will clean up any exporters for resources
+// that no longer exist on the system (a replaced revision, e.g.).  All meterExporter
+// lookups (and creations) run meterExporterForResource, which updates the timestamp
+// on each access.
+func cleanup() {
+	expiryCutoff := allMeters.clock.Now().Add(-1 * maxMeterExporterAge)
+	allMeters.lock.Lock()
+	defer allMeters.lock.Unlock()
+	for key, meter := range allMeters.meters {
+		if key != "" && meter.t.Before(expiryCutoff) {
+			flushGivenExporter(meter.e)
+			delete(allMeters.meters, key)
+		}
+	}
+}
+
+// startCleanup is configured to only run once in production.  For testing,
+// calling startCleanup again will terminate old cleanup threads,
+// and restart anew.
+func startCleanup() {
+	if allMeters.tickerStopChan != nil {
+		close(allMeters.tickerStopChan)
+	}
+
+	curClock := allMeters.clock
+	newTicker := curClock.NewTicker(meterExporterScanFrequency)
+	newStopChan := make(chan struct{})
+	allMeters.tickerStopChan = newStopChan
+	allMeters.ticker = newTicker
+	go func() {
+		defer newTicker.Stop()
+		for {
+			select {
+			case <-newTicker.C():
+				cleanup()
+			case <-newStopChan:
+				return
+			}
+		}
+	}()
 }
 
 // RegisterResourceView is similar to view.Register(), except that it will
@@ -174,7 +229,9 @@ func flushResourceExporters() {
 }
 
 // ClearMetersForTest clears the internal set of metrics being exported,
-// including cleaning up background threads.
+// including cleaning up background threads, and restarts cleanup thread.
+//
+// If a replacement clock is desired, it should be in allMeters.clock before calling.
 func ClearMetersForTest() {
 	allMeters.lock.Lock()
 	defer allMeters.lock.Unlock()
@@ -186,6 +243,7 @@ func ClearMetersForTest() {
 		meter.m.Stop()
 		delete(allMeters.meters, k)
 	}
+	startCleanup()
 }
 
 func meterExporterForResource(r *resource.Resource) *meterExporter {
@@ -195,6 +253,7 @@ func meterExporterForResource(r *resource.Resource) *meterExporter {
 		mE = &meterExporter{}
 		allMeters.meters[key] = mE
 	}
+	mE.t = allMeters.clock.Now()
 	if mE.o != nil {
 		return mE
 	}
@@ -219,6 +278,9 @@ func meterExporterForResource(r *resource.Resource) *meterExporter {
 // optionForResource finds or creates a stats exporter for the resource, and
 // returns a stats.Option indicating which meter to record to.
 func optionForResource(r *resource.Resource) (stats.Options, error) {
+	// Start the allMeters cleanup thread, if not already started
+	cleanupOnce.Do(startCleanup)
+
 	allMeters.lock.Lock()
 	defer allMeters.lock.Unlock()
 
@@ -313,6 +375,7 @@ var _ view.Meter = (*defaultMeterImpl)(nil)
 var defaultMeter = meterExporter{
 	m: &defaultMeterImpl{},
 	o: stats.WithRecorder(nil),
+	t: time.Now(), // time.Now() here is ok - defaultMeter never expires, so this won't be checked
 }
 
 func (*defaultMeterImpl) Record(*tag.Map, interface{}, map[string]interface{}) {

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -37,6 +37,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+	"k8s.io/apimachinery/pkg/util/clock"
 
 	emptypb "github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/go-cmp/cmp"
@@ -142,6 +143,70 @@ func TestSetFactory(t *testing.T) {
 	if e.id != "456" {
 		t.Error("Expect id to be 456, instead got", e.id)
 	}
+}
+
+func TestAllMetersExpiration(t *testing.T) {
+	allMeters.clock = clock.Clock(clock.NewFakeClock(time.Now()))
+	var fakeClock *clock.FakeClock = allMeters.clock.(*clock.FakeClock)
+	ClearMetersForTest() // t+0m
+
+	// Add resource123
+	resource123 := r
+	resource123.Labels["id"] = "123"
+	_, err := optionForResource(&resource123)
+	if err != nil {
+		t.Error("Should succeed getting option, instead got error ", err)
+	}
+	// (123=0m, 456=Inf)
+
+	// Bump time to make resource123's expiry offset from resource456
+	fakeClock.Step(90 * time.Second) // t+1.5m
+	// (123=0m, 456=Inf)
+
+	// Add 456
+	resource456 := r
+	resource456.Labels["id"] = "456"
+	_, err = optionForResource(&resource456)
+	if err != nil {
+		t.Error("Should succeed getting option, instead got error ", err)
+	}
+	allMeters.lock.Lock()
+	if len(allMeters.meters) != 3 {
+		t.Errorf("len(allMeters)=%d, want: 3", len(allMeters.meters))
+	}
+	allMeters.lock.Unlock()
+	// (123=1.5m, 456=0m)
+
+	// Warm up the older entry
+	fakeClock.Step(90 * time.Second) //t+3m
+	// (123=4.5m, 456=3m)
+
+	// Refresh the first entry
+	_, err = optionForResource(&resource123)
+	if err != nil {
+		t.Error("Should succeed getting option, instead got error ", err)
+	}
+	// (123=0, 456=1.5m)
+
+	// Expire the second entry
+	fakeClock.Step(9 * time.Minute) // t+12m
+	time.Sleep(1 * time.Second)     // Wait a second on the wallclock, so that the cleanup thread has time to finish a loop
+	allMeters.lock.Lock()
+	if len(allMeters.meters) != 2 {
+		t.Errorf("len(allMeters)=%d, want: 2", len(allMeters.meters))
+	}
+	allMeters.lock.Unlock()
+	// (123=9m, 456=10.5m)
+	// non-expiring defaultMeter was just tested
+
+	// Add resource789
+	resource789 := r
+	resource789.Labels["id"] = "789"
+	_, err = optionForResource(&resource789)
+	if err != nil {
+		t.Error("Should succeed getting option, instead got error ", err)
+	}
+	// (123=9m, 456=evicted, 789=0m)
 }
 
 func TestResourceAsString(t *testing.T) {


### PR DESCRIPTION
Currently, pkg/metrics keeps one meterExporter for each resource the system is sending metrics about.

As resources  fall off the system and no longer send metrics (deleting a knative revision, for example), a slow leak occurs as orphaned meterExporters are never cleaned up.

This PR adds a TTL expiry bit for each meterExporter, and cleans them up when they expire.