### PR TITLE
Introduce a nostackdriver build tag

### DIFF
--- a/.github/workflows/nostackdriver.yaml
+++ b/.github/workflows/nostackdriver.yaml
@@ -1,0 +1,37 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Test
+
+on:
+  pull_request:
+    branches: [ 'main', 'master', 'release-*' ]
+
+jobs:
+
+  nostackdriver:
+    name: Unit Tests w/o stackdriver
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Go 1.15.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.x
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Test w/nostackdriver
+        run: go test -tags=nostackdriver -race ./...

--- a/tracing/depcheck_test.go
+++ b/tracing/depcheck_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing_test
+
+import (
+	"testing"
+
+	"knative.dev/pkg/depcheck"
+)
+
+func TestNoDeps(t *testing.T) {
+	depcheck.AssertNoDependency(t, map[string][]string{
+		"knative.dev/pkg/tracing": depcheck.KnownHeavyDependencies,
+	}, "-tags=nostackdriver")
+}

--- a/tracing/nostackdriver.go
+++ b/tracing/nostackdriver.go
@@ -1,0 +1,30 @@
+// +build nostackdriver
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"errors"
+
+	"go.opencensus.io/trace"
+	"knative.dev/pkg/tracing/config"
+)
+
+func newStackdriver(cfg *config.Config) (trace.Exporter, error) {
+	return nil, errors.New("Stackdriver is not configured")
+}

--- a/tracing/opencensus.go
+++ b/tracing/opencensus.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package tracing
 
 import (
@@ -7,9 +23,8 @@ import (
 	"os"
 	"sync"
 
-	"contrib.go.opencensus.io/exporter/stackdriver"
 	oczipkin "contrib.go.opencensus.io/exporter/zipkin"
-	zipkin "github.com/openzipkin/zipkin-go"
+	"github.com/openzipkin/zipkin-go"
 	httpreporter "github.com/openzipkin/zipkin-go/reporter/http"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
@@ -128,17 +143,14 @@ func WithExporterFull(name, host string, logger *zap.SugaredLogger) ConfigOption
 		var (
 			exporter trace.Exporter
 			closer   io.Closer
+			err      error
 		)
 		switch cfg.Backend {
 		case config.Stackdriver:
-			exp, err := stackdriver.NewExporter(stackdriver.Options{
-				ProjectID: cfg.StackdriverProjectID,
-			})
+			exporter, err = newStackdriver(cfg)
 			if err != nil {
-				logger.Errorw("error reading project-id from metadata", zap.Error(err))
 				return err
 			}
-			exporter = exp
 		case config.Zipkin:
 			// If host isn't specified, then zipkin.NewEndpoint will return an error saying that it
 			// can't find the host named ''. So, if not specified, default it to this machine's
@@ -161,6 +173,7 @@ func WithExporterFull(name, host string, logger *zap.SugaredLogger) ConfigOption
 			reporter := httpreporter.NewReporter(cfg.ZipkinEndpoint)
 			exporter = oczipkin.NewExporter(reporter, zipEP)
 			closer = reporter
+
 		default:
 			// Disables tracing.
 		}

--- a/tracing/stackdriver.go
+++ b/tracing/stackdriver.go
@@ -1,0 +1,31 @@
+// +build !nostackdriver
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"contrib.go.opencensus.io/exporter/stackdriver"
+	"go.opencensus.io/trace"
+	"knative.dev/pkg/tracing/config"
+)
+
+func newStackdriver(cfg *config.Config) (trace.Exporter, error) {
+	return stackdriver.NewExporter(stackdriver.Options{
+		ProjectID: cfg.StackdriverProjectID,
+	})
+}


### PR DESCRIPTION
This teaches `depcheck` to support passing build flags through, and uses it to ensure that with `-tags=nostackdriver` that the expensive stack driver libraries are not linked.

I'm starting in `./tracing` since it is considerably simpler than the mess in metrics, but my intention is to do something similar in `./metrics` next.