### PR TITLE
Add a flag to disable QP profiling.

### DIFF
--- a/metrics/config_observability.go
+++ b/metrics/config_observability.go
@@ -73,6 +73,12 @@ type ObservabilityConfig struct {
 	// the pods via an HTTP server in the format expected by the pprof visualization tool.
 	EnableProfiling bool
 
+	// DisableQPProfiling indicates whether EnableProfiling flag applies to the QueueProxy processes.
+	// If false (default) — enabling or disabling profiling causes a global rolling restart of the
+	// Knative service pods, which might not be desireable (especially if there is no need to profile
+	// QP processes).
+	DisableQPProfiling bool
+
 	// EnableRequestLog enables activator/queue-proxy to write request logs.
 	EnableRequestLog bool
 
@@ -86,6 +92,7 @@ func defaultConfig() *ObservabilityConfig {
 		LoggingURLTemplate:    DefaultLogURLTemplate,
 		RequestLogTemplate:    DefaultRequestLogTemplate,
 		RequestMetricsBackend: defaultRequestMetricsBackend,
+		DisableQPProfiling:    true, // True for backwards compatibility.
 	}
 }
 
@@ -101,6 +108,7 @@ func NewObservabilityConfigFromConfigMap(configMap *corev1.ConfigMap) (*Observab
 		cm.AsBool(EnableProbeReqLogKey, &oc.EnableProbeRequestLog),
 		cm.AsString("metrics.request-metrics-backend-destination", &oc.RequestMetricsBackend),
 		cm.AsBool("profiling.enable", &oc.EnableProfiling),
+		cm.AsBool("profiling.enable-qp", &oc.DisableQPProfiling),
 		cm.AsString("metrics.opencensus-address", &oc.MetricsCollectorAddress),
 	); err != nil {
 		return nil, err

--- a/metrics/config_observability.go
+++ b/metrics/config_observability.go
@@ -75,7 +75,7 @@ type ObservabilityConfig struct {
 
 	// DisableQPProfiling indicates whether EnableProfiling flag applies to the QueueProxy processes.
 	// If false (default) — enabling or disabling profiling causes a global rolling restart of the
-	// Knative service pods, which might not be desireable (especially if there is no need to profile
+	// Knative service pods, which might not be desirable (especially if there is no need to profile
 	// QP processes).
 	DisableQPProfiling bool
 
@@ -92,7 +92,6 @@ func defaultConfig() *ObservabilityConfig {
 		LoggingURLTemplate:    DefaultLogURLTemplate,
 		RequestLogTemplate:    DefaultRequestLogTemplate,
 		RequestMetricsBackend: defaultRequestMetricsBackend,
-		DisableQPProfiling:    true, // True for backwards compatibility.
 	}
 }
 
@@ -108,7 +107,7 @@ func NewObservabilityConfigFromConfigMap(configMap *corev1.ConfigMap) (*Observab
 		cm.AsBool(EnableProbeReqLogKey, &oc.EnableProbeRequestLog),
 		cm.AsString("metrics.request-metrics-backend-destination", &oc.RequestMetricsBackend),
 		cm.AsBool("profiling.enable", &oc.EnableProfiling),
-		cm.AsBool("profiling.enable-qp", &oc.DisableQPProfiling),
+		cm.AsBool("profiling.disable-qp", &oc.DisableQPProfiling),
 		cm.AsString("metrics.opencensus-address", &oc.MetricsCollectorAddress),
 	); err != nil {
 		return nil, err

--- a/metrics/config_observability_test.go
+++ b/metrics/config_observability_test.go
@@ -37,6 +37,7 @@ func TestObservabilityConfiguration(t *testing.T) {
 		wantConfig: &ObservabilityConfig{
 			EnableProbeRequestLog:  true,
 			EnableProfiling:        true,
+			DisableQPProfiling:     true,
 			EnableVarLogCollection: true,
 			EnableRequestLog:       true,
 			LoggingURLTemplate:     "https://logging.io",
@@ -51,6 +52,7 @@ func TestObservabilityConfiguration(t *testing.T) {
 			EnableReqLogKey:                               "true",
 			"metrics.request-metrics-backend-destination": "stackdriver",
 			"profiling.enable":                            "true",
+			"profiling.disable-qp":                        "true",
 		},
 	}, {
 		name:       "observability config with no map",
@@ -64,78 +66,61 @@ func TestObservabilityConfiguration(t *testing.T) {
 	}, {
 		name: "observability configuration with request log set and template default",
 		data: map[string]string{
-			EnableProbeReqLogKey:                          "true",
-			EnableReqLogKey:                               "true",
-			"logging.enable-var-log-collection":           "true",
-			"logging.revision-url-template":               "https://logging.io",
-			"metrics.request-metrics-backend-destination": "stackdriver",
-			"profiling.enable":                            "true",
+			EnableProbeReqLogKey:            "true",
+			EnableReqLogKey:                 "true",
+			"logging.revision-url-template": "https://logging.io",
 		},
-		wantConfig: &ObservabilityConfig{
-			EnableProbeRequestLog:  true,
-			EnableProfiling:        true,
-			EnableRequestLog:       true,
-			EnableVarLogCollection: true,
-			LoggingURLTemplate:     "https://logging.io",
-			RequestLogTemplate:     DefaultRequestLogTemplate,
-			RequestMetricsBackend:  "stackdriver",
-		},
+		wantConfig: func() *ObservabilityConfig {
+			oc := defaultConfig()
+			oc.EnableProbeRequestLog = true
+			oc.EnableRequestLog = true
+			oc.LoggingURLTemplate = "https://logging.io"
+			return oc
+		}(),
 	}, {
 		name: "observability configuration with request log and template not set",
-		wantConfig: &ObservabilityConfig{
-			EnableProbeRequestLog:  true,
-			EnableProfiling:        true,
-			EnableVarLogCollection: true,
-			LoggingURLTemplate:     "https://logging.io",
-			RequestMetricsBackend:  "stackdriver",
-		},
+		wantConfig: func() *ObservabilityConfig {
+			oc := defaultConfig()
+			oc.RequestLogTemplate = ""
+			oc.EnableProbeRequestLog = true
+			return oc
+		}(),
 		data: map[string]string{
-			EnableProbeReqLogKey:                          "true",
-			EnableReqLogKey:                               "false",
-			"logging.enable-var-log-collection":           "true",
-			ReqLogTemplateKey:                             "",
-			"logging.revision-url-template":               "https://logging.io",
-			"metrics.request-metrics-backend-destination": "stackdriver",
-			"profiling.enable":                            "true",
+			EnableProbeReqLogKey: "true",
+			EnableReqLogKey:      "false", // Explicit default.
+			ReqLogTemplateKey:    "",
 		},
 	}, {
 		name:    "observability configuration with request log set and template not set",
 		wantErr: true,
 		data: map[string]string{
-			EnableProbeReqLogKey:                          "true",
-			EnableReqLogKey:                               "true",
-			"logging.enable-var-log-collection":           "true",
-			ReqLogTemplateKey:                             "",
-			"logging.revision-url-template":               "https://logging.io",
-			"metrics.request-metrics-backend-destination": "stackdriver",
-			"profiling.enable":                            "true",
+			EnableProbeReqLogKey:                "true",
+			EnableReqLogKey:                     "true",
+			"logging.enable-var-log-collection": "true",
+			ReqLogTemplateKey:                   "",
 		},
 	}, {
 		name: "observability configuration with request log not set and with template set",
-		wantConfig: &ObservabilityConfig{
-			EnableProbeRequestLog:  true,
-			EnableProfiling:        true,
-			EnableVarLogCollection: true,
-			LoggingURLTemplate:     "https://logging.io",
-			RequestLogTemplate:     `{"requestMethod": "{{.Request.Method}}"}`,
-			RequestMetricsBackend:  "stackdriver",
-		},
+		wantConfig: func() *ObservabilityConfig {
+			oc := defaultConfig()
+			oc.EnableProbeRequestLog = true
+			oc.EnableVarLogCollection = true
+			oc.RequestLogTemplate = `{"requestMethod": "{{.Request.Method}}"}`
+			return oc
+		}(),
 		data: map[string]string{
-			EnableProbeReqLogKey:                          "true",
-			"logging.enable-var-log-collection":           "true",
-			ReqLogTemplateKey:                             `{"requestMethod": "{{.Request.Method}}"}`,
-			"logging.revision-url-template":               "https://logging.io",
-			"metrics.request-metrics-backend-destination": "stackdriver",
-			"profiling.enable":                            "true",
+			EnableProbeReqLogKey:                "true",
+			"logging.enable-var-log-collection": "true",
+			ReqLogTemplateKey:                   `{"requestMethod": "{{.Request.Method}}"}`,
 		},
 	}, {
 		name: "observability configuration with collector address",
-		wantConfig: &ObservabilityConfig{
-			LoggingURLTemplate:      DefaultLogURLTemplate,
-			RequestLogTemplate:      DefaultRequestLogTemplate,
-			RequestMetricsBackend:   "opencensus",
-			MetricsCollectorAddress: "otel:55678",
-		},
+		wantConfig: func() *ObservabilityConfig {
+			oc := defaultConfig()
+			oc.RequestMetricsBackend = "opencensus"
+			oc.MetricsCollectorAddress = "otel:55678"
+			return oc
+		}(),
 		data: map[string]string{
 			"metrics.request-metrics-backend-destination": "opencensus",
 			"metrics.opencensus-address":                  "otel:55678",


### PR DESCRIPTION
Turning profiling on or off toggles full rolling restart
of knative pods. And if profiling QP is not of interest, this
might be quite undesireable. To permit that.

For https://github.com/knative/serving/issues/10051