### PR TITLE
Return context.Canceled error in pkg/signals

### DIFF
--- a/signals/signal.go
+++ b/signals/signal.go
@@ -18,7 +18,6 @@ package signals
 
 import (
 	"context"
-	"errors"
 	"os"
 	"os/signal"
 	"time"
@@ -65,12 +64,14 @@ func (scc *signalContext) Done() <-chan struct{} {
 	return scc.stopCh
 }
 
-// Err implements context.Context
+// Err implements context.Context. If the underlying stop channel is closed, Err
+// always returns context.Canceled, and nil otherwise.
 func (scc *signalContext) Err() error {
 	select {
 	case _, ok := <-scc.Done():
 		if !ok {
-			return errors.New("received a termination signal")
+			// TODO: revisit this behavior when Deadline() implementation is changed
+			return context.Canceled
 		}
 	default:
 	}


### PR DESCRIPTION
Return a typed `context.Canceled` error following the context package
semantic.

Closes: #1854

Might break existing users if they rely on the current error string
being returned with string matching, which is unlikely though.

Signed-off-by: Michael Gasch <mgasch@vmware.com>