### PR TITLE
Bump github.com/go-logr/logr to v0.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/ghodss/yaml v1.0.0
-	github.com/go-logr/logr v0.1.0
+	github.com/go-logr/logr v0.2.1
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.2
 	github.com/google/go-github/v27 v27.0.6

--- a/go.sum
+++ b/go.sum
@@ -426,6 +426,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
+github.com/go-logr/logr v0.2.1 h1:fV3MLmabKIZ383XifUjFSwcoGee0v9qgPp8wy5svibE=
+github.com/go-logr/logr v0.2.1/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/zapr v0.1.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-logr/zapr v0.1.1/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=

--- a/test/logging/zapr.go
+++ b/test/logging/zapr.go
@@ -18,11 +18,23 @@
 
 package logging
 
+import (
+	"github.com/go-logr/logr"
+)
+
 // noopInfoLogger is a logr.InfoLogger that's always disabled, and does nothing.
 type noopInfoLogger struct{}
 
-func (l *noopInfoLogger) Enabled() bool                   { return false }
-func (l *noopInfoLogger) Info(_ string, _ ...interface{}) {}
+func (l *noopInfoLogger) Enabled() bool                                             { return false }
+func (l *noopInfoLogger) Info(_ string, _ ...interface{})                           {}
+func (i *noopInfoLogger) Error(err error, msg string, keysAndValues ...interface{}) {}
+func (i *noopInfoLogger) V(level int) logr.InfoLogger                               { return &noopInfoLogger{} }
+func (i *noopInfoLogger) WithValues(keysAndValues ...interface{}) logr.InfoLogger {
+	return &noopInfoLogger{}
+}
+func (i *noopInfoLogger) WithName(name string) logr.InfoLogger {
+	return &noopInfoLogger{}
+}
 
 var disabledInfoLogger = &noopInfoLogger{}
 
@@ -37,6 +49,10 @@ func (i *infoLogger) Enabled() bool { return true }
 func (i *infoLogger) Info(msg string, keysAndVals ...interface{}) {
 	i.indirectWrite(msg, keysAndVals...)
 }
