### PR TITLE
Various stuff around the logstream

### DIFF
--- a/test/logstream/v2/stream_test.go
+++ b/test/logstream/v2/stream_test.go
@@ -17,17 +17,19 @@ limitations under the License.
 package logstream_test
 
 import (
-	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -39,75 +41,149 @@ import (
 
 var pod = &corev1.Pod{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      "chaosduck",
+		Name:      logstream.ChaosDuck,
 		Namespace: "default",
 	},
 	Spec: corev1.PodSpec{
-		Containers: []corev1.Container{
-			{Name: "chaosduck"},
-		},
+		Containers: []corev1.Container{{
+			Name: logstream.ChaosDuck,
+		}},
 	},
 }
 
 var readyStatus = corev1.PodStatus{
 	Phase: corev1.PodRunning,
-	Conditions: []corev1.PodCondition{
-		{Type: corev1.PodReady, Status: corev1.ConditionTrue},
-	},
+	Conditions: []corev1.PodCondition{{
+		Type:   corev1.PodReady,
+		Status: corev1.ConditionTrue,
+	}},
+}
+
+func TestStreamErr(t *testing.T) {
+	f := newK8sFake(fake.NewSimpleClientset(), errors.New("lookin' good!"))
+	stream := logstream.FromNamespace(context.Background(), f, "a-namespace")
+	_, err := stream.StartStream(pod.Name, nil)
+	if err == nil {
+		t.Fatal("LogStream creation should have failed")
+	}
 }
 
 func TestNamespaceStream(t *testing.T) {
-	f := newK8sFake(fake.NewSimpleClientset())
+	f := newK8sFake(fake.NewSimpleClientset(), nil)
 
-	// We populate this buffer first to avoid races and the need to synchronize
-	if _, err := f.logBuffer.WriteString("test\n"); err != nil {
-		t.Fatal("WriteString()=", err)
-	}
-
-	logFuncInvoked := make(chan string)
+	logFuncInvoked := make(chan struct{}, 2)
+	t.Cleanup(func() { close(logFuncInvoked) })
 	logFunc := func(format string, args ...interface{}) {
-		close(logFuncInvoked)
+		logFuncInvoked <- struct{}{}
 	}
 
-	stream := logstream.FromNamespace(context.TODO(), f, pod.Namespace)
-	stream.StartStream(pod.Name, logFunc)
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := logstream.FromNamespace(ctx, f, pod.Namespace)
+	streamC, err := stream.StartStream(pod.Name, logFunc)
+	if err != nil {
+		t.Fatal("Failed to start the stream: ", err)
+	}
+	t.Cleanup(streamC)
 
 	podClient := f.CoreV1().Pods(pod.Namespace)
-	if _, err := podClient.Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
+	if _, err := podClient.Create(context.Background(), pod, metav1.CreateOptions{}); err != nil {
 		t.Fatal("CreatePod()=", err)
 	}
 
+	select {
+	case <-time.After(time.Second):
+	case <-logFuncInvoked:
+		t.Error("Unready pod should not report logs")
+	}
+
 	pod.Status = readyStatus
-	if _, err := podClient.Update(context.TODO(), pod, metav1.UpdateOptions{}); err != nil {
+	if _, err := podClient.Update(context.Background(), pod, metav1.UpdateOptions{}); err != nil {
 		t.Fatal("UpdatePod()=", err)
 	}
 
 	select {
 	case <-time.After(time.Second):
-		t.Error("timed out: log message wasn't received")
+		t.Error("Timed out: log message wasn't received")
 	case <-logFuncInvoked:
 	}
+
+	if _, err := podClient.Update(context.Background(), pod, metav1.UpdateOptions{}); err != nil {
+		t.Fatal("UpdatePod()=", err)
+	}
+
+	select {
+	case <-time.After(time.Second):
+	case <-logFuncInvoked:
+		t.Error("Repeat updates to the same pod shoould not trigger GetLogs")
+	}
+
+	if err := podClient.Delete(context.Background(), pod.Name, metav1.DeleteOptions{}); err != nil {
+		t.Fatal("UpdatePod()=", err)
+	}
+
+	select {
+	case <-time.After(time.Second):
+	case <-logFuncInvoked:
+		t.Error("Deletion shoould not trigger GetLogs")
+	}
+
+	// Create pod with the same name? Why not. And let's make it ready from the get go.
+	if _, err := podClient.Create(context.Background(), pod, metav1.CreateOptions{}); err != nil {
+		t.Fatal("CreatePod()=", err)
+	}
+
+	select {
+	case <-time.After(time.Second):
+		t.Error("Timed out: log message wasn't received")
+	case <-logFuncInvoked:
+	}
+
+	// Delete again.
+	if err := podClient.Delete(context.Background(), pod.Name, metav1.DeleteOptions{}); err != nil {
+		t.Fatal("UpdatePod()=", err)
+	}
+	// Kill the context.
+	cancel()
+
+	// Re-create pod, but the watch cycle must have finished by now.
+	if _, err := podClient.Create(context.Background(), pod, metav1.CreateOptions{}); err != nil {
+		t.Fatal("CreatePod()=", err)
+	}
+
+	select {
+	case <-time.After(time.Second):
+	case <-logFuncInvoked:
+		t.Error("No watching should have happened")
+	}
+	// Delete again.
 }
 
-func newK8sFake(c *fake.Clientset) *fakeclient {
+func newK8sFake(c *fake.Clientset, watchErr error) *fakeclient {
 	return &fakeclient{
 		Clientset:  c,
 		FakeCoreV1: &fakecorev1.FakeCoreV1{Fake: &c.Fake},
-		logBuffer:  new(bytes.Buffer),
+		watchErr:   watchErr,
 	}
 }
 
 type fakeclient struct {
 	*fake.Clientset
 	*fakecorev1.FakeCoreV1
-
-	logBuffer *bytes.Buffer
+	watchErr error
 }
 
 type fakePods struct {
 	*fakeclient
 	v1.PodInterface
-	ns string
+	ns       string
+	watchErr error
+}
+
+func (f *fakePods) Watch(ctx context.Context, lo metav1.ListOptions) (watch.Interface, error) {
+	if f.watchErr == nil {
+		return f.PodInterface.Watch(ctx, lo)
+	}
+	return nil, f.watchErr
 }
 
 func (f *fakeclient) CoreV1() v1.CoreV1Interface { return f }
@@ -117,6 +193,7 @@ func (f *fakeclient) Pods(ns string) v1.PodInterface {
 		f,
 		f.FakeCoreV1.Pods(ns),
 		ns,
+		f.watchErr,
 	}
 }
 
@@ -125,7 +202,7 @@ func (f *fakePods) GetLogs(name string, opts *corev1.PodLogOptions) *restclient.
 		Client: fakerest.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(f.logBuffer),
+				Body:       ioutil.NopCloser(strings.NewReader("hello\n")),
 			}
 			return resp, nil
 		}),

