### PR TITLE
Bump kubernetes minimum version to v1.17.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -30,7 +30,7 @@ const (
 	// the Kubernetes minimum version required by Knative.
 	KubernetesMinVersionKey = "KUBERNETES_MIN_VERSION"
 
-	defaultMinimumVersion = "v1.16.0"
+	defaultMinimumVersion = "v1.17.0"
 )
 
 func getMinimumVersion() string {

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -41,16 +41,16 @@ func TestVersionCheck(t *testing.T) {
 		wantError       bool
 	}{{
 		name:          "greater version (patch)",
-		actualVersion: &testVersioner{version: "v1.16.2"},
+		actualVersion: &testVersioner{version: "v1.17.2"},
 	}, {
 		name:          "greater version (minor)",
-		actualVersion: &testVersioner{version: "v1.17.0"},
+		actualVersion: &testVersioner{version: "v1.18.0"},
 	}, {
 		name:          "same version",
-		actualVersion: &testVersioner{version: "v1.16.0"},
+		actualVersion: &testVersioner{version: "v1.17.0"},
 	}, {
 		name:          "same version with build",
-		actualVersion: &testVersioner{version: "v1.16.0+k3s.1"},
+		actualVersion: &testVersioner{version: "v1.17.0+k3s.1"},
 	}, {
 		name:          "smaller version",
 		actualVersion: &testVersioner{version: "v1.14.3"},


### PR DESCRIPTION
This patch bumps up `defaultMinimumVersion` to v1.17.0

As per https://github.com/knative/community/issues/245#issuecomment-718316003,
v0.19(next release)'s minimum version is v1.17.

/cc @dprotaso @mattmoor @evankanderson 