### PR TITLE
Make the profiling port configurable via envvar.

### DIFF
--- a/profiling/server.go
+++ b/profiling/server.go
@@ -34,7 +34,7 @@ const (
 	ProfilingPortKey = "PROFILING_PORT"
 
 	// ProfilingPort specifies the default port where profiling data is available when profiling is enabled
-	ProfilingPort = "8008"
+	ProfilingPort = 8008
 
 	// profilingKey is the name of the key in config-observability config map
 	// that indicates whether profiling is enabled
@@ -107,7 +107,7 @@ func (h *Handler) UpdateFromConfigMap(configMap *corev1.ConfigMap) {
 func NewServer(handler http.Handler) *http.Server {
 	port := os.Getenv(ProfilingPortKey)
 	if port == "" {
-		port = ProfilingPort
+		port = strconv.Itoa(ProfilingPort)
 	}
 
 	return &http.Server{

--- a/profiling/server.go
+++ b/profiling/server.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/pprof"
+	"os"
 	"strconv"
 
 	"go.uber.org/atomic"
@@ -28,8 +29,12 @@ import (
 )
 
 const (
-	// ProfilingPort specifies the port where profiling data is available when profiling is enabled
-	ProfilingPort = 8008
+	// ProfilingPortKey specified the name of an environment variable that
+	// may be used to override the default profiling port.
+	ProfilingPortKey = "PROFILING_PORT"
+
+	// ProfilingPort specifies the default port where profiling data is available when profiling is enabled
+	ProfilingPort = "8008"
 
 	// profilingKey is the name of the key in config-observability config map
 	// that indicates whether profiling is enabled
@@ -100,8 +105,13 @@ func (h *Handler) UpdateFromConfigMap(configMap *corev1.ConfigMap) {
 
 // NewServer creates a new http server that exposes profiling data on the default profiling port
 func NewServer(handler http.Handler) *http.Server {
+	port := os.Getenv(ProfilingPortKey)
+	if port == "" {
+		port = ProfilingPort
+	}
+
 	return &http.Server{
-		Addr:    ":" + strconv.Itoa(ProfilingPort),
+		Addr:    ":" + port,
 		Handler: handler,
 	}
 }


### PR DESCRIPTION
With this folks can override the default 8008 with PROFILING_PORT.

Fixes: https://github.com/knative/pkg/issues/1948