--- a/test/logstream/v2/stream_test.go
+++ b/test/logstream/v2/stream_test.go
@@ -153,7 +153,7 @@ func TestNamespaceStream(t *testing.T) {
 	select {
 	case <-time.After(time.Second):
 	case <-logFuncInvoked:
-		t.Error("No watching should have happened")
+		t.Error("No watching should have happened.")
 	}
 }
 

--- a/test/logstream/v2/stream_test.go
+++ b/test/logstream/v2/stream_test.go
@@ -71,7 +71,7 @@ func TestStreamErr(t *testing.T) {
 func TestNamespaceStream(t *testing.T) {
 	f := newK8sFake(fake.NewSimpleClientset(), nil)
 
-	logFuncInvoked := make(chan struct{}, 2)
+	logFuncInvoked := make(chan struct{})
 	t.Cleanup(func() { close(logFuncInvoked) })
 	logFunc := func(format string, args ...interface{}) {
 		logFuncInvoked <- struct{}{}

--- a/test/logstream/v2/stream_test.go
+++ b/test/logstream/v2/stream_test.go
@@ -114,7 +114,7 @@ func TestNamespaceStream(t *testing.T) {
 	select {
 	case <-time.After(time.Second):
 	case <-logFuncInvoked:
-		t.Error("Repeat updates to the same pod shoould not trigger GetLogs")
+		t.Error("Repeat updates to the same pod should not trigger GetLogs")
 	}
 
 	if err := podClient.Delete(context.Background(), pod.Name, metav1.DeleteOptions{}); err != nil {
@@ -124,7 +124,7 @@ func TestNamespaceStream(t *testing.T) {
 	select {
 	case <-time.After(time.Second):
 	case <-logFuncInvoked:
-		t.Error("Deletion shoould not trigger GetLogs")
+		t.Error("Deletion should not trigger GetLogs")
 	}
 
 	// Create pod with the same name? Why not. And let's make it ready from the get go.

--- a/test/logstream/v2/stream_test.go
+++ b/test/logstream/v2/stream_test.go
@@ -155,7 +155,6 @@ func TestNamespaceStream(t *testing.T) {
 	case <-logFuncInvoked:
 		t.Error("No watching should have happened")
 	}
-	// Delete again.
 }
 
 func newK8sFake(c *fake.Clientset, watchErr error) *fakeclient {

--- a/test/logstream/v2/stream_test.go
+++ b/test/logstream/v2/stream_test.go
@@ -60,7 +60,7 @@ var readyStatus = corev1.PodStatus{
 }
 
 func TestStreamErr(t *testing.T) {
-	f := newK8sFake(fake.NewSimpleClientset(), errors.New("lookin' good!"))
+	f := newK8sFake(fake.NewSimpleClientset(), errors.New("lookin' good"))
 	stream := logstream.FromNamespace(context.Background(), f, "a-namespace")
 	_, err := stream.StartStream(pod.Name, nil)
 	if err == nil {


### PR DESCRIPTION
- handle `event.Object == nil` case. We have reports of this. Strange
  edgecase, but :shrug:.
- add tons of tests around various cases, should raise the coverage a
bit (although, we exclude test, still should be better).

/assign @dprotaso @tcnghia @markusthoemmes 