### PR TITLE
use k8s.interface

### DIFF
--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -253,7 +253,7 @@ func flush(logger *zap.SugaredLogger) {
 
 // ParseAndGetConfigOrDie parses the rest config flags and creates a client or
 // dies by calling log.Fatalf.
-// Deprecated: use injeciton.ParseAndGetRESTConfigOrDie
+// Deprecated: use injection.ParseAndGetRESTConfigOrDie
 func ParseAndGetConfigOrDie() *rest.Config {
 	return injection.ParseAndGetRESTConfigOrDie()
 }

--- a/metrics/stackdriver_exporter.go
+++ b/metrics/stackdriver_exporter.go
@@ -69,7 +69,7 @@ var (
 	newStackdriverExporterFunc func(sd.Options) (view.Exporter, error)
 
 	// kubeclient is the in-cluster Kubernetes kubeclient, which is lazy-initialized on first use.
-	kubeclient *kubernetes.Clientset
+	kubeclient kubernetes.Interface
 	// initClientOnce is the lazy initializer for kubeclient.
 	initClientOnce sync.Once
 	// kubeclientInitErr capture an error during initClientOnce

--- a/test/clients.go
+++ b/test/clients.go
@@ -35,13 +35,13 @@ import (
 
 // KubeClient holds instances of interfaces for making requests to kubernetes client.
 type KubeClient struct {
-	Kube kubernetes.Interface
+	kubernetes.Interface
 }
 
 // NewSpoofingClient returns a spoofing client to make requests
 func NewSpoofingClient(ctx context.Context, client *KubeClient, logf logging.FormatLogger,
 	domain string, resolvable bool, opts ...spoof.TransportOption) (*spoof.SpoofingClient, error) {
-	return spoof.New(ctx, client.Kube, logf, domain, resolvable, Flags.IngressEndpoint,
+	return spoof.New(ctx, client, logf, domain, resolvable, Flags.IngressEndpoint,
 		Flags.SpoofRequestInterval, Flags.SpoofRequestTimeout, opts...)
 }
 
@@ -57,7 +57,7 @@ func NewKubeClient(configPath string, clusterName string) (*KubeClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &KubeClient{Kube: k}, nil
+	return &KubeClient{Interface: k}, nil
 }
 
 // BuildClientConfig builds the client config specified by the config path and the cluster name
@@ -73,8 +73,14 @@ func BuildClientConfig(kubeConfigPath string, clusterName string) (*rest.Config,
 }
 
 // UpdateConfigMap updates the config map for specified @name with values
+// Deprecated: use UpdateConfigMap
 func (client *KubeClient) UpdateConfigMap(ctx context.Context, name string, configName string, values map[string]string) error {
-	configMap, err := client.GetConfigMap(name).Get(ctx, configName, metav1.GetOptions{})
+	return UpdateConfigMap(ctx, client, name, configName, values)
+}
+
+// UpdateConfigMap updates the config map for specified @name with values
+func UpdateConfigMap(ctx context.Context, client kubernetes.Interface, name string, configName string, values map[string]string) error {
+	configMap, err := client.CoreV1().ConfigMaps(name).Get(ctx, configName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -83,24 +89,37 @@ func (client *KubeClient) UpdateConfigMap(ctx context.Context, name string, conf
 		configMap.Data[key] = value
 	}
 
-	_, err = client.GetConfigMap(name).Update(ctx, configMap, metav1.UpdateOptions{})
+	_, err = client.CoreV1().ConfigMaps(name).Update(ctx, configMap, metav1.UpdateOptions{})
 	return err
 }
 
 // GetConfigMap gets the knative serving config map.
+// Deprecated: use kubeclient.CoreV1().ConfigMaps(name)
 func (client *KubeClient) GetConfigMap(name string) k8styped.ConfigMapInterface {
-	return client.Kube.CoreV1().ConfigMaps(name)
+	return client.CoreV1().ConfigMaps(name)
 }
 
 // CreatePod will create a Pod
+// Deprecated: use CreatePod
 func (client *KubeClient) CreatePod(ctx context.Context, pod *corev1.Pod) (*corev1.Pod, error) {
-	pods := client.Kube.CoreV1().Pods(pod.GetNamespace())
+	return CreatePod(ctx, client, pod)
+}
+
+// CreatePod will create a Pod
+func CreatePod(ctx context.Context, client kubernetes.Interface, pod *corev1.Pod) (*corev1.Pod, error) {
+	pods := client.CoreV1().Pods(pod.GetNamespace())
 	return pods.Create(ctx, pod, metav1.CreateOptions{})
 }
 
 // PodLogs returns Pod logs for given Pod and Container in the namespace
+// Deprecated: use PodLogs
 func (client *KubeClient) PodLogs(ctx context.Context, podName, containerName, namespace string) ([]byte, error) {
-	pods := client.Kube.CoreV1().Pods(namespace)
+	return PodLogs(ctx, client, podName, containerName, namespace)
+}
+
+// PodLogs returns Pod logs for given Pod and Container in the namespace
+func PodLogs(ctx context.Context, client kubernetes.Interface, podName, containerName, namespace string) ([]byte, error) {
+	pods := client.CoreV1().Pods(namespace)
 	podList, err := pods.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err

--- a/test/clients.go
+++ b/test/clients.go
@@ -34,6 +34,7 @@ import (
 )
 
 // KubeClient holds instances of interfaces for making requests to kubernetes client.
+// Deprecated: use a kubeclient and the helper methods in test.
 type KubeClient struct {
 	kubernetes.Interface
 }
@@ -47,6 +48,7 @@ func NewSpoofingClient(ctx context.Context, client *KubeClient, logf logging.For
 
 // NewKubeClient instantiates and returns several clientsets required for making request to the
 // kube client specified by the combination of clusterName and configPath. Clients can make requests within namespace.
+// Deprecated: use a kubeclient and the helper methods in test.
 func NewKubeClient(configPath string, clusterName string) (*KubeClient, error) {
 	cfg, err := BuildClientConfig(configPath, clusterName)
 	if err != nil {

--- a/test/clients.go
+++ b/test/clients.go
@@ -35,7 +35,7 @@ import (
 
 // KubeClient holds instances of interfaces for making requests to kubernetes client.
 type KubeClient struct {
-	Kube *kubernetes.Clientset
+	Kube kubernetes.Interface
 }
 
 // NewSpoofingClient returns a spoofing client to make requests

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -51,7 +51,7 @@ func extractDeployment(pod string) string {
 // GetLeaders collects all of the leader pods from the specified deployment.
 // GetLeaders will return duplicate pods by design.
 func GetLeaders(ctx context.Context, t *testing.T, client *test.KubeClient, deploymentName, namespace string) ([]string, error) {
-	leases, err := client.Kube.CoordinationV1().Leases(namespace).List(ctx, metav1.ListOptions{})
+	leases, err := client.CoordinationV1().Leases(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error getting leases for deployment %q: %w", deploymentName, err)
 	}
@@ -104,7 +104,7 @@ func WaitForNewLeader(ctx context.Context, client *test.KubeClient, lease, names
 	defer span.End()
 	var leader string
 	err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
-		lease, err := client.Kube.CoordinationV1().Leases(namespace).Get(ctx, lease, metav1.GetOptions{})
+		lease, err := client.CoordinationV1().Leases(namespace).Get(ctx, lease, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("error getting lease %s: %w", lease, err)
 		}

--- a/test/ingress/ingress.go
+++ b/test/ingress/ingress.go
@@ -38,7 +38,7 @@ const (
 //    should connect.  This is used when the resolution to address goes through some
 //    sort of port-mapping, e.g. Kubernetes node ports.
 // err - an error when address/portMap cannot be established.
-func GetIngressEndpoint(ctx context.Context, kubeClientset *kubernetes.Clientset, endpointOverride string) (address string, portMap func(string) string, err error) {
+func GetIngressEndpoint(ctx context.Context, kubeClientset kubernetes.Interface, endpointOverride string) (address string, portMap func(string) string, err error) {
 	ingressName := istioIngressName
 	if gatewayOverride := os.Getenv("GATEWAY_OVERRIDE"); gatewayOverride != "" {
 		ingressName = gatewayOverride

--- a/test/kube_checks.go
+++ b/test/kube_checks.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -45,8 +47,8 @@ const (
 // from client every interval until inState returns `true` indicating it
 // is done, returns an error or timeout. desc will be used to name the metric
 // that is emitted to track how long it took for name to get into the state checked by inState.
-func WaitForDeploymentState(ctx context.Context, client *KubeClient, name string, inState func(d *appsv1.Deployment) (bool, error), desc string, namespace string, timeout time.Duration) error {
-	d := client.Kube.AppsV1().Deployments(namespace)
+func WaitForDeploymentState(ctx context.Context, client kubernetes.Interface, name string, inState func(d *appsv1.Deployment) (bool, error), desc string, namespace string, timeout time.Duration) error {
+	d := client.AppsV1().Deployments(namespace)
 	span := logging.GetEmitableSpan(ctx, fmt.Sprintf("WaitForDeploymentState/%s/%s", name, desc))
 	defer span.End()
 
@@ -63,8 +65,8 @@ func WaitForDeploymentState(ctx context.Context, client *KubeClient, name string
 // from client every interval until inState returns `true` indicating it
 // is done, returns an error or timeout. desc will be used to name the metric
 // that is emitted to track how long it took to get into the state checked by inState.
-func WaitForPodListState(ctx context.Context, client *KubeClient, inState func(p *corev1.PodList) (bool, error), desc string, namespace string) error {
-	p := client.Kube.CoreV1().Pods(namespace)
+func WaitForPodListState(ctx context.Context, client kubernetes.Interface, inState func(p *corev1.PodList) (bool, error), desc string, namespace string) error {
+	p := client.CoreV1().Pods(namespace)
 	span := logging.GetEmitableSpan(ctx, "WaitForPodListState/"+desc)
 	defer span.End()
 
@@ -81,8 +83,8 @@ func WaitForPodListState(ctx context.Context, client *KubeClient, inState func(p
 // from client every interval until inState returns `true` indicating it
 // is done, returns an error or timeout. desc will be used to name the metric
 // that is emitted to track how long it took to get into the state checked by inState.
-func WaitForPodState(ctx context.Context, client *KubeClient, inState func(p *corev1.Pod) (bool, error), name string, namespace string) error {
-	p := client.Kube.CoreV1().Pods(namespace)
+func WaitForPodState(ctx context.Context, client kubernetes.Interface, inState func(p *corev1.Pod) (bool, error), name string, namespace string) error {
+	p := client.CoreV1().Pods(namespace)
 	span := logging.GetEmitableSpan(ctx, "WaitForPodState/"+name)
 	defer span.End()
 
@@ -96,7 +98,7 @@ func WaitForPodState(ctx context.Context, client *KubeClient, inState func(p *co
 }
 
 // WaitForPodDeleted waits for the given pod to disappear from the given namespace.
-func WaitForPodDeleted(ctx context.Context, client *KubeClient, name, namespace string) error {
+func WaitForPodDeleted(ctx context.Context, client kubernetes.Interface, name, namespace string) error {
 	if err := WaitForPodState(ctx, client, func(p *corev1.Pod) (bool, error) {
 		// Always return false. We're oly interested in the error which indicates pod deletion or timeout.
 		return false, nil
@@ -110,8 +112,8 @@ func WaitForPodDeleted(ctx context.Context, client *KubeClient, name, namespace 
 
 // WaitForServiceHasAtLeastOneEndpoint polls the status of the specified Service
 // from client every interval until number of service endpoints = numOfEndpoints
-func WaitForServiceEndpoints(ctx context.Context, client *KubeClient, svcName string, svcNamespace string, numOfEndpoints int) error {
-	endpointsService := client.Kube.CoreV1().Endpoints(svcNamespace)
+func WaitForServiceEndpoints(ctx context.Context, client kubernetes.Interface, svcName string, svcNamespace string, numOfEndpoints int) error {
+	endpointsService := client.CoreV1().Endpoints(svcNamespace)
 	span := logging.GetEmitableSpan(ctx, "WaitForServiceHasAtLeastOneEndpoint/"+svcName)
 	defer span.End()
 
@@ -137,8 +139,8 @@ func countEndpointsNum(e *corev1.Endpoints) int {
 }
 
 // GetEndpointAddresses returns addresses of endpoints for the given service.
-func GetEndpointAddresses(ctx context.Context, client *KubeClient, svcName, svcNamespace string) ([]string, error) {
-	endpoints, err := client.Kube.CoreV1().Endpoints(svcNamespace).Get(ctx, svcName, metav1.GetOptions{})
+func GetEndpointAddresses(ctx context.Context, client kubernetes.Interface, svcName, svcNamespace string) ([]string, error) {
+	endpoints, err := client.CoreV1().Endpoints(svcNamespace).Get(ctx, svcName, metav1.GetOptions{})
 	if err != nil || countEndpointsNum(endpoints) == 0 {
 		return nil, fmt.Errorf("no endpoints or error: %w", err)
 	}
@@ -152,7 +154,7 @@ func GetEndpointAddresses(ctx context.Context, client *KubeClient, svcName, svcN
 }
 
 // WaitForChangedEndpoints waits until the endpoints for the given service differ from origEndpoints.
-func WaitForChangedEndpoints(ctx context.Context, client *KubeClient, svcName, svcNamespace string, origEndpoints []string) error {
+func WaitForChangedEndpoints(ctx context.Context, client kubernetes.Interface, svcName, svcNamespace string, origEndpoints []string) error {
 	return wait.PollImmediate(1*time.Second, 2*time.Minute, func() (bool, error) {
 		newEndpoints, err := GetEndpointAddresses(ctx, client, svcName, svcNamespace)
 		return !cmp.Equal(origEndpoints, newEndpoints), err
@@ -184,13 +186,13 @@ func WaitForLogContent(ctx context.Context, client *KubeClient, podName, contain
 }
 
 // WaitForAllPodsRunning waits for all the pods to be in running state
-func WaitForAllPodsRunning(ctx context.Context, client *KubeClient, namespace string) error {
+func WaitForAllPodsRunning(ctx context.Context, client kubernetes.Interface, namespace string) error {
 	return WaitForPodListState(ctx, client, podsRunning, "PodsAreRunning", namespace)
 }
 
 // WaitForPodRunning waits for the given pod to be in running state
-func WaitForPodRunning(ctx context.Context, client *KubeClient, name string, namespace string) error {
-	p := client.Kube.CoreV1().Pods(namespace)
+func WaitForPodRunning(ctx context.Context, client kubernetes.Interface, name string, namespace string) error {
+	p := client.CoreV1().Pods(namespace)
 	return wait.PollImmediate(interval, podTimeout, func() (bool, error) {
 		p, err := p.Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
@@ -217,7 +219,7 @@ func podRunning(pod *corev1.Pod) bool {
 }
 
 // WaitForDeploymentScale waits until the given deployment has the expected scale.
-func WaitForDeploymentScale(ctx context.Context, client *KubeClient, name, namespace string, scale int) error {
+func WaitForDeploymentScale(ctx context.Context, client kubernetes.Interface, name, namespace string, scale int) error {
 	return WaitForDeploymentState(
 		ctx,
 		client,

--- a/test/kube_checks.go
+++ b/test/kube_checks.go
@@ -162,8 +162,8 @@ func WaitForChangedEndpoints(ctx context.Context, client kubernetes.Interface, s
 }
 
 // GetConfigMap gets the configmaps for a given namespace
-func GetConfigMap(client *KubeClient, namespace string) k8styped.ConfigMapInterface {
-	return client.Kube.CoreV1().ConfigMaps(namespace)
+func GetConfigMap(client kubernetes.Interface, namespace string) k8styped.ConfigMapInterface {
+	return client.CoreV1().ConfigMaps(namespace)
 }
 
 // DeploymentScaledToZeroFunc returns a func that evaluates if a deployment has scaled to 0 pods

--- a/test/logstream/interface.go
+++ b/test/logstream/interface.go
@@ -44,7 +44,7 @@ func Start(t test.TLegacy) Canceler {
 				return
 			}
 
-			stream = &shim{logstreamv2.FromNamespace(context.TODO(), kc.Kube, ns)}
+			stream = &shim{logstreamv2.FromNamespace(context.TODO(), kc, ns)}
 
 		} else {
 			// Otherwise set up a null stream.

--- a/test/monitoring/doc.go
+++ b/test/monitoring/doc.go
@@ -21,7 +21,7 @@ This package exposes following methods:
 
 	CheckPortAvailability(port int) error
 		Checks if the given port is available
-	GetPods(kubeClientset *kubernetes.Clientset, app string) (*v1.PodList, error)
+	GetPods(kubeClientset kubernetes.Interface, app string) (*v1.PodList, error)
 		Gets the list of pods that satisfy the lable selector app=<app>
 	Cleanup(pid int) error
 		Kill the current port forwarding process running in the background

--- a/test/monitoring/monitoring.go
+++ b/test/monitoring/monitoring.go
@@ -43,7 +43,7 @@ func CheckPortAvailability(port int) error {
 
 // GetPods retrieves the current existing podlist for the app in monitoring namespace
 // This uses app=<app> as labelselector for selecting pods
-func GetPods(ctx context.Context, kubeClientset *kubernetes.Clientset, app, namespace string) (*v1.PodList, error) {
+func GetPods(ctx context.Context, kubeClientset kubernetes.Interface, app, namespace string) (*v1.PodList, error) {
 	pods, err := kubeClientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=" + app})
 	if err == nil && len(pods.Items) == 0 {
 		err = fmt.Errorf("pod %s not found on the cluster. Ensure monitoring is switched on for your Knative Setup", app)

--- a/test/prometheus/prometheus.go
+++ b/test/prometheus/prometheus.go
@@ -51,7 +51,7 @@ type PromProxy struct {
 }
 
 // Setup performs a port forwarding for app prometheus-test in given namespace
-func (p *PromProxy) Setup(ctx context.Context, kubeClientset *kubernetes.Clientset, logf logging.FormatLogger) {
+func (p *PromProxy) Setup(ctx context.Context, kubeClientset kubernetes.Interface, logf logging.FormatLogger) {
 	setupOnce.Do(func() {
 		if err := monitoring.CheckPortAvailability(prometheusPort); err != nil {
 			logf("Prometheus port not available: %v", err)

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -86,7 +86,7 @@ type TransportOption func(transport *http.Transport) *http.Transport
 // If that's a problem, see test/request.go#WaitForEndpointState for oneshot spoofing.
 func New(
 	ctx context.Context,
-	kubeClientset *kubernetes.Clientset,
+	kubeClientset kubernetes.Interface,
 	logf logging.FormatLogger,
 	domain string,
 	resolvable bool,
@@ -133,7 +133,7 @@ func New(
 
 // ResolveEndpoint resolves the endpoint address considering whether the domain is resolvable and taking into
 // account whether the user overrode the endpoint address externally
-func ResolveEndpoint(ctx context.Context, kubeClientset *kubernetes.Clientset, domain string, resolvable bool, endpointOverride string) (string, func(string) string, error) {
+func ResolveEndpoint(ctx context.Context, kubeClientset kubernetes.Interface, domain string, resolvable bool, endpointOverride string) (string, func(string) string, error) {
 	id := func(in string) string { return in }
 	// If the domain is resolvable, it can be used directly
 	if resolvable {

--- a/test/zipkin/doc.go
+++ b/test/zipkin/doc.go
@@ -21,7 +21,7 @@ i.e HTTP request that have HTTP status between 500 to 600.
 
 This package exposes following methods:
 
-	SetupZipkinTracing(*kubernetes.Clientset) error
+	SetupZipkinTracing(kubernetes.Interface) error
 		SetupZipkinTracing sets up zipkin tracing by setting up port-forwarding from
 		localhost to zipkin pod on the cluster. On successful setup this method sets
 		an internal flag zipkinTracingEnabled to true.
@@ -33,7 +33,7 @@ This package exposes following methods:
 
 A general flow for a Test Suite to use Zipkin Tracing support is as follows:
 
-		1. Call SetupZipkinTracing(*kubernetes.Clientset) in TestMain.
+		1. Call SetupZipkinTracing(kubernetes.Interface) in TestMain.
 		2. Use SpoofingClient to make HTTP requests.
 		3. Call CleanupZipkinTracingSetup on cleanup after tests are executed.
 

--- a/test/zipkin/util.go
+++ b/test/zipkin/util.go
@@ -72,7 +72,7 @@ var (
 
 // SetupZipkinTracingFromConfigTracing setups zipkin tracing like SetupZipkinTracing but retrieving the zipkin configuration
 // from config-tracing config map
-func SetupZipkinTracingFromConfigTracing(ctx context.Context, kubeClientset *kubernetes.Clientset, logf logging.FormatLogger, configMapNamespace string) error {
+func SetupZipkinTracingFromConfigTracing(ctx context.Context, kubeClientset kubernetes.Interface, logf logging.FormatLogger, configMapNamespace string) error {
 	cm, err := kubeClientset.CoreV1().ConfigMaps(configMapNamespace).Get(ctx, "config-tracing", metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error while retrieving config-tracing config map: %w", err)
@@ -103,7 +103,7 @@ func SetupZipkinTracingFromConfigTracing(ctx context.Context, kubeClientset *kub
 }
 
 // SetupZipkinTracingFromConfigTracingOrFail is same as SetupZipkinTracingFromConfigTracing, but fails the test if an error happens
-func SetupZipkinTracingFromConfigTracingOrFail(ctx context.Context, t testing.TB, kubeClientset *kubernetes.Clientset, configMapNamespace string) {
+func SetupZipkinTracingFromConfigTracingOrFail(ctx context.Context, t testing.TB, kubeClientset kubernetes.Interface, configMapNamespace string) {
 	if err := SetupZipkinTracingFromConfigTracing(ctx, kubeClientset, t.Logf, configMapNamespace); err != nil {
 		t.Fatal("Error while setup Zipkin tracing:", err)
 	}
@@ -114,7 +114,7 @@ func SetupZipkinTracingFromConfigTracingOrFail(ctx context.Context, t testing.TB
 //    (pid of the process doing Port-Forward is stored in a global variable).
 // 2. Enable AlwaysSample config for tracing for the SpoofingClient.
 // The zipkin deployment must have the label app=zipkin
-func SetupZipkinTracing(ctx context.Context, kubeClientset *kubernetes.Clientset, logf logging.FormatLogger, zipkinRemotePort int, zipkinNamespace string) (err error) {
+func SetupZipkinTracing(ctx context.Context, kubeClientset kubernetes.Interface, logf logging.FormatLogger, zipkinRemotePort int, zipkinNamespace string) (err error) {
 	setupOnce.Do(func() {
 		if e := monitoring.CheckPortAvailability(zipkinRemotePort); e != nil {
 			err = fmt.Errorf("zipkin port not available on the machine: %w", err)
@@ -143,7 +143,7 @@ func SetupZipkinTracing(ctx context.Context, kubeClientset *kubernetes.Clientset
 }
 
 // SetupZipkinTracingOrFail is same as SetupZipkinTracing, but fails the test if an error happens
-func SetupZipkinTracingOrFail(ctx context.Context, t testing.TB, kubeClientset *kubernetes.Clientset, zipkinRemotePort int, zipkinNamespace string) {
+func SetupZipkinTracingOrFail(ctx context.Context, t testing.TB, kubeClientset kubernetes.Interface, zipkinRemotePort int, zipkinNamespace string) {
 	if err := SetupZipkinTracing(ctx, kubeClientset, t.Logf, zipkinRemotePort, zipkinNamespace); err != nil {
 		t.Fatal("Error while setup zipkin tracing:", err)
 	}


### PR DESCRIPTION
Use  `kubernetes.Interface` over `*kubernetes.Clientset` and `*test.Client`.

The change to the helpers is a breaking change, but simple to fix downstream.