### PR TITLE
Format optimization cleanup

### DIFF
--- a/apiextensions/storageversion/migrator_test.go
+++ b/apiextensions/storageversion/migrator_test.go
@@ -72,7 +72,7 @@ func TestMigrate(t *testing.T) {
 	m := NewMigrator(dclient, cclient)
 
 	if err := m.Migrate(context.Background(), fakeGR); err != nil {
-		t.Fatalf("Migrate() = %v", err)
+		t.Fatal("Migrate() =", err)
 	}
 
 	assertPatches(t, dclient.Actions(),

--- a/apis/condition_set_impl_test.go
+++ b/apis/condition_set_impl_test.go
@@ -1152,7 +1152,7 @@ func TestRemoveNonTerminalConditions(t *testing.T) {
 
 	err := manager.ClearCondition("Bar")
 	if err != nil {
-		t.Errorf("Clear condition should not return err %v", err)
+		t.Error("Clear condition should not return err", err)
 	}
 	if got, want := len(status.c), 2; got != want {
 		t.Errorf("Marking true() = %v, wanted %v", got, want)
@@ -1169,7 +1169,7 @@ func TestClearConditionWithNilManager(t *testing.T) {
 
 	err := manager.ClearCondition("Bar")
 	if err != nil {
-		t.Errorf("ClearCondition() expected to return nil if status is nil, got %s", err)
+		t.Error("ClearCondition() expected to return nil if status is nil, got", err)
 	}
 
 }

--- a/apis/convert_test.go
+++ b/apis/convert_test.go
@@ -30,7 +30,7 @@ func TestConvertToViaProxy(t *testing.T) {
 	err := ConvertToViaProxy(context.Background(), source, proxy, sink)
 
 	if err != nil {
-		t.Errorf("ConvertToViaProxy returned unexpected err: %s", err)
+		t.Error("ConvertToViaProxy returned unexpected err:", err)
 	}
 
 	if source.to != proxy {
@@ -83,7 +83,7 @@ func TestConvertFromViaProxy(t *testing.T) {
 	err := ConvertFromViaProxy(context.Background(), source, proxy, sink)
 
 	if err != nil {
-		t.Errorf("ConvertFromViaProxy returned unexpected err: %s", err)
+		t.Error("ConvertFromViaProxy returned unexpected err:", err)
 	}
 
 	if proxy.from != source {

--- a/apis/duck/enqueue_test.go
+++ b/apis/duck/enqueue_test.go
@@ -47,7 +47,7 @@ func TestEnqueueInformerFactory(t *testing.T) {
 	}
 	inf, _, err := eif.Get(context.Background(), gvr)
 	if err != nil {
-		t.Fatalf("Get() = %v", err)
+		t.Fatal("Get() =", err)
 	}
 	if inf != fsii {
 		t.Fatalf("Get() = %v, wanted %v", inf, fsii)

--- a/apis/duck/patch_test.go
+++ b/apis/duck/patch_test.go
@@ -120,7 +120,7 @@ func TestCreateMergePatch(t *testing.T) {
 			got, err := CreateMergePatch(test.before, test.after)
 			if err != nil {
 				if !test.wantErr {
-					t.Errorf("CreateMergePatch() = %v", err)
+					t.Error("CreateMergePatch() =", err)
 				}
 				return
 			} else if test.wantErr {
@@ -305,7 +305,7 @@ func TestCreatePatch(t *testing.T) {
 			got, err := CreateBytePatch(test.before, test.after)
 			if err != nil {
 				if !test.wantErr {
-					t.Errorf("CreateBytePatch() = %v", err)
+					t.Error("CreateBytePatch() =", err)
 				}
 				return
 			} else if test.wantErr {
@@ -319,7 +319,7 @@ func TestCreatePatch(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(want, got); diff != "" {
-				t.Errorf("CreateBytePatch (-want, +got) = %v", diff)
+				t.Error("CreateBytePatch (-want, +got) =", diff)
 			}
 
 		})
@@ -327,7 +327,7 @@ func TestCreatePatch(t *testing.T) {
 			got, err := CreatePatch(test.before, test.after)
 			if err != nil {
 				if !test.wantErr {
-					t.Errorf("CreatePatch() = %v", err)
+					t.Error("CreatePatch() =", err)
 				}
 				return
 			} else if test.wantErr {
@@ -336,7 +336,7 @@ func TestCreatePatch(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("CreatePatch (-want, +got) = %v", diff)
+				t.Error("CreatePatch (-want, +got) =", diff)
 			}
 		})
 	}
@@ -354,7 +354,7 @@ func TestPatchToJSON(t *testing.T) {
 
 	b, err := input.MarshalJSON()
 	if err != nil {
-		t.Errorf("MarshalJSON() = %v", err)
+		t.Error("MarshalJSON() =", err)
 	}
 
 	want := `[{"op":"replace","path":"/status/patchable/field1","value":42},{"op":"remove","path":"/status/patchable/field2"}]`

--- a/apis/duck/typed_test.go
+++ b/apis/duck/typed_test.go
@@ -76,12 +76,12 @@ func TestSimpleList(t *testing.T) {
 	// https://github.com/kubernetes/kubernetes/pull/68552
 	_, lister, err := tif.Get(ctx, SchemeGroupVersion.WithResource("resources"))
 	if err != nil {
-		t.Fatalf("Get() = %v", err)
+		t.Fatal("Get() =", err)
 	}
 
 	elt, err := lister.ByNamespace(namespace).Get(name)
 	if err != nil {
-		t.Fatalf("Get() = %v", err)
+		t.Fatal("Get() =", err)
 	}
 
 	got, ok := elt.(*duckv1alpha1.AddressableType)
@@ -138,7 +138,7 @@ func TestAsStructuredWatcherClosedChannel(t *testing.T) {
 
 	wi, err := wf(metav1.ListOptions{})
 	if err != nil {
-		t.Errorf("WatchFunc() = %v", err)
+		t.Error("WatchFunc() =", err)
 	}
 
 	ch := wi.ResultChan()
@@ -159,7 +159,7 @@ func TestAsStructuredWatcherPassThru(t *testing.T) {
 
 	wi, err := wf(metav1.ListOptions{})
 	if err != nil {
-		t.Errorf("WatchFunc() = %v", err)
+		t.Error("WatchFunc() =", err)
 	}
 	defer wi.Stop()
 	ch := wi.ResultChan()
@@ -205,7 +205,7 @@ func TestAsStructuredWatcherPassThruErrors(t *testing.T) {
 
 	wi, err := wf(metav1.ListOptions{})
 	if err != nil {
-		t.Errorf("WatchFunc() = %v", err)
+		t.Error("WatchFunc() =", err)
 	}
 	defer wi.Stop()
 	ch := wi.ResultChan()
@@ -225,7 +225,7 @@ func TestAsStructuredWatcherPassThruErrors(t *testing.T) {
 			t.Fatal("<-ch = closed, wanted *metav1.Status{}")
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
-			t.Errorf("<-ch (-want, +got) = %v", diff)
+			t.Error("<-ch (-want, +got) =", diff)
 		}
 	case <-time.After(100 * time.Millisecond):
 		t.Error("Didn't see expected message on channel.")
@@ -242,7 +242,7 @@ func TestAsStructuredWatcherErrorConverting(t *testing.T) {
 
 	wi, err := wf(metav1.ListOptions{})
 	if err != nil {
-		t.Errorf("WatchFunc() = %v", err)
+		t.Error("WatchFunc() =", err)
 	}
 	defer wi.Stop()
 	ch := wi.ResultChan()

--- a/apis/duck/unstructured_test.go
+++ b/apis/duck/unstructured_test.go
@@ -77,18 +77,18 @@ func TestFromUnstructuredFooable(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			raw, err := json.Marshal(tc.in)
 			if err != nil {
-				t.Fatalf("failed to marshal: %v", err)
+				t.Fatal("failed to marshal:", err)
 			}
 
-			t.Logf("Marshalled: %s", string(raw))
+			t.Log("Marshalled:", string(raw))
 
 			got := Foo{}
 			if err := FromUnstructured(tc.in, &got); err != tc.wantError {
-				t.Fatalf("FromUnstructured() = %v", err)
+				t.Fatal("FromUnstructured() =", err)
 			}
 
 			if !cmp.Equal(tc.want, got.Status) {
-				t.Errorf("ToUnstructured (-want, +got) = %s", cmp.Diff(tc.want, got.Status))
+				t.Error("ToUnstructured (-want, +got) =", cmp.Diff(tc.want, got.Status))
 			}
 		})
 	}
@@ -146,11 +146,11 @@ func TestToUnstructured(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := ToUnstructured(tc.in)
 			if err != tc.wantError {
-				t.Fatalf("ToUnstructured() = %v", err)
+				t.Fatal("ToUnstructured() =", err)
 			}
 
 			if !cmp.Equal(tc.want, got) {
-				t.Errorf("ToUnstructured (-want, +got) = %s", cmp.Diff(tc.want, got))
+				t.Error("ToUnstructured (-want, +got) =", cmp.Diff(tc.want, got))
 			}
 		})
 	}

--- a/apis/duck/v1/addressable_types_test.go
+++ b/apis/duck/v1/addressable_types_test.go
@@ -50,7 +50,7 @@ func TestConversion(t *testing.T) {
 			conv := test.conv
 			if err := test.addr.ConvertTo(context.Background(), conv); err != nil {
 				if !test.wantErrUp {
-					t.Errorf("ConvertTo() = %v", err)
+					t.Error("ConvertTo() =", err)
 				}
 			} else if test.wantErrUp {
 				t.Errorf("ConvertTo() = %#v, wanted error", conv)
@@ -58,7 +58,7 @@ func TestConversion(t *testing.T) {
 			got := &Addressable{}
 			if err := got.ConvertFrom(context.Background(), conv); err != nil {
 				if !test.wantErrDown {
-					t.Errorf("ConvertFrom() = %v", err)
+					t.Error("ConvertFrom() =", err)
 				}
 				return
 			} else if test.wantErrDown {
@@ -67,7 +67,7 @@ func TestConversion(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(test.addr, got); diff != "" {
-				t.Errorf("roundtrip (-want, +got) = %v", diff)
+				t.Error("roundtrip (-want, +got) =", diff)
 			}
 		})
 	}

--- a/apis/duck/v1/destination_test.go
+++ b/apis/duck/v1/destination_test.go
@@ -164,7 +164,7 @@ func TestDestinationGetRef(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			got := tc.dest.GetRef()
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("Unexpected result (-want +got): %s", diff)
+				t.Error("Unexpected result (-want +got):", diff)
 			}
 		})
 	}
@@ -210,7 +210,7 @@ func TestDestinationSetDefaults(t *testing.T) {
 				t.Errorf("Got: %s wanted %s", tc.d.Ref.Namespace, tc.want)
 			}
 			if tc.d.Ref == nil && tc.want != "" {
-				t.Errorf("Got: nil Ref wanted %s", tc.want)
+				t.Error("Got: nil Ref wanted", tc.want)
 			}
 		})
 	}

--- a/apis/duck/v1/register_test.go
+++ b/apis/duck/v1/register_test.go
@@ -37,6 +37,6 @@ func TestRegisterHelpers(t *testing.T) {
 
 	scheme := runtime.NewScheme()
 	if err := addKnownTypes(scheme); err != nil {
-		t.Errorf("addKnownTypes() = %v", err)
+		t.Error("addKnownTypes() =", err)
 	}
 }

--- a/apis/duck/v1/status_types_test.go
+++ b/apis/duck/v1/status_types_test.go
@@ -42,12 +42,12 @@ func TestStatusGetCondition(t *testing.T) {
 
 	got := s.GetCondition(foo.Type)
 	if diff := cmp.Diff(got, foo); diff != "" {
-		t.Errorf("GetCondition(foo) = %s", diff)
+		t.Error("GetCondition(foo) =", diff)
 	}
 
 	got = s.GetCondition(bar.Type)
 	if diff := cmp.Diff(got, bar); diff != "" {
-		t.Errorf("GetCondition(bar) = %s", diff)
+		t.Error("GetCondition(bar) =", diff)
 	}
 
 	if got := s.GetCondition("None"); got != nil {

--- a/apis/duck/v1alpha1/addressable_types_test.go
+++ b/apis/duck/v1alpha1/addressable_types_test.go
@@ -119,7 +119,7 @@ func TestConversion(t *testing.T) {
 			conv := test.conv
 			if err := test.addr.ConvertTo(context.Background(), conv); err != nil {
 				if !test.wantErrUp {
-					t.Errorf("ConvertTo() = %v", err)
+					t.Error("ConvertTo() =", err)
 				}
 			} else if test.wantErrUp {
 				t.Errorf("ConvertTo() = %#v, wanted error", conv)
@@ -127,7 +127,7 @@ func TestConversion(t *testing.T) {
 			got := &Addressable{}
 			if err := got.ConvertFrom(context.Background(), conv); err != nil {
 				if !test.wantErrDown {
-					t.Errorf("ConvertFrom() = %v", err)
+					t.Error("ConvertFrom() =", err)
 				}
 				return
 			} else if test.wantErrDown {
@@ -136,7 +136,7 @@ func TestConversion(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(test.addr, got); diff != "" {
-				t.Errorf("roundtrip (-want, +got) = %v", diff)
+				t.Error("roundtrip (-want, +got) =", diff)
 			}
 		})
 	}
@@ -193,14 +193,14 @@ func TestConvertTo(t *testing.T) {
 			got := test.conv
 			if err := test.addr.ConvertTo(context.Background(), got); err != nil {
 				if !test.wantErrUp {
-					t.Errorf("ConvertTo() = %v", err)
+					t.Error("ConvertTo() =", err)
 				}
 			} else if test.wantErrUp {
 				t.Errorf("ConvertTo() = %#v, wanted error", got)
 			}
 
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("roundtrip (-want, +got) = %v", diff)
+				t.Error("roundtrip (-want, +got) =", diff)
 			}
 		})
 	}
@@ -225,11 +225,11 @@ func TestConvertFrom(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := &Addressable{}
 			if err := got.ConvertFrom(context.Background(), test.in); err != nil {
-				t.Errorf("ConvertFrom() = %v", err)
+				t.Error("ConvertFrom() =", err)
 			}
 
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("roundtrip (-want, +got) = %v", diff)
+				t.Error("roundtrip (-want, +got) =", diff)
 			}
 		})
 	}

--- a/apis/duck/v1alpha1/register_test.go
+++ b/apis/duck/v1alpha1/register_test.go
@@ -37,6 +37,6 @@ func TestRegisterHelpers(t *testing.T) {
 
 	scheme := runtime.NewScheme()
 	if err := addKnownTypes(scheme); err != nil {
-		t.Errorf("addKnownTypes() = %v", err)
+		t.Error("addKnownTypes() =", err)
 	}
 }

--- a/apis/duck/v1beta1/addressable_types_test.go
+++ b/apis/duck/v1beta1/addressable_types_test.go
@@ -74,7 +74,7 @@ func TestConversion(t *testing.T) {
 			conv := test.conv
 			if err := test.addr.ConvertTo(context.Background(), conv); err != nil {
 				if !test.wantErrUp {
-					t.Errorf("ConvertTo() = %v", err)
+					t.Error("ConvertTo() =", err)
 				}
 			} else if test.wantErrUp {
 				t.Errorf("ConvertTo() = %#v, wanted error", conv)
@@ -82,7 +82,7 @@ func TestConversion(t *testing.T) {
 			got := &Addressable{}
 			if err := got.ConvertFrom(context.Background(), conv); err != nil {
 				if !test.wantErrDown {
-					t.Errorf("ConvertFrom() = %v", err)
+					t.Error("ConvertFrom() =", err)
 				}
 				return
 			} else if test.wantErrDown {
@@ -91,7 +91,7 @@ func TestConversion(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(test.addr, got); diff != "" {
-				t.Errorf("roundtrip (-want, +got) = %v", diff)
+				t.Error("roundtrip (-want, +got) =", diff)
 			}
 		})
 	}

--- a/apis/duck/v1beta1/destination_test.go
+++ b/apis/duck/v1beta1/destination_test.go
@@ -420,7 +420,7 @@ func TestDestination_GetRef(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			got := tc.dest.GetRef()
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("Unexpected result (-want +got): %s", diff)
+				t.Error("Unexpected result (-want +got):", diff)
 			}
 		})
 	}

--- a/apis/duck/v1beta1/register_test.go
+++ b/apis/duck/v1beta1/register_test.go
@@ -37,6 +37,6 @@ func TestRegisterHelpers(t *testing.T) {
 
 	scheme := runtime.NewScheme()
 	if err := addKnownTypes(scheme); err != nil {
-		t.Errorf("addKnownTypes() = %v", err)
+		t.Error("addKnownTypes() =", err)
 	}
 }

--- a/apis/duck/v1beta1/status_types_test.go
+++ b/apis/duck/v1beta1/status_types_test.go
@@ -42,12 +42,12 @@ func TestStatusGetCondition(t *testing.T) {
 
 	got := s.GetCondition(foo.Type)
 	if diff := cmp.Diff(got, foo); diff != "" {
-		t.Errorf("GetCondition(foo) = %s", diff)
+		t.Error("GetCondition(foo) =", diff)
 	}
 
 	got = s.GetCondition(bar.Type)
 	if diff := cmp.Diff(got, bar); diff != "" {
-		t.Errorf("GetCondition(bar) = %s", diff)
+		t.Error("GetCondition(bar) =", diff)
 	}
 
 	if got := s.GetCondition("None"); got != nil {

--- a/apis/kind2resource_test.go
+++ b/apis/kind2resource_test.go
@@ -73,7 +73,7 @@ func TestGVK2GVR(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := KindToResource(test.input)
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("KindToResource (-want, +got) = %v", diff)
+				t.Error("KindToResource (-want, +got) =", diff)
 			}
 		})
 	}

--- a/apis/testing/roundtrip/roundtrip.go
+++ b/apis/testing/roundtrip/roundtrip.go
@@ -169,7 +169,7 @@ func roundTripViaHub(t *testing.T, gvk schema.GroupVersionKind, scheme, hubs *ru
 	obj = obj.DeepCopyObject().(convertibleObject)
 
 	if !apiequality.Semantic.DeepEqual(original, obj) {
-		t.Errorf("DeepCopy modified the original object (DeepCopy should not have side-effects), diff: %v", diff(original, obj))
+		t.Error("DeepCopy modified the original object (DeepCopy should not have side-effects), diff:", diff(original, obj))
 		return
 	}
 
@@ -210,7 +210,7 @@ func objForGVK(t *testing.T,
 
 	obj, err := scheme.New(gvk)
 	if err != nil {
-		t.Fatalf("unable to create object instance for type %s", err)
+		t.Fatal("unable to create object instance for type", err)
 	}
 
 	objType, err := apimeta.TypeAccessor(obj)
@@ -244,7 +244,7 @@ func hubInstanceForGK(t *testing.T,
 		if hubGVK.GroupKind() == gk {
 			obj, err := hubs.New(hubGVK)
 			if err != nil {
-				t.Fatalf("error creating objects %s", err)
+				t.Fatal("error creating objects", err)
 			}
 
 			return obj.(apis.Convertible), hubGVK

--- a/apis/url_test.go
+++ b/apis/url_test.go
@@ -70,7 +70,7 @@ func TestParseURL(t *testing.T) {
 			got, err := ParseURL(tc.t)
 			if err != nil {
 				if !tc.wantErr {
-					t.Fatalf("ParseURL() = %v", err)
+					t.Fatal("ParseURL() =", err)
 				}
 				return
 			} else if tc.wantErr {
@@ -82,7 +82,7 @@ func TestParseURL(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("unexpected object (-want, +got) = %v", diff)
+				t.Error("unexpected object (-want, +got) =", diff)
 			}
 		})
 	}
@@ -112,15 +112,15 @@ func TestJsonMarshalURL(t *testing.T) {
 			var got []byte
 			tt, err := ParseURL(tc.t)
 			if err != nil {
-				t.Fatalf("ParseURL() = %v", err)
+				t.Fatal("ParseURL() =", err)
 			}
 			if tt != nil {
 				got, _ = tt.MarshalJSON()
 			}
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Logf("got: %s", string(got))
-				t.Errorf("unexpected object (-want, +got) = %v", diff)
+				t.Log("got:", string(got))
+				t.Error("unexpected object (-want, +got) =", diff)
 			}
 		})
 	}
@@ -166,13 +166,13 @@ func TestJsonUnmarshalURL(t *testing.T) {
 					gotErr = err.Error()
 				}
 				if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
-					t.Errorf("unexpected error (-want, +got) = %v", diff)
+					t.Error("unexpected error (-want, +got) =", diff)
 				}
 				return
 			}
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("unexpected object (-want, +got) = %v", diff)
+				t.Error("unexpected object (-want, +got) =", diff)
 			}
 		})
 	}
