### PR TITLE
Eventing no longer needs this constant

### DIFF
--- a/leaderelection/config.go
+++ b/leaderelection/config.go
@@ -34,8 +34,8 @@ import (
 
 const (
 	configMapNameEnv = "CONFIG_LEADERELECTION_NAME"
-	// KnativeResourceLock is the only supported lock mechanism for Knative.
-	KnativeResourceLock = resourcelock.LeasesResourceLock
+	// knativeResourceLock is the only supported lock mechanism for Knative.
+	knativeResourceLock = resourcelock.LeasesResourceLock
 )
 
 // MaxBuckets is the maximum number of buckets to allow users to define.

--- a/leaderelection/context.go
+++ b/leaderelection/context.go
@@ -124,7 +124,7 @@ func (b *standardBuilder) buildElector(ctx context.Context, la reconciler.Leader
 		// Use a local var which won't change across the for loop since it is
 		// used in a callback asynchronously.
 		bkt := bkt
-		rl, err := resourcelock.New(KnativeResourceLock,
+		rl, err := resourcelock.New(knativeResourceLock,
 			system.Namespace(), // use namespace we are running in
 			bkt.Name(),
 			b.kc.CoreV1(),


### PR DESCRIPTION
Revert "Make knativeResourceLock exported (#1656)"

This reverts commit a79802cd7814b248b4676cbe7561b81f3b6c5c83.

Discussion: https://knative.slack.com/archives/C9JP909F0/p1603733670379700?thread_ts=1603733520.379100&cid=C9JP909F0