### PR TITLE
Fix nolint warnings and adhere to best practices

### DIFF
--- a/configmap/hash-gen/main.go
+++ b/configmap/hash-gen/main.go
@@ -49,7 +49,7 @@ func processFile(fileName string) error {
 		return err
 	}
 
-	// nolint:gosec // This is not security critical so open permissions are fine.
+	//nolint:gosec // This is not security critical so open permissions are fine.
 	if err := ioutil.WriteFile(fileName, out, 0644); err != nil {
 		return fmt.Errorf("failed to write file: %w", err)
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -207,7 +207,7 @@ type Impl struct {
 
 // ControllerOptions encapsulates options for creating a new controller,
 // including throttling and stats behavior.
-type ControllerOptions struct { //nolint for backcompat.
+type ControllerOptions struct { //nolint // for backcompat.
 	WorkQueueName string
 	Logger        *zap.SugaredLogger
 	Reporter      StatsReporter

--- a/kmeta/names.go
+++ b/kmeta/names.go
@@ -17,7 +17,7 @@ limitations under the license.
 package kmeta
 
 import (
-	"crypto/md5" // nolint:gosec // No strong cryptography needed.
+	"crypto/md5" //nolint:gosec // No strong cryptography needed.
 	"fmt"
 	"strings"
 )
@@ -42,7 +42,7 @@ func ChildName(parent, suffix string) string {
 		// If the suffix is longer than the longest allowed suffix, then
 		// we hash the whole combined string and use that as the suffix.
 		if head-len(suffix) <= 0 {
-			// nolint:gosec // No strong cryptography needed.
+			//nolint:gosec // No strong cryptography needed.
 			h := md5.Sum([]byte(parent + suffix))
 			// 1. trim parent, if needed
 			if head < len(parent) {
@@ -59,7 +59,7 @@ func ChildName(parent, suffix string) string {
 			// remove it.
 			return strings.TrimRight(ret, "-")
 		}
-		// nolint:gosec // No strong cryptography needed.
+		//nolint:gosec // No strong cryptography needed.
 		n = fmt.Sprintf("%s%x", parent[:head-len(suffix)], md5.Sum([]byte(parent)))
 	}
 	return n + suffix

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -346,7 +346,7 @@ func prometheusPort() (int, error) {
 
 // JsonToMetricsOptions converts a json string of a
 // ExporterOptions. Returns a non-nil ExporterOptions always.
-func JsonToMetricsOptions(jsonOpts string) (*ExporterOptions, error) { // nolint No rename due to backwards incompatibility.
+func JsonToMetricsOptions(jsonOpts string) (*ExporterOptions, error) { //nolint // No rename due to backwards incompatibility.
 	var opts ExporterOptions
 	if jsonOpts == "" {
 		return nil, errors.New("json options string is empty")
@@ -360,7 +360,7 @@ func JsonToMetricsOptions(jsonOpts string) (*ExporterOptions, error) { // nolint
 }
 
 // MetricsOptionsToJson converts a ExporterOptions to a json string.
-func MetricsOptionsToJson(opts *ExporterOptions) (string, error) { // nolint No rename due to backwards incompatibility.
+func MetricsOptionsToJson(opts *ExporterOptions) (string, error) { //nolint // No rename due to backwards incompatibility.
 	if opts == nil {
 		return "", nil
 	}

--- a/reconciler/events.go
+++ b/reconciler/events.go
@@ -62,7 +62,7 @@ func NewEvent(eventtype, reason, messageFmt string, args ...interface{}) Event {
 
 // ReconcilerEvent wraps the fields required for recorders to create a
 // kubernetes recorder Event.
-type ReconcilerEvent struct { //nolint for backcompat.
+type ReconcilerEvent struct { //nolint:golint // for backcompat.
 	EventType string
 	Reason    string
 	Format    string

--- a/test/gcs/gcs.go
+++ b/test/gcs/gcs.go
@@ -31,7 +31,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-//nolint — there's also Client so they collide.
+//nolint // there's also Client so they collide.
 type GCSClient struct {
 	*storage.Client
 }

--- a/test/logging/example_tlogger_test.go
+++ b/test/logging/example_tlogger_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint
+//nolint
 package logging_test
 
 import (

--- a/test/logging/tlogger.go
+++ b/test/logging/tlogger.go
@@ -160,7 +160,7 @@ func (o *TLogger) interfacesToFields(things ...interface{}) []interface{} {
 	return fields
 }
 
-func (o *TLogger) errorWithRuntimeCheck(stringThenKeysAndValues ...interface{}) (error, string, []interface{}) { //nolint Returning the error first is okay and expected here.
+func (o *TLogger) errorWithRuntimeCheck(stringThenKeysAndValues ...interface{}) (error, string, []interface{}) { //nolint // Returning the error first is okay and expected here.
 	if len(stringThenKeysAndValues) == 0 {
 		return nil, "", nil
 	}

--- a/test/mako/config/benchmark.go
+++ b/test/mako/config/benchmark.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/golang/protobuf/proto" //nolint apis incompatible with the new version
+	"github.com/golang/protobuf/proto" //nolint // apis incompatible with the new version
 	mpb "github.com/google/mako/spec/proto/mako_go_proto"
 )
 

--- a/test/mako/stub-sidecar/main.go
+++ b/test/mako/stub-sidecar/main.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/golang/protobuf/jsonpb" //nolint: the newer package has different interface.
+	"github.com/golang/protobuf/jsonpb" //nolint // the newer package has different interface.
 	mako "github.com/google/mako/spec/proto/mako_go_proto"
 
 	"log"

--- a/testutils/clustermanager/perf-tests/pkg/benchmark.go
+++ b/testutils/clustermanager/perf-tests/pkg/benchmark.go
@@ -40,7 +40,7 @@ const (
 )
 
 // backupLocations are used in retrying cluster creation, if stockout happens in one location.
-// nolint // TODO(chizhg): it's currently not used, use it in the cluster creation retry logic.
+//nolint // TODO(chizhg): it's currently not used, use it in the cluster creation retry logic.
 var backupLocations = []string{"us-west1", "us-west2", "us-east1"}
 
 // GKECluster saves the config information for the GKE cluster

--- a/tracing/config/tracing.go
+++ b/tracing/config/tracing.go
@@ -136,7 +136,7 @@ func NewTracingConfigFromConfigMap(config *corev1.ConfigMap) (*Config, error) {
 
 // JsonToTracingConfig converts a json string of a Config.
 // Returns a non-nil Config always and an eventual error.
-func JsonToTracingConfig(jsonCfg string) (*Config, error) { //nolint:stylecheck for backcompat.
+func JsonToTracingConfig(jsonCfg string) (*Config, error) { //nolint // for backcompat.
 
 	if jsonCfg == "" {
 		return NoopConfig(), errors.New("empty json tracing config")
@@ -155,7 +155,7 @@ func JsonToTracingConfig(jsonCfg string) (*Config, error) { //nolint:stylecheck 
 }
 
 // TracingConfigToJson converts a Config to a json string.
-func TracingConfigToJson(cfg *Config) (string, error) { //nolint:stylecheck for backcompat.
+func TracingConfigToJson(cfg *Config) (string, error) { //nolint // for backcompat.
 	if cfg == nil {
 		return "", nil
 	}


### PR DESCRIPTION
As per title.

This gets rid of

```
WARN [runner/nolint] Found unknown linters in //nolint directives: stylecheck for backcompat., the newer package has different interface. 
```

and also adheres to the best practice of not having a space in front of `nolint`, see https://golangci-lint.run/usage/false-positives/#nolint