+func (i *infoLogger) Error(err error, msg string, keysAndValues ...interface{}) {}
+func (i *infoLogger) V(level int) logr.InfoLogger                               { return &infoLogger{} }
+func (i *infoLogger) WithValues(keysAndValues ...interface{}) logr.InfoLogger   { return &infoLogger{} }
+func (i *infoLogger) WithName(name string) logr.InfoLogger                      { return &infoLogger{} }
 
 // This function just exists to have consistent 2-level call depth for Zap proxying
 func (i *infoLogger) indirectWrite(msg string, keysAndVals ...interface{}) {

--- a/test/logging/zapr.go
+++ b/test/logging/zapr.go
@@ -27,12 +27,12 @@ type noopInfoLogger struct{}
 
 func (l *noopInfoLogger) Enabled() bool                                             { return false }
 func (l *noopInfoLogger) Info(_ string, _ ...interface{})                           {}
-func (i *noopInfoLogger) Error(err error, msg string, keysAndValues ...interface{}) {}
-func (i *noopInfoLogger) V(level int) logr.InfoLogger                               { return &noopInfoLogger{} }
-func (i *noopInfoLogger) WithValues(keysAndValues ...interface{}) logr.InfoLogger {
+func (l *noopInfoLogger) Error(err error, msg string, keysAndValues ...interface{}) {}
+func (l *noopInfoLogger) V(level int) logr.InfoLogger                               { return &noopInfoLogger{} }
+func (l *noopInfoLogger) WithValues(keysAndValues ...interface{}) logr.InfoLogger {
 	return &noopInfoLogger{}
 }
-func (i *noopInfoLogger) WithName(name string) logr.InfoLogger {
+func (l *noopInfoLogger) WithName(name string) logr.InfoLogger {
 	return &noopInfoLogger{}
 }
 

--- a/vendor/github.com/go-logr/logr/README.md
+++ b/vendor/github.com/go-logr/logr/README.md
@@ -1,9 +1,9 @@
 # A more minimal logging API for Go
 
-Before you consider this package, please read [this blog post by the inimitable
-Dave Cheney](http://dave.cheney.net/2015/11/05/lets-talk-about-logging).  I
-really appreciate what he has to say, and it largely aligns with my own
-experiences.  Too many choices of levels means inconsistent logs.
+Before you consider this package, please read [this blog post by the
+inimitable Dave Cheney][warning-makes-no-sense].  I really appreciate what
+he has to say, and it largely aligns with my own experiences.  Too many
+choices of levels means inconsistent logs.
 
 This package offers a purely abstract interface, based on these ideas but with
 a few twists.  Code can depend on just this interface and have the actual
@@ -31,6 +31,152 @@ may feel very similar, but the primary difference is the lack of semantics.
 Because verbosity is a numerical value, it's safe to assume that an app running
 with higher verbosity means more (and less important) logs will be generated.
 
-This is a BETA grade API.  I have implemented it for
-[glog](https://godoc.org/github.com/golang/glog). Until there is a significant
-2nd implementation, I don't really know how it will change.
+This is a BETA grade API.
+
+There are implementations for the following logging libraries:
+
+- **github.com/google/glog**: [glogr](https://github.com/go-logr/glogr)
+- **k8s.io/klog**: [klogr](https://git.k8s.io/klog/klogr)
+- **go.uber.org/zap**: [zapr](https://github.com/go-logr/zapr)
+- **log** (the Go standard library logger):
+  [stdr](https://github.com/go-logr/stdr)
+- **github.com/sirupsen/logrus**: [logrusr](https://github.com/bombsimon/logrusr)
+- **github.com/wojas/genericr**: [genericr](https://github.com/wojas/genericr) (makes it easy to implement your own backend)
+
+# FAQ
+
+## Conceptual
+
+## Why structured logging?
+
+- **Structured logs are more easily queriable**: Since you've got
+  key-value pairs, it's much easier to query your structured logs for
+  particular values by filtering on the contents of a particular key --
+  think searching request logs for error codes, Kubernetes reconcilers for
+  the name and namespace of the reconciled object, etc
+
+- **Structured logging makes it easier to have cross-referencable logs**:
+  Similarly to searchability, if you maintain conventions around your
+  keys, it becomes easy to gather all log lines related to a particular
+  concept.
+ 
+- **Structured logs allow better dimensions of filtering**: if you have
+  structure to your logs, you've got more precise control over how much
+  information is logged -- you might choose in a particular configuration
+  to log certain keys but not others, only log lines where a certain key
+  matches a certain value, etc, instead of just having v-levels and names
+  to key off of.
+
+- **Structured logs better represent structured data**: sometimes, the
+  data that you want to log is inherently structured (think tuple-link
+  objects).  Structured logs allow you to preserve that structure when
+  outputting.
+
+## Why V-levels?
+
+**V-levels give operators an easy way to control the chattiness of log
+operations**.  V-levels provide a way for a given package to distinguish
+the relative importance or verbosity of a given log message.  Then, if
+a particular logger or package is logging too many messages, the user
+of the package can simply change the v-levels for that library. 
+
+## Why not more named levels, like Warning?
+
+Read [Dave Cheney's post][warning-makes-no-sense].  Then read [Differences
+from Dave's ideas](#differences-from-daves-ideas).
+
+## Why not allow format strings, too?
+
+**Format strings negate many of the benefits of structured logs**:
+
+- They're not easily searchable without resorting to fuzzy searching,
+  regular expressions, etc
+
+- They don't store structured data well, since contents are flattened into
+  a string
+
+- They're not cross-referencable
+
+- They don't compress easily, since the message is not constant
+
+(unless you turn positional parameters into key-value pairs with numerical
+keys, at which point you've gotten key-value logging with meaningless
+keys)
+
+## Practical
+
+## Why key-value pairs, and not a map?
+
+Key-value pairs are *much* easier to optimize, especially around
+allocations.  Zap (a structured logger that inspired logr's interface) has
+[performance measurements](https://github.com/uber-go/zap#performance)
+that show this quite nicely.
+
+While the interface ends up being a little less obvious, you get
+potentially better performance, plus avoid making users type
+`map[string]string{}` every time they want to log.
+
+## What if my V-levels differ between libraries?
+
+That's fine.  Control your V-levels on a per-logger basis, and use the
+`WithName` function to pass different loggers to different libraries.
+
+Generally, you should take care to ensure that you have relatively
+consistent V-levels within a given logger, however, as this makes deciding
+on what verbosity of logs to request easier.
+
+## But I *really* want to use a format string!
+
+That's not actually a question.  Assuming your question is "how do
+I convert my mental model of logging with format strings to logging with
+constant messages":
+
+1. figure out what the error actually is, as you'd write in a TL;DR style,
+   and use that as a message
+
+2. For every place you'd write a format specifier, look to the word before
+   it, and add that as a key value pair
+
+For instance, consider the following examples (all taken from spots in the
+Kubernetes codebase):
+
+- `klog.V(4).Infof("Client is returning errors: code %v, error %v",
+  responseCode, err)` becomes `logger.Error(err, "client returned an
+  error", "code", responseCode)`
+
+- `klog.V(4).Infof("Got a Retry-After %ds response for attempt %d to %v",
+  seconds, retries, url)` becomes `logger.V(4).Info("got a retry-after
+  response when requesting url", "attempt", retries, "after
+  seconds", seconds, "url", url)`
+
+If you *really* must use a format string, place it as a key value, and
+call `fmt.Sprintf` yourself -- for instance, `log.Printf("unable to
+reflect over type %T")` becomes `logger.Info("unable to reflect over
+type", "type", fmt.Sprintf("%T"))`.  In general though, the cases where
+this is necessary should be few and far between.
+
+## How do I choose my V-levels?
+
+This is basically the only hard constraint: increase V-levels to denote
+more verbose or more debug-y logs.
+
+Otherwise, you can start out with `0` as "you always want to see this",
+`1` as "common logging that you might *possibly* want to turn off", and
+`10` as "I would like to performance-test your log collection stack".
+
+Then gradually choose levels in between as you need them, working your way
+down from 10 (for debug and trace style logs) and up from 1 (for chattier
+info-type logs).
+
+## How do I choose my keys
+
+- make your keys human-readable
+- constant keys are generally a good idea
+- be consistent across your codebase
+- keys should naturally match parts of the message string
+
+While key names are mostly unrestricted (and spaces are acceptable),
+it's generally a good idea to stick to printable ascii characters, or at
+least match the general character set of your log lines.
+
+[warning-makes-no-sense]: http://dave.cheney.net/2015/11/05/lets-talk-about-logging

--- a/vendor/github.com/go-logr/logr/go.mod
+++ b/vendor/github.com/go-logr/logr/go.mod
@@ -1,0 +1,3 @@
+module github.com/go-logr/logr
+
+go 1.14

--- a/vendor/github.com/go-logr/logr/logr.go
+++ b/vendor/github.com/go-logr/logr/logr.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package logr defines abstract interfaces for logging.  Packages can depend on
 // these interfaces and callers can implement logging in whatever way is
 // appropriate.
@@ -13,22 +29,22 @@
 //
 // Usage
 //
-// Logging is done using a Logger.  Loggers can have name prefixes and named values
-// attached, so that all log messages logged with that Logger have some base context
-// associated.
+// Logging is done using a Logger.  Loggers can have name prefixes and named
+// values attached, so that all log messages logged with that Logger have some
+// base context associated.
 //
-// The term "key" is used to refer to the name associated with a particular value, to
-// disambiguate it from the general Logger name.
+// The term "key" is used to refer to the name associated with a particular
+// value, to disambiguate it from the general Logger name.
 //
-// For instance, suppose we're trying to reconcile the state of an object, and we want
-// to log that we've made some decision.
+// For instance, suppose we're trying to reconcile the state of an object, and
+// we want to log that we've made some decision.
 //
-// With the traditional log package, we might write
+// With the traditional log package, we might write:
 //  log.Printf(
 //      "decided to set field foo to value %q for object %s/%s",
 //       targetValue, object.Namespace, object.Name)
 //
-// With logr's structured logging, we'd write
+// With logr's structured logging, we'd write:
 //  // elsewhere in the file, set up the logger to log with the prefix of "reconcilers",
 //  // and the named value target-type=Foo, for extra context.
 //  log := mainLogger.WithName("reconcilers").WithValues("target-type", "Foo")
@@ -36,72 +52,95 @@
 //  // later on...
 //  log.Info("setting field foo on object", "value", targetValue, "object", object)
 //
-// Depending on our logging implementation, we could then make logging decisions based on field values
-// (like only logging such events for objects in a certain namespace), or copy the structured
-// information into a structured log store.
+// Depending on our logging implementation, we could then make logging decisions
+// based on field values (like only logging such events for objects in a certain
+// namespace), or copy the structured information into a structured log store.
 //
-// For logging errors, Logger has a method called Error.  Suppose we wanted to log an
-// error while reconciling.  With the traditional log package, we might write
+// For logging errors, Logger has a method called Error.  Suppose we wanted to
+// log an error while reconciling.  With the traditional log package, we might
+// write:
 //   log.Errorf("unable to reconcile object %s/%s: %v", object.Namespace, object.Name, err)
 //
-// With logr, we'd instead write
+// With logr, we'd instead write:
 //   // assuming the above setup for log
 //   log.Error(err, "unable to reconcile object", "object", object)
 //
 // This functions similarly to:
 //   log.Info("unable to reconcile object", "error", err, "object", object)
 //
-// However, it ensures that a standard key for the error value ("error") is used across all
-// error logging.  Furthermore, certain implementations may choose to attach additional
-// information (such as stack traces) on calls to Error, so it's preferred to use Error
-// to log errors.
+// However, it ensures that a standard key for the error value ("error") is used
+// across all error logging.  Furthermore, certain implementations may choose to
+// attach additional information (such as stack traces) on calls to Error, so
+// it's preferred to use Error to log errors.
 //
 // Parts of a log line
 //
 // Each log message from a Logger has four types of context:
 // logger name, log verbosity, log message, and the named values.
 //
-// The Logger name constists of a series of name "segments" added by successive calls to WithName.
-// These name segments will be joined in some way by the underlying implementation.  It is strongly
-// reccomended that name segements contain simple identifiers (letters, digits, and hyphen), and do
-// not contain characters that could muddle the log output or confuse the joining operation (e.g.
-// whitespace, commas, periods, slashes, brackets, quotes, etc).
+// The Logger name consists of a series of name "segments" added by successive
+// calls to WithName.  These name segments will be joined in some way by the
+// underlying implementation.  It is strongly recommended that name segments
+// contain simple identifiers (letters, digits, and hyphen), and do not contain
+// characters that could muddle the log output or confuse the joining operation
+// (e.g.  whitespace, commas, periods, slashes, brackets, quotes, etc).
 //
-// Log verbosity represents how little a log matters.  Level zero, the default, matters most.
-// Increasing levels matter less and less.  Try to avoid lots of different verbosity levels,
-// and instead provide useful keys, logger names, and log messages for users to filter on.
-// It's illegal to pass a log level below zero.
+// Log verbosity represents how little a log matters.  Level zero, the default,
+// matters most.  Increasing levels matter less and less.  Try to avoid lots of
+// different verbosity levels, and instead provide useful keys, logger names,
+// and log messages for users to filter on.  It's illegal to pass a log level
+// below zero.
 //
-// The log message consists of a constant message attached to the the log line.  This
-// should generally be a simple description of what's occuring, and should never be a format string.
+// The log message consists of a constant message attached to the log line.
+// This should generally be a simple description of what's occurring, and should
+// never be a format string.
 //
-// Variable information can then be attached using named values (key/value pairs).  Keys are arbitrary
-// strings, while values may be any Go value.
+// Variable information can then be attached using named values (key/value
+// pairs).  Keys are arbitrary strings, while values may be any Go value.
 //
 // Key Naming Conventions
 //
-// While users are generally free to use key names of their choice, it's generally best to avoid
-// using the following keys, as they're frequently used by implementations:
+// Keys are not strictly required to conform to any specification or regex, but
+// it is recommended that they:
+//   * be human-readable and meaningful (not auto-generated or simple ordinals)
+//   * be constant (not dependent on input data)
+//   * contain only printable characters
+//   * not contain whitespace or punctuation
 //
-// - `"error"`: the underlying error value in the `Error` method.
-// - `"stacktrace"`: the stack trace associated with a particular log line or error
-//                   (often from the `Error` message).
+// These guidelines help ensure that log data is processed properly regardless
+// of the log implementation.  For example, log implementations will try to
+// output JSON data or will store data for later database (e.g. SQL) queries.
+//
+// While users are generally free to use key names of their choice, it's
+// generally best to avoid using the following keys, as they're frequently used
+// by implementations:
+//
 // - `"caller"`: the calling information (file/line) of a particular log line.
-// - `"msg"`: the log message.
+// - `"error"`: the underlying error value in the `Error` method.
 // - `"level"`: the log level.
+// - `"logger"`: the name of the associated logger.
+// - `"msg"`: the log message.
+// - `"stacktrace"`: the stack trace associated with a particular log line or
+//                   error (often from the `Error` message).
 // - `"ts"`: the timestamp for a log line.
 //
-// Implementations are encouraged to make use of these keys to represent the above
-// concepts, when neccessary (for example, in a pure-JSON output form, it would be
-// necessary to represent at least message and timestamp as ordinary named values).
+// Implementations are encouraged to make use of these keys to represent the
+// above concepts, when necessary (for example, in a pure-JSON output form, it
+// would be necessary to represent at least message and timestamp as ordinary
+// named values).
 package logr
 
 // TODO: consider adding back in format strings if they're really needed
 // TODO: consider other bits of zap/zapcore functionality like ObjectMarshaller (for arbitrary objects)
 // TODO: consider other bits of glog functionality like Flush, InfoDepth, OutputStats
 
-// InfoLogger represents the ability to log non-error messages, at a particular verbosity.
-type InfoLogger interface {
+// Logger represents the ability to log messages, both errors and not.
+type Logger interface {
+	// Enabled tests whether this Logger is enabled.  For example, commandline
+	// flags might be used to set the logging verbosity and disable some info
+	// logs.
+	Enabled() bool
+
 	// Info logs a non-error message with the given key/value pairs as context.
 	//
 	// The msg argument should be used to add some constant description to
@@ -109,19 +148,6 @@ type InfoLogger interface {
 	// variable information.  The key/value pairs should alternate string
 	// keys and arbitrary values.
 	Info(msg string, keysAndValues ...interface{})
-
-	// Enabled tests whether this InfoLogger is enabled.  For example,
-	// commandline flags might be used to set the logging verbosity and disable
-	// some info logs.
-	Enabled() bool
-}
-
-// Logger represents the ability to log messages, both errors and not.
-type Logger interface {
-	// All Loggers implement InfoLogger.  Calling InfoLogger methods directly on
-	// a Logger value is equivalent to calling them on a V(0) InfoLogger.  For
-	// example, logger.Info() produces the same result as logger.V(0).Info.
-	InfoLogger
 
 	// Error logs an error, with the given message and key/value pairs as context.
 	// It functions similarly to calling Info with the "error" named value, but may
@@ -133,10 +159,11 @@ type Logger interface {
 	// triggered this log line, if present.
 	Error(err error, msg string, keysAndValues ...interface{})
 
-	// V returns an InfoLogger value for a specific verbosity level.  A higher
-	// verbosity level means a log message is less important.  It's illegal to
-	// pass a log level less than zero.
-	V(level int) InfoLogger
+	// V returns an Logger value for a specific verbosity level, relative to
+	// this Logger.  In other words, V values are additive.  V higher verbosity
+	// level means a log message is less important.  It's illegal to pass a log
+	// level less than zero.
+	V(level int) Logger
 
 	// WithValues adds some key-value pairs of context to a logger.
 	// See Info for documentation on how key/value pairs work.
@@ -144,8 +171,12 @@ type Logger interface {
 
 	// WithName adds a new element to the logger's name.
 	// Successive calls with WithName continue to append
-	// suffixes to the logger's name.  It's strongly reccomended
+	// suffixes to the logger's name.  It's strongly recommended
 	// that name segments contain only letters, digits, and hyphens
 	// (see the package documentation for more information).
 	WithName(name string) Logger
 }
+
+// InfoLogger provides compatibility with code that relies on the v0.1.0 interface
+// Deprecated: use Logger instead. This will be removed in a future release.
+type InfoLogger = Logger

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -99,7 +99,7 @@ github.com/evanphx/json-patch
 # github.com/ghodss/yaml v1.0.0
 ## explicit
 github.com/ghodss/yaml
-# github.com/go-logr/logr v0.1.0
+# github.com/go-logr/logr v0.2.1
 ## explicit
 github.com/go-logr/logr
 # github.com/go-openapi/jsonpointer v0.19.3


### PR DESCRIPTION
This patch bumps up github.com/go-logr/logr to v0.2.1.

v0.1.0 is too old and causes compatibility issue sometimes.

For example, github.com/kubernetes-sigs/service-apis uses v0.2.1 as
[kubernetes-sigs's go.mod](https://github.com/kubernetes-sigs/service-apis/blob/3fdc5d3fb0a864d186c709f6b22d6bba088d1688/go.mod#L7) so knative.dev/networking cannot test it.

/cc @coryrc @chizhg @yt3liu @mattmoor @vagababov 