### PR TITLE
[0.19] Backport "Add host config option to the prometheus exporter (#1882)"

### DIFF
--- a/metrics/config.go
+++ b/metrics/config.go
@@ -60,7 +60,9 @@ const (
 	defaultPrometheusPort = 9090
 	maxPrometheusPort     = 65535
 	minPrometheusPort     = 1024
+	defaultPrometheusHost = "0.0.0.0"
 	prometheusPortEnvName = "METRICS_PROMETHEUS_PORT"
+	prometheusHostEnvName = "METRICS_PROMETHEUS_HOST"
 )
 
 // Metrics backend "enum".
@@ -104,6 +106,10 @@ type metricsConfig struct {
 	// prometheusPort is the port where metrics are exposed in Prometheus
 	// format. It defaults to 9090.
 	prometheusPort int
+
+	// prometheusHost is the host where the metrics are exposed in Prometheus
+	// format. It defaults to "0.0.0.0"
+	prometheusHost string
 
 	// ---- Stackdriver specific below ----
 	// True if backendDestination equals to "stackdriver". Store this in a variable
@@ -240,6 +246,7 @@ func createMetricsConfig(ctx context.Context, ops ExporterOptions) (*metricsConf
 		}
 
 		mc.prometheusPort = pp
+		mc.prometheusHost = prometheusHost()
 	case stackdriver:
 		// If stackdriverClientConfig is not provided for stackdriver backend destination, OpenCensus will try to
 		// use the application default credentials. If that is not available, Opencensus would fail to create the
@@ -339,6 +346,17 @@ func prometheusPort() (int, error) {
 	}
 
 	return int(pp), nil
+}
+
+// prometheusHost returns the host configured via the environment
+// for the Prometheus metrics exporter if it's set, a default value otherwise.
+// No validation is done here.
+func prometheusHost() string {
+	phStr := os.Getenv(prometheusHostEnvName)
+	if phStr == "" {
+		return defaultPrometheusHost
+	}
+	return phStr
 }
 
 // JSONToOptions converts a json string to ExporterOptions.

--- a/metrics/config_test.go
+++ b/metrics/config_test.go
@@ -187,6 +187,7 @@ var (
 			backendDestination: prometheus,
 			reportingPeriod:    5 * time.Second,
 			prometheusPort:     defaultPrometheusPort,
+			prometheusHost:     defaultPrometheusHost,
 		},
 		expectedNewExporter: true,
 	}, {
@@ -308,6 +309,7 @@ var (
 			backendDestination: prometheus,
 			reportingPeriod:    5 * time.Second,
 			prometheusPort:     defaultPrometheusPort,
+			prometheusHost:     defaultPrometheusHost,
 		},
 		expectedNewExporter: true,
 	}, {
@@ -349,6 +351,7 @@ var (
 			backendDestination: prometheus,
 			reportingPeriod:    12 * time.Second,
 			prometheusPort:     defaultPrometheusPort,
+			prometheusHost:     defaultPrometheusHost,
 		},
 		expectedNewExporter: true,
 	}, {
@@ -431,6 +434,7 @@ var (
 			backendDestination: prometheus,
 			reportingPeriod:    5 * time.Second,
 			prometheusPort:     defaultPrometheusPort,
+			prometheusHost:     defaultPrometheusHost,
 		},
 		expectedNewExporter: true,
 	}, {
@@ -521,6 +525,7 @@ var (
 			backendDestination: prometheus,
 			reportingPeriod:    5 * time.Second,
 			prometheusPort:     9091,
+			prometheusHost:     defaultPrometheusHost,
 		},
 		expectedNewExporter: true,
 	}}
@@ -595,6 +600,7 @@ func TestGetMetricsConfig_fromEnv(t *testing.T) {
 			backendDestination: prometheus,
 			reportingPeriod:    5 * time.Second,
 			prometheusPort:     defaultPrometheusPort,
+			prometheusHost:     defaultPrometheusHost,
 		},
 	}, {
 		name:     "PrometheusPort from env",
@@ -611,6 +617,7 @@ func TestGetMetricsConfig_fromEnv(t *testing.T) {
 			backendDestination: prometheus,
 			reportingPeriod:    5 * time.Second,
 			prometheusPort:     9999,
+			prometheusHost:     defaultPrometheusHost,
 		},
 	}}
 
@@ -911,12 +918,13 @@ func TestMetricsOptions(t *testing.T) {
 				Domain:         "domain",
 				Component:      "component",
 				PrometheusPort: 9090,
+				PrometheusHost: "0.0.0.0",
 				ConfigMap: map[string]string{
 					"foo":   "bar",
 					"boosh": "kakow",
 				},
 			},
