### PR TITLE
Remove useless logger creation

### DIFF
--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
@@ -226,9 +226,6 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	logger = logger.With(zap.String("targetMethod", name))
 	switch name {
 	case reconciler.DoReconcileKind:
-		// Append the target method to the logger.
-		logger = logger.With(zap.String("targetMethod", "ReconcileKind"))
-
 		// Set and update the finalizer on resource if r.reconciler
 		// implements Finalizer.
 		if resource, err = r.setFinalizerIfFinalizer(ctx, resource); err != nil {

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
@@ -226,9 +226,6 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	logger = logger.With(zap.String("targetMethod", name))
 	switch name {
 	case reconciler.DoReconcileKind:
-		// Append the target method to the logger.
-		logger = logger.With(zap.String("targetMethod", "ReconcileKind"))
-
 		// Set and update the finalizer on resource if r.reconciler
 		// implements Finalizer.
 		if resource, err = r.setFinalizerIfFinalizer(ctx, resource); err != nil {

--- a/client/injection/kube/reconciler/apps/v1/deployment/reconciler.go
+++ b/client/injection/kube/reconciler/apps/v1/deployment/reconciler.go
@@ -226,9 +226,6 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	logger = logger.With(zap.String("targetMethod", name))
 	switch name {
 	case reconciler.DoReconcileKind:
-		// Append the target method to the logger.
-		logger = logger.With(zap.String("targetMethod", "ReconcileKind"))
-
 		// Set and update the finalizer on resource if r.reconciler
 		// implements Finalizer.
 		if resource, err = r.setFinalizerIfFinalizer(ctx, resource); err != nil {

--- a/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
@@ -225,9 +225,6 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	logger = logger.With(zap.String("targetMethod", name))
 	switch name {
 	case reconciler.DoReconcileKind:
-		// Append the target method to the logger.
-		logger = logger.With(zap.String("targetMethod", "ReconcileKind"))
-
 		// Set and update the finalizer on resource if r.reconciler
 		// implements Finalizer.
 		if resource, err = r.setFinalizerIfFinalizer(ctx, resource); err != nil {

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -420,9 +420,6 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 	logger = logger.With(zap.String("targetMethod", name))
 	switch name {
 	case {{.doReconcileKind|raw}}:
-		// Append the target method to the logger.
-		logger = logger.With(zap.String("targetMethod", "ReconcileKind"))
-
 		// Set and update the finalizer on resource if r.reconciler
 		// implements Finalizer.
 		if resource, err = r.setFinalizerIfFinalizer(ctx, resource); err != nil {


### PR DESCRIPTION
This call is redundant as the method is already put onto the logger a few lines above.

/assign @mattmoor @vagababov 