### PR TITLE
Add EnableProbeReqLogKey constant

### DIFF
--- a/metrics/config_observability.go
+++ b/metrics/config_observability.go
@@ -42,6 +42,9 @@ const (
 
 	// EnableReqLogKey is the CM key to enable request log.
 	EnableReqLogKey = "logging.enable-request-log"
+
+	// EnableProbeReqLogKey is the CM key to enable request logs for probe requests.
+	EnableProbeReqLogKey = "logging.enable-probe-request-log"
 )
 
 // ObservabilityConfig contains the configuration defined in the observability ConfigMap.
@@ -94,7 +97,7 @@ func NewObservabilityConfigFromConfigMap(configMap *corev1.ConfigMap) (*Observab
 		cm.AsString("logging.revision-url-template", &oc.LoggingURLTemplate),
 		cm.AsString(ReqLogTemplateKey, &oc.RequestLogTemplate),
 		cm.AsBool(EnableReqLogKey, &oc.EnableRequestLog),
-		cm.AsBool("logging.enable-probe-request-log", &oc.EnableProbeRequestLog),
+		cm.AsBool(EnableProbeReqLogKey, &oc.EnableProbeRequestLog),
 		cm.AsString("metrics.request-metrics-backend-destination", &oc.RequestMetricsBackend),
 		cm.AsBool("profiling.enable", &oc.EnableProfiling),
 		cm.AsString("metrics.opencensus-address", &oc.MetricsCollectorAddress),

--- a/metrics/config_observability_test.go
+++ b/metrics/config_observability_test.go
@@ -44,7 +44,7 @@ func TestObservabilityConfiguration(t *testing.T) {
 			RequestMetricsBackend:  "stackdriver",
 		},
 		data: map[string]string{
-			"logging.enable-probe-request-log":            "true",
+			EnableProbeReqLogKey:                          "true",
 			"logging.enable-var-log-collection":           "true",
 			ReqLogTemplateKey:                             `{"requestMethod": "{{.Request.Method}}"}`,
 			"logging.revision-url-template":               "https://logging.io",
@@ -64,7 +64,7 @@ func TestObservabilityConfiguration(t *testing.T) {
 	}, {
 		name: "observability configuration with request log set and template default",
 		data: map[string]string{
-			"logging.enable-probe-request-log":            "true",
+			EnableProbeReqLogKey:                          "true",
 			EnableReqLogKey:                               "true",
 			"logging.enable-var-log-collection":           "true",
 			"logging.revision-url-template":               "https://logging.io",
@@ -90,7 +90,7 @@ func TestObservabilityConfiguration(t *testing.T) {
 			RequestMetricsBackend:  "stackdriver",
 		},
 		data: map[string]string{
-			"logging.enable-probe-request-log":            "true",
+			EnableProbeReqLogKey:                          "true",
 			EnableReqLogKey:                               "false",
 			"logging.enable-var-log-collection":           "true",
 			ReqLogTemplateKey:                             "",
@@ -102,7 +102,7 @@ func TestObservabilityConfiguration(t *testing.T) {
 		name:    "observability configuration with request log set and template not set",
 		wantErr: true,
 		data: map[string]string{
-			"logging.enable-probe-request-log":            "true",
+			EnableProbeReqLogKey:                          "true",
 			EnableReqLogKey:                               "true",
 			"logging.enable-var-log-collection":           "true",
 			ReqLogTemplateKey:                             "",
@@ -121,7 +121,7 @@ func TestObservabilityConfiguration(t *testing.T) {
 			RequestMetricsBackend:  "stackdriver",
 		},
 		data: map[string]string{
-			"logging.enable-probe-request-log":            "true",
+			EnableProbeReqLogKey:                          "true",
 			"logging.enable-var-log-collection":           "true",
 			ReqLogTemplateKey:                             `{"requestMethod": "{{.Request.Method}}"}`,
 			"logging.revision-url-template":               "https://logging.io",


### PR DESCRIPTION
For consistency with existing `EnableReqLogKey` constant, and because otherwise the [dots don't line up when these two keys are used together outside the package, which makes the pedant in me sad](https://github.com/knative/serving/blob/3b649a8bb37ec82d54089c46774529af55acd886/test/e2e/logging_test.go#L57-L58) 😅.

/assign @markusthoemmes 