-			want: `{"Domain":"domain","Component":"component","PrometheusPort":9090,"ConfigMap":{"boosh":"kakow","foo":"bar"}}`,
+			want: `{"Domain":"domain","Component":"component","PrometheusPort":9090,"PrometheusHost":"0.0.0.0","ConfigMap":{"boosh":"kakow","foo":"bar"}}`,
 		},
 	}
 	for n, tc := range testCases {

--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -66,9 +66,14 @@ type ExporterOptions struct {
 
 	// PrometheusPort is the port to expose metrics if metrics backend is Prometheus.
 	// It should be between maxPrometheusPort and maxPrometheusPort. 0 value means
-	// using the default 9090 value. If is ignored if metrics backend is not
+	// using the default 9090 value. It is ignored if metrics backend is not
 	// Prometheus.
 	PrometheusPort int
+
+	// PrometheusHost is the host to expose metrics on if metrics backend is Prometheus.
+	// The default value is "0.0.0.0". It is ignored if metrics backend is not
+	// Prometheus.
+	PrometheusHost string
 
 	// ConfigMap is the data from config map config-observability. Must be present.
 	// See https://github.com/knative/serving/blob/master/config/config-observability.yaml

--- a/metrics/prometheus_exporter.go
+++ b/metrics/prometheus_exporter.go
@@ -17,8 +17,8 @@ limitations under the License.
 package metrics
 
 import (
-	"fmt"
 	"net/http"
+	"strconv"
 	"sync"
 
 	prom "contrib.go.opencensus.io/exporter/prometheus"
@@ -50,7 +50,7 @@ func newPrometheusExporter(config *metricsConfig, logger *zap.SugaredLogger) (vi
 	logger.Infof("Created Opencensus Prometheus exporter with config: %v. Start the server for Prometheus exporter.", config)
 	// Start the server for Prometheus scraping
 	go func() {
-		srv := startNewPromSrv(e, config.prometheusPort)
+		srv := startNewPromSrv(e, config.prometheusHost, config.prometheusPort)
 		srv.ListenAndServe()
 	}()
 	return e,
@@ -73,7 +73,7 @@ func resetCurPromSrv() {
 	}
 }
 
-func startNewPromSrv(e *prom.Exporter, port int) *http.Server {
+func startNewPromSrv(e *prom.Exporter, host string, port int) *http.Server {
 	sm := http.NewServeMux()
 	sm.Handle("/metrics", e)
 	curPromSrvMux.Lock()
@@ -82,7 +82,7 @@ func startNewPromSrv(e *prom.Exporter, port int) *http.Server {
 		curPromSrv.Close()
 	}
 	curPromSrv = &http.Server{
-		Addr:    fmt.Sprint(":", port),
+		Addr:    host + ":" + strconv.Itoa(port),
 		Handler: sm,
 	}
 	return curPromSrv

--- a/metrics/prometheus_exporter_test.go
+++ b/metrics/prometheus_exporter_test.go
@@ -13,6 +13,8 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -31,8 +33,9 @@ func TestNewPrometheusExporter(t *testing.T) {
 			component:          testComponent,
 			backendDestination: prometheus,
 			prometheusPort:     9090,
+			prometheusHost:     "0.0.0.0",
 		},
-		expectedAddr: ":9090",
+		expectedAddr: "0.0.0.0:9090",
 	}, {
 		name: "port 9091",
 		config: metricsConfig{
@@ -40,14 +43,80 @@ func TestNewPrometheusExporter(t *testing.T) {
 			component:          testComponent,
 			backendDestination: prometheus,
 			prometheusPort:     9091,
+			prometheusHost:     "127.0.0.1",
 		},
-		expectedAddr: ":9091",
+		expectedAddr: "127.0.0.1:9091",
 	}}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			e, _, err := newPrometheusExporter(&tc.config, TestLogger(t))
 			if err != nil {
 				t.Error(err)
+			}
+			if e == nil {
+				t.Fatal("expected a non-nil metrics exporter")
+			}
+			expectPromSrv(t, tc.expectedAddr)
+		})
+	}
+}
+
+func TestNewPrometheusExporter_fromEnv(t *testing.T) {
+	exporterOptions := ExporterOptions{
+		ConfigMap: map[string]string{},
+		Domain:    servingDomain,
+		Component: testComponent,
+	}
+	testCases := []struct {
+		name                   string
+		prometheusPortVarName  string
+		prometheusPortVarValue string
+		prometheusHostVarName  string
+		prometheusHostVarValue string
+		ops                    ExporterOptions
+		expectedAddr           string
+	}{{
+		name:                   "port from env var with no host set",
+		prometheusPortVarName:  prometheusPortEnvName,
+		prometheusPortVarValue: "9092",
+		ops:                    exporterOptions,
+		expectedAddr:           "0.0.0.0:9092",
+	}, {
+		name:                   "no port set with host from env var",
+		prometheusHostVarName:  prometheusHostEnvName,
+		prometheusHostVarValue: "127.0.0.1",
+		ops:                    exporterOptions,
+		expectedAddr:           "127.0.0.1:9090",
+	}, {
+		name:                   "port set and host set to empty string",
+		prometheusPortVarName:  prometheusPortEnvName,
+		prometheusPortVarValue: "",
+		prometheusHostVarName:  prometheusHostEnvName,
+		prometheusHostVarValue: "",
+		ops:                    exporterOptions,
+		expectedAddr:           "0.0.0.0:9090",
+	}, {
+		name:         "no port or host from the env",
+		ops:          exporterOptions,
+		expectedAddr: "0.0.0.0:9090",
+	}}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.prometheusPortVarName != "" {
+				os.Setenv(tc.prometheusPortVarName, tc.prometheusPortVarValue)
+				defer os.Unsetenv(tc.prometheusPortVarName)
+			}
+			if tc.prometheusHostVarName != "" {
+				os.Setenv(tc.prometheusHostVarName, tc.prometheusHostVarValue)
+				defer os.Unsetenv(tc.prometheusHostVarName)
+			}
+			mc, err := createMetricsConfig(context.Background(), tc.ops)
+			if err != nil {
+				t.Fatal("Failed to create the metrics config:", err)
+			}
+			e, _, err := newPrometheusExporter(mc, TestLogger(t))
+			if err != nil {
+				t.Fatal("Failed to create a new Prometheus exporter:", err)
 			}
 			if e == nil {
 				t.Fatal("expected a non-nil metrics exporter")


### PR DESCRIPTION
Backporting #1882, cherry-picked c73d344c89a7e80d9e416cea5b4a797e1195cf0.