### PR TITLE
Add host config option to the prometheus exporter

### DIFF
--- a/metrics/config.go
+++ b/metrics/config.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"knative.dev/pkg/ptr"
 	"net"
 	"net/url"
 	"os"
@@ -33,6 +32,7 @@ import (
 	"go.opencensus.io/stats"
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/metrics/metricskey"
+	"knative.dev/pkg/ptr"
 )
 
 // metricsBackend specifies the backend to use for metrics

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -246,9 +246,7 @@ func createMetricsConfig(ctx context.Context, ops ExporterOptions) (*metricsConf
 		}
 
 		mc.prometheusPort = pp
-
-		phost := prometheusHost()
-		mc.prometheusHost = phost
+		mc.prometheusHost = prometheusHost()
 	case stackdriver:
 		// If stackdriverClientConfig is not provided for stackdriver backend destination, OpenCensus will try to
 		// use the application default credentials. If that is not available, Opencensus would fail to create the

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -356,7 +356,7 @@ func prometheusPort() (int, error) {
 	return int(pp), nil
 }
 
-// prometheusPort returns the host configured via the environment
+// prometheusHost returns the host configured via the environment
 // for the Prometheus metrics exporter if it's set, a default value otherwise.
 // Validation is performed via parsing the host value as part of a url.
 func prometheusHost() (*string, error) {

--- a/metrics/config_test.go
+++ b/metrics/config_test.go
@@ -187,6 +187,7 @@ var (
 			backendDestination: prometheus,
 			reportingPeriod:    5 * time.Second,
 			prometheusPort:     defaultPrometheusPort,
+			prometheusHost:     defaultPrometheusHost,
 		},
 		expectedNewExporter: true,
 	}, {
@@ -308,6 +309,7 @@ var (
 			backendDestination: prometheus,
 			reportingPeriod:    5 * time.Second,
 			prometheusPort:     defaultPrometheusPort,
+			prometheusHost:     defaultPrometheusHost,
 		},
 		expectedNewExporter: true,
 	}, {
@@ -349,6 +351,7 @@ var (
 			backendDestination: prometheus,
 			reportingPeriod:    12 * time.Second,
 			prometheusPort:     defaultPrometheusPort,
+			prometheusHost:     defaultPrometheusHost,
 		},
 		expectedNewExporter: true,
 	}, {
@@ -431,6 +434,7 @@ var (
 			backendDestination: prometheus,
 			reportingPeriod:    5 * time.Second,
 			prometheusPort:     defaultPrometheusPort,
+			prometheusHost:     defaultPrometheusHost,
 		},
 		expectedNewExporter: true,
 	}, {
@@ -521,6 +525,7 @@ var (
 			backendDestination: prometheus,
 			reportingPeriod:    5 * time.Second,
 			prometheusPort:     9091,
+			prometheusHost:     defaultPrometheusHost,
 		},
 		expectedNewExporter: true,
 	}}
@@ -595,6 +600,7 @@ func TestGetMetricsConfig_fromEnv(t *testing.T) {
 			backendDestination: prometheus,
 			reportingPeriod:    5 * time.Second,
 			prometheusPort:     defaultPrometheusPort,
+			prometheusHost:     defaultPrometheusHost,
 		},
 	}, {
 		name:     "PrometheusPort from env",
@@ -611,6 +617,7 @@ func TestGetMetricsConfig_fromEnv(t *testing.T) {
 			backendDestination: prometheus,
 			reportingPeriod:    5 * time.Second,
 			prometheusPort:     9999,
+			prometheusHost:     defaultPrometheusHost,
 		},
 	}}
 

--- a/metrics/config_test.go
+++ b/metrics/config_test.go
@@ -918,13 +918,13 @@ func TestMetricsOptions(t *testing.T) {
 				Domain:         "domain",
 				Component:      "component",
 				PrometheusPort: 9090,
-				PrometheusHost: "",
+				PrometheusHost: "0.0.0.0",
 				ConfigMap: map[string]string{
 					"foo":   "bar",
 					"boosh": "kakow",
 				},
 			},
