### PR TITLE
Allow global resync & reconcilerImpl informers to be filtered via filterfunc

### DIFF
--- a/client/injection/kube/reconciler/apps/v1/deployment/controller.go
+++ b/client/injection/kube/reconciler/apps/v1/deployment/controller.go
@@ -59,6 +59,7 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	lister := deploymentInformer.Lister()
 
+	filterFunc := controller.GetFilterFunc(ctx)
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
@@ -67,11 +68,12 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 					return err
 				}
 				for _, elt := range all {
-					// TODO: Consider letting users specify a filter in options.
-					enq(bkt, types.NamespacedName{
-						Namespace: elt.GetNamespace(),
-						Name:      elt.GetName(),
-					})
+					if ok := filterFunc(elt); ok {
+						enq(bkt, types.NamespacedName{
+							Namespace: elt.GetNamespace(),
+							Name:      elt.GetName(),
+						})
+					}
 				}
 				return nil
 			},

--- a/client/injection/kube/reconciler/core/v1/namespace/controller.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/controller.go
@@ -59,6 +59,7 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	lister := namespaceInformer.Lister()
 
+	filterFunc := controller.GetFilterFunc(ctx)
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
@@ -67,11 +68,12 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 					return err
 				}
 				for _, elt := range all {
-					// TODO: Consider letting users specify a filter in options.
-					enq(bkt, types.NamespacedName{
-						Namespace: elt.GetNamespace(),
-						Name:      elt.GetName(),
-					})
+					if ok := filterFunc(elt); ok {
+						enq(bkt, types.NamespacedName{
+							Namespace: elt.GetNamespace(),
+							Name:      elt.GetName(),
+						})
+					}
 				}
 				return nil
 			},

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -56,6 +56,11 @@ var (
 	// may adjust this process-wide default.  For finer control, invoke
 	// Run on the controller directly.
 	DefaultThreadsPerController = 2
+
+	// alwaysTrue is the default filterFunc, which allows all objects
+	// passed through this is used in the default case for passing all
+	// objects to the slowlane from the passed sharedInformer
+	alwaysTrue = func(interface{}) bool { return true }
 )
 
 // Reconciler is the interface that controller implementations are expected
