### PR TITLE
Remove unnecessary intermediate loggers

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -267,9 +267,8 @@ func (c *Impl) EnqueueAfter(obj interface{}, after time.Duration) {
 func (c *Impl) EnqueueSlowKey(key types.NamespacedName) {
 	c.workQueue.SlowLane().Add(key)
 
-	desugared := c.logger.Desugar()
-	if desugared.Core().Enabled(zapcore.DebugLevel) {
-		desugared.Debug(fmt.Sprintf("Adding to the slow queue %s (depth(total/slow): %d/%d)",
+	if logger := c.logger.Desugar(); logger.Core().Enabled(zapcore.DebugLevel) {
+		logger.Debug(fmt.Sprintf("Adding to the slow queue %s (depth(total/slow): %d/%d)",
 			safeKey(key), c.workQueue.Len(), c.workQueue.SlowLane().Len()),
 			zap.String(logkey.Key, key.String()))
 	}
@@ -399,9 +398,8 @@ func (c *Impl) EnqueueNamespaceOf(obj interface{}) {
 func (c *Impl) EnqueueKey(key types.NamespacedName) {
 	c.workQueue.Add(key)
 
-	desugared := c.logger.Desugar()
-	if desugared.Core().Enabled(zapcore.DebugLevel) {
-		desugared.Debug(fmt.Sprintf("Adding to queue %s (depth: %d)", safeKey(key), c.workQueue.Len()),
+	if logger := c.logger.Desugar(); logger.Core().Enabled(zapcore.DebugLevel) {
+		logger.Debug(fmt.Sprintf("Adding to queue %s (depth: %d)", safeKey(key), c.workQueue.Len()),
 			zap.String(logkey.Key, key.String()))
 	}
 }
@@ -419,9 +417,8 @@ func (c *Impl) MaybeEnqueueBucketKey(bkt reconciler.Bucket, key types.Namespaced
 func (c *Impl) EnqueueKeyAfter(key types.NamespacedName, delay time.Duration) {
 	c.workQueue.AddAfter(key, delay)
 
-	desugared := c.logger.Desugar()
-	if desugared.Core().Enabled(zapcore.DebugLevel) {
-		desugared.Debug(fmt.Sprintf("Adding to queue %s (delay: %v, depth: %d)", safeKey(key), delay, c.workQueue.Len()),
+	if logger := c.logger.Desugar(); logger.Core().Enabled(zapcore.DebugLevel) {
+		logger.Debug(fmt.Sprintf("Adding to queue %s (delay: %v, depth: %d)", safeKey(key), delay, c.workQueue.Len()),
 			zap.String(logkey.Key, key.String()))
 	}
 }

--- a/logging/config.go
+++ b/logging/config.go
@@ -195,8 +195,7 @@ func UpdateLevelFromConfigMap(logger *zap.SugaredLogger, atomicLevel zap.AtomicL
 			case errors.Is(err, errEmptyLoggerConfig):
 				level = zap.NewAtomicLevel().Level()
 			case err != nil:
-				logger.Errorw(
-					fmt.Sprintf("Failed to parse logger configuration. Previous log level retained for %v", levelKey),
+				logger.Errorw("Failed to parse logger configuration. Previous log level retained for "+levelKey,
 					zap.Error(err))
 				return
 			default:

--- a/logging/config.go
+++ b/logging/config.go
@@ -195,8 +195,9 @@ func UpdateLevelFromConfigMap(logger *zap.SugaredLogger, atomicLevel zap.AtomicL
 			case errors.Is(err, errEmptyLoggerConfig):
 				level = zap.NewAtomicLevel().Level()
 			case err != nil:
-				logger.With(zap.Error(err)).Errorf("Failed to parse logger configuration. "+
-					"Previous log level retained for %v", levelKey)
+				logger.Errorw(
+					fmt.Sprintf("Failed to parse logger configuration. Previous log level retained for %v", levelKey),
+					zap.Error(err))
 				return
 			default:
 				level = loggingCfg.Level.Level()

--- a/websocket/connection.go
+++ b/websocket/connection.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http/httputil"
@@ -165,7 +166,7 @@ func NewDurableConnection(target string, messageChan chan []byte, logger *zap.Su
 				}
 				logger.Debug("Connected to ", target)
 				if err := c.keepalive(); err != nil {
-					logger.With(zap.Error(err)).Errorf("Connection to %s broke down, reconnecting...", target)
+					logger.Errorw(fmt.Sprintf("Connection to %s broke down, reconnecting...", target), zap.Error(err))
 				}
 				if err := c.closeConnection(); err != nil {
 					logger.Errorw("Failed to close the connection after crashing", zap.Error(err))


### PR DESCRIPTION
Ref #1968 

This removes all occurrences where we unnecessarily allocate an intermediate logger rather than using the respective logger directly. Debug statements are additionally guarded as that level is disabled in production most likely.

/assign @mattmoor @vagababov 