### PR TITLE
Use default no-op logger for maxprocs

### DIFF
--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -52,7 +52,7 @@ import (
 )
 
 func init() {
-	maxprocs.Set(maxprocs.Logger(func(string, ...interface{}) {}))
+	maxprocs.Set()
 }
 
 // GetConfig returns a rest.Config to be used for kubernetes client creation.


### PR DESCRIPTION
maxprocs.Set already [uses a no-op logger by default](https://github.com/uber-go/automaxprocs/blob/master/maxprocs/maxprocs.go#L56-L57), so no need to explicitly pass one. (The non-noop printer is [in the top-level automaxprocs package](https://github.com/uber-go/automaxprocs/blob/master/automaxprocs.go#L32), which we no longer import).

/assign @vagababov 