@@ -224,14 +224,14 @@ func TestJsonMarshalURLAsMember(t *testing.T) {
 					gotErr = err.Error()
 				}
 				if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
-					t.Errorf("unexpected error (-want, +got) = %v", diff)
+					t.Error("unexpected error (-want, +got) =", diff)
 				}
 				return
 			}
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("unexpected object (-want, +got) = %v", diff)
-				t.Logf("got: %s", string(got))
+				t.Error("unexpected object (-want, +got) =", diff)
+				t.Log("got:", string(got))
 			}
 		})
 	}
@@ -283,14 +283,14 @@ func TestJsonMarshalURLAsPointerMember(t *testing.T) {
 					gotErr = err.Error()
 				}
 				if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
-					t.Errorf("unexpected error (-want, +got) = %v", diff)
+					t.Error("unexpected error (-want, +got) =", diff)
 				}
 				return
 			}
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("unexpected object (-want, +got) = %v", diff)
-				t.Logf("got: %s", string(got))
+				t.Error("unexpected object (-want, +got) =", diff)
+				t.Log("got:", string(got))
 			}
 		})
 	}
@@ -353,7 +353,7 @@ func TestJsonUnmarshalURLAsMember(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("Unexpected object (-want, +got) = %v", diff)
+				t.Error("Unexpected object (-want, +got) =", diff)
 			}
 		})
 	}
@@ -416,7 +416,7 @@ func TestJsonUnmarshalURLAsMemberPointer(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("Unexpected object (-want, +got) = %v", diff)
+				t.Error("Unexpected object (-want, +got) =", diff)
 			}
 		})
 	}
@@ -454,10 +454,10 @@ func TestURLString(t *testing.T) {
 			got := tc.t
 
 			if diff := cmp.Diff(tc.want, got.String()); diff != "" {
-				t.Errorf("unexpected string (-want, +got) = %v", diff)
+				t.Error("unexpected string (-want, +got) =", diff)
 			}
 			if diff := cmp.Diff(tc.want, got.URL().String()); diff != "" {
-				t.Errorf("unexpected URL (-want, +got) = %v", diff)
+				t.Error("unexpected URL (-want, +got) =", diff)
 			}
 		})
 	}
