### PR TITLE
Add smart handling of selectors in webhooks

### DIFF
--- a/webhook/helper.go
+++ b/webhook/helper.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EnsureLabelSelectorExpressions merges the current label selector's MatchExpressions
+// with the ones wanted.
+// It keeps all non-knative keys intact, removes all knative-keys no longer wanted and
+// adds all knative-keys not yet there.
+func EnsureLabelSelectorExpressions(
+	current *metav1.LabelSelector,
+	want *metav1.LabelSelector) *metav1.LabelSelector {
+
+	if current == nil {
+		return want
+	}
+
+	if len(current.MatchExpressions) == 0 {
+		return want
+	}
+
+	var wantExpressions []metav1.LabelSelectorRequirement
+	if want != nil {
+		wantExpressions = want.MatchExpressions
+	}
+
+	return &metav1.LabelSelector{
+		MatchExpressions: ensureLabelSelectorRequirements(
+			current.MatchExpressions, wantExpressions),
+	}
+}
+
+func ensureLabelSelectorRequirements(
+	current []metav1.LabelSelectorRequirement,
+	want []metav1.LabelSelectorRequirement) []metav1.LabelSelectorRequirement {
+
+	nonKnative := make([]metav1.LabelSelectorRequirement, 0, len(current))
+	for _, r := range current {
+		if !strings.Contains(r.Key, "knative.dev") {
+			nonKnative = append(nonKnative, r)
+		}
+	}
+
+	return append(want, nonKnative...)
+}

