### PR TITLE
Drop the usage of knative.dev/pkg/test in the helpers package

### DIFF
--- a/test/helpers/name.go
+++ b/test/helpers/name.go
@@ -23,7 +23,6 @@ import (
 	"unicode"
 
 	"knative.dev/pkg/kmeta"
-	"knative.dev/pkg/test"
 )
 
 const (
@@ -41,13 +40,17 @@ func init() {
 	rand.Seed(seed)
 }
 
+type named interface {
+	Name() string
+}
+
 // ObjectPrefixForTest returns the name prefix for this test's random names.
-func ObjectPrefixForTest(t test.T) string {
+func ObjectPrefixForTest(t named) string {
 	return MakeK8sNamePrefix(strings.TrimPrefix(t.Name(), testNamePrefix))
 }
 
 // ObjectNameForTest generates a random object name based on the test name.
-func ObjectNameForTest(t test.T) string {
+func ObjectNameForTest(t named) string {
 	return kmeta.ChildName(ObjectPrefixForTest(t), string(sep)+RandomString())
 }
 


### PR DESCRIPTION
This has the side effects of pulling in a bunch of global variables