### PR TITLE
BucketList cleanup

### DIFF
--- a/hash/bucketer.go
+++ b/hash/bucketer.go
@@ -81,20 +81,13 @@ func (b *Bucket) Has(nn types.NamespacedName) bool {
 // ordered by bucket name.
 func (bs *BucketSet) Buckets() []reconciler.Bucket {
 	bkts := make([]reconciler.Bucket, len(bs.buckets))
-	for i, n := range bs.sortedBucketNames() {
+	for i, n := range bs.BucketList() {
 		bkts[i] = &Bucket{
 			name:    n,
 			buckets: bs,
 		}
 	}
 	return bkts
-}
-
-func (bs *BucketSet) sortedBucketNames() []string {
-	bs.mu.RLock()
-	defer bs.mu.RUnlock()
-
-	return bs.buckets.List()
 }
 
 // Owner returns the owner of the key.
@@ -116,12 +109,12 @@ func (bs *BucketSet) HasBucket(bkt string) bool {
 	return bs.buckets.Has(bkt)
 }
 
-// BucketList returns the bucket names of this BucketSet in random order.
+// BucketList returns the bucket names of this BucketSet in sorted order.
 func (bs *BucketSet) BucketList() []string {
 	bs.mu.RLock()
 	defer bs.mu.RUnlock()
 
-	return bs.buckets.UnsortedList()
+	return bs.buckets.List()
 }
 
 // Update updates the universe of buckets.

--- a/hash/bucketer_test.go
+++ b/hash/bucketer_test.go
@@ -18,7 +18,6 @@ package hash
 
 import (
 	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -69,7 +68,6 @@ func TestBucketSetList(t *testing.T) {
 	bs := NewBucketSet(buckets)
 
 	got := bs.BucketList()
-	sort.Strings(got)
 	if want := buckets.List(); !reflect.DeepEqual(got, want) {
 		t.Errorf("Name = %q, want: %q, diff(-want,+got):\n%s", got, want, cmp.Diff(want, got))
 	}

--- a/leaderelection/context_test.go
+++ b/leaderelection/context_test.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sort"
 	"testing"
 	"time"
 
@@ -252,7 +251,6 @@ func TestNewStatefulSetBucketAndSet(t *testing.T) {
 	}
 
 	gotNames := bs.BucketList()
-	sort.Strings(gotNames)
 	if !cmp.Equal(gotNames, wantNames) {
 		t.Errorf("BucketSet.BucketList() = %q, want: %q", gotNames, wantNames)
 	}


### PR DESCRIPTION
The `BucketList` func is only used in tests. No need to return a random order. Make the return sorted to simplify tests.

/assign @vagababov 