### PR TITLE
Wait for prometheus server to start serving before fetching metrics

### DIFF
--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -38,6 +38,7 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	emptypb "github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/go-cmp/cmp"
@@ -362,7 +363,14 @@ func TestMetricsExport(t *testing.T) {
 	}{{
 		name: "Prometheus",
 		init: func() error {
-			return UpdateExporter(context.Background(), configForBackend(prometheus), logtesting.TestLogger(t))
+			if err := UpdateExporter(context.Background(), configForBackend(prometheus), logtesting.TestLogger(t)); err != nil {
+				return err
+			}
+			// Wait for the webserver to actually start serving metrics
+			return wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (bool, error) {
+				resp, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", prometheusPort))
+				return err == nil && resp.StatusCode == http.StatusOK, nil
+			})
 		},
 		validate: func(t *testing.T) {
 			metricstest.EnsureRecorded()


### PR DESCRIPTION
This should avoid failures like in https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_pkg/1818/pull-knative-pkg-unit-tests/1318114477454921728, where the test failed because of:

```
    resource_view_test.go:371: failed to fetch prometheus metrics: Get "http://localhost:19090/metrics": dial tcp 127.0.0.1:19090: connect: connection refused
```

/assign @julz @vagababov 