### PR TITLE
Add webhookname from env

### DIFF
--- a/webhook/env.go
+++ b/webhook/env.go
@@ -24,6 +24,9 @@ import (
 
 const portEnvKey = "WEBHOOK_PORT"
 
+// Webhook is the name of the override key used inside of the logging config for Webhook Controller.
+const webhookNameEnv = "WEBHOOK_NAME"
+
 // PortFromEnv returns the webhook port set by portEnvKey, or default port if env var is not set.
 func PortFromEnv(defaultPort int) int {
 	if os.Getenv(portEnvKey) == "" {
@@ -36,4 +39,18 @@ func PortFromEnv(defaultPort int) int {
 		panic(fmt.Sprintf("the environment variable %q can't be zero", portEnvKey))
 	}
 	return port
+}
+
+func NameFromEnv() string {
+	if webhook := os.Getenv(webhookNameEnv); webhook != "" {
+		return webhook
+	}
+
+	panic(fmt.Sprintf(`The environment variable %q is not set.
+This should be unique for the webhooks in a namespace
+If this is a process running on Kubernetes, then initialize this variable via:
+  env:
+  - name: WEBHOOK_NAME
+    value: webhook
+`, webhookNameEnv))
 }

--- a/webhook/env_test.go
+++ b/webhook/env_test.go
@@ -33,6 +33,13 @@ type portTest struct {
 	wantPanic bool
 }
 
+type webhookNameTest struct {
+	name      string
+	in        string
+	want      string
+	wantPanic bool
+}
+
 func TestPort(t *testing.T) {
 	tests := []portTest{{
 		name: testMissingInputName,
@@ -77,6 +84,40 @@ func TestPort(t *testing.T) {
 
 			if got := PortFromEnv(testDefaultPort); got != tc.want {
 				t.Errorf("PortFromEnv = %d, want: %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWebhookName(t *testing.T) {
+	tests := []webhookNameTest{{
+		name:      "EmptyInput",
+		in:        "",
+		wantPanic: true,
+	}, {
+		name: "ValidInput",
+		in:   "mywebhook",
+		want: "mywebhook",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// webhookNameEnv is unset when testing missing input.
+			if tc.name != testMissingInputName {
+				os.Setenv(webhookNameEnv, tc.in)
+			}
+
+			defer func() {
+				if r := recover(); r == nil && tc.wantPanic {
+					t.Error("Did not panic")
+				} else if r != nil && !tc.wantPanic {
+					t.Error("Got unexpected panic")
+				}
+				os.Unsetenv(webhookNameEnv)
+			}()
+
+			if got := NameFromEnv(); got != tc.want {
+				t.Errorf("NameFromEnv = %s, want: %s", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Arghya Sadhu <arghya88@gmail.com>

Ref: https://github.com/knative/eventing/issues/4530

This is currently used here
https://github.com/knative/eventing/blob/52597d174b52a680756b52b377c81bfb96fb636b/pkg/logconfig/config.go#L37

Moving it to pkg to be used across all knative components