### PR TITLE
Use special error type to designate skips.

### DIFF
--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
@@ -191,7 +191,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	// If we are not the leader, and we don't implement either ReadOnly
 	// observer interfaces, then take a fast-path out.
 	if s.isNotLeaderNorObserver() {
-		return nil
+		return controller.NewSkipKey(key)
 	}
 
 	// If configStore is set, attach the frozen configuration to the context.

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
@@ -191,7 +191,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	// If we are not the leader, and we don't implement either ReadOnly
 	// observer interfaces, then take a fast-path out.
 	if s.isNotLeaderNorObserver() {
-		return nil
+		return controller.NewSkipKey(key)
 	}
 
 	// If configStore is set, attach the frozen configuration to the context.

--- a/client/injection/kube/reconciler/apps/v1/deployment/reconciler.go
+++ b/client/injection/kube/reconciler/apps/v1/deployment/reconciler.go
@@ -191,7 +191,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	// If we are not the leader, and we don't implement either ReadOnly
 	// observer interfaces, then take a fast-path out.
 	if s.isNotLeaderNorObserver() {
-		return nil
+		return controller.NewSkipKey(key)
 	}
 
 	// If configStore is set, attach the frozen configuration to the context.

--- a/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
@@ -190,7 +190,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	// If we are not the leader, and we don't implement either ReadOnly
 	// observer interfaces, then take a fast-path out.
 	if s.isNotLeaderNorObserver() {
-		return nil
+		return controller.NewSkipKey(key)
 	}
 
 	// If configStore is set, attach the frozen configuration to the context.

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -89,6 +89,10 @@ func (g *reconcilerReconcilerGenerator) GenerateType(c *generator.Context, t *ty
 			Package: "knative.dev/pkg/controller",
 			Name:    "WithEventRecorder",
 		}),