--- a/webhook/helper_test.go
+++ b/webhook/helper_test.go
@@ -105,7 +105,7 @@ func TestEnsureLabelSelectorExpressions(t *testing.T) {
 	}, {
 		name: "remove obsolete",
 		current: &metav1.LabelSelector{
-			MatchExpressions: []metav1.LabelSelectorRequirement{fooExpression, metav1.LabelSelectorRequirement{
+			MatchExpressions: []metav1.LabelSelectorRequirement{fooExpression, {
 				Key:      "knative.dev/bar",
 				Operator: metav1.LabelSelectorOpDoesNotExist,
 			}},

--- a/webhook/psbinding/psbinding.go
+++ b/webhook/psbinding/psbinding.go
@@ -349,7 +349,7 @@ func (ac *Reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 		if cur.ClientConfig.Service == nil {
 			return fmt.Errorf("missing service reference for webhook: %s", wh.Name)
 		}
-		current.Webhooks[i].ClientConfig.Service.Path = ptr.String(ac.Path())
+		cur.ClientConfig.Service.Path = ptr.String(ac.Path())
 	}
 
 	if ok := equality.Semantic.DeepEqual(configuredWebhook, current); !ok {

--- a/webhook/psbinding/psbinding.go
+++ b/webhook/psbinding/psbinding.go
@@ -131,11 +131,6 @@ var (
 			Key:      duck.BindingExcludeLabel,
 			Operator: metav1.LabelSelectorOpNotIn,
 			Values:   []string{"true"},
-		}, {
-			// "control-plane" is added to support Azure's AKS, otherwise the controllers fight.
-			// See knative/pkg#1590 for details.
-			Key:      "control-plane",
-			Operator: metav1.LabelSelectorOpDoesNotExist,
 		}},
 		// TODO(mattmoor): Consider also having a GVR-based one, e.g.
 		//    foobindings.blah.knative.dev/exclude: "true"
@@ -145,11 +140,6 @@ var (
 			Key:      duck.BindingIncludeLabel,
 			Operator: metav1.LabelSelectorOpIn,
 			Values:   []string{"true"},
-		}, {
-			// "control-plane" is added to support Azure's AKS, otherwise the controllers fight.
-			// See knative/pkg#1590 for details.
-			Key:      "control-plane",
-			Operator: metav1.LabelSelectorOpDoesNotExist,
 		}},
 		// TODO(mattmoor): Consider also having a GVR-based one, e.g.
 		//    foobindings.blah.knative.dev/include: "true"
@@ -338,31 +328,34 @@ func (ac *Reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 	if err != nil {
 		return fmt.Errorf("error retrieving webhook: %w", err)
 	}
-	webhook := configuredWebhook.DeepCopy()
+	current := configuredWebhook.DeepCopy()
 
 	// Use the "Equivalent" match policy so that we don't need to enumerate versions for same-types.
 	// This is only supported by 1.15+ clusters.
 	matchPolicy := admissionregistrationv1.Equivalent
 
-	for i, wh := range webhook.Webhooks {
-		if wh.Name != webhook.Name {
+	for i, wh := range current.Webhooks {
+		if wh.Name != current.Name {
 			continue
 		}
-		webhook.Webhooks[i].MatchPolicy = &matchPolicy
-		webhook.Webhooks[i].Rules = rules
-		webhook.Webhooks[i].NamespaceSelector = &ac.selector
-		webhook.Webhooks[i].ObjectSelector = &ac.selector // 1.15+ only
-		webhook.Webhooks[i].ClientConfig.CABundle = caCert
-		if webhook.Webhooks[i].ClientConfig.Service == nil {
+		cur := &current.Webhooks[i]
+		selector := webhook.EnsureLabelSelectorExpressions(cur.NamespaceSelector, &ac.selector)
+
+		cur.MatchPolicy = &matchPolicy
+		cur.Rules = rules
+		cur.NamespaceSelector = selector
+		cur.ObjectSelector = selector // 1.15+ only
+		cur.ClientConfig.CABundle = caCert
+		if cur.ClientConfig.Service == nil {
 			return fmt.Errorf("missing service reference for webhook: %s", wh.Name)
 		}
-		webhook.Webhooks[i].ClientConfig.Service.Path = ptr.String(ac.Path())
+		current.Webhooks[i].ClientConfig.Service.Path = ptr.String(ac.Path())
 	}
 
-	if ok := equality.Semantic.DeepEqual(configuredWebhook, webhook); !ok {
+	if ok := equality.Semantic.DeepEqual(configuredWebhook, current); !ok {
 		logging.FromContext(ctx).Info("Updating webhook")
 		mwhclient := ac.Client.AdmissionregistrationV1().MutatingWebhookConfigurations()
-		if _, err := mwhclient.Update(ctx, webhook, metav1.UpdateOptions{}); err != nil {
+		if _, err := mwhclient.Update(ctx, current, metav1.UpdateOptions{}); err != nil {
 			return fmt.Errorf("failed to update webhook: %w", err)
 		}
 	} else {

--- a/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/webhook/resourcesemantics/defaulting/defaulting.go
@@ -171,41 +171,42 @@ func (ac *reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 		return fmt.Errorf("error retrieving webhook: %w", err)
 	}
 
-	webhook := configuredWebhook.DeepCopy()
+	current := configuredWebhook.DeepCopy()
 
 	// Clear out any previous (bad) OwnerReferences.
 	// See: https://github.com/knative/serving/issues/5845
-	webhook.OwnerReferences = nil
+	current.OwnerReferences = nil
 
-	for i, wh := range webhook.Webhooks {
-		if wh.Name != webhook.Name {
+	for i, wh := range current.Webhooks {
+		if wh.Name != current.Name {
 			continue
 		}
-		webhook.Webhooks[i].Rules = rules
-		webhook.Webhooks[i].NamespaceSelector = &metav1.LabelSelector{
-			MatchExpressions: []metav1.LabelSelectorRequirement{{
-				Key:      "webhooks.knative.dev/exclude",
-				Operator: metav1.LabelSelectorOpDoesNotExist,
-			}, {
-				// "control-plane" is added to support Azure's AKS, otherwise the controllers fight.
-				// See knative/pkg#1590 for details.
-				Key:      "control-plane",
-				Operator: metav1.LabelSelectorOpDoesNotExist,
-			}},
-		}
-		webhook.Webhooks[i].ClientConfig.CABundle = caCert
-		if webhook.Webhooks[i].ClientConfig.Service == nil {
+
+		cur := &current.Webhooks[i]
+		cur.Rules = rules
+
+		cur.NamespaceSelector = webhook.EnsureLabelSelectorExpressions(
+			cur.NamespaceSelector,
+			&metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "webhooks.knative.dev/exclude",
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+				}},
+			})
+
+		cur.ClientConfig.CABundle = caCert
+		if cur.ClientConfig.Service == nil {
 			return fmt.Errorf("missing service reference for webhook: %s", wh.Name)
 		}
-		webhook.Webhooks[i].ClientConfig.Service.Path = ptr.String(ac.Path())
+		cur.ClientConfig.Service.Path = ptr.String(ac.Path())
 	}
 
-	if ok, err := kmp.SafeEqual(configuredWebhook, webhook); err != nil {
+	if ok, err := kmp.SafeEqual(configuredWebhook, current); err != nil {
 		return fmt.Errorf("error diffing webhooks: %w", err)
 	} else if !ok {
 		logger.Info("Updating webhook")
 		mwhclient := ac.client.AdmissionregistrationV1().MutatingWebhookConfigurations()
-		if _, err := mwhclient.Update(ctx, webhook, metav1.UpdateOptions{}); err != nil {
+		if _, err := mwhclient.Update(ctx, current, metav1.UpdateOptions{}); err != nil {
 			return fmt.Errorf("failed to update webhook: %w", err)
 		}
 	} else {

--- a/webhook/resourcesemantics/validation/reconcile_config.go
+++ b/webhook/resourcesemantics/validation/reconcile_config.go
@@ -134,41 +134,41 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 		return fmt.Errorf("error retrieving webhook: %w", err)
 	}
 
-	webhook := configuredWebhook.DeepCopy()
+	current := configuredWebhook.DeepCopy()
 
 	// Clear out any previous (bad) OwnerReferences.
 	// See: https://github.com/knative/serving/issues/5845
-	webhook.OwnerReferences = nil
+	current.OwnerReferences = nil
 
-	for i, wh := range webhook.Webhooks {
-		if wh.Name != webhook.Name {
+	for i, wh := range current.Webhooks {
+		if wh.Name != current.Name {
 			continue
 		}
-		webhook.Webhooks[i].Rules = rules
-		webhook.Webhooks[i].NamespaceSelector = &metav1.LabelSelector{
-			MatchExpressions: []metav1.LabelSelectorRequirement{{
-				Key:      "webhooks.knative.dev/exclude",
-				Operator: metav1.LabelSelectorOpDoesNotExist,
-			}, {
-				// "control-plane" is added to support Azure's AKS, otherwise the controllers fight.
-				// See knative/pkg#1590 for details.
-				Key:      "control-plane",
-				Operator: metav1.LabelSelectorOpDoesNotExist,
-			}},
-		}
-		webhook.Webhooks[i].ClientConfig.CABundle = caCert
-		if webhook.Webhooks[i].ClientConfig.Service == nil {
+		cur := &current.Webhooks[i]
+		cur.Rules = rules
+
+		cur.NamespaceSelector = webhook.EnsureLabelSelectorExpressions(
+			cur.NamespaceSelector,
+			&metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "webhooks.knative.dev/exclude",
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+				}},
+			})
+
+		cur.ClientConfig.CABundle = caCert
+		if cur.ClientConfig.Service == nil {
 			return fmt.Errorf("missing service reference for webhook: %s", wh.Name)
 		}
-		webhook.Webhooks[i].ClientConfig.Service.Path = ptr.String(ac.Path())
+		cur.ClientConfig.Service.Path = ptr.String(ac.Path())
 	}
 
-	if ok, err := kmp.SafeEqual(configuredWebhook, webhook); err != nil {
+	if ok, err := kmp.SafeEqual(configuredWebhook, current); err != nil {
 		return fmt.Errorf("error diffing webhooks: %w", err)
 	} else if !ok {
 		logger.Info("Updating webhook")
 		vwhclient := ac.client.AdmissionregistrationV1().ValidatingWebhookConfigurations()
-		if _, err := vwhclient.Update(ctx, webhook, metav1.UpdateOptions{}); err != nil {
+		if _, err := vwhclient.Update(ctx, current, metav1.UpdateOptions{}); err != nil {
 			return fmt.Errorf("failed to update webhook: %w", err)
 		}
 	} else {

--- a/webhook/resourcesemantics/validation/reconcile_config_test.go
+++ b/webhook/resourcesemantics/validation/reconcile_config_test.go
@@ -66,9 +66,6 @@ func TestReconcile(t *testing.T) {
 		MatchExpressions: []metav1.LabelSelectorRequirement{{
 			Key:      "webhooks.knative.dev/exclude",
 			Operator: metav1.LabelSelectorOpDoesNotExist,
-		}, {
-			Key:      "control-plane",
-			Operator: metav1.LabelSelectorOpDoesNotExist,
 		}},
 	}
 
@@ -322,11 +319,85 @@ func TestReconcile(t *testing.T) {
 						CABundle: []byte("present"),
 					},
 					// Rules are fine.
-					Rules:             expectedRules,
-					NamespaceSelector: namespaceSelector,
+					Rules: expectedRules,
+					// A non-knative key in the namespace selector is fine.
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "webhooks.knative.dev/exclude",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						}, {
+							Key:      "foo.bar/baz",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						}},
+					},
 				}},
 			},
 		},
+	}, {
+		Name: "secret and VWH exist, correcting namespaceSelector",
+		Key:  key,
+		Objects: []runtime.Object{secret,
+			&admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1.ValidatingWebhook{{
+					Name: name,
+					ClientConfig: admissionregistrationv1.WebhookClientConfig{
+						Service: &admissionregistrationv1.ServiceReference{
+							Namespace: system.Namespace(),
+							Name:      "webhook",
+							// Path is fine.
+							Path: ptr.String(path),
+						},
+						// CABundle is fine.
+						CABundle: []byte("present"),
+					},
+					// Rules are fine.
+					Rules: expectedRules,
+					// NamespaceSelector contains non-knative things.
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "foo.knative.dev/exclude",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						}, {
+							Key:      "foo.bar/baz",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						}},
+					},
+				}},
+			},
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: &admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Webhooks: []admissionregistrationv1.ValidatingWebhook{{
+					Name: name,
+					ClientConfig: admissionregistrationv1.WebhookClientConfig{
+						Service: &admissionregistrationv1.ServiceReference{
+							Namespace: system.Namespace(),
+							Name:      "webhook",
+							Path:      ptr.String(path),
+						},
+						CABundle: []byte("present"),
+					},
+					Rules: expectedRules,
+					NamespaceSelector: &metav1.LabelSelector{
+						// The knative key is added while the non-knative key is kept.
+						// Old knative key is removed.
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "webhooks.knative.dev/exclude",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						}, {
+							Key:      "foo.bar/baz",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						}},
+					},
+				}},
+			},
+		}},
 	}}
 
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

This is an alternative fix for #1590. Instead of arbitrarily adding a label from a different project to avoid the reconcilers racing, this adds "smart" handling of the selectors in that labels not inside the knative.dev domain are plainly ignored and our own selectors are added additively.

Fixes #1943

**Release Note**

```release-note
Fixed an issue where our webhooks arbitrarily ignored namespaces labeled with `control-plane`.
```

/assign @mattmoor @n3wscott @dprotaso 
