### PR TITLE
feat/perf-test: continue test when fail to get commit id

### DIFF
--- a/test/mako/sidecar.go
+++ b/test/mako/sidecar.go
@@ -93,7 +93,7 @@ func SetupHelper(ctx context.Context, benchmarkKey *string, benchmarkName *strin
 	// Get the commit of the benchmarks
 	commitID, err := changeset.Get()
 	if err != nil {
-		return nil, err
+		log.Print("Cannot find commit ID")
 	}
 
 	// Setup a deployment informer, so that we can use the lister to track

--- a/test/mako/sidecar.go
+++ b/test/mako/sidecar.go
@@ -93,7 +93,7 @@ func SetupHelper(ctx context.Context, benchmarkKey *string, benchmarkName *strin
 	// Get the commit of the benchmarks
 	commitID, err := changeset.Get()
 	if err != nil {
-		log.Print("Cannot find commit ID")
+		log.Println("Cannot find commit ID")
 	}
 
 	// Setup a deployment informer, so that we can use the lister to track


### PR DESCRIPTION
changeset.Get does not work well when the test image is in the
vendor directory because there is no kodata setup. After this
commit, failure to get the commit id will result in a
log entry instead of failing the whole test.