### PR TITLE
preserve the stable webhook logger names we had before

### DIFF
--- a/apis/duck/ABOUT.md
+++ b/apis/duck/ABOUT.md
@@ -301,7 +301,8 @@ is used with duck types:
                 Base:             reconciler.NewBase(opt, controllerAgentName),
                 ...
         }
-        impl := controller.NewImpl(c, c.Logger, "Revisions")
+        logger := c.Logger.Named("Revisions")
+        impl := controller.NewImpl(c, logger, "Revisions")
 
         // Calls to Track create a 30 minute lease before they must be renewed.
         // Coordinate this value with controller resync periods.

--- a/injection/README.md
+++ b/injection/README.md
@@ -138,7 +138,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		Client:        kubeclient.Get(ctx),
 		ServiceLister: svcInformer.Lister(),
 	}
-  logger = logger.Named("NameOfController")
+	logger = logger.Named("NameOfController")
 	impl := controller.NewImpl(c, logger, "NameOfController")
 
 	// Set up event handlers.

--- a/injection/README.md
+++ b/injection/README.md
@@ -138,6 +138,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		Client:        kubeclient.Get(ctx),
 		ServiceLister: svcInformer.Lister(),
 	}
+  logger = logger.Named("NameOfController")
 	impl := controller.NewImpl(c, logger, "NameOfController")
 
 	// Set up event handlers.

--- a/webhook/certificates/controller.go
+++ b/webhook/certificates/controller.go
@@ -66,7 +66,8 @@ func NewController(
 		secretlister: secretInformer.Lister(),
 	}
 
-	c := controller.NewImpl(wh, logging.FromContext(ctx), "WebhookCertificates")
+	queueName := "WebhookCertificates"
+	c := controller.NewImpl(wh, logging.FromContext(ctx).Named(queueName), queueName)
 
 	// Reconcile when the cert bundle changes.
 	secretInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/webhook/certificates/controller.go
+++ b/webhook/certificates/controller.go
@@ -66,7 +66,7 @@ func NewController(
 		secretlister: secretInformer.Lister(),
 	}
 
-	queueName := "WebhookCertificates"
+	const queueName = "WebhookCertificates"
 	c := controller.NewImpl(wh, logging.FromContext(ctx).Named(queueName), queueName)
 
 	// Reconcile when the cert bundle changes.

--- a/webhook/configmaps/controller.go
+++ b/webhook/configmaps/controller.go
@@ -73,7 +73,8 @@ func NewAdmissionController(
 		wh.registerConfig(configName, constructor)
 	}
 
-	c := controller.NewImpl(wh, logging.FromContext(ctx), "ConfigMapWebhook")
+	queueName := "ConfigMapWebhook"
+	c := controller.NewImpl(wh, logging.FromContext(ctx).Named(queueName), queueName)
 
 	// Reconcile when the named ValidatingWebhookConfiguration changes.
 	vwhInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/webhook/configmaps/controller.go
+++ b/webhook/configmaps/controller.go
@@ -73,7 +73,7 @@ func NewAdmissionController(
 		wh.registerConfig(configName, constructor)
 	}
 
-	queueName := "ConfigMapWebhook"
+	const queueName = "ConfigMapWebhook"
 	c := controller.NewImpl(wh, logging.FromContext(ctx).Named(queueName), queueName)
 
 	// Reconcile when the named ValidatingWebhookConfiguration changes.

--- a/webhook/psbinding/README.md
+++ b/webhook/psbinding/README.md
@@ -142,6 +142,7 @@ func NewController(
 		Recorder: record.NewBroadcaster().NewRecorder(
 			scheme.Scheme, corev1.EventSource{Component: controllerAgentName}),
 	}
+  logger = logger.Named("GithubBindings")
 	impl := controller.NewImpl(c, logger, "GithubBindings")
 
 	logger.Info("Setting up event handlers")

--- a/webhook/psbinding/README.md
+++ b/webhook/psbinding/README.md
@@ -142,7 +142,7 @@ func NewController(
 		Recorder: record.NewBroadcaster().NewRecorder(
 			scheme.Scheme, corev1.EventSource{Component: controllerAgentName}),
 	}
-  logger = logger.Named("GithubBindings")
+	logger = logger.Named("GithubBindings")
 	impl := controller.NewImpl(c, logger, "GithubBindings")
 
 	logger.Info("Setting up event handlers")