@@ -246,7 +251,7 @@ func NewImplFull(r Reconciler, options ControllerOptions) *Impl {
 		options.Reporter = MustNewStatsReporter(options.WorkQueueName, options.Logger)
 	}
 	if options.GlobalResyncFilterFunc == nil {
-		options.GlobalResyncFilterFunc = func(obj interface{}) bool { return true }
+		options.GlobalResyncFilterFunc = alwaysTrue
 	}
 	return &Impl{
 		Name:                   options.WorkQueueName,
@@ -735,7 +740,7 @@ func WithFilterFunc(ctx context.Context, filter filterFunc) context.Context {
 func GetFilterFunc(ctx context.Context) filterFunc {
 	value := ctx.Value(filterFuncKey{})
 	if value == nil {
-		return func(interface{}) bool { return true }
+		return alwaysTrue
 	}
 	return value.(filterFunc)
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -57,7 +57,7 @@ var (
 	// Run on the controller directly.
 	DefaultThreadsPerController = 2
 
-	// alwaysTrue is the default filterFunc, which allows all objects
+	// alwaysTrue is the default FilterFunc, which allows all objects
 	// passed through this is used in the default case for passing all
 	// objects to the slowlane from the passed sharedInformer
 	alwaysTrue = func(interface{}) bool { return true }
@@ -179,7 +179,7 @@ func FilterWithNameAndNamespace(namespace, name string) func(obj interface{}) bo
 	}
 }
 
-type filterFunc func(obj interface{}) bool
+type FilterFunc func(obj interface{}) bool
 
 // Impl is our core controller implementation.  It handles queuing and feeding work
 // from the queue to an implementation of Reconciler.
@@ -215,7 +215,7 @@ type Impl struct {
 	// the shared cache on a global resync, be default and if not
 	// set by the controller implemenation, it will default to
 	// allowing every object in the cache
-	globalResyncFilterFunc filterFunc
+	globalResyncFilterFunc FilterFunc
 }
 
 // ControllerOptions encapsulates options for creating a new controller,
@@ -225,7 +225,7 @@ type ControllerOptions struct { //nolint // for backcompat.
 	Logger                 *zap.SugaredLogger
 	Reporter               StatsReporter
 	RateLimiter            workqueue.RateLimiter
-	GlobalResyncFilterFunc filterFunc
+	GlobalResyncFilterFunc FilterFunc
 }
 
 // NewImpl instantiates an instance of our controller that will feed work to the
@@ -566,7 +566,7 @@ func (c *Impl) GlobalResync(si cache.SharedInformer) {
 
 // FilteredGlobalResync enqueues objects from the
 // SharedInformer that pass the filter function in to the slow queue.
-func (c *Impl) FilteredGlobalResync(f filterFunc, si cache.SharedInformer) {
+func (c *Impl) FilteredGlobalResync(f FilterFunc, si cache.SharedInformer) {
 	if c.workQueue.ShuttingDown() {
 		return
 	}
@@ -734,14 +734,14 @@ func safeKey(key types.NamespacedName) string {
 // This is a filterFunc for leaderelection informer and listers
 type filterFuncKey struct{}
 
-func WithFilterFunc(ctx context.Context, filter filterFunc) context.Context {
+func WithFilterFunc(ctx context.Context, filter FilterFunc) context.Context {
 	return context.WithValue(ctx, filterFuncKey{}, filter)
 }
 
-func GetFilterFunc(ctx context.Context) filterFunc {
+func GetFilterFunc(ctx context.Context) FilterFunc {
 	value := ctx.Value(filterFuncKey{})
 	if value == nil {
 		return alwaysTrue
 	}
-	return value.(filterFunc)
+	return value.(FilterFunc)
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -58,7 +58,7 @@ var (
 	DefaultThreadsPerController = 2
 
 	// alwaysTrue is the default FilterFunc, which allows all objects
-	// passed through this is used in the default case for passing all
+	// passed through. This is used in the default case for passing all
 	// objects to the slowlane from the passed sharedInformer
 	alwaysTrue = func(interface{}) bool { return true }
 )
@@ -211,10 +211,10 @@ type Impl struct {
 	// StatsReporter is used to send common controller metrics.
 	statsReporter StatsReporter
 
-	// GlobalResyncFilterFunc is used to filter our objects from
-	// the shared cache on a global resync, be default and if not
+	// GlobalResyncFilterFunc is used to filter out objects from
+	// the shared cache on a global resync. By default and if not
 	// set by the controller implemenation, it will default to
-	// allowing every object in the cache
+	// allowing every object in the cache.
 	globalResyncFilterFunc FilterFunc
 }
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1621,7 +1621,7 @@ func TestGetEventRecorder(t *testing.T) {
 func TestFilteredGlobalResync(t *testing.T) {
 	tests := []struct {
 		name       string
-		filterFunc filterFunc
+		filterFunc FilterFunc
 		wantQueue  []types.NamespacedName
 	}{{
 		name:       "do nothing",
@@ -1636,8 +1636,6 @@ func TestFilteredGlobalResync(t *testing.T) {
 			if mo, ok := obj.(metav1.Object); ok {
 				if mo.GetNamespace() == "foo" {
 					return true
-				} else {
-					return false
 				}
 			}
 			return false
@@ -1649,8 +1647,6 @@ func TestFilteredGlobalResync(t *testing.T) {
 			if mo, ok := obj.(metav1.Object); ok {
 				if mo.GetName() == "foo" {
 					return true
-				} else {
-					return false
 				}
 			}
 			return false


### PR DESCRIPTION
related to #1764

There were two missing places where the informers from the shared cache we're not being filtered.
1. in the globalresync functions (where the filterFunc being passed through was ~= `return true`
1. the informer in the `LeaderAwareFuncs.PromoteFunc` which was marked with a TODO to allow filtering

The former has been changed to allow for a `controllerImpl.GlobalResyncFilterFunc` to be set (and if not, the former default of `return true` is passed to allow objects.

The latter was complicated to pass as a function, if done as a `controller.Option`, it would be too late for the closure in the initial `reconcilerImpl`.  I've opted instead for a `pkg/controller/controller.go` variable that will store via the shared context and again -- if not set -- pass a default filter of `return true` filtering over the objects. 


/cc @vaikas @n3wscott @matzew