### PR TITLE
Fix duration field in the logs

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -528,7 +528,7 @@ func (c *Impl) processNextWorkItem() bool {
 	// Finally, if no error occurs we Forget this item so it does not
 	// have any delay when another change happens.
 	c.workQueue.Forget(key)
-	logger.Info("Reconcile succeeded. Time taken: ", zap.Duration("duration", time.Since(startTime)))
+	logger.Infow("Reconcile succeeded", zap.Duration("duration", time.Since(startTime)))
 
 	return true
 }


### PR DESCRIPTION
The duration was being appended to the log message 
```
Reconcile succeeded. Time taken: {duration 8 252289  <nil>}
```

now it's a field as intended

```
 "duration": 0.00065144,
```
/assign @mattmoor 