### PR TITLE
Fix excessive allocation in the resource metrics

### DIFF
--- a/metrics/resource_view.go
+++ b/metrics/resource_view.go
@@ -322,7 +322,7 @@ func resourceToKey(r *resource.Resource) string {
 	}
 
 	var s strings.Builder
-	writeKV := func(key, value string) {
+	writeKV := func(key, value string) { // This lambda doesn't force an allocation.
 		// We use byte values 1 and 2 to avoid colliding with valid resource labels
 		// and to make unpacking easy
 		s.WriteByte('\x01')

--- a/metrics/resource_view.go
+++ b/metrics/resource_view.go
@@ -333,16 +333,12 @@ func resourceToKey(r *resource.Resource) string {
 
 	// If there's only one label, we can skip building and sorting a slice of keys.
 	if len(r.Labels) == 1 {
-		l := len(r.Type)
-		var key string
 		for k, v := range r.Labels {
-			key = k
-			l += len(k) + len(v) + 2
+			// We know this only executes once.
+			s.Grow(len(r.Type) + len(k) + len(v) + 2)
+			s.WriteString(r.Type)
+			writeKV(k, v)
 		}
-		s.Grow(l)
-
-		s.WriteString(r.Type)
-		writeKV(key, r.Labels[key])
 		return s.String()
 	}
 

--- a/metrics/resource_view.go
+++ b/metrics/resource_view.go
@@ -315,21 +315,26 @@ func resourceToKey(r *resource.Resource) string {
 	if r == nil {
 		return ""
 	}
-	var s strings.Builder
+
 	l := len(r.Type)
-	kvs := make([]string, 0, len(r.Labels))
+	keys := make([]string, 0, len(r.Labels))
 	for k, v := range r.Labels {
 		l += len(k) + len(v) + 2
-		// We use byte values 1 and 2 to avoid colliding with valid resource labels
-		// and to make unpacking easy
-		kvs = append(kvs, fmt.Sprintf("\x01%s\x02%s", k, v))
+		keys = append(keys, k)
 	}
+
+	var s strings.Builder
 	s.Grow(l)
 	s.WriteString(r.Type)
 
-	sort.Strings(kvs) // Go maps are unsorted, so sort by key to produce stable output.
-	for _, kv := range kvs {
-		s.WriteString(kv)
+	sort.Strings(keys) // Go maps are unsorted, so sort by key to produce stable output.
+	for _, key := range keys {
+		// We use byte values 1 and 2 to avoid colliding with valid resource labels
+		// and to make unpacking easy
+		s.WriteByte('\x01')
+		s.WriteString(key)
+		s.WriteByte('\x02')
+		s.WriteString(r.Labels[key])
 	}
 
 	return s.String()

--- a/metrics/resource_view.go
+++ b/metrics/resource_view.go
@@ -338,8 +338,8 @@ func resourceToKey(r *resource.Resource) string {
 			s.Grow(len(r.Type) + len(k) + len(v) + 2)
 			s.WriteString(r.Type)
 			writeKV(k, v)
+			return s.String()
 		}
-		return s.String()
 	}
 
 	l := len(r.Type)

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -228,6 +228,14 @@ func TestResourceAsString(t *testing.T) {
 	}
 }
 
+func BenchmarkResourceToKey(b *testing.B) {
+	r1 := &resource.Resource{Type: "foobar", Labels: map[string]string{"k1": "v1", "k3": "v3", "k2": "v2"}}
+
+	for i := 0; i < b.N; i++ {
+		resourceToKey(r1)
+	}
+}
+
 type metricExtract struct {
 	Name   string
 	Labels map[string]string

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -232,7 +232,7 @@ func BenchmarkResourceToKey(b *testing.B) {
 	for _, count := range []int{0, 1, 5, 10} {
 		labels := make(map[string]string, count)
 		for i := 0; i < count; i++ {
-			labels[fmt.Sprintf("key%d", i)] = fmt.Sprintf("value%d", i)
+			labels[fmt.Sprint("key", i)] = fmt.Sprint("value", i)
 		}
 		r := &resource.Resource{Type: "foobar", Labels: labels}
 

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -229,10 +229,18 @@ func TestResourceAsString(t *testing.T) {
 }
 
 func BenchmarkResourceToKey(b *testing.B) {
-	r1 := &resource.Resource{Type: "foobar", Labels: map[string]string{"k1": "v1", "k3": "v3", "k2": "v2"}}
+	for _, count := range []int{0, 1, 5, 10} {
+		labels := make(map[string]string, count)
+		for i := 0; i < count; i++ {
+			labels[fmt.Sprintf("key%d", i)] = fmt.Sprintf("value%d", i)
+		}
+		r := &resource.Resource{Type: "foobar", Labels: labels}
 
-	for i := 0; i < b.N; i++ {
-		resourceToKey(r1)
+		b.Run(fmt.Sprintf("%d-labels", count), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				resourceToKey(r)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Through a bit of cleanup work in Knative Serving, it got kinda apparent that our metric recording calls are kinda expensive. I triaged it down to the `resourceToKey` being quite expensive.

Discussing with @evankanderson, we came up with this quick fix to make the allocations of the functions much more reasonable without coming up with a different way of handling the keys here altogether.

## Benchmark results

```
benchmark                               old ns/op     new ns/op     delta
BenchmarkResourceToKey/0-labels-16      139           2.38          -98.29%
BenchmarkResourceToKey/1-labels-16      677           168           -75.18%
BenchmarkResourceToKey/5-labels-16      2344          802           -65.78%
BenchmarkResourceToKey/10-labels-16     4625          1645          -64.43%

benchmark                               old allocs     new allocs     delta
BenchmarkResourceToKey/0-labels-16      2              0              -100.00%
BenchmarkResourceToKey/1-labels-16      6              1              -83.33%
BenchmarkResourceToKey/5-labels-16      18             3              -83.33%
BenchmarkResourceToKey/10-labels-16     33             3              -90.91%

benchmark                               old bytes     new bytes     delta
BenchmarkResourceToKey/0-labels-16      40            0             -100.00%
BenchmarkResourceToKey/1-labels-16      128           32            -75.00%
BenchmarkResourceToKey/5-labels-16      432           192           -55.56%
BenchmarkResourceToKey/10-labels-16     800           320           -60.00%
```

/assign @evankanderson 