### PR TITLE
Simplify defaulting and force-default kubeconfig location in tests

### DIFF
--- a/injection/config.go
+++ b/injection/config.go
@@ -55,7 +55,7 @@ func Flags() *Environment {
 		flag.StringVar(&env.ServerURL, "server", "",
 			"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 
-		flag.StringVar(&env.Kubeconfig, "kubeconfig", "",
+		flag.StringVar(&env.Kubeconfig, "kubeconfig", os.Getenv("KUBECONFIG"),
 			"Path to a kubeconfig. Only required if out-of-cluster.")
 
 		flag.IntVar(&env.Burst, "kube-api-burst", 0, "Maximum burst for throttle.")
@@ -97,10 +97,6 @@ func ParseAndGetRESTConfigOrDie() *rest.Config {
 //   3. Fallback to in-cluster config.
 //   4. Fallback to the ~/.kube/config.
 func GetRESTConfig(serverURL, kubeconfig string) (*rest.Config, error) {
-	if kubeconfig == "" {
-		kubeconfig = os.Getenv("KUBECONFIG")
-	}
-
 	// If we have an explicit indication of where the kubernetes config lives, read that.
 	if kubeconfig != "" {
 		c, err := clientcmd.BuildConfigFromFlags(serverURL, kubeconfig)

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -22,6 +22,8 @@ package test
 import (
 	"bytes"
 	"flag"
+	"os/user"
+	"path/filepath"
 	"text/template"
 
 	"knative.dev/pkg/injection"
@@ -50,6 +52,15 @@ func initializeFlags() *EnvironmentFlags {
 
 	f.TestEnvironment = testflags.Flags()
 	f.Environment = injection.Flags()
+
+	// We want to do this defaulting for tests only. The flags are reused between tests
+	// and production code and we want to make sure that production code defaults to
+	// the in-cluster config correctly.
+	if f.Environment.Kubeconfig == "" {
+		if usr, err := user.Current(); err == nil {
+			f.Environment.Kubeconfig = filepath.Join(usr.HomeDir, ".kube", "config")
+		}
+	}
 
 	return f
 }


### PR DESCRIPTION
This fixes test errors like in https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_serving/9864/pull-knative-serving-istio-stable-no-mesh/1318368526817300480, where the tests no longer properly default the kubeconfig variable as we have dropped said defaulting in https://github.com/knative/pkg/commit/fc447086b7b09678604d545098401f79bfa10032.

It also slightly simplifies the existing defaulting logic, as `KUBECONFIG` is read first nonetheless, so just default the flag to that.

Successfully tested in https://github.com/knative/serving/pull/9869