### PR TITLE
Add tests for pre-release versions and add a better error message

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -64,6 +64,10 @@ func CheckMinimumVersion(versioner discovery.ServerVersionInterface) error {
 	// Compare returns 1 if the first version is greater than the
 	// second version.
 	if currentVersion.LT(minimumVersion) {
+		if len(currentVersion.Pre) > 0 {
+			return fmt.Errorf("pre-release kubernetes version %q is not compatible, need at least %q (this can be overridden with the env var %q); note pre-release version is smaller than the corresponding release version (e.g. 1.x.y-z < 1.x.y), using 1.x.y-0 as the minimum version is likely to help in this case",
+				currentVersion, minimumVersion, KubernetesMinVersionKey)
+		}
 		return fmt.Errorf("kubernetes version %q is not compatible, need at least %q (this can be overridden with the env var %q)",
 			currentVersion, minimumVersion, KubernetesMinVersionKey)
 	}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -43,6 +43,21 @@ func TestVersionCheck(t *testing.T) {
 		name:          "greater version (patch)",
 		actualVersion: &testVersioner{version: "v1.17.2"},
 	}, {
+		name:          "greater version (patch), no v",
+		actualVersion: &testVersioner{version: "1.17.2"},
+	}, {
+		name:          "greater version (patch), pre-release",
+		actualVersion: &testVersioner{version: "1.17.2-kpn-065dce"},
+	}, {
+		name:            "greater version (patch), pre-release, envvar override",
+		actualVersion:   &testVersioner{version: "1.15.11-kpn-065dce"},
+		versionOverride: "1.15.11",
+		wantError:       true,
+	}, {
+		name:            "greater version (patch), pre-release, envvar override, -0 hack",
+		actualVersion:   &testVersioner{version: "1.15.11-kpn-065dce"},
+		versionOverride: "1.15.11-0",
+	}, {
 		name:          "greater version (minor)",
 		actualVersion: &testVersioner{version: "v1.18.0"},
 	}, {
@@ -51,6 +66,10 @@ func TestVersionCheck(t *testing.T) {
 	}, {
 		name:          "same version with build",
 		actualVersion: &testVersioner{version: "v1.17.0+k3s.1"},
+	}, {
+		name:          "same version with pre-release",
+		actualVersion: &testVersioner{version: "v1.17.0-k3s.1"},
+		wantError:     true,
 	}, {
 		name:          "smaller version",
 		actualVersion: &testVersioner{version: "v1.14.3"},


### PR DESCRIPTION
When we have pre-release version it is very unintuitive with the default error message, since just looking at the string
`1.15.11-abs-1234` is larger than `1.15.11`, but semver treats `-abs-1234` as a prerelease version and hence smaller than
`1.15.11`.
So expand the error in this case

Fixes #1883

/assign @dprotaso mattmoor