### PR TITLE
Some cleanups arounds the metrics code

### DIFF
--- a/metrics/config.go
+++ b/metrics/config.go
@@ -200,15 +200,16 @@ func createMetricsConfig(ctx context.Context, ops ExporterOptions) (*metricsConf
 	if backendFromConfig, ok := m[BackendDestinationKey]; ok {
 		backend = backendFromConfig
 	}
-	lb := metricsBackend(strings.ToLower(backend))
-	switch lb {
+
+	switch lb := metricsBackend(strings.ToLower(backend)); lb {
 	case stackdriver, prometheus, openCensus:
 		mc.backendDestination = lb
 	default:
 		return nil, fmt.Errorf("unsupported metrics backend value %q", backend)
 	}
 
-	if mc.backendDestination == openCensus {
+	switch mc.backendDestination {
+	case openCensus:
 		mc.collectorAddress = ops.ConfigMap[collectorAddressKey]
 		if isSecure := ops.ConfigMap[collectorSecureKey]; isSecure != "" {
 			var err error
@@ -223,9 +224,7 @@ func createMetricsConfig(ctx context.Context, ops ExporterOptions) (*metricsConf
 				}
 			}
 		}
-	}
-
-	if mc.backendDestination == prometheus {
+	case prometheus:
 		pp := ops.PrometheusPort
 		if pp == 0 {
 			var err error
@@ -241,12 +240,10 @@ func createMetricsConfig(ctx context.Context, ops ExporterOptions) (*metricsConf
 		}
 
 		mc.prometheusPort = pp
-	}
-
-	// If stackdriverClientConfig is not provided for stackdriver backend destination, OpenCensus will try to
-	// use the application default credentials. If that is not available, Opencensus would fail to create the
-	// metrics exporter.
-	if mc.backendDestination == stackdriver {
+	case stackdriver:
+		// If stackdriverClientConfig is not provided for stackdriver backend destination, OpenCensus will try to
+		// use the application default credentials. If that is not available, Opencensus would fail to create the
+		// metrics exporter.
 		scc := NewStackdriverClientConfigFromMap(m)
 		mc.stackdriverClientConfig = *scc
 		mc.isStackdriverBackend = true
@@ -285,7 +282,7 @@ func createMetricsConfig(ctx context.Context, ops ExporterOptions) (*metricsConf
 	// For Prometheus, we will use a lower value since the exporter doesn't
 	// push anything but just responds to pull requests, and shorter durations
 	// do not really hurt the performance and we rely on the scraping configuration.
-	if repStr, ok := m[reportingPeriodKey]; ok && repStr != "" {
+	if repStr := m[reportingPeriodKey]; repStr != "" {
 		repInt, err := strconv.Atoi(repStr)
 		if err != nil {
 			return nil, fmt.Errorf("invalid %s value %q", reportingPeriodKey, repStr)
@@ -346,7 +343,12 @@ func prometheusPort() (int, error) {
 
 // JsonToMetricsOptions converts a json string of a
 // ExporterOptions. Returns a non-nil ExporterOptions always.
-func JsonToMetricsOptions(jsonOpts string) (*ExporterOptions, error) { //nolint // No rename due to backwards incompatibility.
+// TODO(vagababov): remove after updating deps.
+func JsonToMetricsOptions(jsonOpts string) (*ExporterOptions, error) { //nolint // No rename due to backwards incompatibility. {
+	return JSONToMetricsOptions(jsonOpts)
+}
+
+func JSONToMetricsOptions(jsonOpts string) (*ExporterOptions, error) {
 	var opts ExporterOptions
 	if jsonOpts == "" {
 		return nil, errors.New("json options string is empty")
@@ -360,15 +362,16 @@ func JsonToMetricsOptions(jsonOpts string) (*ExporterOptions, error) { //nolint 
 }
 
 // MetricsOptionsToJson converts a ExporterOptions to a json string.
+// TODO(vagababov): remove after updating deps.
 func MetricsOptionsToJson(opts *ExporterOptions) (string, error) { //nolint // No rename due to backwards incompatibility.
+	return MetricsOptionsToJSON(opts)
+}
+
+func MetricsOptionsToJSON(opts *ExporterOptions) (string, error) {
 	if opts == nil {
 		return "", nil
 	}
 
 	jsonOpts, err := json.Marshal(opts)
-	if err != nil {
-		return "", err
-	}
-
-	return string(jsonOpts), nil
+	return string(jsonOpts), err
 }

--- a/metrics/config_test.go
+++ b/metrics/config_test.go
@@ -81,7 +81,6 @@ var (
 			ConfigMap: map[string]string{
 				BackendDestinationKey: string(prometheus),
 			},
-			Domain:    "",
 			Component: testComponent,
 		},
 		expectedErr: "metrics domain cannot be empty",
@@ -91,8 +90,7 @@ var (
 			ConfigMap: map[string]string{
 				BackendDestinationKey: string(openCensus),
 			},
-			Domain:    servingDomain,
-			Component: "",
+			Domain: servingDomain,
 		},
 		expectedErr: "metrics component name cannot be empty",
 	}, {
@@ -538,7 +536,7 @@ func TestGetMetricsConfig(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := createMetricsConfig(ctx, test.ops)
 			if err == nil || err.Error() != test.expectedErr {
-				t.Errorf("Wanted err: %v, got: %v", test.expectedErr, err)
+				t.Errorf("Err = %v, want: %v", err, test.expectedErr)
 			}
 		})
 	}
@@ -923,7 +921,7 @@ func TestMetricsOptions(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			jsonOpts, err := MetricsOptionsToJson(tc.opts)
+			jsonOpts, err := MetricsOptionsToJSON(tc.opts)
 			if err != nil {
 				t.Error("error while converting metrics config to json:", err)
 			}
@@ -939,7 +937,7 @@ func TestMetricsOptions(t *testing.T) {
 			// Test to options.
 			{
 				want := tc.opts
-				got, gotErr := JsonToMetricsOptions(jsonOpts)
+				got, gotErr := JSONToMetricsOptions(jsonOpts)
 
 				if gotErr != nil {
 					if diff := cmp.Diff(tc.wantErr, gotErr.Error()); diff != "" {


### PR DESCRIPTION
- use switch
- add new method that won't trigger lint, with a deprecation notice when deps are updated
- other minor things
- string(nil) actually works, so no need for an extra if

/assign @yanweiguo @evankanderson 