### PR TITLE
Use the same dial with backoff for H2C as we do for HTTP/1.1

### DIFF
--- a/network/h2c.go
+++ b/network/h2c.go
@@ -17,10 +17,10 @@ limitations under the License.
 package network
 
 import (
+	"context"
 	"crypto/tls"
 	"net"
 	"net/http"
-	"time"
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
@@ -43,13 +43,9 @@ func NewServer(addr string, h http.Handler) *http.Server {
 func NewH2CTransport() http.RoundTripper {
 	return &http2.Transport{
 		AllowHTTP: true,
-		DialTLS: func(netw, addr string, cfg *tls.Config) (net.Conn, error) {
-			d := &net.Dialer{
-				Timeout:   DefaultConnTimeout,
-				KeepAlive: 5 * time.Second,
-				DualStack: true,
-			}
-			return d.Dial(netw, addr)
+		DialTLS: func(netw, addr string, _ *tls.Config) (net.Conn, error) {
+			return DialWithBackOff(context.Background(),
+				netw, addr)
 		},
 	}
 }

--- a/network/network.go
+++ b/network/network.go
@@ -24,19 +24,6 @@ import (
 )
 
 const (
-	// DefaultConnTimeout specifies a short default connection timeout
-	// to avoid hitting the issue fixed in
-	// https://github.com/kubernetes/kubernetes/pull/72534 but only
-	// available after Kubernetes 1.14.
-	//
-	// Our connections are usually between pods in the same cluster
-	// like activator <-> queue-proxy, or even between containers
-	// within the same pod queue-proxy <-> user-container, so a
-	// smaller connect timeout would be justifiable.
-	//
-	// We should consider exposing this as a configuration.
-	DefaultConnTimeout = 200 * time.Millisecond
-
 	// DefaultDrainTimeout is the time that Knative components on the data
 	// path will wait before shutting down server, but after starting to fail
 	// readiness probes to ensure network layer propagation and so that no requests


### PR DESCRIPTION
Also remove the constant that is not used anywhere.

/assign @tcnghia mattmoor