### PR TITLE
Close websocket connection in parallel to read/write calls

### DIFF
--- a/websocket/connection.go
+++ b/websocket/connection.go
@@ -272,6 +272,7 @@ func (c *ManagedConnection) closeConnection() error {
 	// having to wait for a read timeout to happen.
 	c.connectionLock.RLock()
 	if c.connection == nil {
+		c.connectionLock.RUnlock()
 		return nil
 	}
 	err := c.connection.Close()


### PR DESCRIPTION
# Changes

This speeds up the closure of websocket connections by not waiting for (potentially long) i/o operations to finish and rather closes the connection immediately, potentially in parallel to these operations.

/kind enhancement

/assign @vagababov @julz 