@@ -609,17 +609,17 @@ func TestResolveReference(t *testing.T) {
 func TestSemanticEquality(t *testing.T) {
 	u1, err := ParseURL("https://user:password@example.com")
 	if err != nil {
-		t.Fatalf("ParseURL() got err %v", err)
+		t.Fatal("ParseURL() got err", err)
 	}
 
 	u2, err := ParseURL("https://user:password@example.com")
 	if err != nil {
-		t.Fatalf("ParseURL() got err %v", err)
+		t.Fatal("ParseURL() got err", err)
 	}
 
 	u3, err := ParseURL("https://another-user:password@example.com")
 	if err != nil {
-		t.Fatalf("ParseURL() got err %v", err)
+		t.Fatal("ParseURL() got err", err)
 	}
 
 	if !equality.Semantic.DeepEqual(u1, u2) {

--- a/apis/volatile_time_test.go
+++ b/apis/volatile_time_test.go
@@ -35,7 +35,7 @@ func TestVolatileSerializationEmpty(t *testing.T) {
 
 	b, err := json.Marshal(tt)
 	if err != nil {
-		t.Errorf("Marshal() = %v", err)
+		t.Error("Marshal() =", err)
 	}
 
 	if got, want := string(b), `{"lastTransitionTime":null}`; got != want {
@@ -44,7 +44,7 @@ func TestVolatileSerializationEmpty(t *testing.T) {
 
 	got := testType{}
 	if err := json.Unmarshal(b, &got); err != nil {
-		t.Errorf("Unmarshal() = %v", err)
+		t.Error("Unmarshal() =", err)
 	}
 	if got != tt {
 		t.Errorf("Unmarshal() = %v, wanted %v", got, tt)
@@ -58,7 +58,7 @@ func TestVolatileSerializationNow(t *testing.T) {
 
 	b, err := json.Marshal(tt)
 	if err != nil {
-		t.Errorf("Marshal() = %v", err)
+		t.Error("Marshal() =", err)
 	}
 
 	if got, want := string(b), `{"lastTransitionTime":"1970-01-01T00:17:04Z"}`; got != want {
@@ -67,7 +67,7 @@ func TestVolatileSerializationNow(t *testing.T) {
 
 	got := testType{}
 	if err := json.Unmarshal(b, &got); err != nil {
-		t.Errorf("Unmarshal() = %v", err)
+		t.Error("Unmarshal() =", err)
 	}
 	if got != tt {
 		t.Errorf("Unmarshal() = %v, wanted %v", got, tt)

--- a/changeset/commit_test.go
+++ b/changeset/commit_test.go
@@ -82,7 +82,7 @@ func TestReadFile(t *testing.T) {
 			got, err := Get()
 
 			if (err != nil) != test.wantErr {
-				t.Errorf("Get() = %v", err)
+				t.Error("Get() =", err)
 			}
 			if !test.wantErr {
 				if test.want != got {

--- a/configmap/hash-gen/main_test.go
+++ b/configmap/hash-gen/main_test.go
@@ -30,17 +30,17 @@ func TestProcess(t *testing.T) {
 		t.Run(test, func(t *testing.T) {
 			in, err := ioutil.ReadFile(path.Join("testdata", test+".yaml"))
 			if err != nil {
-				t.Fatalf("Failed to load test fixture: %v", err)
+				t.Fatal("Failed to load test fixture:", err)
 			}
 
 			got, err := process(in)
 			if err != nil {
-				t.Fatalf("Expected no error but got %v", err)
+				t.Fatal("Expected no error but got", err)
 			}
 
 			want, err := ioutil.ReadFile(path.Join("testdata", test+"_want.yaml"))
 			if err != nil && !os.IsNotExist(err) {
-				t.Fatalf("Failed to load test fixture: %v", err)
+				t.Fatal("Failed to load test fixture:", err)
 			}
 
 			if diff := cmp.Diff(string(want), string(got)); diff != "" {

--- a/configmap/informed_watcher_test.go
+++ b/configmap/informed_watcher_test.go
@@ -80,7 +80,7 @@ func TestInformedWatcher(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	if err := cmw.Start(stopCh); err != nil {
-		t.Fatalf("cm.Start() = %v", err)
+		t.Fatal("cm.Start() =", err)
 	}
 
 	// When Start returns the callbacks should have been called with the

--- a/configmap/load_test.go
+++ b/configmap/load_test.go
@@ -35,7 +35,7 @@ func TestLoad(t *testing.T) {
 	}
 	tmpdir, err := ioutil.TempDir("", "")
 	if err != nil {
-		t.Fatalf("TempDir() = %v", err)
+		t.Fatal("TempDir() =", err)
 	}
 	defer os.RemoveAll(tmpdir)
 
@@ -50,11 +50,11 @@ func TestLoad(t *testing.T) {
 	tsPart := fmt.Sprintf("..%d", nowUnix)
 	tsDir := path.Join(tmpdir, tsPart)
 	if err := os.Mkdir(tsDir, 0755); err != nil {
-		t.Fatalf("Mkdir() = %v", err)
+		t.Fatal("Mkdir() =", err)
 	}
 	dataLink := path.Join(tmpdir, "..data")
 	if err := os.Symlink(tsDir, dataLink); err != nil {
-		t.Fatalf("Symlink() = %v", err)
+		t.Fatal("Symlink() =", err)
 	}
 
 	// Write out the files as they should be loaded.
@@ -71,10 +71,10 @@ func TestLoad(t *testing.T) {
 
 	got, err := Load(tmpdir)
 	if err != nil {
-		t.Fatalf("Load() = %v", err)
+		t.Fatal("Load() =", err)
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("Load (-want, +got) = %v", diff)
+		t.Error("Load (-want, +got) =", diff)
 	}
 }
 
@@ -93,7 +93,7 @@ func TestLoadError(t *testing.T) {
 // 	}
 // 	tmpdir, err := ioutil.TempDir("", "")
 // 	if err != nil {
-// 		t.Fatalf("TempDir() = %v", err)
+// 		t.Fatal("TempDir() =", err)
 // 	}
 // 	defer os.RemoveAll(tmpdir)
 
@@ -113,12 +113,12 @@ func TestLoadError(t *testing.T) {
 func TestReadSymlinkedFileError(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "")
 	if err != nil {
-		t.Fatalf("TempDir() = %v", err)
+		t.Fatal("TempDir() =", err)
 	}
 	defer os.RemoveAll(tmpdir)
 
 	if err := os.Symlink("not-found", path.Join(tmpdir, "foo")); err != nil {
-		t.Fatalf("Symlink() = %v", err)
+		t.Fatal("Symlink() =", err)
 	}
 
 	if got, err := Load(tmpdir); err == nil {

--- a/configmap/manual_watcher_test.go
+++ b/configmap/manual_watcher_test.go
@@ -28,7 +28,7 @@ func TestManualStartNOOP(t *testing.T) {
 		Namespace: "default",
 	}
 	if err := watcher.Start(nil); err != nil {
-		t.Errorf("Unexpected error watcher.Start() = %v", err)
+		t.Error("Unexpected error watcher.Start() =", err)
 	}
 }
 
@@ -55,7 +55,7 @@ func TestCallbackInvoked(t *testing.T) {
 	})
 
 	if observer.count() == 0 {
-		t.Errorf("Expected callback to be invoked - got invocations %v", observer.count())
+		t.Error("Expected callback to be invoked - got invocations", observer.count())
 	}
 }
 
@@ -75,7 +75,7 @@ func TestDifferentNamespace(t *testing.T) {
 	})
 
 	if observer.count() != 0 {
-		t.Errorf("Expected callback to be not be invoked - got invocations %v", observer.count())
+		t.Error("Expected callback to be not be invoked - got invocations", observer.count())
 	}
 }
 
@@ -96,6 +96,6 @@ func TestDifferentConfigName(t *testing.T) {
 	watcher.Watch("bar", observer.callback)
 
 	if observer.count() != 0 {
-		t.Errorf("Expected callback to be not be invoked - got invocations %v", observer.count())
+		t.Error("Expected callback to be not be invoked - got invocations", observer.count())
 	}
 }

--- a/configmap/static_watcher_test.go
+++ b/configmap/static_watcher_test.go
@@ -48,7 +48,7 @@ func TestStaticWatcher(t *testing.T) {
 
 	err := cm.Start(nil)
 	if err != nil {
-		t.Fatalf("cm.Start() = %v", err)
+		t.Fatal("cm.Start() =", err)
 	}
 
 	// When Start returns the callbacks should have been called with the

--- a/configmap/store_test.go
+++ b/configmap/store_test.go
@@ -156,13 +156,13 @@ func TestStoreConfigChange(t *testing.T) {
 	result := store.UntypedLoad(config1)
 
 	if diff := cmp.Diff(result, config1); diff != "" {
-		t.Errorf("Expected loaded value diff: %s", diff)
+		t.Error("Expected loaded value diff:", diff)
 	}
 
 	result = store.UntypedLoad(config2)
 
 	if diff := cmp.Diff(result, nil); diff != "" {
-		t.Errorf("Unexpected loaded value diff: %s", diff)
+		t.Error("Unexpected loaded value diff:", diff)
 	}
 
 	store.OnConfigChanged(&corev1.ConfigMap{
@@ -174,7 +174,7 @@ func TestStoreConfigChange(t *testing.T) {
 	result = store.UntypedLoad(config2)
 
 	if diff := cmp.Diff(result, config2); diff != "" {
-		t.Errorf("Expected loaded value diff: %s", diff)
+		t.Error("Expected loaded value diff:", diff)
 	}
 }
 
@@ -202,7 +202,7 @@ func TestStoreFailedFirstConversionCrashes(t *testing.T) {
 	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
 		return
 	}
-	t.Fatalf("process should have exited with status 1 - err %v", err)
+	t.Fatal("process should have exited with status 1 - err", err)
 }
 
 func TestStoreFailedUpdate(t *testing.T) {
@@ -238,7 +238,7 @@ func TestStoreFailedUpdate(t *testing.T) {
 	secondLoad := store.UntypedLoad(config1)
 
 	if diff := cmp.Diff(firstLoad, secondLoad); diff != "" {
-		t.Errorf("Expected loaded value to remain the same dff: %s", diff)
+		t.Error("Expected loaded value to remain the same dff:", diff)
 	}
 }
 

--- a/configmap/testing/configmap.go
+++ b/configmap/testing/configmap.go
@@ -47,7 +47,7 @@ func ConfigMapsFromTestFile(t *testing.T, name string, allowed ...string) (*core
 
 	b, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.yaml", name))
 	if err != nil {
-		t.Fatalf("ReadFile() = %v", err)
+		t.Fatal("ReadFile() =", err)
 	}
 
 	var orig corev1.ConfigMap
@@ -55,7 +55,7 @@ func ConfigMapsFromTestFile(t *testing.T, name string, allowed ...string) (*core
 	// Use github.com/ghodss/yaml since it reads json struct
 	// tags so things unmarshal properly
 	if err := yaml.Unmarshal(b, &orig); err != nil {
-		t.Fatalf("yaml.Unmarshal() = %v", err)
+		t.Fatal("yaml.Unmarshal() =", err)
 	}
 
 	// We expect each of the allowed keys, and a key holding an example
@@ -95,7 +95,7 @@ func ConfigMapsFromTestFile(t *testing.T, name string, allowed ...string) (*core
 	// Parse exampleBody into exemplar.Data
 	exemplar := orig.DeepCopy()
 	if err := yaml.Unmarshal([]byte(exampleBody), &exemplar.Data); err != nil {
-		t.Fatalf("yaml.Unmarshal() = %v", err)
+		t.Fatal("yaml.Unmarshal() =", err)
 	}
 	// Augment the sample with actual configuration
 	for k, v := range orig.Data {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -722,7 +722,7 @@ func TestEnqueue(t *testing.T) {
 			gotQueue := drainWorkQueue(impl.WorkQueue())
 
 			if diff := cmp.Diff(test.wantQueue, gotQueue); diff != "" {
-				t.Errorf("unexpected queue (-want +got): %s", diff)
+				t.Error("unexpected queue (-want +got):", diff)
 			}
 		})
 	}
@@ -736,7 +736,7 @@ func TestEnqueue(t *testing.T) {
 			gotQueue := drainWorkQueue(impl.WorkQueue())
 
 			if diff := cmp.Diff(test.wantQueue, gotQueue); diff != "" {
-				t.Errorf("unexpected queue (-want +got): %s", diff)
+				t.Error("unexpected queue (-want +got):", diff)
 			}
 		})
 	}
@@ -1380,7 +1380,7 @@ func TestStartInformersSuccess(t *testing.T) {
 	select {
 	case err := <-errCh:
 		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
+			t.Error("Unexpected error:", err)
 		}
 	case <-time.After(time.Second):
 		t.Error("Timed out waiting for informers to sync.")
@@ -1412,7 +1412,7 @@ func TestStartInformersEventualSuccess(t *testing.T) {
 	select {
 	case err := <-errCh:
 		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
+			t.Error("Unexpected error:", err)
 		}
 	case <-time.After(time.Second):
 		t.Error("Timed out waiting for informers to sync.")
@@ -1465,7 +1465,7 @@ func TestRunInformersSuccess(t *testing.T) {
 	select {
 	case err := <-errCh:
 		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
+			t.Fatal("Unexpected error:", err)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("Timed out waiting for informers to sync.")
@@ -1499,7 +1499,7 @@ func TestRunInformersEventualSuccess(t *testing.T) {
 	select {
 	case err := <-errCh:
 		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
+			t.Fatal("Unexpected error:", err)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("Timed out waiting for informers to sync.")
@@ -1553,7 +1553,7 @@ func TestRunInformersFinished(t *testing.T) {
 
 	waitInformers, err := RunInformers(ctx.Done(), fi)
 	if err != nil {
-		t.Fatalf("Failed to start informers: %v", err)
+		t.Fatal("Failed to start informers:", err)
 	}
 
 	cancel()

--- a/controller/helper_test.go
+++ b/controller/helper_test.go
@@ -134,7 +134,7 @@ func TestEnsureTypeMeta(t *testing.T) {
 			if test.want != nil {
 				cb = func(got interface{}) {
 					if diff := cmp.Diff(got, test.want); diff != "" {
-						t.Errorf("EnsureTypeMeta = %s", diff)
+						t.Error("EnsureTypeMeta =", diff)
 					}
 				}
 			} else {

--- a/controller/stats_reporter_test.go
+++ b/controller/stats_reporter_test.go
@@ -99,6 +99,6 @@ func TestReportReconcile(t *testing.T) {
 func expectSuccess(t *testing.T, f func() error) {
 	t.Helper()
 	if err := f(); err != nil {
-		t.Errorf("Reporter.Report() expected success but got error %v", err)
+		t.Error("Reporter.Report() expected success but got error", err)
 	}
 }

--- a/controller/testing/fake_stats_reporter_test.go
+++ b/controller/testing/fake_stats_reporter_test.go
@@ -32,7 +32,7 @@ func TestReportQueueDepth(t *testing.T) {
 	r := &FakeStatsReporter{}
 	r.ReportQueueDepth(10)
 	if diff := cmp.Diff(r.GetQueueDepths(), []int64{10}); diff != "" {
-		t.Errorf("queue depth len: %v", diff)
+		t.Error("queue depth len:", diff)
 	}
 }
 

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -70,7 +70,7 @@ func TestBuildHashes(t *testing.T) {
 	if !sort.SliceIsSorted(hd1.hashPool, func(i, j int) bool {
 		return hd1.hashPool[i] < hd1.hashPool[j]
 	}) {
-		t.Errorf("From list is not sorted: %v", hd1.hashPool)
+		t.Error("From list is not sorted:", hd1.hashPool)
 	}
 }
 

--- a/injection/clients/dynamicclient/dynamicclient_test.go
+++ b/injection/clients/dynamicclient/dynamicclient_test.go
@@ -37,7 +37,7 @@ func TestGetPanic(t *testing.T) {
 
 	// Get before registration
 	if empty := Get(ctx); empty != nil {
-		t.Errorf("Unexpected informer: %v", empty)
+		t.Error("Unexpected informer:", empty)
 	}
 }
 

--- a/injection/clients/dynamicclient/fake/fake_test.go
+++ b/injection/clients/dynamicclient/fake/fake_test.go
@@ -37,7 +37,7 @@ func TestGetPanic(t *testing.T) {
 
 	// Get before registration
 	if empty := Get(ctx); empty != nil {
-		t.Errorf("Unexpected informer: %v", empty)
+		t.Error("Unexpected informer:", empty)
 	}
 }
 

--- a/kflag/set_test.go
+++ b/kflag/set_test.go
@@ -34,7 +34,7 @@ func TestSet(t *testing.T) {
 		"-flag-name=val3",
 		"-flag-name=val1",
 	}); err != nil {
-		t.Fatalf("Parse() = %v", err)
+		t.Fatal("Parse() =", err)
 	}
 
 	if got, want := f.Value.Len(), 3; got != want {
@@ -58,7 +58,7 @@ func TestEmptySet(t *testing.T) {
 	fs.Var(&f, "flag-name", "usage description")
 
 	if err := fs.Parse([]string{}); err != nil {
-		t.Fatalf("Parse() = %v", err)
+		t.Fatal("Parse() =", err)
 	}
 
 	if got, want := f.Value.Len(), 0; got != want {

--- a/kmeta/accessor_test.go
+++ b/kmeta/accessor_test.go
@@ -67,10 +67,10 @@ func TestAccessor(t *testing.T) {
 			} else {
 				got, err := DeletionHandlingAccessor(test.o)
 				if err != nil {
-					t.Errorf("DeletionHandlingAccessor() = %v", err)
+					t.Error("DeletionHandlingAccessor() =", err)
 				}
 				if diff := cmp.Diff(got, test.want); diff != "" {
-					t.Errorf("DeletionHandlingAccessor = %s", diff)
+					t.Error("DeletionHandlingAccessor =", diff)
 				}
 			}
 		})
@@ -97,6 +97,6 @@ func TestObjectReference(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(want, ObjectReference(r)); diff != "" {
-		t.Errorf("Unexpected ObjectReference (-want, +got) %s", diff)
+		t.Error("Unexpected ObjectReference (-want, +got)", diff)
 	}
 }

--- a/kmeta/map_test.go
+++ b/kmeta/map_test.go
@@ -72,7 +72,7 @@ func TestUnion(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := UnionMaps(test.in...)
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("MakeLabels (-want, +got) = %v", diff)
+				t.Error("MakeLabels (-want, +got) =", diff)
 			}
 		})
 	}
@@ -116,7 +116,7 @@ func TestFilter(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := FilterMap(test.in, test.filter)
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("MakeAnnotations (-want, +got) = %v", diff)
+				t.Error("MakeAnnotations (-want, +got) =", diff)
 			}
 		})
 	}
@@ -144,7 +144,7 @@ func TestCopy(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := CopyMap(test.in)
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("MakeAnnotations (-want, +got) = %v", diff)
+				t.Error("MakeAnnotations (-want, +got) =", diff)
 			}
 		})
 	}

--- a/kmeta/owner_references_test.go
+++ b/kmeta/owner_references_test.go
@@ -59,6 +59,6 @@ func TestNewControllerRef(t *testing.T) {
 
 	got := NewControllerRef(f)
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("Unexpected OwnerReference (-want +got): %v", diff)
+		t.Error("Unexpected OwnerReference (-want +got):", diff)
 	}
 }

--- a/kmeta/ownerrefable_accessor_test.go
+++ b/kmeta/ownerrefable_accessor_test.go
@@ -65,6 +65,6 @@ func TestNewControllerRef_OwnerRefableAccessor(t *testing.T) {
 
 	got := NewControllerRef(goodObject)
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("Unexpected OwnerReference (-want +got): %v", diff)
+		t.Error("Unexpected OwnerReference (-want +got):", diff)
 	}
 }

--- a/kmp/diff_test.go
+++ b/kmp/diff_test.go
@@ -31,15 +31,15 @@ func TestCompareKcmpDefault(t *testing.T) {
 	want := cmp.Diff(a, b, defaultOpts...)
 
 	if got, err := SafeDiff(a, b); err != nil {
-		t.Errorf("unexpected SafeDiff err: %v", err)
+		t.Error("unexpected SafeDiff err:", err)
 	} else if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("SafeDiff (-want, +got): %v", diff)
+		t.Error("SafeDiff (-want, +got):", diff)
 	}
 
 	if got, err := SafeEqual(a, b); err != nil {
-		t.Fatalf("unexpected SafeEqual err: %v", err)
+		t.Fatal("unexpected SafeEqual err:", err)
 	} else if diff := cmp.Diff(false, got); diff != "" {
-		t.Errorf("SafeEqual(-want, +got): %v", diff)
+		t.Error("SafeEqual(-want, +got):", diff)
 	}
 }
 
@@ -88,7 +88,7 @@ func TestFieldDiff(t *testing.T) {
 	got, err := CompareSetFields(a, b)
 
 	if err != nil {
-		t.Errorf("unexpected FieldDiff err: %v", err)
+		t.Error("unexpected FieldDiff err:", err)
 	} else if !cmp.Equal(got, want) {
 		t.Errorf("FieldDiff() = %v, want: %s", got, want)
 	}
@@ -152,9 +152,9 @@ func TestImmutableDiff(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if got, err := ShortDiff(test.x, test.y); err != nil {
-				t.Errorf("unexpected ShortDiff err: %v", err)
+				t.Error("unexpected ShortDiff err:", err)
 			} else if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("SafeDiff (-want, +got): %v", diff)
+				t.Error("SafeDiff (-want, +got):", diff)
 			}
 		})
 	}

--- a/kvstore/kvstore_cm_test.go
+++ b/kvstore/kvstore_cm_test.go
@@ -68,7 +68,7 @@ func TestInitCreates(t *testing.T) {
 	cs := NewConfigMapKVStore(context.Background(), name, namespace, tc.clientset)
 	err := cs.Init(context.Background())
 	if err != nil {
-		t.Errorf("Failed to Init ConfigStore: %v", err)
+		t.Error("Failed to Init ConfigStore:", err)
 	}
 	if tc.created == nil {
 		t.Errorf("ConfigMap not created")
@@ -93,7 +93,7 @@ func TestInitLoads(t *testing.T) {
 	cs := NewConfigMapKVStore(context.Background(), name, namespace, tc.clientset)
 	err := cs.Init(context.Background())
 	if err != nil {
-		t.Errorf("Failed to Init ConfigStore: %v", err)
+		t.Error("Failed to Init ConfigStore:", err)
 	}
 	if tc.created != nil {
 		t.Errorf("ConfigMap created")
@@ -104,7 +104,7 @@ func TestInitLoads(t *testing.T) {
 	var ret string
 	err = cs.Get(context.Background(), "foo", &ret)
 	if err != nil {
-		t.Errorf("failed to return string: %v", err)
+		t.Error("failed to return string:", err)
 	}
 	if ret != "bar" {
 		t.Errorf("got back unexpected value, wanted %q got %q", "bar", ret)
@@ -119,7 +119,7 @@ func TestLoadSaveUpdate(t *testing.T) {
 	cs := NewConfigMapKVStore(context.Background(), name, namespace, tc.clientset)
 	err := cs.Init(context.Background())
 	if err != nil {
-		t.Errorf("Failed to Init ConfigStore: %v", err)
+		t.Error("Failed to Init ConfigStore:", err)
 	}
 	cs.Set(context.Background(), "jimmy", "otherbar")
 	cs.Save(context.Background())
@@ -129,10 +129,10 @@ func TestLoadSaveUpdate(t *testing.T) {
 	var ret string
 	err = cs.Get(context.Background(), "jimmy", &ret)
 	if err != nil {
-		t.Errorf("failed to return string: %v", err)
+		t.Error("failed to return string:", err)
 	}
 	if err != nil {
-		t.Errorf("failed to return string: %v", err)
+		t.Error("failed to return string:", err)
 	}
 	if ret != "otherbar" {
 		t.Errorf("got back unexpected value, wanted %q got %q", "bar", ret)
@@ -149,7 +149,7 @@ func TestLoadSaveUpdateComplex(t *testing.T) {
 	cs := NewConfigMapKVStore(context.Background(), name, namespace, tc.clientset)
 	err := cs.Init(context.Background())
 	if err != nil {
-		t.Errorf("Failed to Init ConfigStore: %v", err)
+		t.Error("Failed to Init ConfigStore:", err)
 	}
 	ts2 := testStruct{
 		LastThingProcessed: "otherthingie",
@@ -163,10 +163,10 @@ func TestLoadSaveUpdateComplex(t *testing.T) {
 	var ret testStruct
 	err = cs.Get(context.Background(), "jimmy", &ret)
 	if err != nil {
-		t.Errorf("failed to return string: %v", err)
+		t.Error("failed to return string:", err)
 	}
 	if err != nil {
-		t.Errorf("failed to return string: %v", err)
+		t.Error("failed to return string:", err)
 	}
 	if !reflect.DeepEqual(ret, ts2) {
 		t.Errorf("got back unexpected value, wanted %+v got %+v", ts2, ret)

--- a/leaderelection/context_test.go
+++ b/leaderelection/context_test.go
@@ -100,7 +100,7 @@ func TestWithBuilder(t *testing.T) {
 
 	le, err := BuildElector(ctx, laf, "name", enq)
 	if err != nil {
-		t.Fatalf("BuildElector() = %v", err)
+		t.Fatal("BuildElector() =", err)
 	}
 
 	// We shouldn't see leases until we Run the elector.
@@ -194,7 +194,7 @@ func TestBuilderWithCustomizedLeaseName(t *testing.T) {
 	ctx = WithDynamicLeaderElectorBuilder(ctx, kc, cc)
 	le, err := BuildElector(ctx, laf, "name", enq)
 	if err != nil {
-		t.Fatalf("BuildElector() = %v", err)
+		t.Fatal("BuildElector() =", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -299,7 +299,7 @@ func TestWithStatefulSetBuilder(t *testing.T) {
 
 	le, err := BuildElector(ctx, laf, "name", enq)
 	if err != nil {
-		t.Fatalf("BuildElector() = %v", err)
+		t.Fatal("BuildElector() =", err)
 	}
 
 	ule, ok := le.(*unopposedElector)

--- a/logging/config_test.go
+++ b/logging/config_test.go
@@ -123,7 +123,7 @@ func TestNewConfigNoEntry(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Errorf("Expected no errors. got: %v", err)
+		t.Error("Expected no errors. got:", err)
 	}
 	if got, want := c.LoggingConfig, defaultZLC; got != want {
 		t.Errorf("LoggingConfig = %v, want %v", got, want)
@@ -147,7 +147,7 @@ func TestNewConfig(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Errorf("Expected no errors. got: %v", err)
+		t.Error("Expected no errors. got:", err)
 	}
 	if got := c.LoggingConfig; got != wantCfg {
 		t.Errorf("LoggingConfig = %v, want %v", got, wantCfg)
@@ -215,10 +215,10 @@ func TestEmptyLevel(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Errorf("Expected no errors. got: %v", err)
+		t.Error("Expected no errors. got:", err)
 	}
 	if l := c.LoggingLevel["queueproxy"]; l != zapcore.InfoLevel {
-		t.Errorf("Expected default Info level for LoggingLevel[queueproxy]. got: %v", l)
+		t.Error("Expected default Info level for LoggingLevel[queueproxy]. got:", l)
 	}
 }
 
@@ -230,10 +230,10 @@ func TestDefaultLevel(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Errorf("Expected no errors. got: %v", err)
+		t.Error("Expected no errors. got:", err)
 	}
 	if l := c.LoggingLevel["queueproxy"]; l != zapcore.InfoLevel {
-		t.Errorf("Expected default Info level for LoggingLevel[queueproxy]. got: %v", l)
+		t.Error("Expected default Info level for LoggingLevel[queueproxy]. got:", l)
 	}
 }
 
@@ -416,7 +416,7 @@ func TestLoggingConfig(t *testing.T) {
 				want := tc.want
 				got := json
 				if diff := cmp.Diff(want, got); diff != "" {
-					t.Errorf("unexpected (-want, +got) = %v", diff)
+					t.Error("unexpected (-want, +got) =", diff)
 				}
 			}
 			want := tc.cfg
@@ -424,14 +424,14 @@ func TestLoggingConfig(t *testing.T) {
 
 			if gotErr != nil {
 				if diff := cmp.Diff(tc.wantErr, gotErr.Error()); diff != "" {
-					t.Errorf("unexpected err (-want, +got) = %v", diff)
+					t.Error("unexpected err (-want, +got) =", diff)
 				}
 			} else if tc.wantErr != "" {
-				t.Errorf("expected err %v", tc.wantErr)
+				t.Error("expected err", tc.wantErr)
 			}
 
 			if diff := cmp.Diff(want, got); diff != "" {
-				t.Errorf("unexpected (-want, +got) = %v", diff)
+				t.Error("unexpected (-want, +got) =", diff)
 				t.Log(got)
 			}
 		})

--- a/metrics/client_test.go
+++ b/metrics/client_test.go
@@ -72,7 +72,7 @@ func TestClientMetrics(t *testing.T) {
 		t.Errorf("len(DefaultViews()) = %d, want %d", got, want)
 	}
 	if err := view.Register(views...); err != nil {
-		t.Errorf("view.Register() = %v", err)
+		t.Error("view.Register() =", err)
 	}
 	defer view.Unregister(views...)
 
@@ -109,7 +109,7 @@ func TestClientMetrics(t *testing.T) {
 	// When we send rest requests, we should trigger the metrics setup above.
 	result := client.Verb(http.MethodGet).Do(context.Background())
 	if err := result.Error(); err != nil {
-		t.Errorf("Do() = %v", err)
+		t.Error("Do() =", err)
 	}
 
 	// Now we have stats reported!

--- a/metrics/config_test.go
+++ b/metrics/config_test.go
@@ -658,7 +658,7 @@ func TestGetMetricsConfig_fromEnv(t *testing.T) {
 
 			mc, err := createMetricsConfig(ctx, test.ops)
 			if mc != nil {
-				t.Errorf("Wanted no config, got %v", mc)
+				t.Error("Wanted no config, got", mc)
 			}
 			if err == nil || !strings.Contains(err.Error(), test.expectedErrContains) {
 				t.Errorf("Wanted err to contain: %q, got: %v", test.expectedErrContains, err)
@@ -842,7 +842,7 @@ func TestUpdateExporterFromConfigMapWithOpts(t *testing.T) {
 			}
 			updateFunc, err := UpdateExporterFromConfigMapWithOpts(ctx, opts, TestLogger(t))
 			if err != nil {
-				t.Errorf("failed to call UpdateExporterFromConfigMapWithOpts: %v", err)
+				t.Error("failed to call UpdateExporterFromConfigMapWithOpts:", err)
 			}
 			updateFunc(&corev1.ConfigMap{Data: test.ops.ConfigMap})
 			mConfig := getCurMetricsConfig()
@@ -925,14 +925,14 @@ func TestMetricsOptions(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			jsonOpts, err := MetricsOptionsToJson(tc.opts)
 			if err != nil {
-				t.Errorf("error while converting metrics config to json: %v", err)
+				t.Error("error while converting metrics config to json:", err)
 			}
 			// Test to json.
 			{
 				want := tc.want
 				got := jsonOpts
 				if diff := cmp.Diff(want, got); diff != "" {
-					t.Errorf("unexpected (-want, +got) = %v", diff)
+					t.Error("unexpected (-want, +got) =", diff)
 					t.Log(got)
 				}
 			}
@@ -943,14 +943,14 @@ func TestMetricsOptions(t *testing.T) {
 
 				if gotErr != nil {
 					if diff := cmp.Diff(tc.wantErr, gotErr.Error()); diff != "" {
-						t.Errorf("unexpected err (-want, +got) = %v", diff)
+						t.Error("unexpected err (-want, +got) =", diff)
 					}
 				} else if tc.wantErr != "" {
-					t.Errorf("expected err %v", tc.wantErr)
+					t.Error("expected err", tc.wantErr)
 				}
 
 				if diff := cmp.Diff(want, got); diff != "" {
-					t.Errorf("unexpected (-want, +got) = %v", diff)
+					t.Error("unexpected (-want, +got) =", diff)
 					t.Log(got)
 				}
 			}

--- a/metrics/exporter_test.go
+++ b/metrics/exporter_test.go
@@ -263,7 +263,7 @@ func TestFlushExporter(t *testing.T) {
 	}
 	e, f, err := newMetricsExporter(c, TestLogger(t))
 	if err != nil {
-		t.Errorf("Expected no error. got %v", err)
+		t.Error("Expected no error. got", err)
 	} else {
 		setCurMetricsExporter(e)
 		if want, got := false, FlushExporter(); got != want {
@@ -289,7 +289,7 @@ func TestFlushExporter(t *testing.T) {
 
 	e, f, err = newMetricsExporter(c, TestLogger(t))
 	if err != nil {
-		t.Errorf("Expected no error. got %v", err)
+		t.Error("Expected no error. got", err)
 	} else {
 		setCurMetricsExporter(e)
 		if want, got := true, FlushExporter(); got != want {

--- a/metrics/memstats_test.go
+++ b/metrics/memstats_test.go
@@ -47,7 +47,7 @@ func TestMemStatsMetrics(t *testing.T) {
 		t.Errorf("len(DefaultViews()) = %d, want %d", got, want)
 	}
 	if err := view.Register(views...); err != nil {
-		t.Errorf("view.Register() = %v", err)
+		t.Error("view.Register() =", err)
 	}
 	defer view.Unregister(views...)
 

--- a/metrics/metricstest/resource_metrics.go
+++ b/metrics/metricstest/resource_metrics.go
@@ -187,7 +187,7 @@ func AssertMetric(t *testing.T, values ...Metric) {
 	EnsureRecorded()
 	for _, v := range values {
 		if diff := cmp.Diff(v, GetOneMetric(v.Name)); diff != "" {
-			t.Errorf("Wrong metric (-want +got): %s", diff)
+			t.Error("Wrong metric (-want +got):", diff)
 		}
 	}
 }

--- a/metrics/metricstest/resource_metrics_test.go
+++ b/metrics/metricstest/resource_metrics_test.go
@@ -388,7 +388,7 @@ func TestMetricShortcuts(t *testing.T) {
 
 	for _, tc := range tests {
 		if diff := cmp.Diff(tc.want, NewMetric(&tc.got)); diff != "" {
-			t.Errorf("Metric.Equal() failed (-want +got): %s", diff)
+			t.Error("Metric.Equal() failed (-want +got):", diff)
 		}
 	}
 }
@@ -412,7 +412,7 @@ func TestMetricFetch(t *testing.T) {
 
 	ctx, err := tag.New(context.Background(), tag.Upsert(tagKey, "alpha"))
 	if err != nil {
-		t.Errorf("Unable to create context: %v", err)
+		t.Error("Unable to create context:", err)
 	}
 	stats.Record(ctx, count.M(5))
 	stats.Record(ctx, count.M(3))
@@ -422,7 +422,7 @@ func TestMetricFetch(t *testing.T) {
 
 	ctx, err = tag.New(ctx, tag.Upsert(tagKey, "beta"))
 	if err != nil {
-		t.Errorf("Unable to create context: %v", err)
+		t.Error("Unable to create context:", err)
 	}
 	stats.Record(ctx, count.M(20))
 	EnsureRecorded()
@@ -444,7 +444,7 @@ func TestMetricFetch(t *testing.T) {
 		},
 	}
 	if diff := cmp.Diff(want, m[0]); diff != "" {
-		t.Errorf("Incorrect received metrics (-want +got): %s", diff)
+		t.Error("Incorrect received metrics (-want +got):", diff)
 	}
 
 }

--- a/metrics/opencensus_exporter_test.go
+++ b/metrics/opencensus_exporter_test.go
@@ -33,11 +33,11 @@ import (
 func TestOpenCensusConfig(t *testing.T) {
 	cert, err := ioutil.ReadFile(filepath.Join("testdata", "client-cert.pem"))
 	if err != nil {
-		t.Fatalf("Couldn't find testdata/client-cert.pem: %v", err)
+		t.Fatal("Couldn't find testdata/client-cert.pem:", err)
 	}
 	key, err := ioutil.ReadFile(filepath.Join("testdata", "client-key.pem"))
 	if err != nil {
-		t.Fatalf("Couldn't find testdata/client-key.pem: %v", err)
+		t.Fatal("Couldn't find testdata/client-key.pem:", err)
 	}
 
 	cases := []struct {
@@ -97,7 +97,7 @@ func TestOpenCensusConfig(t *testing.T) {
 			if c.err == nil {
 				server, shutdown, err = GetServer(c.tls)
 				if err != nil {
-					t.Fatalf("Failed to start server: %v", err)
+					t.Fatal("Failed to start server:", err)
 				}
 				c.config.collectorAddress = server.Addr().String()
 			}
@@ -105,26 +105,26 @@ func TestOpenCensusConfig(t *testing.T) {
 			got, _, gotErr := newOpenCensusExporter(&c.config, logtesting.TestLogger(t))
 			if c.err != nil {
 				if diff := cmp.Diff(c.err, gotErr); diff != "" {
-					t.Errorf("wrong err (-want +got) = %v", diff)
+					t.Error("wrong err (-want +got) =", diff)
 				}
 				return
 			}
 			if gotErr != nil {
-				t.Errorf("unexpected err: %v", gotErr)
+				t.Error("unexpected err:", gotErr)
 				return
 			}
 			if c.wantFunc != nil {
 				c.wantFunc(t, got)
 			}
 
-			t.Logf("Awaiting channel shutdown at %s", server.Addr().String())
+			t.Log("Awaiting channel shutdown at", server.Addr().String())
 			err = <-shutdown
 			if err != nil {
-				t.Errorf("Error from server: %v", err)
+				t.Error("Error from server:", err)
 			}
 			err = server.Close()
 			if err != nil {
-				t.Errorf("Failed to shut down server: %v", err)
+				t.Error("Failed to shut down server:", err)
 			}
 		})
 	}

--- a/metrics/record_test.go
+++ b/metrics/record_test.go
@@ -187,7 +187,7 @@ func TestBucketsNBy10(t *testing.T) {
 		t.Run(fmt.Sprintf("base=%f,n=%d", test.base, test.n), func(t *testing.T) {
 			got := BucketsNBy10(test.base, test.n)
 			if diff := cmp.Diff(got, test.want); diff != "" {
-				t.Errorf("BucketsNBy10 (-want, +got) = %s", diff)
+				t.Error("BucketsNBy10 (-want, +got) =", diff)
 			}
 		})
 	}

--- a/metrics/reflector_test.go
+++ b/metrics/reflector_test.go
@@ -49,7 +49,7 @@ func TestReflectorMetrics(t *testing.T) {
 		t.Errorf("len(DefaultViews()) = %d, want %d", got, want)
 	}
 	if err := view.Register(views...); err != nil {
-		t.Errorf("view.Register() = %v", err)
+		t.Error("view.Register() =", err)
 	}
 	defer view.Unregister(views...)
 

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -73,23 +73,23 @@ func TestRegisterResourceView(t *testing.T) {
 
 	viewToFind := defaultMeter.m.Find("testView")
 	if viewToFind == nil || viewToFind.Name != "testView" {
-		t.Errorf("Registered view should be found in default meter, instead got %v", viewToFind)
+		t.Error("Registered view should be found in default meter, instead got", viewToFind)
 	}
 
 	viewToFind = meter.Find("testView")
 	if viewToFind == nil || viewToFind.Name != "testView" {
-		t.Errorf("Registered view should be found in new meter, instead got %v", viewToFind)
+		t.Error("Registered view should be found in new meter, instead got", viewToFind)
 	}
 }
 
 func TestOptionForResource(t *testing.T) {
 	option, err1 := optionForResource(&r)
 	if err1 != nil {
-		t.Errorf("Should succeed getting option, instead got error %v", err1)
+		t.Error("Should succeed getting option, instead got error", err1)
 	}
 	optionAgain, err2 := optionForResource(&r)
 	if err2 != nil {
-		t.Errorf("Should succeed getting option, instead got error %v", err2)
+		t.Error("Should succeed getting option, instead got error", err2)
 	}
 
 	if fmt.Sprintf("%v", optionAgain) != fmt.Sprintf("%v", option) {
@@ -119,14 +119,14 @@ func TestSetFactory(t *testing.T) {
 	// Create the new meter and apply the factory
 	_, err := optionForResource(&resource123)
 	if err != nil {
-		t.Errorf("Should succeed getting option, instead got error %v", err)
+		t.Error("Should succeed getting option, instead got error", err)
 	}
 
 	// Now get the exporter and verify the id
 	me := meterExporterForResource(&resource123)
 	e := me.e.(*testExporter)
 	if e.id != "123" {
-		t.Errorf("Expect id to be 123, instead got %v", e.id)
+		t.Error("Expect id to be 123, instead got", e.id)
 	}
 
 	resource456 := r
@@ -134,13 +134,13 @@ func TestSetFactory(t *testing.T) {
 	// Create the new meter and apply the factory
 	_, err = optionForResource(&resource456)
 	if err != nil {
-		t.Errorf("Should succeed getting option, instead got error %v", err)
+		t.Error("Should succeed getting option, instead got error", err)
 	}
 
 	me = meterExporterForResource(&resource456)
 	e = me.e.(*testExporter)
 	if e.id != "456" {
-		t.Errorf("Expect id to be 456, instead got %v", e.id)
+		t.Error("Expect id to be 456, instead got", e.id)
 	}
 }
 
@@ -161,7 +161,7 @@ func TestResourceAsString(t *testing.T) {
 	s1 := resourceToKey(r1)
 	s3 := resourceToKey(r3)
 	if s1 == s3 {
-		t.Errorf("Expect different resources, but got the same %s", s1)
+		t.Error("Expect different resources, but got the same", s1)
 	}
 }
 
@@ -331,7 +331,7 @@ testComponent_testing_value{project="p1",revision="r2"} 1
 			if err := ocFake.start(len(resources) + 1); err != nil {
 				return err
 			}
-			t.Logf("Created exporter at %s", ocFake.address)
+			t.Log("Created exporter at", ocFake.address)
 			return UpdateExporter(context.Background(), configForBackend(openCensus), logtesting.TestLogger(t))
 		},
 		validate: func(t *testing.T) {
@@ -553,10 +553,10 @@ func TestStackDriverExports(t *testing.T) {
 
 			sdFake := stackDriverFake{t: t}
 			if err := initSdFake(&sdFake); err != nil {
-				t.Errorf("Init stackdriver failed %s", err)
+				t.Error("Init stackdriver failed", err)
 			}
 			if err := UpdateExporter(context.Background(), eo, logtesting.TestLogger(t)); err != nil {
-				t.Errorf("UpdateExporter failed %s", err)
+				t.Error("UpdateExporter failed", err)
 			}
 
 			if err := RegisterResourceView(desiredPodsCountView, actualPodsCountView, customView); err != nil {
@@ -571,7 +571,7 @@ func TestStackDriverExports(t *testing.T) {
 				tag.Upsert(ConfigTagKey, "config"),
 				tag.Upsert(RevisionTagKey, "revision"))
 			if err != nil {
-				t.Fatalf("Unable to create tags %s", err)
+				t.Fatal("Unable to create tags", err)
 			}
 			Record(ctx, actualPodCountM.M(int64(1)))
 

--- a/metrics/stackdriver_exporter_test.go
+++ b/metrics/stackdriver_exporter_test.go
@@ -233,7 +233,7 @@ func TestSdRecordWithResources(t *testing.T) {
 				v.TagKeys = append(v.TagKeys, tag.MustNewKey(k))
 			}
 			if err := RegisterResourceView(v); err != nil {
-				t.Errorf("Unable to register view: %v", err)
+				t.Error("Unable to register view:", err)
 			}
 			defer UnregisterResourceView(v)
 
@@ -245,7 +245,7 @@ func TestSdRecordWithResources(t *testing.T) {
 			}
 			ctx, err := tag.New(ctx, tags...)
 			if err != nil {
-				t.Errorf("Unable to set tags: %v", err)
+				t.Error("Unable to set tags:", err)
 			}
 
 			if err := recordFunc(ctx, []stats.Measurement{m.M(1)}); err != nil {
@@ -525,7 +525,7 @@ func TestSetStackdriverSecretLocation(t *testing.T) {
 	assertStringsEqual(t, "DefaultSecretNamespace", secretNamespace, StackdriverSecretNamespaceDefault)
 	sec, err := getStackdriverSecret(ctx, secretFetcher)
 	if err != nil {
-		t.Errorf("Got unexpected error when getting secret: %v", err)
+		t.Error("Got unexpected error when getting secret:", err)
 	}
 	if sec != nil {
 		t.Errorf("Stackdriver secret should not be fetched unless SetStackdriverSecretLocation has been called")
@@ -535,7 +535,7 @@ func TestSetStackdriverSecretLocation(t *testing.T) {
 	SetStackdriverSecretLocation(testName, testNamespace)
 	sec, err = getStackdriverSecret(ctx, secretFetcher)
 	if err != nil {
-		t.Errorf("Got unexpected error when getting secret: %v", err)
+		t.Error("Got unexpected error when getting secret:", err)
 	}
 	if sec == nil {
 		t.Error("expected secret to be non-nil if there is no error and SetStackdriverSecretLocation has been called")

--- a/metrics/workqueue_test.go
+++ b/metrics/workqueue_test.go
@@ -69,7 +69,7 @@ func TestWorkqueueMetrics(t *testing.T) {
 		t.Errorf("len(DefaultViews()) = %d, want %d", got, want)
 	}
 	if err := view.Register(views...); err != nil {
-		t.Errorf("view.Register() = %v", err)
+		t.Error("view.Register() =", err)
 	}
 	defer view.Unregister(views...)
 

--- a/network/prober/prober_test.go
+++ b/network/prober/prober_test.go
@@ -111,7 +111,7 @@ func TestBadURL(t *testing.T) {
 	if err == nil {
 		t.Error("Do did not return an error")
 	}
-	t.Logf("For the curious the error was: %v", err)
+	t.Log("For the curious the error was:", err)
 }
 
 func TestDoAsync(t *testing.T) {
@@ -197,7 +197,7 @@ func TestDoAsyncRepeat(t *testing.T) {
 			t.Error("done was false")
 		}
 		if err != nil {
-			t.Errorf("Unexpected error = %v", err)
+			t.Error("Unexpected error =", err)
 		}
 		wch <- arg
 	}
@@ -223,7 +223,7 @@ func TestDoAsyncTimeout(t *testing.T) {
 			t.Errorf("done was true")
 		}
 		if err != wait.ErrWaitTimeout {
-			t.Errorf("Unexpected error = %v", err)
+			t.Error("Unexpected error =", err)
 		}
 		wch <- arg
 	}

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -90,11 +90,11 @@ func TestParallelismNoErrors(t *testing.T) {
 			wg.Wait()
 
 			if err := p.Wait(); err != nil {
-				t.Errorf("Wait() = %v", err)
+				t.Error("Wait() =", err)
 			}
 
 			if err := p.Wait(); err != nil {
-				t.Errorf("Wait() = %v", err)
+				t.Error("Wait() =", err)
 			}
 
 			if got, want := max, int32(tc.size); got != want {

--- a/reconciler/events_test.go
+++ b/reconciler/events_test.go
@@ -80,10 +80,10 @@ func TestNew_As(t *testing.T) {
 	}
 
 	if event.EventType != "Warning" {
-		t.Errorf("Mismatched EventType, expected Warning, got %s", event.EventType)
+		t.Error("Mismatched EventType, expected Warning, got", event.EventType)
 	}
 	if event.Reason != exampleStatusFailed {
-		t.Errorf("Mismatched Reason, expected ExampleStatusFailed, got %s", event.Reason)
+		t.Error("Mismatched Reason, expected ExampleStatusFailed, got", event.Reason)
 	}
 }
 
@@ -102,6 +102,6 @@ func TestNew_Error(t *testing.T) {
 	const want = "this is an example error, yep"
 	got := err.Error()
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("Unexpected diff (-want, +got) = %v", diff)
+		t.Error("Unexpected diff (-want, +got) =", diff)
 	}
 }

--- a/reconciler/leader_test.go
+++ b/reconciler/leader_test.go
@@ -34,10 +34,10 @@ func TestLeaderAwareFuncs(t *testing.T) {
 	wantFunc := func(gotBkt Bucket, gotKey types.NamespacedName) {
 		called = true
 		if !cmp.Equal(gotKey, wantKey) {
-			t.Errorf("key (-want, +got) = %s", cmp.Diff(wantKey, gotKey))
+			t.Error("key (-want, +got) =", cmp.Diff(wantKey, gotKey))
 		}
 		if !cmp.Equal(gotBkt, wantBkt) {
-			t.Errorf("bucket (-want, +got) = %s", cmp.Diff(wantBkt, gotBkt))
+			t.Error("bucket (-want, +got) =", cmp.Diff(wantBkt, gotBkt))
 		}
 	}
 

--- a/reconciler/testing/actions_test.go
+++ b/reconciler/testing/actions_test.go
@@ -52,7 +52,7 @@ func TestActionsByVerb(t *testing.T) {
 	actions, err := list.ActionsByVerb()
 
 	if err != nil {
-		t.Errorf("Unexpected error sorting actions by verb %s", err)
+		t.Error("Unexpected error sorting actions by verb", err)
 	}
 
 	if got, want := len(actions.Creates), 2; got != want {

--- a/reconciler/testing/hooks_test.go
+++ b/reconciler/testing/hooks_test.go
@@ -78,7 +78,7 @@ func ExampleHooks() {
 func TestWaitWithoutHooks(t *testing.T) {
 	h := NewHooks()
 	if err := h.WaitForHooks(time.Second); err != nil {
-		t.Errorf("Expected no error without hooks, but got: %v", err)
+		t.Error("Expected no error without hooks, but got:", err)
 	}
 }
 
@@ -168,7 +168,7 @@ func TestMultiUpdate(t *testing.T) {
 	}
 
 	if updates != 2 {
-		t.Errorf("Unexpected number of Update events; want 2, got %d", updates)
+		t.Error("Unexpected number of Update events; want 2, got", updates)
 	}
 }
 

--- a/reconciler/testing/table.go
+++ b/reconciler/testing/table.go
@@ -307,10 +307,10 @@ func (r *TableRow) Test(t *testing.T, factory Factory) {
 	}
 	if !gotDeletes.Equal(wantDeletes) {
 		if extra := gotDeletes.Difference(wantDeletes); len(extra) > 0 {
-			t.Errorf("Extra or unexpected deletes: %v", extra.UnsortedList())
+			t.Error("Extra or unexpected deletes:", extra.UnsortedList())
 		}
 		if missing := wantDeletes.Difference(gotDeletes); len(missing) > 0 {
-			t.Errorf("Missing deletes: %v", missing.UnsortedList())
+			t.Error("Missing deletes:", missing.UnsortedList())
 		}
 	}
 

--- a/reconciler/testing/tracker_test.go
+++ b/reconciler/testing/tracker_test.go
@@ -55,11 +55,11 @@ func TestFakeTracker(t *testing.T) {
 	// Adding t1 to ref1 and then removing it results in ref1 stopping tracking.
 	trk.TrackReference(ref1, t1)
 	if !isTracking(trk, ref1) {
-		t.Fatalf("Tracker is not tracking %v", ref1)
+		t.Fatal("Tracker is not tracking", ref1)
 	}
 	trk.OnDeletedObserver(t1)
 	if isTracking(trk, ref1) {
-		t.Fatalf("Tracker is still tracking %v", ref1)
+		t.Fatal("Tracker is still tracking", ref1)
 	}
 
 	// Adding t1, t2 to ref1 and t2 to ref2, then removing t2 results in ref2 stopping
@@ -68,21 +68,21 @@ func TestFakeTracker(t *testing.T) {
 	trk.TrackReference(ref1, t2)
 	trk.TrackReference(ref2, t2)
 	if !isTracking(trk, ref1) {
-		t.Fatalf("Tracker is not tracking %v", ref1)
+		t.Fatal("Tracker is not tracking", ref1)
 	}
 	if !isTracking(trk, ref2) {
-		t.Fatalf("Tracker is not tracking %v", ref2)
+		t.Fatal("Tracker is not tracking", ref2)
 	}
 	trk.OnDeletedObserver(t2)
 	if !isTracking(trk, ref1) {
-		t.Fatalf("Tracker is not tracking %v", ref1)
+		t.Fatal("Tracker is not tracking", ref1)
 	}
 	if isTracking(trk, ref2) {
-		t.Fatalf("Tracker is still tracking %v", ref2)
+		t.Fatal("Tracker is still tracking", ref2)
 	}
 	trk.OnDeletedObserver(t1)
 	if isTracking(trk, ref1) {
-		t.Fatalf("Tracker is still tracking %v", ref1)
+		t.Fatal("Tracker is still tracking", ref1)
 	}
 }
 

--- a/reconciler/testing/util.go
+++ b/reconciler/testing/util.go
@@ -44,7 +44,7 @@ func ExpectNormalEventDelivery(t *testing.T, messageRegexp string) CreateHookFun
 	t.Helper()
 	wantRegexp, err := regexp.Compile(messageRegexp)
 	if err != nil {
-		t.Fatalf("Invalid regular expression: %v", err)
+		t.Fatal("Invalid regular expression:", err)
 	}
 	return func(obj runtime.Object) HookResult {
 		t.Helper()
@@ -68,7 +68,7 @@ func ExpectWarningEventDelivery(t *testing.T, messageRegexp string) CreateHookFu
 	t.Helper()
 	wantRegexp, err := regexp.Compile(messageRegexp)
 	if err != nil {
-		t.Fatalf("Invalid regular expression: %v", err)
+		t.Fatal("Invalid regular expression:", err)
 	}
 	return func(obj runtime.Object) HookResult {
 		t.Helper()

--- a/resolver/addressable_resolver_test.go
+++ b/resolver/addressable_resolver_test.go
@@ -348,7 +348,7 @@ func TestGetURIDestinationV1Beta1(t *testing.T) {
 						t.Errorf("Unexpected error (-want, +got) =\n%s", cmp.Diff(want, got))
 					}
 				} else {
-					t.Errorf("Unexpected error: %v", gotErr)
+					t.Error("Unexpected error:", gotErr)
 				}
 				return
 			}
@@ -530,7 +530,7 @@ func TestGetURIDestinationV1(t *testing.T) {
 						t.Errorf("Unexpected error (-want, +got) =\n%s", cmp.Diff(want, got))
 					}
 				} else {
-					t.Errorf("Unexpected error: %v", gotErr)
+					t.Error("Unexpected error:", gotErr)
 				}
 			}
 			if got, want := uri.String(), tc.wantURI; got != want {
@@ -572,7 +572,7 @@ func TestURIFromObjectReferenceErrors(t *testing.T) {
 						t.Errorf("Unexpected error (-want, +got) =\n%s", cmp.Diff(want, got))
 					}
 				} else {
-					t.Errorf("Unexpected error: %v", gotErr)
+					t.Error("Unexpected error:", gotErr)
 				}
 				return
 			}

--- a/source/source_stats_reporter_test.go
+++ b/source/source_stats_reporter_test.go
@@ -38,7 +38,7 @@ func TestStatsReporter(t *testing.T) {
 
 	r, err := NewStatsReporter()
 	if err != nil {
-		t.Fatalf("Failed to create a new reporter: %v", err)
+		t.Fatal("Failed to create a new reporter:", err)
 	}
 
 	wantTags := map[string]string{
@@ -64,7 +64,7 @@ func TestStatsReporter(t *testing.T) {
 func expectSuccess(t *testing.T, f func() error) {
 	t.Helper()
 	if err := f(); err != nil {
-		t.Errorf("Reporter expected success but got error: %v", err)
+		t.Error("Reporter expected success but got error:", err)
 	}
 }
 

--- a/test/cmd/command_test.go
+++ b/test/cmd/command_test.go
@@ -138,7 +138,7 @@ func TestRunCommands(t *testing.T) {
 					t.Fatalf("Expect to get error message %q but got %q", c.expectedErrorOutput, ce.ErrorOutput)
 				}
 			} else {
-				t.Fatalf("Expect to get a CommandLineError but got %s", reflect.TypeOf(err))
+				t.Fatal("Expect to get a CommandLineError but got", reflect.TypeOf(err))
 			}
 		} else {
 			if c.expectedErrorCode != 0 {
@@ -197,7 +197,7 @@ func TestRunCommandsInParallel(t *testing.T) {
 			}
 		} else {
 			if err != nil {
-				t.Fatalf("Expect to get no error but got %v", err)
+				t.Fatal("Expect to get no error but got", err)
 			}
 		}
 	}

--- a/test/gcs/mock/mock_test.go
+++ b/test/gcs/mock/mock_test.go
@@ -102,7 +102,7 @@ func TestSetError(t *testing.T) {
 					}
 
 					if err := mockClient.NewStorageBucket(ctx, bkt, project); err == nil {
-						t.Errorf("expected error %v", v.Err)
+						t.Error("expected error", v.Err)
 					} else if err.Error() != v.Err.Error() {
 						t.Errorf("expected error %v, got error %v", v.Err, err)
 					}
@@ -112,7 +112,7 @@ func TestSetError(t *testing.T) {
 					}
 
 					if err := mockClient.DeleteStorageBucket(ctx, bkt, true); err == nil {
-						t.Errorf("expected error %v", v.Err)
+						t.Error("expected error", v.Err)
 					} else if err.Error() != v.Err.Error() {
 						t.Errorf("expected error %v, got error %v", v.Err, err)
 					}
@@ -122,7 +122,7 @@ func TestSetError(t *testing.T) {
 					}
 
 					if _, err := mockClient.ListChildrenFiles(ctx, bkt, dirPath); err == nil {
-						t.Errorf("expected error %v", v.Err)
+						t.Error("expected error", v.Err)
 					} else if err.Error() != v.Err.Error() {
 						t.Errorf("expected error %v, got error %v", v.Err, err)
 					}
@@ -132,7 +132,7 @@ func TestSetError(t *testing.T) {
 					}
 
 					if _, err := mockClient.ListDirectChildren(ctx, bkt, dirPath); err == nil {
-						t.Errorf("expected error %v", v.Err)
+						t.Error("expected error", v.Err)
 					} else if err.Error() != v.Err.Error() {
 						t.Errorf("expected error %v, got error %v", v.Err, err)
 					}
@@ -142,7 +142,7 @@ func TestSetError(t *testing.T) {
 					}
 
 					if _, err := mockClient.AttrObject(ctx, bkt, dirPath); err == nil {
-						t.Errorf("expected error %v", v.Err)
+						t.Error("expected error", v.Err)
 					} else if err.Error() != v.Err.Error() {
 						t.Errorf("expected error %v, got error %v", v.Err, err)
 					}
@@ -152,7 +152,7 @@ func TestSetError(t *testing.T) {
 					}
 
 					if err := mockClient.CopyObject(ctx, bkt, dirPath, bkt, dirPath); err == nil {
-						t.Errorf("expected error %v", v.Err)
+						t.Error("expected error", v.Err)
 					} else if err.Error() != v.Err.Error() {
 						t.Errorf("expected error %v, got error %v", v.Err, err)
 					}
@@ -162,7 +162,7 @@ func TestSetError(t *testing.T) {
 					}
 
 					if _, err := mockClient.ReadObject(ctx, bkt, dirPath); err == nil {
-						t.Errorf("expected error %v", v.Err)
+						t.Error("expected error", v.Err)
 					} else if err.Error() != v.Err.Error() {
 						t.Errorf("expected error %v, got error %v", v.Err, err)
 					}
@@ -172,7 +172,7 @@ func TestSetError(t *testing.T) {
 					}
 
 					if _, err := mockClient.WriteObject(ctx, bkt, dirPath, []byte{}); err == nil {
-						t.Errorf("expected error %v", v.Err)
+						t.Error("expected error", v.Err)
 					} else if err.Error() != v.Err.Error() {
 						t.Errorf("expected error %v, got error %v", v.Err, err)
 					}
@@ -182,7 +182,7 @@ func TestSetError(t *testing.T) {
 					}
 
 					if err := mockClient.DeleteObject(ctx, bkt, dirPath); err == nil {
-						t.Errorf("expected error %v", v.Err)
+						t.Error("expected error", v.Err)
 					} else if err.Error() != v.Err.Error() {
 						t.Errorf("expected error %v, got error %v", v.Err, err)
 					}
@@ -192,7 +192,7 @@ func TestSetError(t *testing.T) {
 					}
 
 					if err := mockClient.Download(ctx, bkt, dirPath, dirPath); err == nil {
-						t.Errorf("expected error %v", v.Err)
+						t.Error("expected error", v.Err)
 					} else if err.Error() != v.Err.Error() {
 						t.Errorf("expected error %v, got error %v", v.Err, err)
 					}
@@ -202,7 +202,7 @@ func TestSetError(t *testing.T) {
 					}
 
 					if err := mockClient.Upload(ctx, bkt, dirPath, dirPath); err == nil {
-						t.Errorf("expected error %v", v.Err)
+						t.Error("expected error", v.Err)
 					} else if err.Error() != v.Err.Error() {
 						t.Errorf("expected error %v, got error %v", v.Err, err)
 					}
@@ -390,15 +390,15 @@ func TestNewStorageBucket(t *testing.T) {
 			}
 
 			if p, ok := mockClient.revIndex[bucket(tt.bkt)]; !ok {
-				t.Fatalf("expected revIndex to contain key %v", bucket(tt.bkt))
+				t.Fatal("expected revIndex to contain key", bucket(tt.bkt))
 			} else if p != project(tt.projectName) {
 				t.Fatalf("expected revIndex value %v, got %v", project(tt.projectName), p)
 			}
 
 			if p, ok := mockClient.gcp[project(tt.projectName)]; !ok {
-				t.Fatalf("expected gcp to contain key %v", project(tt.projectName))
+				t.Fatal("expected gcp to contain key", project(tt.projectName))
 			} else if _, ok := p.bkt[bucket(tt.bkt)]; !ok {
-				t.Fatalf("expected gcp.bucket to contain key %v", bucket(tt.bkt))
+				t.Fatal("expected gcp.bucket to contain key", bucket(tt.bkt))
 			}
 		})
 	}
@@ -914,7 +914,7 @@ func TestWriteObject(t *testing.T) {
 			}
 
 			if content, err := mockClient.ReadObject(ctx, tt.bkt, tt.objpath); err != nil {
-				t.Fatalf("read object returned error %v", err)
+				t.Fatal("read object returned error", err)
 			} else if !bytes.Equal(content, tt.content) {
 				t.Fatalf("expected content %v, got content %v", tt.content, content)
 			}

--- a/test/gke/endpoint_test.go
+++ b/test/gke/endpoint_test.go
@@ -39,7 +39,7 @@ func TestServiceEndpoint(t *testing.T) {
 				data.env, got, data.want)
 		}
 		if err != nil && !data.errorExpected {
-			t.Errorf("Error is not expected by got %v", err)
+			t.Error("Error is not expected by got", err)
 		}
 		if err == nil && data.errorExpected {
 			t.Error("Expected one error but got nil")

--- a/test/mako/alerter/slack/message_test.go
+++ b/test/mako/alerter/slack/message_test.go
@@ -54,36 +54,36 @@ func TestMessaging(t *testing.T) {
 		for i, channel := range mh.channels {
 			initHistory, err := mh.readClient.MessageHistory(channel.Identity, time.Now().Add(-1*time.Hour))
 			if err != nil {
-				t.Fatalf("expected to get the message history, but failed: %v", err)
+				t.Fatal("expected to get the message history, but failed:", err)
 			}
 			historySizes[i] = len(initHistory)
 		}
 
 		firstMsg := "first message"
 		if err := mh.SendAlert(tc.name, firstMsg); err != nil {
-			t.Fatalf("expected to send the message, but failed: %v", err)
+			t.Fatal("expected to send the message, but failed:", err)
 		}
 		for i, channel := range mh.channels {
 			history, err := mh.readClient.MessageHistory(channel.Identity, time.Now().Add(-1*time.Hour))
 			if err != nil {
-				t.Fatalf("expected to get the message history, but failed: %v", err)
+				t.Fatal("expected to get the message history, but failed:", err)
 			}
 			if len(history) != historySizes[i]+1 {
-				t.Fatalf("the message is expected to be successfully sent, but failed: %v", err)
+				t.Fatal("the message is expected to be successfully sent, but failed:", err)
 			}
 		}
 
 		secondMsg := "second message"
 		if err := mh.SendAlert(tc.name, secondMsg); err != nil {
-			t.Fatalf("expected to send the message, but failed: %v", err)
+			t.Fatal("expected to send the message, but failed:", err)
 		}
 		for i, channel := range mh.channels {
 			history, err := mh.readClient.MessageHistory(channel.Identity, time.Now().Add(-1*time.Hour))
 			if err != nil {
-				t.Fatalf("expected to get the message history, but failed: %v", err)
+				t.Fatal("expected to get the message history, but failed:", err)
 			}
 			if len(history) != historySizes[i]+1 {
-				t.Fatalf("the message history is expected to be unchanged, but now it's: %d", len(history))
+				t.Fatal("the message history is expected to be unchanged, but now it's:", len(history))
 			}
 		}
 	}

--- a/test/mako/config/configmap_test.go
+++ b/test/mako/config/configmap_test.go
@@ -25,9 +25,9 @@ import (
 func TestOurConfig(t *testing.T) {
 	cm, example := ConfigMapsFromTestFile(t, ConfigName)
 	if _, err := NewConfigFromConfigMap(cm); err != nil {
-		t.Errorf("NewConfigFromConfigMap(actual) = %v", err)
+		t.Error("NewConfigFromConfigMap(actual) =", err)
 	}
 	if _, err := NewConfigFromConfigMap(example); err != nil {
-		t.Errorf("NewConfigFromConfigMap(example) = %v", err)
+		t.Error("NewConfigFromConfigMap(example) =", err)
 	}
 }

--- a/test/prometheus/prometheus_test.go
+++ b/test/prometheus/prometheus_test.go
@@ -107,7 +107,7 @@ func getTestAPI() *TestPromAPI {
 func TestRunQuery(t *testing.T) {
 	r, err := prometheus.RunQuery(context.Background(), t.Logf, getTestAPI(), query)
 	if err != nil {
-		t.Fatalf("Error running query: %v", err)
+		t.Fatal("Error running query:", err)
 	}
 	if r != expected {
 		t.Fatalf("Want: %f Got: %f", expected, r)
@@ -118,7 +118,7 @@ func TestRunQueryRange(t *testing.T) {
 	r := v1.Range{Start: time.Now(), End: time.Now().Add(duration)}
 	val, err := prometheus.RunQueryRange(context.Background(), t.Logf, getTestAPI(), query, r)
 	if err != nil {
-		t.Fatalf("Error running query: %v", err)
+		t.Fatal("Error running query:", err)
 	}
 	if val != expected {
 		t.Fatalf("Want: %f Got: %f", expected, val)

--- a/test/prow/env_test.go
+++ b/test/prow/env_test.go
@@ -28,9 +28,9 @@ func TestGetEnvConfig(t *testing.T) {
 
 	os.Setenv("CI", "true")
 	ec, err := GetEnvConfig()
-	t.Logf("EnvConfig is: %v", ec)
+	t.Log("EnvConfig is:", ec)
 	if err != nil {
-		t.Fatalf("Error getting envconfig for Prow: %v", err)
+		t.Fatal("Error getting envconfig for Prow:", err)
 	}
 	if !ec.CI {
 		t.Fatal("Expected CI to be true but is false")

--- a/test/zipkin/util.go
+++ b/test/zipkin/util.go
@@ -105,7 +105,7 @@ func SetupZipkinTracingFromConfigTracing(ctx context.Context, kubeClientset *kub
 // SetupZipkinTracingFromConfigTracingOrFail is same as SetupZipkinTracingFromConfigTracing, but fails the test if an error happens
 func SetupZipkinTracingFromConfigTracingOrFail(ctx context.Context, t testing.TB, kubeClientset *kubernetes.Clientset, configMapNamespace string) {
 	if err := SetupZipkinTracingFromConfigTracing(ctx, kubeClientset, t.Logf, configMapNamespace); err != nil {
-		t.Fatalf("Error while setup Zipkin tracing: %v", err)
+		t.Fatal("Error while setup Zipkin tracing:", err)
 	}
 }
 
@@ -145,7 +145,7 @@ func SetupZipkinTracing(ctx context.Context, kubeClientset *kubernetes.Clientset
 // SetupZipkinTracingOrFail is same as SetupZipkinTracing, but fails the test if an error happens
 func SetupZipkinTracingOrFail(ctx context.Context, t testing.TB, kubeClientset *kubernetes.Clientset, zipkinRemotePort int, zipkinNamespace string) {
 	if err := SetupZipkinTracing(ctx, kubeClientset, t.Logf, zipkinRemotePort, zipkinNamespace); err != nil {
-		t.Fatalf("Error while setup zipkin tracing: %v", err)
+		t.Fatal("Error while setup zipkin tracing:", err)
 	}
 }
 

--- a/testing/inner_default_resource_test.go
+++ b/testing/inner_default_resource_test.go
@@ -32,6 +32,6 @@ func TestInnerDefaultResource_SetDefaults(t *testing.T) {
 	r := InnerDefaultResource{}
 	r.SetDefaults(context.Background())
 	if r.Spec.FieldWithDefault != "I'm a default." {
-		t.Errorf("Unexpected defaulted value: %v", r.Spec.FieldWithDefault)
+		t.Error("Unexpected defaulted value:", r.Spec.FieldWithDefault)
 	}
 }

--- a/testutils/clustermanager/e2e-tests/boskos/boskos_test.go
+++ b/testutils/clustermanager/e2e-tests/boskos/boskos_test.go
@@ -87,7 +87,7 @@ func TestAcquireGKEProject(t *testing.T) {
 				"", /* boskos user */
 				"" /* boskos password file */)
 			if err != nil {
-				t.Fatalf("Failed to create test client %v", err)
+				t.Fatal("Failed to create test client", err)
 			}
 			_, err = client.AcquireGKEProject(GKEProjectResource)
 			if tt.expErr && (err == nil) {
@@ -145,7 +145,7 @@ func TestReleaseGKEProject(t *testing.T) {
 				"", /* boskos user */
 				"" /* boskos password file */)
 			if err != nil {
-				t.Fatalf("Failed to create test client %v", err)
+				t.Fatal("Failed to create test client", err)
 			}
 			err = client.ReleaseGKEProject(tt.resName)
 			if tt.expErr && (err == nil) {

--- a/tracing/config/tracing_test.go
+++ b/tracing/config/tracing_test.go
@@ -131,7 +131,7 @@ func TestNewConfigSuccess(t *testing.T) {
 				t.Fatal("Failed to create tracing config:", err)
 			}
 			if diff := cmp.Diff(tc.output, cfg); diff != "" {
-				t.Errorf("Got config from map (-want, +got) = %v", diff)
+				t.Error("Got config from map (-want, +got) =", diff)
 			}
 		})
 	}

--- a/tracing/http_test.go
+++ b/tracing/http_test.go
@@ -62,7 +62,7 @@ func TestHTTPSpanMiddleware(t *testing.T) {
 	})
 
 	if err := oct.ApplyConfig(&cfg); err != nil {
-		t.Errorf("Failed to apply tracer config: %v", err)
+		t.Error("Failed to apply tracer config:", err)
 	}
 
 	next := testHandler{}

--- a/tracing/opencensus_test.go
+++ b/tracing/opencensus_test.go
@@ -31,7 +31,7 @@ func TestOpenCensusTracerGlobalLifecycle(t *testing.T) {
 	oct := NewOpenCensusTracer(co)
 	// Apply a config to make us the global OCT
 	if err := oct.ApplyConfig(&config.Config{}); err != nil {
-		t.Fatalf("Failed to ApplyConfig on tracer: %v", err)
+		t.Fatal("Failed to ApplyConfig on tracer:", err)
 	}
 
 	otherOCT := NewOpenCensusTracer(co)
@@ -40,11 +40,11 @@ func TestOpenCensusTracerGlobalLifecycle(t *testing.T) {
 	}
 
 	if err := oct.Finish(); err != nil {
-		t.Fatalf("Failed to finish OCT: %v", err)
+		t.Fatal("Failed to finish OCT:", err)
 	}
 
 	if err := otherOCT.ApplyConfig(&config.Config{}); err != nil {
-		t.Fatalf("Failed to ApplyConfig on OtherOCT after finishing OCT: %v", err)
+		t.Fatal("Failed to ApplyConfig on OtherOCT after finishing OCT:", err)
 	}
 	otherOCT.Finish()
 }

--- a/tracing/propagation/tracecontextb3/http_format_test.go
+++ b/tracing/propagation/tracecontextb3/http_format_test.go
@@ -174,6 +174,6 @@ func assertFormatReadsSpanContext(t *testing.T, r *http.Request, format ocpropag
 		t.Error("Expected to get the SpanContext")
 	}
 	if diff := cmp.Diff(spanContext, sc); diff != "" {
-		t.Errorf("Unexpected SpanContext (-want +got): %s", diff)
+		t.Error("Unexpected SpanContext (-want +got):", diff)
 	}
 }

--- a/tracing/zipkin_test.go
+++ b/tracing/zipkin_test.go
@@ -66,10 +66,10 @@ func TestOpenCensusTracerApplyConfig(t *testing.T) {
 			}, endpoint))
 
 			if err := oct.ApplyConfig(&tc.cfg); (err == nil) == tc.reporterError {
-				t.Errorf("Failed to apply config: %v", err)
+				t.Error("Failed to apply config:", err)
 			}
 			if diff := cmp.Diff(gotCfg, tc.expect); diff != "" {
-				t.Errorf("Got tracer config (-want, +got) = %v", diff)
+				t.Error("Got tracer config (-want, +got) =", diff)
 			}
 
 			oct.Finish()

--- a/tracker/enqueue_test.go
+++ b/tracker/enqueue_test.go
@@ -78,7 +78,7 @@ func TestHappyPathsExact(t *testing.T) {
 	// Tracked gets called
 	{
 		if err := trk.Track(ref.ObjectReference(), thing2); err != nil {
-			t.Fatalf("Track() = %v", err)
+			t.Fatal("Track() =", err)
 		}
 		// New registrations should result in an immediate callback.
 		if got, want := calls, 1; got != want {
@@ -114,7 +114,7 @@ func TestHappyPathsExact(t *testing.T) {
 	// Starts getting called again
 	{
 		if err := trk.Track(ref.ObjectReference(), thing2); err != nil {
-			t.Fatalf("Track() = %v", err)
+			t.Fatal("Track() =", err)
 		}
 		// New registrations should result in an immediate callback.
 		if got, want := calls, 4; got != want {
@@ -509,7 +509,7 @@ func TestHappyPathsInexact(t *testing.T) {
 	// Tracked gets called
 	{
 		if err := trk.TrackReference(ref, thing2); err != nil {
-			t.Fatalf("Track() = %v", err)
+			t.Fatal("Track() =", err)
 		}
 		// New registrations should result in an immediate callback.
 		if got, want := calls, 1; got != want {
@@ -545,7 +545,7 @@ func TestHappyPathsInexact(t *testing.T) {
 	// Starts getting called again
 	{
 		if err := trk.TrackReference(ref, thing2); err != nil {
-			t.Fatalf("Track() = %v", err)
+			t.Fatal("Track() =", err)
 		}
 		// New registrations should result in an immediate callback.
 		if got, want := calls, 4; got != want {
@@ -598,7 +598,7 @@ func TestHappyPathsInexact(t *testing.T) {
 	// Not called when something about the reference matching changes.
 	{
 		if err := trk.TrackReference(ref, thing2); err != nil {
-			t.Fatalf("Track() = %v", err)
+			t.Fatal("Track() =", err)
 		}
 		// New registrations should result in an immediate callback.
 		if got, want := calls, 6; got != want {
@@ -720,7 +720,7 @@ func TestHappyPathsByBoth(t *testing.T) {
 	// Tracked gets called
 	{
 		if err := trk.TrackReference(ref1, thing2); err != nil {
-			t.Fatalf("Track() = %v", err)
+			t.Fatal("Track() =", err)
 		}
 		// New registrations should result in an immediate callback.
 		if got, want := calls, 1; got != want {
@@ -728,7 +728,7 @@ func TestHappyPathsByBoth(t *testing.T) {
 		}
 
 		if err := trk.TrackReference(ref2, thing2); err != nil {
-			t.Fatalf("Track() = %v", err)
+			t.Fatal("Track() =", err)
 		}
 		// New registrations should result in an immediate callback.
 		if got, want := calls, 2; got != want {

--- a/webhook/admission_integration_test.go
+++ b/webhook/admission_integration_test.go
@@ -69,7 +69,7 @@ func TestAdmissionValidResponseForResource(t *testing.T) {
 	}
 	wh, serverURL, ctx, cancel, err := testSetup(t, ac)
 	if err != nil {
-		t.Fatalf("testSetup() = %v", err)
+		t.Fatal("testSetup() =", err)
 	}
 
 	eg, _ := errgroup.WithContext(ctx)
@@ -77,17 +77,17 @@ func TestAdmissionValidResponseForResource(t *testing.T) {
 	defer func() {
 		cancel()
 		if err := eg.Wait(); err != nil {
-			t.Errorf("Unable to run controller: %s", err)
+			t.Error("Unable to run controller:", err)
 		}
 	}()
 
 	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
 	if pollErr != nil {
-		t.Fatalf("waitForServerAvailable() = %v", err)
+		t.Fatal("waitForServerAvailable() =", err)
 	}
 	tlsClient, err := createSecureTLSClient(t, wh.Client, &wh.Options)
 	if err != nil {
-		t.Fatalf("createSecureTLSClient() = %v", err)
+		t.Fatal("createSecureTLSClient() =", err)
 	}
 
 	admissionreq := &admissionv1.AdmissionRequest{
@@ -101,7 +101,7 @@ func TestAdmissionValidResponseForResource(t *testing.T) {
 	testRev := createResource("testrev")
 	marshaled, err := json.Marshal(testRev)
 	if err != nil {
-		t.Fatalf("Failed to marshal resource: %s", err)
+		t.Fatal("Failed to marshal resource:", err)
 	}
 
 	admissionreq.Resource.Group = "pkg.knative.dev"
@@ -113,19 +113,19 @@ func TestAdmissionValidResponseForResource(t *testing.T) {
 	reqBuf := new(bytes.Buffer)
 	err = json.NewEncoder(reqBuf).Encode(&rev)
 	if err != nil {
-		t.Fatalf("Failed to marshal admission review: %v", err)
+		t.Fatal("Failed to marshal admission review:", err)
 	}
 
 	u, err := url.Parse(fmt.Sprintf("https://%s", serverURL))
 	if err != nil {
-		t.Fatalf("bad url %v", err)
+		t.Fatal("bad url", err)
 	}
 
 	u.Path = path.Join(u.Path, ac.Path())
 
 	req, err := http.NewRequest("GET", u.String(), reqBuf)
 	if err != nil {
-		t.Fatalf("http.NewRequest() = %v", err)
+		t.Fatal("http.NewRequest() =", err)
 	}
 	req.Header.Add("Content-Type", "application/json")
 
@@ -134,7 +134,7 @@ func TestAdmissionValidResponseForResource(t *testing.T) {
 		defer close(doneCh)
 		response, err := tlsClient.Do(req)
 		if err != nil {
-			t.Errorf("Failed to get response %v", err)
+			t.Error("Failed to get response", err)
 			return
 		}
 
@@ -146,7 +146,7 @@ func TestAdmissionValidResponseForResource(t *testing.T) {
 		defer response.Body.Close()
 		responseBody, err := ioutil.ReadAll(response.Body)
 		if err != nil {
-			t.Errorf("Failed to read response body %v", err)
+			t.Error("Failed to read response body", err)
 			return
 		}
 
@@ -154,7 +154,7 @@ func TestAdmissionValidResponseForResource(t *testing.T) {
 
 		err = json.NewDecoder(bytes.NewReader(responseBody)).Decode(&reviewResponse)
 		if err != nil {
-			t.Errorf("Failed to decode response: %v", err)
+			t.Error("Failed to decode response:", err)
 			return
 		}
 
@@ -192,7 +192,7 @@ func TestAdmissionInvalidResponseForResource(t *testing.T) {
 	}
 	wh, serverURL, ctx, cancel, err := testSetup(t, ac)
 	if err != nil {
-		t.Fatalf("testSetup() = %v", err)
+		t.Fatal("testSetup() =", err)
 	}
 
 	eg, _ := errgroup.WithContext(ctx)
@@ -201,17 +201,17 @@ func TestAdmissionInvalidResponseForResource(t *testing.T) {
 	defer func() {
 		cancel()
 		if err := eg.Wait(); err != nil {
-			t.Errorf("Unable to run controller: %s", err)
+			t.Error("Unable to run controller:", err)
 		}
 	}()
 
 	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
 	if pollErr != nil {
-		t.Fatalf("waitForServerAvailable() = %v", err)
+		t.Fatal("waitForServerAvailable() =", err)
 	}
 	tlsClient, err := createSecureTLSClient(t, wh.Client, &wh.Options)
 	if err != nil {
-		t.Fatalf("createSecureTLSClient() = %v", err)
+		t.Fatal("createSecureTLSClient() =", err)
 	}
 
 	resource := createResource(testResourceName)
@@ -219,7 +219,7 @@ func TestAdmissionInvalidResponseForResource(t *testing.T) {
 	resource.Spec.FieldWithValidation = "not the right value"
 	marshaled, err := json.Marshal(resource)
 	if err != nil {
-		t.Fatalf("Failed to marshal resource: %s", err)
+		t.Fatal("Failed to marshal resource:", err)
 	}
 
 	admissionreq := &admissionv1.AdmissionRequest{
@@ -243,26 +243,26 @@ func TestAdmissionInvalidResponseForResource(t *testing.T) {
 	reqBuf := new(bytes.Buffer)
 	err = json.NewEncoder(reqBuf).Encode(&rev)
 	if err != nil {
-		t.Fatalf("Failed to marshal admission review: %v", err)
+		t.Fatal("Failed to marshal admission review:", err)
 	}
 
 	u, err := url.Parse(fmt.Sprintf("https://%s", serverURL))
 	if err != nil {
-		t.Fatalf("bad url %v", err)
+		t.Fatal("bad url", err)
 	}
 
 	u.Path = path.Join(u.Path, ac.Path())
 
 	req, err := http.NewRequest("GET", u.String(), reqBuf)
 	if err != nil {
-		t.Fatalf("http.NewRequest() = %v", err)
+		t.Fatal("http.NewRequest() =", err)
 	}
 
 	req.Header.Add("Content-Type", "application/json")
 
 	response, err := tlsClient.Do(req)
 	if err != nil {
-		t.Fatalf("Failed to receive response %v", err)
+		t.Fatal("Failed to receive response", err)
 	}
 
 	if got, want := response.StatusCode, http.StatusOK; got != want {
@@ -272,14 +272,14 @@ func TestAdmissionInvalidResponseForResource(t *testing.T) {
 	defer response.Body.Close()
 	respBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		t.Fatalf("Failed to read response body %v", err)
+		t.Fatal("Failed to read response body", err)
 	}
 
 	reviewResponse := admissionv1.AdmissionReview{}
 
 	err = json.NewDecoder(bytes.NewReader(respBody)).Decode(&reviewResponse)
 	if err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
+		t.Fatal("Failed to decode response:", err)
 	}
 
 	var respPatch []jsonpatch.JsonPatchOperation
@@ -293,7 +293,7 @@ func TestAdmissionInvalidResponseForResource(t *testing.T) {
 	}
 
 	if !strings.Contains(reviewResponse.Response.Result.Message, expectedError) {
-		t.Errorf("Received unexpected response status message %s", reviewResponse.Response.Result.Message)
+		t.Error("Received unexpected response status message", reviewResponse.Response.Result.Message)
 	}
 
 	// Stats should be reported for requests that have admission disallowed

--- a/webhook/certificates/certificates_test.go
+++ b/webhook/certificates/certificates_test.go
@@ -50,7 +50,7 @@ func TestReconcile(t *testing.T) {
 	secret, err := certresources.MakeSecret(context.Background(),
 		secretName, system.Namespace(), serviceName)
 	if err != nil {
-		t.Fatalf("MakeSecret() = %v", err)
+		t.Fatal("MakeSecret() =", err)
 	}
 
 	// Mutate the MakeSecret to return our secret deterministically.
@@ -156,7 +156,7 @@ func TestReconcileMakeSecretFailure(t *testing.T) {
 	secret, err := certresources.MakeSecret(context.Background(),
 		secretName, system.Namespace(), serviceName)
 	if err != nil {
-		t.Fatalf("MakeSecret() = %v", err)
+		t.Fatal("MakeSecret() =", err)
 	}
 
 	// Mutate the MakeSecret to return our secret deterministically.
@@ -239,7 +239,7 @@ func TestNew(t *testing.T) {
 	}
 
 	if err := la.Promote(pkgreconciler.UniversalBucket(), c.MaybeEnqueueBucketKey); err != nil {
-		t.Errorf("Promote() = %v", err)
+		t.Error("Promote() =", err)
 	}
 
 	// Queue has async moving parts so if we check at the wrong moment, this might still be 0.
@@ -254,7 +254,7 @@ func secretWithCertData(t *testing.T, expiration time.Time) *corev1.Secret {
 	const secretName = "webhook-secret"
 	serverKey, serverCert, caCert, err := certresources.CreateCerts(context.Background(), "webhook-service", system.Namespace(), expiration)
 	if err != nil {
-		t.Fatalf("Failed to create cert: %v", err)
+		t.Fatal("Failed to create cert:", err)
 	}
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/webhook/certificates/resources/certs_test.go
+++ b/webhook/certificates/resources/certs_test.go
@@ -31,7 +31,7 @@ import (
 func TestCreateCerts(t *testing.T) {
 	sKey, serverCertPEM, caCertBytes, err := CreateCerts(TestContextWithLogger(t), "got-the-hook", "knative-webhook", time.Now().AddDate(1, 0, 0))
 	if err != nil {
-		t.Fatalf("Failed to create certs %v", err)
+		t.Fatal("Failed to create certs", err)
 	}
 
 	// Test server private key
@@ -41,7 +41,7 @@ func TestCreateCerts(t *testing.T) {
 	}
 	key, err := x509.ParsePKCS1PrivateKey(p.Bytes)
 	if err != nil {
-		t.Fatalf("Failed to parse private key %v", err)
+		t.Fatal("Failed to parse private key", err)
 	}
 	if err := key.Validate(); err != nil {
 		t.Fatalf("Failed to validate private key")
@@ -74,11 +74,11 @@ func TestCreateCerts(t *testing.T) {
 		"got-the-hook.knative-webhook.svc.cluster.local",
 	}
 	if diff := cmp.Diff(caParsedCert.DNSNames, expectedDNSNames); diff != "" {
-		t.Fatalf("Unexpected CA Cert DNS Name (-want +got) : %v", diff)
+		t.Fatal("Unexpected CA Cert DNS Name (-want +got) :", diff)
 	}
 
 	if diff := cmp.Diff(caParsedCert.DNSNames, expectedDNSNames); diff != "" {
-		t.Fatalf("Unexpected CA Cert DNS Name (-want +got): %s", diff)
+		t.Fatal("Unexpected CA Cert DNS Name (-want +got):", diff)
 	}
 
 	// Verify Server Cert is Signed by CA Cert

--- a/webhook/certificates/resources/secret_test.go
+++ b/webhook/certificates/resources/secret_test.go
@@ -26,7 +26,7 @@ func TestMakeSecret(t *testing.T) {
 	ctx := TestContextWithLogger(t)
 	secret, err := MakeSecret(ctx, "foo", "ns", "bar")
 	if err != nil {
-		t.Errorf("MakeSecret() = %v", err)
+		t.Error("MakeSecret() =", err)
 	}
 
 	for _, key := range []string{ServerKey, ServerCert, CACert} {

--- a/webhook/configmaps/configmaps_test.go
+++ b/webhook/configmaps/configmaps_test.go
@@ -338,7 +338,7 @@ func configMapRequest(
 	}
 	marshaled, err := json.Marshal(r)
 	if err != nil {
-		t.Fatalf("Failed to marshal resource: %v", err)
+		t.Fatal("Failed to marshal resource:", err)
 	}
 	req.Object.Raw = marshaled
 	req.Resource.Group = ""

--- a/webhook/configmaps/table_test.go
+++ b/webhook/configmaps/table_test.go
@@ -337,7 +337,7 @@ func TestNew(t *testing.T) {
 	}
 
 	if err := la.Promote(pkgreconciler.UniversalBucket(), c.MaybeEnqueueBucketKey); err != nil {
-		t.Errorf("Promote() = %v", err)
+		t.Error("Promote() =", err)
 	}
 
 	// Queue has async moving parts so if we check at the wrong moment, this might still be 0.

--- a/webhook/conversion_integration_test.go
+++ b/webhook/conversion_integration_test.go
@@ -66,7 +66,7 @@ func TestConversionValidResponse(t *testing.T) {
 	}
 	wh, serverURL, ctx, cancel, err := testSetup(t, cc)
 	if err != nil {
-		t.Fatalf("testSetup() = %v", err)
+		t.Fatal("testSetup() =", err)
 	}
 
 	eg, _ := errgroup.WithContext(ctx)
@@ -74,17 +74,17 @@ func TestConversionValidResponse(t *testing.T) {
 	defer func() {
 		cancel()
 		if err := eg.Wait(); err != nil {
-			t.Errorf("Unable to run controller: %s", err)
+			t.Error("Unable to run controller:", err)
 		}
 	}()
 
 	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
 	if pollErr != nil {
-		t.Fatalf("waitForServerAvailable() = %v", err)
+		t.Fatal("waitForServerAvailable() =", err)
 	}
 	tlsClient, err := createSecureTLSClient(t, wh.Client, &wh.Options)
 	if err != nil {
-		t.Fatalf("createSecureTLSClient() = %v", err)
+		t.Fatal("createSecureTLSClient() =", err)
 	}
 
 	review := apixv1.ConversionReview{
@@ -102,18 +102,18 @@ func TestConversionValidResponse(t *testing.T) {
 	reqBuf := new(bytes.Buffer)
 	err = json.NewEncoder(reqBuf).Encode(&review)
 	if err != nil {
-		t.Fatalf("Failed to marshal conversion review: %v", err)
+		t.Fatal("Failed to marshal conversion review:", err)
 	}
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s%s", serverURL, cc.Path()), reqBuf)
 	if err != nil {
-		t.Fatalf("http.NewRequest() = %v", err)
+		t.Fatal("http.NewRequest() =", err)
 	}
 	req.Header.Add("Content-Type", "application/json")
 
 	response, err := tlsClient.Do(req)
 	if err != nil {
-		t.Fatalf("Failed to get response %v", err)
+		t.Fatal("Failed to get response", err)
 	}
 
 	defer response.Body.Close()
@@ -124,14 +124,14 @@ func TestConversionValidResponse(t *testing.T) {
 
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		t.Fatalf("Failed to read response body %v", err)
+		t.Fatal("Failed to read response body", err)
 	}
 
 	reviewResponse := apixv1.ConversionReview{}
 
 	err = json.NewDecoder(bytes.NewReader(responseBody)).Decode(&reviewResponse)
 	if err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
+		t.Fatal("Failed to decode response:", err)
 	}
 
 	if reviewResponse.Response.UID != "some-uid" {
@@ -155,7 +155,7 @@ func TestConversionInvalidResponse(t *testing.T) {
 	}
 	wh, serverURL, ctx, cancel, err := testSetup(t, cc)
 	if err != nil {
-		t.Fatalf("testSetup() = %v", err)
+		t.Fatal("testSetup() =", err)
 	}
 
 	eg, _ := errgroup.WithContext(ctx)
@@ -163,17 +163,17 @@ func TestConversionInvalidResponse(t *testing.T) {
 	defer func() {
 		cancel()
 		if err := eg.Wait(); err != nil {
-			t.Errorf("Unable to run controller: %s", err)
+			t.Error("Unable to run controller:", err)
 		}
 	}()
 
 	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
 	if pollErr != nil {
-		t.Fatalf("waitForServerAvailable() = %v", err)
+		t.Fatal("waitForServerAvailable() =", err)
 	}
 	tlsClient, err := createSecureTLSClient(t, wh.Client, &wh.Options)
 	if err != nil {
-		t.Fatalf("createSecureTLSClient() = %v", err)
+		t.Fatal("createSecureTLSClient() =", err)
 	}
 
 	review := apixv1.ConversionReview{
@@ -191,18 +191,18 @@ func TestConversionInvalidResponse(t *testing.T) {
 	reqBuf := new(bytes.Buffer)
 	err = json.NewEncoder(reqBuf).Encode(&review)
 	if err != nil {
-		t.Fatalf("Failed to marshal conversion review: %v", err)
+		t.Fatal("Failed to marshal conversion review:", err)
 	}
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s%s", serverURL, cc.Path()), reqBuf)
 	if err != nil {
-		t.Fatalf("http.NewRequest() = %v", err)
+		t.Fatal("http.NewRequest() =", err)
 	}
 	req.Header.Add("Content-Type", "application/json")
 
 	response, err := tlsClient.Do(req)
 	if err != nil {
-		t.Fatalf("Failed to get response %v", err)
+		t.Fatal("Failed to get response", err)
 	}
 
 	defer response.Body.Close()
@@ -213,14 +213,14 @@ func TestConversionInvalidResponse(t *testing.T) {
 
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		t.Fatalf("Failed to read response body %v", err)
+		t.Fatal("Failed to read response body", err)
 	}
 
 	reviewResponse := apixv1.ConversionReview{}
 
 	err = json.NewDecoder(bytes.NewReader(responseBody)).Decode(&reviewResponse)
 	if err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
+		t.Fatal("Failed to decode response:", err)
 	}
 
 	if reviewResponse.Response.UID != "some-uid" {

--- a/webhook/psbinding/index_test.go
+++ b/webhook/psbinding/index_test.go
@@ -59,7 +59,7 @@ func TestExact(t *testing.T) {
 	if got, ok := em.Get(key); !ok {
 		t.Errorf("Get(%+v) = %v, %v; wanted b, true", key, want, ok)
 	} else if !cmp.Equal(got, want) {
-		t.Errorf("Get (-want, +got): %s", cmp.Diff(want, got))
+		t.Error("Get (-want, +got):", cmp.Diff(want, got))
 	}
 
 	otherKey := exactKey{
@@ -117,7 +117,7 @@ func TestInexact(t *testing.T) {
 		if got, ok := im.Get(key, ls); !ok {
 			t.Errorf("Get(%+v) = %v, %v; wanted b, true", key, want, ok)
 		} else if !cmp.Equal(got, want) {
-			t.Errorf("Get (-want, +got): %s", cmp.Diff(want, got))
+			t.Error("Get (-want, +got):", cmp.Diff(want, got))
 		}
 	})
 
@@ -133,7 +133,7 @@ func TestInexact(t *testing.T) {
 		if got, ok := im.Get(key, ls); !ok {
 			t.Errorf("Get(%+v) = %v, %v; wanted b, true", key, want, ok)
 		} else if !cmp.Equal(got, want) {
-			t.Errorf("Get (-want, +got): %s", cmp.Diff(want, got))
+			t.Error("Get (-want, +got):", cmp.Diff(want, got))
 		}
 	})
 
@@ -164,7 +164,7 @@ func TestInexact(t *testing.T) {
 		if got, ok := im.Get(key, ls); !ok {
 			t.Errorf("Get(%+v) = %v, %v; wanted b, true", key, want, ok)
 		} else if !cmp.Equal(got, want) {
-			t.Errorf("Get (-want, +got): %s", cmp.Diff(want, got))
+			t.Error("Get (-want, +got):", cmp.Diff(want, got))
 		}
 	})
 

--- a/webhook/psbinding/table_test.go
+++ b/webhook/psbinding/table_test.go
@@ -91,7 +91,7 @@ func checkDeploymentIsPatched(t *testing.T, r *TableRow) {
 	}
 	b, err := json.Marshal(d)
 	if err != nil {
-		t.Fatalf("Unable to serialize deployment: %v", err)
+		t.Fatal("Unable to serialize deployment:", err)
 	}
 
 	req := &admissionv1.AdmissionRequest{
@@ -146,7 +146,7 @@ func checkDeploymentIsPatchedBack(t *testing.T, r *TableRow) {
 	}
 	b, err := json.Marshal(d)
 	if err != nil {
-		t.Fatalf("Unable to serialize deployment: %v", err)
+		t.Fatal("Unable to serialize deployment:", err)
 	}
 
 	req := &admissionv1.AdmissionRequest{
@@ -193,7 +193,7 @@ func checkDeploymentIsNotPatched(t *testing.T, r *TableRow) {
 	}
 	b, err := json.Marshal(d)
 	if err != nil {
-		t.Fatalf("Unable to serialize deployment: %v", err)
+		t.Fatal("Unable to serialize deployment:", err)
 	}
 
 	req := &admissionv1.AdmissionRequest{
@@ -239,7 +239,7 @@ func checkDeleteIgnored(t *testing.T, r *TableRow) {
 	}
 	b, err := json.Marshal(d)
 	if err != nil {
-		t.Fatalf("Unable to serialize deployment: %v", err)
+		t.Fatal("Unable to serialize deployment:", err)
 	}
 
 	req := &admissionv1.AdmissionRequest{
@@ -1050,7 +1050,7 @@ func TestNew(t *testing.T) {
 	}
 
 	if err := la.Promote(pkgreconciler.UniversalBucket(), c.MaybeEnqueueBucketKey); err != nil {
-		t.Errorf("Promote() = %v", err)
+		t.Error("Promote() =", err)
 	}
 
 	// Queue has async moving parts so if we check at the wrong moment, this might still be 0.

--- a/webhook/resourcesemantics/conversion/conversion_test.go
+++ b/webhook/resourcesemantics/conversion/conversion_test.go
@@ -116,7 +116,7 @@ func TestConversionToHub(t *testing.T) {
 
 	got := conversion.Convert(ctx, req)
 	if diff := cmp.Diff(want, got, cmpOpts...); diff != "" {
-		t.Errorf("unexpected response: %s", diff)
+		t.Error("unexpected response:", diff)
 	}
 }
 
@@ -156,7 +156,7 @@ func TestConversionFromHub(t *testing.T) {
 
 			got := conversion.Convert(ctx, req)
 			if diff := cmp.Diff(want, got, cmpOpts...); diff != "" {
-				t.Errorf("unexpected response: %s", diff)
+				t.Error("unexpected response:", diff)
 			}
 		})
 	}
@@ -202,7 +202,7 @@ func TestConversionThroughHub(t *testing.T) {
 
 			got := conversion.Convert(ctx, req)
 			if diff := cmp.Diff(want, got, cmpOpts...); diff != "" {
-				t.Errorf("unexpected response: %s", diff)
+				t.Error("unexpected response:", diff)
 			}
 		})
 	}
@@ -261,7 +261,7 @@ func TestConversionErrorBadGVK(t *testing.T) {
 
 			got := conversion.Convert(ctx, req)
 			if diff := cmp.Diff(want, got, cmpOpts...); diff != "" {
-				t.Errorf("unexpected response: %s", diff)
+				t.Error("unexpected response:", diff)
 			}
 
 			if !strings.HasPrefix(got.Result.Message, "invalid GroupVersionKind") {
@@ -299,7 +299,7 @@ func TestConversionUnknownInputGVK(t *testing.T) {
 
 	got := conversion.Convert(ctx, req)
 	if diff := cmp.Diff(want, got, cmpOpts...); diff != "" {
-		t.Errorf("unexpected response: %s", diff)
+		t.Error("unexpected response:", diff)
 	}
 }
 
@@ -328,7 +328,7 @@ func TestConversionInvalidTypeMeta(t *testing.T) {
 
 	got := conversion.Convert(ctx, req)
 	if diff := cmp.Diff(want, got, cmpOpts...); diff != "" {
-		t.Errorf("unexpected response: %s", diff)
+		t.Error("unexpected response:", diff)
 	}
 
 	if !strings.HasPrefix(got.Result.Message, "error parsing type meta") {
@@ -361,7 +361,7 @@ func TestConversionFailureToUnmarshalInput(t *testing.T) {
 
 	got := conversion.Convert(ctx, req)
 	if diff := cmp.Diff(want, got, cmpOpts...); diff != "" {
-		t.Errorf("unexpected response: %s", diff)
+		t.Error("unexpected response:", diff)
 	}
 
 	if !strings.HasPrefix(got.Result.Message, "unable to unmarshal input") {
@@ -396,7 +396,7 @@ func TestConversionFailureToMarshalOutput(t *testing.T) {
 
 	got := conversion.Convert(ctx, req)
 	if diff := cmp.Diff(want, got, cmpOpts...); diff != "" {
-		t.Errorf("unexpected response: %s", diff)
+		t.Error("unexpected response:", diff)
 	}
 
 	if !strings.HasPrefix(got.Result.Message, "unable to marshal output") {
@@ -451,7 +451,7 @@ func TestConversionFailureToConvert(t *testing.T) {
 
 			got := conversion.Convert(ctx, req)
 			if diff := cmp.Diff(want, got, cmpOpts...); diff != "" {
-				t.Errorf("unexpected response: %s", diff)
+				t.Error("unexpected response:", diff)
 			}
 
 			if !strings.HasPrefix(got.Result.Message, "conversion failed") {
@@ -502,7 +502,7 @@ func TestConversionFailureInvalidDesiredAPIVersion(t *testing.T) {
 
 			got := conversion.Convert(ctx, req)
 			if diff := cmp.Diff(want, got, cmpOpts...); diff != "" {
-				t.Errorf("unexpected response: %s", diff)
+				t.Error("unexpected response:", diff)
 			}
 		})
 	}
@@ -568,7 +568,7 @@ func TestConversionMissingZygotes(t *testing.T) {
 
 			got := conversion.Convert(ctx, req)
 			if diff := cmp.Diff(want, got, cmpOpts...); diff != "" {
-				t.Errorf("unexpected response: %s", diff)
+				t.Error("unexpected response:", diff)
 			}
 
 			if !strings.HasPrefix(got.Result.Message, "conversion not supported") {
@@ -604,7 +604,7 @@ func toRaw(t *testing.T, obj runtime.Object) runtime.RawExtension {
 
 	raw, err := json.Marshal(obj)
 	if err != nil {
-		t.Fatalf("unable to marshal resource: %s", err)
+		t.Fatal("unable to marshal resource:", err)
 	}
 
 	return runtime.RawExtension{Raw: raw}

--- a/webhook/resourcesemantics/defaulting/defaulting_test.go
+++ b/webhook/resourcesemantics/defaulting/defaulting_test.go
@@ -179,7 +179,7 @@ func TestUnknownFieldFails(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to marshal resource: %v", err)
+		t.Fatal("Failed to marshal resource:", err)
 	}
 	req.Object.Raw = marshaled
 
@@ -332,7 +332,7 @@ func createCreateResource(ctx context.Context, t *testing.T, r *Resource) *admis
 	}
 	marshaled, err := json.Marshal(r)
 	if err != nil {
-		t.Fatalf("Failed to marshal resource: %v", err)
+		t.Fatal("Failed to marshal resource:", err)
 	}
 	req.Object.Raw = marshaled
 	req.Resource.Group = "pkg.knative.dev"
@@ -442,12 +442,12 @@ func createUpdateResource(ctx context.Context, t *testing.T, old, new *Resource)
 	}
 	marshaled, err := json.Marshal(new)
 	if err != nil {
-		t.Errorf("Failed to marshal resource: %v", err)
+		t.Error("Failed to marshal resource:", err)
 	}
 	req.Object.Raw = marshaled
 	marshaledOld, err := json.Marshal(old)
 	if err != nil {
-		t.Errorf("Failed to marshal resource: %v", err)
+		t.Error("Failed to marshal resource:", err)
 	}
 	req.OldObject.Raw = marshaledOld
 	req.Resource.Group = "pkg.knative.dev"
@@ -491,16 +491,16 @@ func createInnerDefaultResourceWithoutSpec(t *testing.T) []byte {
 	// generic map[string]interface{}, removing 'spec', and marshaling it again.
 	origBytes, err := json.Marshal(r)
 	if err != nil {
-		t.Fatalf("Error marshaling origBytes: %v", err)
+		t.Fatal("Error marshaling origBytes:", err)
 	}
 	var q map[string]interface{}
 	if err := json.Unmarshal(origBytes, &q); err != nil {
-		t.Fatalf("Error unmarshaling origBytes: %v", err)
+		t.Fatal("Error unmarshaling origBytes:", err)
 	}
 	delete(q, "spec")
 	b, err := json.Marshal(q)
 	if err != nil {
-		t.Fatalf("Error marshaling q: %v", err)
+		t.Fatal("Error marshaling q:", err)
 	}
 	return b
 }

--- a/webhook/resourcesemantics/defaulting/table_test.go
+++ b/webhook/resourcesemantics/defaulting/table_test.go
@@ -370,7 +370,7 @@ func TestNew(t *testing.T) {
 	}
 
 	if err := la.Promote(pkgreconciler.UniversalBucket(), c.MaybeEnqueueBucketKey); err != nil {
-		t.Errorf("Promote() = %v", err)
+		t.Error("Promote() =", err)
 	}
 
 	// Queue has async moving parts so if we check at the wrong moment, this might still be 0.

--- a/webhook/resourcesemantics/defaulting/user_info_test.go
+++ b/webhook/resourcesemantics/defaulting/user_info_test.go
@@ -84,7 +84,7 @@ func TestSetUserInfoAnnotationsWhenWithinCreate(t *testing.T) {
 				t.Logf("Got :  %#v", r.Annotations)
 				t.Logf("Want: %#v", tc.expectedAnnotations)
 				if diff := cmp.Diff(tc.expectedAnnotations, r.Annotations, cmpopts.EquateEmpty()); diff != "" {
-					t.Logf("diff: %v", diff)
+					t.Log("diff:", diff)
 				}
 				t.Fatalf("Annotations don't match")
 			}

--- a/webhook/resourcesemantics/validation/reconcile_config_test.go
+++ b/webhook/resourcesemantics/validation/reconcile_config_test.go
@@ -371,7 +371,7 @@ func TestNew(t *testing.T) {
 	}
 
 	if err := la.Promote(pkgreconciler.UniversalBucket(), c.MaybeEnqueueBucketKey); err != nil {
-		t.Errorf("Promote() = %v", err)
+		t.Error("Promote() =", err)
 	}
 
 	// Queue has async moving parts so if we check at the wrong moment, thist might still be 0.

--- a/webhook/resourcesemantics/validation/validation_admit_test.go
+++ b/webhook/resourcesemantics/validation/validation_admit_test.go
@@ -205,7 +205,7 @@ func TestUnknownFieldFails(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to marshal resource: %v", err)
+		t.Fatal("Failed to marshal resource:", err)
 	}
 	req.Object.Raw = marshaled
 
@@ -410,7 +410,7 @@ func createDeleteResource(ctx context.Context, t *testing.T, old *Resource) *adm
 	}
 	marshaledOld, err := json.Marshal(old)
 	if err != nil {
-		t.Fatalf("Failed to marshal resource: %v", err)
+		t.Fatal("Failed to marshal resource:", err)
 	}
 	req.OldObject.Raw = marshaledOld
 	req.Resource.Group = "pkg.knative.dev"
@@ -430,7 +430,7 @@ func createCreateResource(ctx context.Context, t *testing.T, r *Resource) *admis
 	}
 	marshaled, err := json.Marshal(r)
 	if err != nil {
-		t.Fatalf("Failed to marshal resource: %v", err)
+		t.Fatal("Failed to marshal resource:", err)
 	}
 	req.Object.Raw = marshaled
 	req.Resource.Group = "pkg.knative.dev"
@@ -516,12 +516,12 @@ func createUpdateResource(ctx context.Context, t *testing.T, old, new *Resource)
 	}
 	marshaled, err := json.Marshal(new)
 	if err != nil {
-		t.Fatalf("Failed to marshal resource: %v", err)
+		t.Fatal("Failed to marshal resource:", err)
 	}
 	req.Object.Raw = marshaled
 	marshaledOld, err := json.Marshal(old)
 	if err != nil {
-		t.Fatalf("Failed to marshal resource: %v", err)
+		t.Fatal("Failed to marshal resource:", err)
 	}
 	req.OldObject.Raw = marshaledOld
 	req.Resource.Group = "pkg.knative.dev"
@@ -544,16 +544,16 @@ func createInnerDefaultResourceWithoutSpec(t *testing.T) []byte {
 	// generic map[string]interface{}, removing 'spec', and marshaling it again.
 	origBytes, err := json.Marshal(r)
 	if err != nil {
-		t.Fatalf("Error marshaling origBytes: %v", err)
+		t.Fatal("Error marshaling origBytes:", err)
 	}
 	var q map[string]interface{}
 	if err := json.Unmarshal(origBytes, &q); err != nil {
-		t.Fatalf("Error unmarshaling origBytes: %v", err)
+		t.Fatal("Error unmarshaling origBytes:", err)
 	}
 	delete(q, "spec")
 	b, err := json.Marshal(q)
 	if err != nil {
-		t.Fatalf("Error marshaling q: %v", err)
+		t.Fatal("Error marshaling q:", err)
 	}
 	return b
 }
@@ -579,7 +579,7 @@ func createInnerDefaultResourceWithSpecAndStatus(t *testing.T, spec *InnerDefaul
 
 	b, err := json.Marshal(r)
 	if err != nil {
-		t.Fatalf("Error marshaling bytes: %v", err)
+		t.Fatal("Error marshaling bytes:", err)
 	}
 	return b
 }
@@ -657,7 +657,7 @@ func NewTestResourceAdmissionController(t *testing.T) *reconciler {
 	}
 
 	if err := la.Promote(pkgreconciler.UniversalBucket(), c.MaybeEnqueueBucketKey); err != nil {
-		t.Errorf("Promote() = %v", err)
+		t.Error("Promote() =", err)
 	}
 
 	// Queue has async moving parts so if we check at the wrong moment, this might still be 0.

--- a/webhook/testing/factory.go
+++ b/webhook/testing/factory.go
@@ -129,23 +129,23 @@ func ToUnstructured(t *testing.T, sch *runtime.Scheme, objs []runtime.Object) (u
 		// Determine and set the TypeMeta for this object based on our test scheme.
 		gvks, _, err := sch.ObjectKinds(obj)
 		if err != nil {
-			t.Fatalf("Unable to determine kind for type: %v", err)
+			t.Fatal("Unable to determine kind for type:", err)
 		}
 		apiv, k := gvks[0].ToAPIVersionAndKind()
 		ta, err := meta.TypeAccessor(obj)
 		if err != nil {
-			t.Fatalf("Unable to create type accessor: %v", err)
+			t.Fatal("Unable to create type accessor:", err)
 		}
 		ta.SetAPIVersion(apiv)
 		ta.SetKind(k)
 
 		b, err := json.Marshal(obj)
 		if err != nil {
-			t.Fatalf("Unable to marshal: %v", err)
+			t.Fatal("Unable to marshal:", err)
 		}
 		u := &unstructured.Unstructured{}
 		if err := json.Unmarshal(b, u); err != nil {
-			t.Fatalf("Unable to unmarshal: %v", err)
+			t.Fatal("Unable to unmarshal:", err)
 		}
 		us = append(us, u)
 	}

--- a/webhook/testing/testing.go
+++ b/webhook/testing/testing.go
@@ -81,7 +81,7 @@ func ExpectPatches(t *testing.T, a []byte, e []jsonpatch.JsonPatchOperation) {
 
 	err := json.Unmarshal(a, &got)
 	if err != nil {
-		t.Errorf("Failed to unmarshal patches: %s", err)
+		t.Error("Failed to unmarshal patches:", err)
 		return
 	}
 
@@ -108,7 +108,7 @@ func ExpectPatches(t *testing.T, a []byte, e []jsonpatch.JsonPatchOperation) {
 	t.Logf("Got Patches:  %#v", got)
 	t.Logf("Want Patches: %#v", e)
 	if diff := cmp.Diff(e, got, cmpopts.EquateEmpty()); diff != "" {
-		t.Logf("diff Patches: %v", diff)
-		t.Errorf("ExpectPatches (-want, +got) = %s", diff)
+		t.Log("diff Patches:", diff)
+		t.Error("ExpectPatches (-want, +got) =", diff)
 	}
 }

--- a/webhook/webhook_integration_test.go
+++ b/webhook/webhook_integration_test.go
@@ -53,7 +53,7 @@ const testTimeout = 10 * time.Second
 func TestMissingContentType(t *testing.T) {
 	wh, serverURL, ctx, cancel, err := testSetup(t)
 	if err != nil {
-		t.Fatalf("testSetup() = %v", err)
+		t.Fatal("testSetup() =", err)
 	}
 
 	eg, _ := errgroup.WithContext(ctx)
@@ -62,23 +62,23 @@ func TestMissingContentType(t *testing.T) {
 	defer func() {
 		cancel()
 		if err := eg.Wait(); err != nil {
-			t.Errorf("Unable to run controller: %s", err)
+			t.Error("Unable to run controller:", err)
 		}
 	}()
 
 	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
 	if pollErr != nil {
-		t.Fatalf("waitForServerAvailable() = %v", err)
+		t.Fatal("waitForServerAvailable() =", err)
 	}
 
 	tlsClient, err := createSecureTLSClient(t, wh.Client, &wh.Options)
 	if err != nil {
-		t.Fatalf("createSecureTLSClient() = %v", err)
+		t.Fatal("createSecureTLSClient() =", err)
 	}
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s", serverURL), nil)
 	if err != nil {
-		t.Fatalf("http.NewRequest() = %v", err)
+		t.Fatal("http.NewRequest() =", err)
 	}
 
 	response, err := tlsClient.Do(req)
@@ -93,7 +93,7 @@ func TestMissingContentType(t *testing.T) {
 	defer response.Body.Close()
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		t.Fatalf("Failed to read response body %v", err)
+		t.Fatal("Failed to read response body", err)
 	}
 
 	if !strings.Contains(string(responseBody), "invalid Content-Type") {
@@ -107,7 +107,7 @@ func TestMissingContentType(t *testing.T) {
 func testEmptyRequestBody(t *testing.T, controller interface{}) {
 	wh, serverURL, ctx, cancel, err := testSetup(t, controller)
 	if err != nil {
-		t.Fatalf("testSetup() = %v", err)
+		t.Fatal("testSetup() =", err)
 	}
 
 	eg, _ := errgroup.WithContext(ctx)
@@ -116,30 +116,30 @@ func testEmptyRequestBody(t *testing.T, controller interface{}) {
 	defer func() {
 		cancel()
 		if err := eg.Wait(); err != nil {
-			t.Errorf("Unable to run controller: %s", err)
+			t.Error("Unable to run controller:", err)
 		}
 	}()
 
 	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
 	if pollErr != nil {
-		t.Fatalf("waitForServerAvailable() = %v", err)
+		t.Fatal("waitForServerAvailable() =", err)
 	}
 
 	tlsClient, err := createSecureTLSClient(t, wh.Client, &wh.Options)
 	if err != nil {
-		t.Fatalf("createSecureTLSClient() = %v", err)
+		t.Fatal("createSecureTLSClient() =", err)
 	}
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/bazinga", serverURL), nil)
 	if err != nil {
-		t.Fatalf("http.NewRequest() = %v", err)
+		t.Fatal("http.NewRequest() =", err)
 	}
 
 	req.Header.Add("Content-Type", "application/json")
 
 	response, err := tlsClient.Do(req)
 	if err != nil {
-		t.Fatalf("failed to get resp %v", err)
+		t.Fatal("failed to get resp", err)
 	}
 
 	if got, want := response.StatusCode, http.StatusBadRequest; got != want {
@@ -149,7 +149,7 @@ func testEmptyRequestBody(t *testing.T, controller interface{}) {
 
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		t.Fatalf("Failed to read response body %v", err)
+		t.Fatal("Failed to read response body", err)
 	}
 
 	if !strings.Contains(string(responseBody), "could not decode body") {
@@ -166,11 +166,11 @@ func TestSetupWebhookHTTPServerError(t *testing.T) {
 
 	nsErr := createNamespace(t, kubeClient, metav1.NamespaceSystem)
 	if nsErr != nil {
-		t.Fatalf("createNamespace() = %v", nsErr)
+		t.Fatal("createNamespace() =", nsErr)
 	}
 	cMapsErr := createTestConfigMap(t, kubeClient)
 	if cMapsErr != nil {
-		t.Fatalf("createTestConfigMap() = %v", cMapsErr)
+		t.Fatal("createTestConfigMap() =", cMapsErr)
 	}
 
 	stopCh := make(chan struct{})

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -55,7 +55,7 @@ func newNonRunningTestWebhook(t *testing.T, options Options, acs ...interface{})
 
 	stopCb, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
-		t.Fatalf("StartInformers() = %v", err)
+		t.Fatal("StartInformers() =", err)
 	}
 	cancel = func() {
 		ctxCancel()
@@ -64,7 +64,7 @@ func newNonRunningTestWebhook(t *testing.T, options Options, acs ...interface{})
 
 	ac, err = New(ctx, acs)
 	if err != nil {
-		t.Fatalf("Failed to create new admission controller: %v", err)
+		t.Fatal("Failed to create new admission controller:", err)
 	}
 	ac.gracePeriod = 100 * time.Millisecond
 	return
@@ -89,6 +89,6 @@ func TestRegistrationStopChanFire(t *testing.T) {
 	conn, err := net.Dial("tcp", fmt.Sprintf(":%d", opts.Port))
 	if err == nil {
 		conn.Close()
-		t.Errorf("Unexpected success to dial to port %d", opts.Port)
+		t.Error("Unexpected success to dial to port", opts.Port)
 	}
 }

--- a/websocket/connection_test.go
+++ b/websocket/connection_test.go
@@ -128,7 +128,7 @@ func TestRetriesWhileConnect(t *testing.T) {
 	}
 
 	if len(spy.closeCalls) != 1 {
-		t.Fatalf("Wanted 'Close' to be called once, but got %v", len(spy.closeCalls))
+		t.Fatal("Wanted 'Close' to be called once, but got", len(spy.closeCalls))
 	}
 }
 
@@ -241,7 +241,7 @@ func TestCloseClosesConnection(t *testing.T) {
 	conn.Shutdown()
 
 	if len(spy.closeCalls) != 1 {
-		t.Fatalf("Expected 'Close' to be called once, got %v", len(spy.closeCalls))
+		t.Fatal("Expected 'Close' to be called once, got", len(spy.closeCalls))
 	}
 }
 
@@ -252,7 +252,7 @@ func TestCloseIgnoresNoConnection(t *testing.T) {
 	got := conn.Shutdown()
 
 	if got != nil {
-		t.Fatalf("Expected no error, got %v", got)
+		t.Fatal("Expected no error, got", got)
 	}
 }
 
@@ -369,7 +369,7 @@ func TestDurableConnectionWhenConnectionBreaksDown(t *testing.T) {
 		})
 
 		if err != nil {
-			t.Errorf("Timed out trying to send a message: %v", err)
+			t.Error("Timed out trying to send a message:", err)
 		}
 
 		// Message successfully sent, instruct the server to drop the connection.
@@ -446,13 +446,13 @@ func TestNewDurableSendingConnectionGuaranteed(t *testing.T) {
 	target := "ws" + strings.TrimPrefix(s.URL, "http")
 	conn, err := NewDurableSendingConnectionGuaranteed(target, time.Second, logger)
 	if err != nil {
-		t.Errorf("Got error from NewDurableSendingConnectionGuaranteed: %v", err)
+		t.Error("Got error from NewDurableSendingConnectionGuaranteed:", err)
 	}
 	defer conn.Shutdown()
 
 	// Sending the message immediately should be fine as the connection has been established.
 	if err := conn.Send(testPayload); err != nil {
-		t.Errorf("Failed to send a message: %v", err)
+		t.Error("Failed to send a message:", err)
 	}
 
 	// Message successfully sent, instruct the server to drop the connection.


### PR DESCRIPTION
Running the script at test items first
The script is smart enough not to capture '\n%s' for proper diff printing even :-)

Note that `t.X()` methods always put a space between the output items, vs what `fmt` does (only if next param is not string) and zap (never).

/assign mattmoor