### PR TITLE
Fix a few more occurrences of divisive language

### DIFF
--- a/apis/duck/cached_test.go
+++ b/apis/duck/cached_test.go
@@ -170,12 +170,12 @@ func TestDifferentGVRs(t *testing.T) {
 	}
 }
 
-// fakeGenericLister returns a dummy cache.GenericLister.
+// fakeGenericLister returns a fake cache.GenericLister.
 func fakeGenericLister(gr schema.GroupResource) cache.GenericLister {
-	var dummyKeyFunc cache.KeyFunc = func(interface{}) (string, error) {
+	var fakeKeyFunc cache.KeyFunc = func(interface{}) (string, error) {
 		return "", nil
 	}
 
-	dummyIndexer := cache.NewIndexer(dummyKeyFunc, cache.Indexers{})
-	return cache.NewGenericLister(dummyIndexer, gr)
+	fakeIndexer := cache.NewIndexer(fakeKeyFunc, cache.Indexers{})
+	return cache.NewGenericLister(fakeIndexer, gr)
 }

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1243,21 +1243,21 @@ func drainWorkQueue(wq workqueue.RateLimitingInterface) (hasQueue []types.Namesp
 	return
 }
 
-type dummyInformer struct {
+type fakeInformer struct {
 	cache.SharedInformer
 }
 
-type dummyStore struct {
+type fakeStore struct {
 	cache.Store
 }
 
-func (*dummyInformer) GetStore() cache.Store {
-	return &dummyStore{}
+func (*fakeInformer) GetStore() cache.Store {
+	return &fakeStore{}
 }
 
 var (
-	dummyKeys = []string{"foo/bar", "bar/foo", "fizz/buzz"}
-	dummyObjs = []interface{}{
+	fakeKeys = []string{"foo/bar", "bar/foo", "fizz/buzz"}
+	fakeObjs = []interface{}{
 		&Resource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "bar",
@@ -1279,12 +1279,12 @@ var (
 	}
 )
 
-func (*dummyStore) ListKeys() []string {
-	return dummyKeys
+func (*fakeStore) ListKeys() []string {
+	return fakeKeys
 }
 
-func (*dummyStore) List() []interface{} {
-	return dummyObjs
+func (*fakeStore) List() []interface{} {
+	return fakeObjs
 }
 
 func TestImplGlobalResync(t *testing.T) {
@@ -1302,10 +1302,10 @@ func TestImplGlobalResync(t *testing.T) {
 		<-doneCh
 	})
 
-	impl.GlobalResync(&dummyInformer{})
+	impl.GlobalResync(&fakeInformer{})
 
 	// The global resync delays enqueuing things by a second with a jitter that
-	// goes up to len(dummyObjs) times a second: time.Duration(1+len(dummyObjs)) * time.Second.
+	// goes up to len(fakeObjs) times a second: time.Duration(1+len(fakeObjs)) * time.Second.
 	// In this test, the fast lane is empty, so we can assume immediate enqueuing.
 	select {
 	case <-time.After(50 * time.Millisecond):

--- a/metrics/stackdriver_exporter_test.go
+++ b/metrics/stackdriver_exporter_test.go
@@ -520,7 +520,7 @@ func TestSetStackdriverSecretLocation(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Sanity checks
+	// Default checks
 	assertStringsEqual(t, "DefaultSecretName", secretName, StackdriverSecretNameDefault)
 	assertStringsEqual(t, "DefaultSecretNamespace", secretNamespace, StackdriverSecretNamespaceDefault)
 	sec, err := getStackdriverSecret(ctx, secretFetcher)

--- a/test/gcs/mock/mock_test.go
+++ b/test/gcs/mock/mock_test.go
@@ -31,8 +31,8 @@ import (
 
 func TestSetError(t *testing.T) {
 	ctx := context.Background()
-	bkt := "dummy"
-	project := "dummy"
+	bkt := "fake"
+	project := "fake"
 	dirPath := "/"
 
 	testCases := []struct {
@@ -217,8 +217,8 @@ func TestSetError(t *testing.T) {
 
 func TestClearError(t *testing.T) {
 	ctx := context.Background()
-	bkt := "dummy"
-	project := "dummy"
+	bkt := "fake"
+	project := "fake"
 	dirPath := "/"
 
 	testCases := []struct {

--- a/webhook/psbinding/table_test.go
+++ b/webhook/psbinding/table_test.go
@@ -2158,7 +2158,7 @@ func TestBaseReconcileWithSubResourcesReconciler(t *testing.T) {
 		dc := dynamicclient.Get(ctx)
 
 		kc := kubeclient.Get(ctx)
-		srr := &dummySubResourcesReconciler{
+		srr := &fakeSubResourcesReconciler{
 			client: kc,
 		}
 		return &BaseReconciler{
@@ -2282,11 +2282,11 @@ func deletedConfigmap(namespace string, name string) clientgotesting.DeleteActio
 	return action
 }
 
-type dummySubResourcesReconciler struct {
+type fakeSubResourcesReconciler struct {
 	client *fakek8s.Clientset
 }
 
-func (d *dummySubResourcesReconciler) Reconcile(ctx context.Context, fb Bindable) error {
+func (d *fakeSubResourcesReconciler) Reconcile(ctx context.Context, fb Bindable) error {
 	cfg := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fb.GetName(),
@@ -2297,6 +2297,6 @@ func (d *dummySubResourcesReconciler) Reconcile(ctx context.Context, fb Bindable
 	return err
 }
 
-func (d *dummySubResourcesReconciler) ReconcileDeletion(ctx context.Context, fb Bindable) error {
+func (d *fakeSubResourcesReconciler) ReconcileDeletion(ctx context.Context, fb Bindable) error {
 	return d.client.CoreV1().ConfigMaps(fb.GetNamespace()).Delete(ctx, fb.GetName(), metav1.DeleteOptions{})
 }


### PR DESCRIPTION
As per title. Dummy and "sanity check" are considered divisive language.

/assign @mattmoor 