### PR TITLE
Fix issue 1876

### DIFF
--- a/reconciler/testing/reactions.go
+++ b/reconciler/testing/reactions.go
@@ -38,7 +38,7 @@ import (
 //      InduceFailure("patch", "inmemorychannels", "status"),
 //   },
 // Specifying more than one subresource results in panic.
-func InduceFailure(verb, resource string, subresources... string) clientgotesting.ReactionFunc {
+func InduceFailure(verb, resource string, subresources ...string) clientgotesting.ReactionFunc {
 	if len(subresources) > 1 {
 		panic(fmt.Sprintf("Can only specify one subresource, got %+v", subresources))
 	}

--- a/reconciler/testing/reactions.go
+++ b/reconciler/testing/reactions.go
@@ -35,21 +35,12 @@ import (
 // Or to target a subresource, say a patch to InMemoryChannel.Status, you would add:
 //   WithReactors: []clientgotesting.ReactionFunc{
 //      // Makes calls to patch inmemorychannels status subresource return an error.
-//      InduceFailure("patch", "inmemorychannels", "status"),
+//      InduceFailure("patch", "inmemorychannels/status"),
 //   },
-// Specifying more than one subresource results in panic.
-func InduceFailure(verb, resource string, subresources ...string) clientgotesting.ReactionFunc {
-	if len(subresources) > 1 {
-		panic(fmt.Sprintf("Can only specify one subresource, got %+v", subresources))
-	}
+func InduceFailure(verb, resource string) clientgotesting.ReactionFunc {
 	return func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 		if !action.Matches(verb, resource) {
 			return false, nil, nil
-		}
-		if len(subresources) > 0 {
-			if action.GetSubresource() != subresources[0] {
-				return false, nil, nil
-			}
 		}
 		return true, nil, fmt.Errorf("inducing failure for %s %s", action.GetVerb(), action.GetResource().Resource)
 	}

--- a/reconciler/testing/reactions_test.go
+++ b/reconciler/testing/reactions_test.go
@@ -88,9 +88,7 @@ func TestInduceFailure(t *testing.T) {
 		wantHandled:     false,
 	}}
 	for _, tc := range tests {
-		var f clientgotesting.ReactionFunc
-
-		f = InduceFailure(tc.verb, tc.resource)
+		f := InduceFailure(tc.verb, tc.resource)
 		var patchAction clientgotesting.PatchActionImpl
 		if tc.testSubresource != "" {
 			patchAction = clientgotesting.NewPatchSubresourceAction(tc.testSource, "testns", "test", types.JSONPatchType, []byte{}, tc.testSubresource)

--- a/reconciler/testing/reactions_test.go
+++ b/reconciler/testing/reactions_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package testing
 
 import (
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	clientgotesting "k8s.io/client-go/testing"
@@ -42,9 +40,8 @@ func TestInduceFailure(t *testing.T) {
 	tests := []struct {
 		name string
 		// These set up the InduceFailure function
-		verb        string
-		resource    string
-		subresource string
+		verb     string
+		resource string
 		// This is the resource fed to the function
 		testSource schema.GroupVersionResource
 		// This is the subresource fed to the function
@@ -72,35 +69,28 @@ func TestInduceFailure(t *testing.T) {
 		name:            "resource and subresource",
 		verb:            "patch",
 		testSource:      imc,
-		resource:        "inmemorychannels",
-		subresource:     "status",
+		resource:        "inmemorychannels/status",
 		testSubresource: "status",
 		wantHandled:     true,
 	}, {
 		name:            "resource and subresource, wrong verb",
 		verb:            "get",
 		testSource:      imc,
-		resource:        "inmemorychannels",
-		subresource:     "status",
+		resource:        "inmemorychannels/status",
 		testSubresource: "status",
 		wantHandled:     false,
 	}, {
 		name:            "resource and subresource, subresource does not match",
 		verb:            "patch",
 		testSource:      imc,
-		resource:        "inmemorychannels",
-		subresource:     "status",
+		resource:        "inmemorychannels/status",
 		testSubresource: "finalizers",
 		wantHandled:     false,
 	}}
 	for _, tc := range tests {
 		var f clientgotesting.ReactionFunc
 
-		if tc.subresource != "" {
-			f = InduceFailure(tc.verb, fmt.Sprintf("%s/%s", tc.resource, tc.subresource))
-		} else {
-			f = InduceFailure(tc.verb, tc.resource)
-		}
+		f = InduceFailure(tc.verb, tc.resource)
 		var patchAction clientgotesting.PatchActionImpl
 		if tc.testSubresource != "" {
 			patchAction = clientgotesting.NewPatchSubresourceAction(tc.testSource, "testns", "test", types.JSONPatchType, []byte{}, tc.testSubresource)

--- a/reconciler/testing/reactions_test.go
+++ b/reconciler/testing/reactions_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgotesting "k8s.io/client-go/testing"
+
+	"testing"
+)
+
+var imc = schema.GroupVersionResource{
+	Group:    "messaging.knative.dev",
+	Version:  "v1",
+	Resource: "inmemorychannels",
+}
+
+var revision = schema.GroupVersionResource{
+	Group:    "serving.knative.dev",
+	Version:  "v1",
+	Resource: "revisions",
+}
+
+func TestInduceFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		// These set up the InduceFailure function
+		verb        string
+		resource    string
+		subresource string
+		// This is the resource fed to the function
+		testSource schema.GroupVersionResource
+		// This is the subresource fed to the function
+		testSubresource string
+		wantHandled     bool
+	}{{
+		name:        "resource",
+		verb:        "patch",
+		testSource:  imc,
+		resource:    "inmemorychannels",
+		wantHandled: true,
+	}, {
+		name:        "resource, wrong verb",
+		verb:        "create",
+		testSource:  imc,
+		resource:    "inmemorychannels",
+		wantHandled: false,
+	}, {
+		name:        "wrong resource",
+		verb:        "patch",
+		testSource:  revision,
+		resource:    "inmemorychannels",
+		wantHandled: false,
+	}, {
+		name:            "resource and subresource",
+		verb:            "patch",
+		testSource:      imc,
+		resource:        "inmemorychannels",
+		subresource:     "status",
+		testSubresource: "status",
+		wantHandled:     true,
+	}, {
+		name:            "resource and subresource, wrong verb",
+		verb:            "get",
+		testSource:      imc,
+		resource:        "inmemorychannels",
+		subresource:     "status",
+		testSubresource: "status",
+		wantHandled:     false,
+	}, {
+		name:            "resource and subresource, subresource does not match",
+		verb:            "patch",
+		testSource:      imc,
+		resource:        "inmemorychannels",
+		subresource:     "status",
+		testSubresource: "finalizers",
+		wantHandled:     false,
+	}}
+	for _, tc := range tests {
+		var f clientgotesting.ReactionFunc
+
+		if tc.subresource != "" {
+			f = InduceFailure(tc.verb, tc.resource, tc.subresource)
+		} else {
+			f = InduceFailure(tc.verb, tc.resource)
+		}
+		var patchAction clientgotesting.PatchActionImpl
+		if tc.testSubresource != "" {
+			patchAction = clientgotesting.NewPatchSubresourceAction(tc.testSource, "testns", "test", types.JSONPatchType, []byte{}, tc.testSubresource)
+		} else {
+			patchAction = clientgotesting.NewPatchAction(tc.testSource, "testns", "test", types.JSONPatchType, []byte{})
+		}
+		if handled, _, _ := f(patchAction); handled != tc.wantHandled {
+			t.Errorf("%q failed wanted %v got %v", tc.name, tc.wantHandled, handled)
+		}
+	}
+}

--- a/reconciler/testing/reactions_test.go
+++ b/reconciler/testing/reactions_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Knative Authors.
+Copyright 2020 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/reconciler/testing/reactions_test.go
+++ b/reconciler/testing/reactions_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package testing
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	clientgotesting "k8s.io/client-go/testing"
@@ -95,7 +97,7 @@ func TestInduceFailure(t *testing.T) {
 		var f clientgotesting.ReactionFunc
 
 		if tc.subresource != "" {
-			f = InduceFailure(tc.verb, tc.resource, tc.subresource)
+			f = InduceFailure(tc.verb, fmt.Sprintf("%s/%s", tc.resource, tc.subresource))
 		} else {
 			f = InduceFailure(tc.verb, tc.resource)
 		}


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@vmware.com>

Add a vararg that allows you to induce failures for only specific subresources.

I want that here:
https://github.com/knative/eventing/pull/4435