### PR TITLE
Add GetObservers to tracker interface

### DIFF
--- a/reconciler/testing/tracker.go
+++ b/reconciler/testing/tracker.go
@@ -56,11 +56,10 @@ func (n *FakeTracker) GetObservers(obj interface{}) []types.NamespacedName {
 		Name:       or.Name,
 	}
 
-	keys := make([]types.NamespacedName, 0, len(n.references[ref]))
-
 	n.Lock()
 	defer n.Unlock()
 
+	keys := make([]types.NamespacedName, 0, len(n.references[ref]))
 	for key := range n.references[ref] {
 		keys = append(keys, key)
 	}

--- a/reconciler/testing/tracker.go
+++ b/reconciler/testing/tracker.go
@@ -41,6 +41,32 @@ var _ tracker.Interface = (*FakeTracker)(nil)
 // OnChanged implements OnChanged.
 func (*FakeTracker) OnChanged(interface{}) {}
 
+// GetObservers implements GetObservers.
+func (n *FakeTracker) GetObservers(obj interface{}) []types.NamespacedName {
+	item, err := kmeta.DeletionHandlingAccessor(obj)
+	if err != nil {
+		return nil
+	}
+
+	or := kmeta.ObjectReference(item)
+	ref := tracker.Reference{
+		APIVersion: or.APIVersion,
+		Kind:       or.Kind,
+		Namespace:  or.Namespace,
+		Name:       or.Name,
+	}
+
+	keys := make([]types.NamespacedName, 0, len(n.references[ref]))
+
+	n.Lock()
+	defer n.Unlock()
+
+	for key := range n.references[ref] {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
 // OnDeletedObserver implements OnDeletedObserver.
 func (n *FakeTracker) OnDeletedObserver(obj interface{}) {
 	item, err := kmeta.DeletionHandlingAccessor(obj)

--- a/reconciler/testing/tracker_test.go
+++ b/reconciler/testing/tracker_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	. "knative.dev/pkg/testing"
 	"knative.dev/pkg/tracker"
 )
@@ -30,24 +31,52 @@ func TestFakeTracker(t *testing.T) {
 			Name:      "foo",
 		},
 	}
+	t1Name := types.NamespacedName{
+		Namespace: t1.Namespace,
+		Name:      t1.Name,
+	}
 	t2 := &Resource{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "bar.baz.this-is-fine",
 		},
 	}
+	t2Name := types.NamespacedName{
+		Namespace: t2.Namespace,
+		Name:      t2.Name,
+	}
 
+	obj1 := &Resource{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "fakeapi",
+			Kind:       "Fake",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "bar",
+		},
+	}
 	ref1 := tracker.Reference{
-		APIVersion: "fakeapi",
-		Kind:       "Fake",
-		Namespace:  "foo",
-		Name:       "bar",
+		APIVersion: obj1.APIVersion,
+		Kind:       obj1.Kind,
+		Namespace:  obj1.Namespace,
+		Name:       obj1.Name,
+	}
+	obj2 := &Resource{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "fakeapi2",
+			Kind:       "Fake2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo2",
+			Name:      "bar2",
+		},
 	}
 	ref2 := tracker.Reference{
-		APIVersion: "fakeapi2",
-		Kind:       "Fake2",
-		Namespace:  "foo2",
-		Name:       "bar2",
+		APIVersion: obj2.APIVersion,
+		Kind:       obj2.Kind,
+		Namespace:  obj2.Namespace,
+		Name:       obj2.Name,
 	}
 
 	trk := &FakeTracker{}