--- a/webhook/psbinding/controller.go
+++ b/webhook/psbinding/controller.go
@@ -87,7 +87,7 @@ func NewAdmissionController(
 
 	// Construct the reconciler for the mutating webhook configuration.
 	wh := NewReconciler(name, path, options.SecretName, client, mwhInformer.Lister(), secretInformer.Lister(), withContext, reconcilerOptions...)
-	c := controller.NewImpl(wh, logging.FromContext(ctx), name)
+	c := controller.NewImpl(wh, logging.FromContext(ctx).Named(name), name)
 
 	// Enqueue a sentinel when we become leader.
 	wh.PromoteFunc = func(bkt pkgreconciler.Bucket, enq func(pkgreconciler.Bucket, types.NamespacedName)) error {

--- a/webhook/resourcesemantics/conversion/controller.go
+++ b/webhook/resourcesemantics/conversion/controller.go
@@ -117,8 +117,8 @@ func NewConversionController(
 		crdLister:    crdInformer.Lister(),
 	}
 
+	const queueName = "ConversionWebhook"
 	logger := logging.FromContext(ctx)
-	queueName := "ConversionWebhook"
 	c := controller.NewImpl(r, logger.Named(queueName), queueName)
 
 	// Reconciler when the named CRDs change.

--- a/webhook/resourcesemantics/conversion/controller.go
+++ b/webhook/resourcesemantics/conversion/controller.go
@@ -117,7 +117,9 @@ func NewConversionController(
 		crdLister:    crdInformer.Lister(),
 	}
 
-	c := controller.NewImpl(r, logging.FromContext(ctx), "ConversionWebhook")
+	logger := logging.FromContext(ctx)
+	queueName := "ConversionWebhook"
+	c := controller.NewImpl(r, logger.Named(queueName), queueName)
 
 	// Reconciler when the named CRDs change.
 	for _, gkc := range kinds {

--- a/webhook/resourcesemantics/defaulting/controller.go
+++ b/webhook/resourcesemantics/defaulting/controller.go
@@ -74,7 +74,8 @@ func NewAdmissionController(
 	}
 
 	logger := logging.FromContext(ctx)
-	c := controller.NewImpl(wh, logger, "DefaultingWebhook")
+	queueName := "DefaultingWebhook"
+	c := controller.NewImpl(wh, logger.Named(queueName), queueName)
 
 	// Reconcile when the named MutatingWebhookConfiguration changes.
 	mwhInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/webhook/resourcesemantics/defaulting/controller.go
+++ b/webhook/resourcesemantics/defaulting/controller.go
@@ -74,7 +74,7 @@ func NewAdmissionController(
 	}
 
 	logger := logging.FromContext(ctx)
-	queueName := "DefaultingWebhook"
+	const queueName = "DefaultingWebhook"
 	c := controller.NewImpl(wh, logger.Named(queueName), queueName)
 
 	// Reconcile when the named MutatingWebhookConfiguration changes.

--- a/webhook/resourcesemantics/validation/controller.go
+++ b/webhook/resourcesemantics/validation/controller.go
@@ -89,7 +89,8 @@ func NewAdmissionController(
 	}
 
 	logger := logging.FromContext(ctx)
-	c := controller.NewImpl(wh, logger, "ValidationWebhook")
+	queueName := "ValidationWebhook"
+	c := controller.NewImpl(wh, logger.Named(queueName), queueName)
 
 	// Reconcile when the named ValidatingWebhookConfiguration changes.
 	vwhInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/webhook/resourcesemantics/validation/controller.go
+++ b/webhook/resourcesemantics/validation/controller.go
@@ -89,7 +89,7 @@ func NewAdmissionController(
 	}
 
 	logger := logging.FromContext(ctx)
-	queueName := "ValidationWebhook"
+	const queueName = "ValidationWebhook"
 	c := controller.NewImpl(wh, logger.Named(queueName), queueName)
 
 	// Reconcile when the named ValidatingWebhookConfiguration changes.


### PR DESCRIPTION
[I dropped the queue name being added to the logger](https://github.com/knative/pkg/pull/1991/files#diff-3c5bb5f48211873c58fcba055dcae2ac7b1958969219e06e1508d76d485dace7L233) in https://github.com/knative/pkg/pull/1991 but forgot to keep the webhook logger names stable


/assign @vagababov 