-			want: `{"Domain":"domain","Component":"component","PrometheusPort":9090,"PrometheusHost":"","ConfigMap":{"boosh":"kakow","foo":"bar"}}`,
+			want: `{"Domain":"domain","Component":"component","PrometheusPort":9090,"PrometheusHost":"0.0.0.0","ConfigMap":{"boosh":"kakow","foo":"bar"}}`,
 		},
 	}
 	for n, tc := range testCases {

--- a/metrics/config_test.go
+++ b/metrics/config_test.go
@@ -911,12 +911,13 @@ func TestMetricsOptions(t *testing.T) {
 				Domain:         "domain",
 				Component:      "component",
 				PrometheusPort: 9090,
+				PrometheusHost: "",
 				ConfigMap: map[string]string{
 					"foo":   "bar",
 					"boosh": "kakow",
 				},
 			},
-			want: `{"Domain":"domain","Component":"component","PrometheusPort":9090,"ConfigMap":{"boosh":"kakow","foo":"bar"}}`,
+			want: `{"Domain":"domain","Component":"component","PrometheusPort":9090,"PrometheusHost":"","ConfigMap":{"boosh":"kakow","foo":"bar"}}`,
 		},
 	}
 	for n, tc := range testCases {

--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -66,12 +66,12 @@ type ExporterOptions struct {
 
 	// PrometheusPort is the port to expose metrics if metrics backend is Prometheus.
 	// It should be between maxPrometheusPort and maxPrometheusPort. 0 value means
-	// using the default 9090 value. If it is ignored if metrics backend is not
+	// using the default 9090 value. It is ignored if metrics backend is not
 	// Prometheus.
 	PrometheusPort int
 
 	// PrometheusHost is the host to expose metrics on if metrics backend is Prometheus.
-	// The default value is "0.0.0.0" If it is ignored if metrics backend is not
+	// The default value is "0.0.0.0". It is ignored if metrics backend is not
 	// Prometheus.
 	PrometheusHost string
 

--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -66,12 +66,12 @@ type ExporterOptions struct {
 
 	// PrometheusPort is the port to expose metrics if metrics backend is Prometheus.
 	// It should be between maxPrometheusPort and maxPrometheusPort. 0 value means
-	// using the default 9090 value. If is ignored if metrics backend is not
+	// using the default 9090 value. If it is ignored if metrics backend is not
 	// Prometheus.
 	PrometheusPort int
 
 	// PrometheusHost is the host to expose metrics on if metrics backend is Prometheus.
-	// The dfault value is "0.0.0.0" If is ignored if metrics backend is not
+	// The default value is "0.0.0.0" If it is ignored if metrics backend is not
 	// Prometheus.
 	PrometheusHost string
 

--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -70,6 +70,11 @@ type ExporterOptions struct {
 	// Prometheus.
 	PrometheusPort int
 
+	// PrometheusHost is the host to expose metrics on if metrics backend is Prometheus.
+	// The dfault value is "0.0.0.0" If is ignored if metrics backend is not
+	// Prometheus.
+	PrometheusHost string
+
 	// ConfigMap is the data from config map config-observability. Must be present.
 	// See https://github.com/knative/serving/blob/master/config/config-observability.yaml
 	// for details.

--- a/metrics/prometheus_exporter.go
+++ b/metrics/prometheus_exporter.go
@@ -50,7 +50,7 @@ func newPrometheusExporter(config *metricsConfig, logger *zap.SugaredLogger) (vi
 	logger.Infof("Created Opencensus Prometheus exporter with config: %v. Start the server for Prometheus exporter.", config)
 	// Start the server for Prometheus scraping
 	go func() {
-		srv := startNewPromSrv(e, config.prometheusPort)
+		srv := startNewPromSrv(e, config.prometheusHost, config.prometheusPort)
 		srv.ListenAndServe()
 	}()
 	return e,
@@ -73,7 +73,7 @@ func resetCurPromSrv() {
 	}
 }
 
-func startNewPromSrv(e *prom.Exporter, port int) *http.Server {
+func startNewPromSrv(e *prom.Exporter, host string, port int) *http.Server {
 	sm := http.NewServeMux()
 	sm.Handle("/metrics", e)
 	curPromSrvMux.Lock()
@@ -82,7 +82,7 @@ func startNewPromSrv(e *prom.Exporter, port int) *http.Server {
 		curPromSrv.Close()
 	}
 	curPromSrv = &http.Server{
-		Addr:    fmt.Sprint(":", port),
+		Addr:    fmt.Sprintf("%s:%d", host, port),
 		Handler: sm,
 	}
 	return curPromSrv

--- a/metrics/prometheus_exporter.go
+++ b/metrics/prometheus_exporter.go
@@ -17,8 +17,8 @@ limitations under the License.
 package metrics
 
 import (
-	"fmt"
 	"net/http"
+	"strconv"
 	"sync"
 
 	prom "contrib.go.opencensus.io/exporter/prometheus"
@@ -82,7 +82,7 @@ func startNewPromSrv(e *prom.Exporter, host string, port int) *http.Server {
 		curPromSrv.Close()
 	}
 	curPromSrv = &http.Server{
-		Addr:    fmt.Sprintf("%s:%d", host, port),
+		Addr:    host + ":" + strconv.Itoa(port),
 		Handler: sm,
 	}
 	return curPromSrv

--- a/metrics/prometheus_exporter_test.go
+++ b/metrics/prometheus_exporter_test.go
@@ -112,11 +112,11 @@ func TestNewPrometheusExporter_fromEnv(t *testing.T) {
 			}
 			mc, err := createMetricsConfig(context.Background(), tc.ops)
 			if err != nil {
-				t.Error(err)
+				t.Fatal("Failed to create the metrics config:", err)
 			}
 			e, _, err := newPrometheusExporter(mc, TestLogger(t))
 			if err != nil {
-				t.Error(err)
+				t.Fatal("Failed to create a new Prometheus exporter:", err)
 			}
 			if e == nil {
 				t.Fatal("expected a non-nil metrics exporter")

--- a/metrics/prometheus_exporter_test.go
+++ b/metrics/prometheus_exporter_test.go
@@ -111,6 +111,9 @@ func TestNewPrometheusExporter_fromEnv(t *testing.T) {
 				defer os.Unsetenv(tc.prometheusHostVarName)
 			}
 			mc, err := createMetricsConfig(context.Background(), tc.ops)
+			if err != nil {
+				t.Error(err)
+			}
 			e, _, err := newPrometheusExporter(mc, TestLogger(t))
 			if err != nil {
 				t.Error(err)

--- a/metrics/prometheus_exporter_test.go
+++ b/metrics/prometheus_exporter_test.go
@@ -31,6 +31,7 @@ func TestNewPrometheusExporter(t *testing.T) {
 			component:          testComponent,
 			backendDestination: prometheus,
 			prometheusPort:     9090,
+			prometheusHost:     "",
 		},
 		expectedAddr: ":9090",
 	}, {
@@ -40,8 +41,9 @@ func TestNewPrometheusExporter(t *testing.T) {
 			component:          testComponent,
 			backendDestination: prometheus,
 			prometheusPort:     9091,
+			prometheusHost:     "127.0.0.1",
 		},
-		expectedAddr: ":9091",
+		expectedAddr: "127.0.0.1:9091",
 	}}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/metrics/prometheus_exporter_test.go
+++ b/metrics/prometheus_exporter_test.go
@@ -33,9 +33,9 @@ func TestNewPrometheusExporter(t *testing.T) {
 			component:          testComponent,
 			backendDestination: prometheus,
 			prometheusPort:     9090,
-			prometheusHost:     "",
+			prometheusHost:     "0.0.0.0",
 		},
-		expectedAddr: ":9090",
+		expectedAddr: "0.0.0.0:9090",
 	}, {
 		name: "port 9091",
 		config: metricsConfig{


### PR DESCRIPTION
Right now controller, autoscaler pods etc emit metrics using "0.0.0.0" which allows an arbitrary pod to view sensitive service information eg list all svcs etc in a multi-tenancy setting. We can disable metrics by setting no metrics backend, but ideally we would like a fine-grained configuration. My use case is to allow metrics to be exposed safely via a side-car like [rbac-proxy](https://github.com/brancz/kube-rbac-proxy). In this scenario first step is to constraint metrics on localhost by using an env var to pick up the right addr.
