### PR TITLE
Add suggested fix when checksums dont match

### DIFF
--- a/configmap/testing/configmap.go
+++ b/configmap/testing/configmap.go
@@ -88,7 +88,7 @@ func ConfigMapsFromTestFile(t *testing.T, name string, allowed ...string) (*core
 	if hasExampleBody && hasExampleChecksumAnnotation {
 		wantChecksum := configmap.Checksum(exampleBody)
 		if gotChecksum != wantChecksum {
-			t.Errorf("example checksum annotation = %s, want %s", gotChecksum, wantChecksum)
+			t.Errorf("example checksum annotation = %s, want %s (you may need to re-run ./hack/update-codegen.sh)", gotChecksum, wantChecksum)
 		}
 	}
 


### PR DESCRIPTION
This confused someone in https://github.com/knative/serving/pull/9778#issuecomment-709285563, and I can't think of any obvious downside to including a suggested fix since the person hitting this may often not know why.

/assign @markusthoemmes 