### PR TITLE
Default to the lowest pre-release version to be the minimum

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -61,6 +61,12 @@ func CheckMinimumVersion(versioner discovery.ServerVersionInterface) error {
 		return err
 	}
 
+	// If no specific pre-release requirement is set, we default to "-0" to always allow
+	// pre-release versions of the same Major.Minor.Patch version.
+	if len(minimumVersion.Pre) == 0 {
+		minimumVersion.Pre = []semver.PRVersion{{VersionNum: 0}}
+	}
+
 	// Compare returns 1 if the first version is greater than the
 	// second version.
 	if currentVersion.LT(minimumVersion) {

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -52,7 +52,6 @@ func TestVersionCheck(t *testing.T) {
 		name:            "greater version (patch), pre-release, envvar override",
 		actualVersion:   &testVersioner{version: "1.15.11-kpn-065dce"},
 		versionOverride: "1.15.11",
-		wantError:       true,
 	}, {
 		name:            "greater version (patch), pre-release, envvar override, -0 hack",
 		actualVersion:   &testVersioner{version: "1.15.11-kpn-065dce"},
@@ -69,7 +68,6 @@ func TestVersionCheck(t *testing.T) {
 	}, {
 		name:          "same version with pre-release",
 		actualVersion: &testVersioner{version: "v1.17.0-k3s.1"},
-		wantError:     true,
 	}, {
 		name:          "smaller version",
 		actualVersion: &testVersioner{version: "v1.14.3"},


### PR DESCRIPTION
As per title.

Several users have hit this inconvience already (pre-release versions are by definition smaller than "normal" versions) and we've added a more verbose log message in the past to accomodate.

I can't think of a situation where you would not want to actually allow a pre-release version of a specific Major.Minor.Patch level, if you do not specify a very specific pre-build number, so this always assumes "-0" if no other pre-release version is specified.

/assign @vagababov 