@@ -57,9 +86,16 @@ func TestFakeTracker(t *testing.T) {
 	if !isTracking(trk, ref1) {
 		t.Fatal("Tracker is not tracking", ref1)
 	}
+	if !hasObserver(trk, obj1, t1Name) {
+		t.Fatalf("Object %v is not being observed by %v", obj1, t1Name)
+	}
+
 	trk.OnDeletedObserver(t1)
 	if isTracking(trk, ref1) {
 		t.Fatal("Tracker is still tracking", ref1)
+	}
+	if hasObserver(trk, obj1, t1Name) {
+		t.Fatalf("Object %v is still being observed by %v", obj1, t1Name)
 	}
 
 	// Adding t1, t2 to ref1 and t2 to ref2, then removing t2 results in ref2 stopping
@@ -73,22 +109,58 @@ func TestFakeTracker(t *testing.T) {
 	if !isTracking(trk, ref2) {
 		t.Fatal("Tracker is not tracking", ref2)
 	}
+	if !hasObserver(trk, obj1, t1Name) {
+		t.Fatalf("Object %v is not being observed by %v", obj1, t1Name)
+	}
+	if !hasObserver(trk, obj1, t2Name) {
+		t.Fatalf("Object %v is not being observed by %v", obj1, t2Name)
+	}
+	if hasObserver(trk, obj2, t1Name) {
+		t.Fatalf("Object %v wrongly being observed by %v", obj2, t1Name)
+	}
+	if !hasObserver(trk, obj2, t2Name) {
+		t.Fatalf("Object %v is not being observed by %v", obj2, t2Name)
+	}
+
 	trk.OnDeletedObserver(t2)
 	if !isTracking(trk, ref1) {
 		t.Fatal("Tracker is not tracking", ref1)
 	}
+	if !hasObserver(trk, obj1, t1Name) {
+		t.Fatalf("Object %v is not being observed by %v", obj1, t1Name)
+	}
 	if isTracking(trk, ref2) {
 		t.Fatal("Tracker is still tracking", ref2)
 	}
+	if hasObserver(trk, obj1, t2Name) {
+		t.Fatalf("Object %v is still being observed by %v", obj1, t2Name)
+	}
+	if hasObserver(trk, obj2, t2Name) {
+		t.Fatalf("Object %v is still being observed by %v", obj2, t2Name)
+	}
+
 	trk.OnDeletedObserver(t1)
 	if isTracking(trk, ref1) {
 		t.Fatal("Tracker is still tracking", ref1)
+	}
+	if hasObserver(trk, obj1, t1Name) {
+		t.Fatalf("Object %v is still being observed by %v", obj1, t1Name)
 	}
 }
 
 func isTracking(tracker *FakeTracker, ref1 tracker.Reference) bool {
 	for _, tracking := range tracker.References() {
 		if tracking == ref1 {
+			return true
+		}
+	}
+	return false
+}
+
+func hasObserver(tracker *FakeTracker, obj *Resource, obs types.NamespacedName) bool {
+	observers := tracker.GetObservers(obj)
+	for _, observer := range observers {
+		if observer == obs {
 			return true
 		}
 	}

--- a/tracker/enqueue.go
+++ b/tracker/enqueue.go
@@ -216,9 +216,18 @@ func isExpired(expiry time.Time) bool {
 
 // OnChanged implements Interface.
 func (i *impl) OnChanged(obj interface{}) {
+	observers := i.GetObservers(obj)
+
+	for _, observer := range observers {
+		i.cb(observer)
+	}
+}
+
+// GetObservers implements Interface.
+func (i *impl) GetObservers(obj interface{}) []types.NamespacedName {
 	item, err := kmeta.DeletionHandlingAccessor(obj)
 	if err != nil {
-		return
+		return nil
 	}
 
 	or := kmeta.ObjectReference(item)
@@ -229,14 +238,9 @@ func (i *impl) OnChanged(obj interface{}) {
 		Name:       or.Name,
 	}
 
-	i.m.Lock()
-	// Call the callbacks without the lock held.
 	var keys []types.NamespacedName
-	defer func(cb func(types.NamespacedName)) {
-		for _, key := range keys {
-			cb(key)
-		}
-	}(i.cb) // read i.cb with the lock held
+
+	i.m.Lock()
 	defer i.m.Unlock()
 
 	// Handle exact matches.
@@ -274,6 +278,8 @@ func (i *impl) OnChanged(obj interface{}) {
 			delete(i.exact, ref)
 		}
 	}
+
+	return keys
 }
 
 // OnChanged implements Interface.

--- a/tracker/enqueue_test.go
+++ b/tracker/enqueue_test.go
@@ -73,6 +73,10 @@ func TestHappyPathsExact(t *testing.T) {
 		if got, want := calls, 0; got != want {
 			t.Fatalf("OnChanged() = %v, wanted %v", got, want)
 		}
+		obs := trk.GetObservers(thing1)
+		if got, want := len(obs), 0; got != want {
+			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
+		}
 	}
 
 	// Tracked gets called
@@ -88,6 +92,10 @@ func TestHappyPathsExact(t *testing.T) {
 		trk.OnChanged(thing1)
 		if got, want := calls, 2; got != want {
 			t.Fatalf("OnChanged() = %v, wanted %v", got, want)
+		}
+		obs := trk.GetObservers(thing1)
+		if got, want := len(obs), 1; got != want {
+			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
 		}
 	}
 
@@ -109,6 +117,10 @@ func TestHappyPathsExact(t *testing.T) {
 		if _, stillThere := trk.(*impl).exact[ref]; stillThere {
 			t.Fatal("Timeout passed, but exact for objectReference is still there")
 		}
+		obs := trk.GetObservers(thing1)
+		if got, want := len(obs), 0; got != want {
+			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
+		}
 	}
 
 	// Starts getting called again
@@ -124,6 +136,10 @@ func TestHappyPathsExact(t *testing.T) {
 		trk.OnChanged(thing1)
 		if got, want := calls, 5; got != want {
 			t.Fatalf("OnChanged() = %v, wanted %v", got, want)
+		}
+		obs := trk.GetObservers(thing1)
+		if got, want := len(obs), 1; got != want {
+			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
 		}
 	}
 
@@ -171,12 +187,20 @@ func TestHappyPathsExact(t *testing.T) {
 		if got, want := calls, 6; got != want {
 			t.Fatalf("OnChanged() = %v, wanted %v", got, want)
 		}
+		obs := trk.GetObservers(thing1)
+		if got, want := len(obs), 0; got != want {
+			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
+		}
 	}
 
 	// Track bad object
 	{
 		if err := trk.Track(ref.ObjectReference(), struct{}{}); err == nil {
 			t.Fatal("Track() = nil, wanted error")
+		}
+		obs := trk.GetObservers(thing1)
+		if got, want := len(obs), 0; got != want {
+			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
 		}
 	}
 }
@@ -504,6 +528,10 @@ func TestHappyPathsInexact(t *testing.T) {
 		if got, want := calls, 0; got != want {
 			t.Fatalf("OnChanged() = %v, wanted %v", got, want)
 		}
+		obs := trk.GetObservers(thing1)
+		if got, want := len(obs), 0; got != want {
+			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
+		}
 	}
 
 	// Tracked gets called
@@ -519,6 +547,10 @@ func TestHappyPathsInexact(t *testing.T) {
 		trk.OnChanged(thing1)
 		if got, want := calls, 2; got != want {
 			t.Fatalf("OnChanged() = %v, wanted %v", got, want)
+		}
+		obs := trk.GetObservers(thing1)
+		if got, want := len(obs), 1; got != want {
+			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
 		}
 	}
 
@@ -540,6 +572,10 @@ func TestHappyPathsInexact(t *testing.T) {
 		if _, stillThere := trk.(*impl).exact[ref]; stillThere {
 			t.Fatal("Timeout passed, but exact for objectReference is still there")
 		}
+		obs := trk.GetObservers(thing1)
+		if got, want := len(obs), 0; got != want {
+			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
+		}
 	}
 
 	// Starts getting called again
@@ -555,6 +591,10 @@ func TestHappyPathsInexact(t *testing.T) {
 		trk.OnChanged(thing1)
 		if got, want := calls, 5; got != want {
 			t.Fatalf("OnChanged() = %v, wanted %v", got, want)
+		}
+		obs := trk.GetObservers(thing1)
+		if got, want := len(obs), 1; got != want {
+			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
 		}
 	}
 
@@ -604,6 +644,10 @@ func TestHappyPathsInexact(t *testing.T) {
 		if got, want := calls, 6; got != want {
 			t.Fatalf("Track() = %v, wanted %v", got, want)
 		}
+		obs := trk.GetObservers(thing1)
+		if got, want := len(obs), 1; got != want {
+			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
+		}
 
 		thing1unlabeled := thing1.DeepCopy()
 		thing1unlabeled.Labels = nil
@@ -647,12 +691,20 @@ func TestHappyPathsInexact(t *testing.T) {
 		if got, want := calls, 7; got != want {
 			t.Fatalf("OnChanged() = %v, wanted %v", got, want)
 		}
+		obs := trk.GetObservers(thing1)
+		if got, want := len(obs), 0; got != want {
+			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
+		}
 	}
 
 	// Track bad object
 	{
 		if err := trk.TrackReference(ref, struct{}{}); err == nil {
 			t.Fatal("Track() = nil, wanted error")
+		}
+		obs := trk.GetObservers(thing1)
+		if got, want := len(obs), 0; got != want {
+			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
 		}
 	}
 }
@@ -726,6 +778,9 @@ func TestHappyPathsByBoth(t *testing.T) {
 		if got, want := calls, 1; got != want {
 			t.Fatalf("Track() = %v, wanted %v", got, want)
 		}
+		if got, want := len(trk.GetObservers(thing1)), 1; got != want {
+			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
+		}
 
 		if err := trk.TrackReference(ref2, thing2); err != nil {
 			t.Fatal("Track() =", err)
@@ -733,6 +788,9 @@ func TestHappyPathsByBoth(t *testing.T) {
 		// New registrations should result in an immediate callback.
 		if got, want := calls, 2; got != want {
 			t.Fatalf("Track() = %v, wanted %v", got, want)
+		}
+		if got, want := len(trk.GetObservers(thing1)), 2; got != want {
+			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
 		}
 
 		// The callback should be called for each of the tracks (exact and inexact)
@@ -748,6 +806,9 @@ func TestHappyPathsByBoth(t *testing.T) {
 		trk.OnChanged(thing1)
 		if got, want := calls, 4; got != want {
 			t.Fatalf("OnChanged() = %v, wanted %v", got, want)
+		}
+		if got, want := len(trk.GetObservers(thing1)), 0; got != want {
+			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
 		}
 	}
 }

--- a/tracker/interface.go
+++ b/tracker/interface.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	"knative.dev/pkg/apis"
@@ -70,6 +71,10 @@ type Interface interface {
 	// OnChanged is a callback to register with the InformerFactory
 	// so that we are notified for appropriate object changes.
 	OnChanged(obj interface{})
+
+	// GetObservers returns the names of all observers for the given
+	// object.
+	GetObservers(obj interface{}) []types.NamespacedName
 
 	// OnDeletedObserver is a callback to register with the InformerFactory
 	// so that we are notified for deletions of a watching parent to


### PR DESCRIPTION
This allows an arbitrary client to fetch all the observers of a given object. Ultimately, this enables an informer setup that can use this knowledge as a filter to decide whether or not the current object is actually watched by anything.

/assign @mattmoor @dprotaso 