### PR TITLE
Fail louder when bad context given to injection

### DIFF
--- a/client/injection/apiextensions/client/client.go
+++ b/client/injection/apiextensions/client/client.go
@@ -42,8 +42,13 @@ func withClient(ctx context.Context, cfg *rest.Config) context.Context {
 func Get(ctx context.Context) clientset.Interface {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
-		logging.FromContext(ctx).Panic(
-			"Unable to fetch k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset.Interface from context.")
+		if injection.GetConfig(ctx) == nil {
+			logging.FromContext(ctx).Panic(
+				"Unable to fetch k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset.Interface from context. This context is not the application context (which is typically given to constructors via sharedmain).")
+		} else {
+			logging.FromContext(ctx).Panic(
+				"Unable to fetch k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset.Interface from context.")
+		}
 	}
 	return untyped.(clientset.Interface)
 }

--- a/client/injection/kube/client/client.go
+++ b/client/injection/kube/client/client.go
@@ -42,8 +42,13 @@ func withClient(ctx context.Context, cfg *rest.Config) context.Context {
 func Get(ctx context.Context) kubernetes.Interface {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
-		logging.FromContext(ctx).Panic(
-			"Unable to fetch k8s.io/client-go/kubernetes.Interface from context.")
+		if injection.GetConfig(ctx) == nil {
+			logging.FromContext(ctx).Panic(
+				"Unable to fetch k8s.io/client-go/kubernetes.Interface from context. This context is not the application context (which is typically given to constructors via sharedmain).")
+		} else {
+			logging.FromContext(ctx).Panic(
+				"Unable to fetch k8s.io/client-go/kubernetes.Interface from context.")
+		}
 	}
 	return untyped.(kubernetes.Interface)
 }

--- a/codegen/cmd/injection-gen/generators/client.go
+++ b/codegen/cmd/injection-gen/generators/client.go
@@ -98,8 +98,13 @@ func withClient(ctx {{.contextContext|raw}}, cfg *{{.restConfig|raw}}) context.C
 func Get(ctx {{.contextContext|raw}}) {{.clientSetInterface|raw}} {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
-		{{.loggingFromContext|raw}}(ctx).Panic(
-			"Unable to fetch {{.clientSetInterface}} from context.")
+		if injection.GetConfig(ctx) == nil {
+		    {{.loggingFromContext|raw}}(ctx).Panic(
+		    	    "Unable to fetch {{.clientSetInterface}} from context. This context is not the application context (which is typically given to constructors via sharedmain).")
+		} else {
+		    {{.loggingFromContext|raw}}(ctx).Panic(
+		    	    "Unable to fetch {{.clientSetInterface}} from context.")
+		}
 	}
 	return untyped.({{.clientSetInterface|raw}})
 }


### PR DESCRIPTION
This uses the presence of the config key to determine whether
this is an injection context, and if it is not, the panic
message includes a notice about injection context behavior.