### PR TITLE
Allow override QPS and Burst via flag

### DIFF
--- a/injection/config.go
+++ b/injection/config.go
@@ -50,25 +50,17 @@ func ParseAndGetRESTConfigOrDie() *rest.Config {
 		log.Fatal("Error building kubeconfig: ", err)
 	}
 
-	validBurstOrDie(*burst)
-	validQPSOrDie(*qps)
+	if *burst < 0 {
+		log.Fatal("Invalid burst value", *burst)
+	}
+	if *qps < 0 || *qps > math.MaxFloat32 {
+		log.Fatal("Invalid QPS value", *qps)
+	}
 
 	cfg.Burst = *burst
 	cfg.QPS = float32(*qps)
 
 	return cfg
-}
-
-func validBurstOrDie(burst int) {
-	if burst < 0 {
-		log.Fatal("Invalid burst value", burst)
-	}
-}
-
-func validQPSOrDie(qps float64) {
-	if qps < 0 || qps > math.MaxFloat32 {
-		log.Fatal("Invalid QPS value", qps)
-	}
 }
 
 // GetRESTConfig returns a rest.Config to be used for kubernetes client creation.


### PR DESCRIPTION
Fixes #1700 

Add `--kube-api-qps` and `--kube-api-burst` command-line flags 
to control client QPS and Burst respectively.

The default value is set to 0 to keep backward compatibility.