+		"controllerNewSkipKey": c.Universe.Type(types.Name{
+			Package: "knative.dev/pkg/controller",
+			Name:    "NewSkipKey",
+		}),
 		"corev1EventSource": c.Universe.Function(types.Name{
 			Package: "k8s.io/api/core/v1",
 			Name:    "EventSource",
@@ -375,7 +379,7 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 	// If we are not the leader, and we don't implement either ReadOnly
 	// observer interfaces, then take a fast-path out.
 	if s.isNotLeaderNorObserver() {
-		return nil
+		return {{.controllerNewSkipKey|raw}}(key)
 	}
 
 	// If configStore is set, attach the frozen configuration to the context.

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -521,21 +521,24 @@ func (c *Impl) processNextWorkItem() bool {
 	// Run Reconcile, passing it the namespace/name string of the
 	// resource to be synced.
 	if err = c.Reconciler.Reconcile(ctx, keyStr); err != nil {
-		c.handleErr(err, key)
-		logger.Info("Reconcile failed. Time taken: ", time.Since(startTime))
+		c.handleErr(err, key, startTime)
 		return true
 	}
 
 	// Finally, if no error occurs we Forget this item so it does not
 	// have any delay when another change happens.
 	c.workQueue.Forget(key)
-	logger.Info("Reconcile succeeded. Time taken: ", time.Since(startTime))
+	logger.Info("Reconcile succeeded. Time taken: ", zap.Duration("duration", time.Since(startTime)))
 
 	return true
 }
 
-func (c *Impl) handleErr(err error, key types.NamespacedName) {
-	c.logger.Errorw("Reconcile error", zap.Error(err))
+func (c *Impl) handleErr(err error, key types.NamespacedName, startTime time.Time) {
+	if IsSkipKey(err) {
+		c.workQueue.Forget(key)
+		return
+	}
+	c.logger.Errorw("Reconcile error", zap.Duration("duration", time.Since(startTime)), zap.Error(err))
 
 	// Re-queue the key if it's a transient error.
 	// We want to check that the queue is shutting down here
@@ -568,6 +571,38 @@ func (c *Impl) FilteredGlobalResync(f func(interface{}) bool, si cache.SharedInf
 			c.EnqueueSlow(obj)
 		}
 	}
+}
+
+// NewSkipKey returns a new instance of skipKeyError.
+// Users can return this type of error to indicate that the key was skipped.
+func NewSkipKey(key string) error {
+	return skipKeyError{key: key}
+}
+
+// permanentError is an error that is considered not transient.
+// We should not re-queue keys when it returns with thus error in reconcile.
+type skipKeyError struct {
+	key string
+}
+
+var _ error = skipKeyError{}
+
+// Error implements the Error() interface of error.
+func (err skipKeyError) Error() string {
+	return fmt.Sprintf("skipped key: %q", err.key)
+}
+
+// IsSkipKey returns true if the given error is a skipKeyError.
+func IsSkipKey(err error) bool {
+	return errors.Is(err, skipKeyError{})
+}
+
+// Is implements the Is() interface of error. It returns whether the target
+// error can be treated as equivalent to a permanentError.
+func (skipKeyError) Is(target error) bool {
+	//nolint: errorlint // This check is actually fine.
+	_, ok := target.(skipKeyError)
+	return ok
 }
 
 // NewPermanentError returns a new instance of permanentError.

--- a/webhook/certificates/certificates.go
+++ b/webhook/certificates/certificates.go
@@ -57,7 +57,7 @@ func (r *reconciler) Reconcile(ctx context.Context, key string) error {
 		// only reconciler the certificate when we are leader.
 		return r.reconcileCertificate(ctx)
 	}
-	return nil
+	return controller.NewSkipKey(key)
 }
 
 func (r *reconciler) reconcileCertificate(ctx context.Context) error {

--- a/webhook/configmaps/configmaps.go
+++ b/webhook/configmaps/configmaps.go
@@ -72,8 +72,7 @@ func (ac *reconciler) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
 
 	if !ac.IsLeaderFor(ac.key) {
-		logger.Debugf("Skipping key %q, not the leader.", ac.key)
-		return nil
+		return controller.NewSkipKey(key)
 	}
 
 	secret, err := ac.secretlister.Secrets(system.Namespace()).Get(ac.secretName)

--- a/webhook/psbinding/psbinding.go
+++ b/webhook/psbinding/psbinding.go
@@ -292,6 +292,9 @@ func (ac *Reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 	// After we've updated our indices, bail out unless we are the leader.
 	// Only the leader should be mutating the webhook.
 	if !ac.IsLeaderFor(sentinel) {
+		// We don't use controller.NewSkipKey here because we did do
+		// some amount of processing and the timing information may be
+		// useful.
 		return nil
 	}
 

--- a/webhook/psbinding/reconciler.go
+++ b/webhook/psbinding/reconciler.go
@@ -119,8 +119,7 @@ func (r *BaseReconciler) Reconcile(ctx context.Context, key string) error {
 		Namespace: namespace,
 		Name:      name,
 	}) {
-		logging.FromContext(ctx).Debugf("Skipping key %q, not the leader.", key)
-		return nil
+		return controller.NewSkipKey(key)
 	}
 
 	// Get the resource with this namespace/name.

--- a/webhook/resourcesemantics/conversion/reconciler.go
+++ b/webhook/resourcesemantics/conversion/reconciler.go
@@ -65,8 +65,7 @@ func (r *reconciler) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
 
 	if !r.IsLeaderFor(types.NamespacedName{Name: key}) {
-		logger.Debugf("Skipping key %q, not the leader.", key)
-		return nil
+		return controller.NewSkipKey(key)
 	}
 
 	// Look up the webhook secret, and fetch the CA cert bundle.

--- a/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/webhook/resourcesemantics/defaulting/defaulting.go
@@ -80,8 +80,7 @@ func (ac *reconciler) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
 
 	if !ac.IsLeaderFor(ac.key) {
-		logger.Debugf("Skipping key %q, not the leader.", ac.key)
-		return nil
+		return controller.NewSkipKey(key)
 	}
 
 	// Look up the webhook secret, and fetch the CA cert bundle.

--- a/webhook/resourcesemantics/validation/reconcile_config.go
+++ b/webhook/resourcesemantics/validation/reconcile_config.go
@@ -77,8 +77,7 @@ func (ac *reconciler) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
 
 	if !ac.IsLeaderFor(ac.key) {
-		logger.Debugf("Skipping key %q, not the leader.", ac.key)
-		return nil
+		return controller.NewSkipKey(key)
 	}
 
 	// Look up the webhook secret, and fetch the CA cert bundle.


### PR DESCRIPTION
This change introduces a new `controller.NewSkipKey` method to designate certain reconciliations as "skipped".

The primary motivation for this is to squelch useless logging on non-leader replicas, which currently report success with trivial latency.

I have plumbed this through existing reconcilers and the code-gen so most things downstream should get this for free.  In places where a key is observed, I do not mark the reconcile as skipped as the reconciler did some processing for which the awareness of side-effects and reported latency may be interesting.

