### PR TITLE
More test coverage for logstream

### DIFF
--- a/test/logstream/v2/stream.go
+++ b/test/logstream/v2/stream.go
@@ -97,13 +97,9 @@ func (s *namespaceSource) watchPods() error {
 				case watch.Deleted:
 					watchedPods.Delete(p.Name)
 				case watch.Added, watch.Modified:
-					if watchedPods.Has(p.Name) {
-						continue
-					}
-					if isPodReady(p) {
+					if !watchedPods.Has(p.Name) && isPodReady(p) {
 						watchedPods.Insert(p.Name)
 						s.startForPod(p)
-						continue
 					}
 				}
 
@@ -146,8 +142,7 @@ func (s *namespaceSource) startForPod(pod *corev1.Pod) {
 			}
 			defer stream.Close()
 			// Read this container's stream.
-			scanner := bufio.NewScanner(stream)
-			for scanner.Scan() {
+			for scanner := bufio.NewScanner(stream); scanner.Scan(); {
 				handleLine(scanner.Bytes(), pn)
 			}
 			// Pods get killed with chaos duck, so logs might end


### PR DESCRIPTION
- cover the actual log parsing (without verification for now)
- cover errors from starting stream
- other nits

```
>go test -race -count=5
PASS
ok  	knative.dev/pkg/test/logstream/v2	2.625s
```

/assign @dprotaso mattmoor