### PR TITLE
move fuzzers

### DIFF
--- a/apis/duck/v1/test/fuzzer.go
+++ b/apis/duck/v1/test/fuzzer.go
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1
+package test
 
 import (
 	fuzz "github.com/google/gofuzz"
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/apis/duck/v1"
 	pkgfuzzer "knative.dev/pkg/apis/testing/fuzzer"
 )
 
@@ -34,7 +35,7 @@ var testConditions = apis.Conditions{{Type: apis.ConditionReady}, {Type: apis.Co
 var FuzzerFuncs = fuzzer.MergeFuzzerFuncs(
 	func(codecs serializer.CodecFactory) []interface{} {
 		return []interface{}{
-			func(status *Status, c fuzz.Continue) {
+			func(status *v1.Status, c fuzz.Continue) {
 				c.FuzzNoCustom(status) // fuzz the Status
 				status.SetConditions(testConditions)
 				pkgfuzzer.FuzzConditions(status, c)

--- a/apis/duck/v1/test/fuzzer.go
+++ b/apis/duck/v1/test/fuzzer.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"knative.dev/pkg/apis"
-	"knative.dev/pkg/apis/duck/v1"
+	v1 "knative.dev/pkg/apis/duck/v1"
 	pkgfuzzer "knative.dev/pkg/apis/testing/fuzzer"
 )
 

--- a/apis/duck/v1/test/roundtrip_test.go
+++ b/apis/duck/v1/test/roundtrip_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package test
 
 import (
-	"knative.dev/pkg/apis/duck/v1"
 	"testing"
 
+	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"

--- a/apis/duck/v1/test/roundtrip_test.go
+++ b/apis/duck/v1/test/roundtrip_test.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package test
 
 import (
+	"knative.dev/pkg/apis/duck/v1"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
@@ -28,7 +29,7 @@ import (
 
 func TestEventingRoundTripTypesToJSON(t *testing.T) {
 	scheme := runtime.NewScheme()
-	utilruntime.Must(AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
 
 	fuzzerFuncs := fuzzer.MergeFuzzerFuncs(
 		pkgfuzzer.Funcs,

--- a/apis/duck/v1beta1/test/fuzzer.go
+++ b/apis/duck/v1beta1/test/fuzzer.go
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package test
 
 import (
 	fuzz "github.com/google/gofuzz"
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/apis/duck/v1beta1"
 	pkgfuzzer "knative.dev/pkg/apis/testing/fuzzer"
 )
 
@@ -33,7 +34,7 @@ var testConditions = apis.Conditions{{Type: apis.ConditionReady}, {Type: apis.Co
 var FuzzerFuncs = fuzzer.MergeFuzzerFuncs(
 	func(codecs serializer.CodecFactory) []interface{} {
 		return []interface{}{
-			func(status *Status, c fuzz.Continue) {
+			func(status *v1beta1.Status, c fuzz.Continue) {
 				c.FuzzNoCustom(status) // fuzz the Status
 				status.SetConditions(testConditions)
 				pkgfuzzer.FuzzConditions(status, c)

--- a/apis/duck/v1beta1/test/roundtrip_test.go
+++ b/apis/duck/v1beta1/test/roundtrip_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package test
 
 import (
-	"knative.dev/pkg/apis/duck/v1beta1"
 	"testing"
+
+	"knative.dev/pkg/apis/duck/v1beta1"
 
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/apis/duck/v1beta1/test/roundtrip_test.go
+++ b/apis/duck/v1beta1/test/roundtrip_test.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1
+package test
 
 import (
+	"knative.dev/pkg/apis/duck/v1beta1"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
@@ -28,7 +29,7 @@ import (
 
 func TestEventingRoundTripTypesToJSON(t *testing.T) {
 	scheme := runtime.NewScheme()
-	utilruntime.Must(AddToScheme(scheme))
+	utilruntime.Must(v1beta1.AddToScheme(scheme))
 
 	fuzzerFuncs := fuzzer.MergeFuzzerFuncs(
 		pkgfuzzer.Funcs,


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@vmware.com>

We currently ship fuzzers in our binaries, this is hoping to remove the last bits of them. Note that I did not inline them into the roundtrip_test because I was thinking that if downstream wants to test them, they can continue to do so.

Addresses:
https://github.com/knative/eventing/issues/4398
https://github.com/knative/serving/issues/9725
