### PR TITLE
Switch Webhook to ed25519 and expiration of the certificate to seven days

### DIFF
--- a/webhook/certificates/certificates.go
+++ b/webhook/certificates/certificates.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	// Time used for updating a certificate before it expires.
-	oneWeek = 7 * 24 * time.Hour
+	oneDay = 24 * time.Hour
 )
 
 type reconciler struct {
@@ -89,7 +89,7 @@ func (r *reconciler) reconcileCertificate(ctx context.Context) error {
 			certData, err := x509.ParseCertificate(cert.Certificate[0])
 			if err != nil {
 				logger.Errorw("Error parsing certificate", zap.Error(err))
-			} else if time.Now().Add(oneWeek).Before(certData.NotAfter) {
+			} else if time.Now().Add(oneDay).Before(certData.NotAfter) {
 				return nil
 			}
 		}

--- a/webhook/certificates/certificates_test.go
+++ b/webhook/certificates/certificates_test.go
@@ -126,7 +126,7 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "certificate expiring soon",
 		Key:  key,
-		// 6 days falls inside of the grace period of 7 days so the secret will be updated
+		// 23 hours  falls inside of the grace period of 1 day so the secret will be updated.
 		Objects: []runtime.Object{secretWithCertData(t, time.Now().Add(23*time.Hour))},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: secret,
@@ -134,8 +134,8 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "certificate not expiring soon",
 		Key:  key,
-		// 8 days falls outside of the grace period of 7 days so the secret will not be updated
-		Objects: []runtime.Object{secretWithCertData(t, time.Now().Add(8*24*time.Hour))},
+		// 25 hours falls outside of the grace period of 1 day so the secret will not be updated.
+		Objects: []runtime.Object{secretWithCertData(t, time.Now().Add(25*time.Hour))},
 	}}
 
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {

--- a/webhook/certificates/certificates_test.go
+++ b/webhook/certificates/certificates_test.go
@@ -127,7 +127,7 @@ func TestReconcile(t *testing.T) {
 		Name: "certificate expiring soon",
 		Key:  key,
 		// 6 days falls inside of the grace period of 7 days so the secret will be updated
-		Objects: []runtime.Object{secretWithCertData(t, time.Now().Add(6*24*time.Hour))},
+		Objects: []runtime.Object{secretWithCertData(t, time.Now().Add(23*time.Hour))},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: secret,
 		}},

--- a/webhook/certificates/resources/certs.go
+++ b/webhook/certificates/resources/certs.go
@@ -18,8 +18,8 @@ package resources
 
 import (
 	"context"
+	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -62,7 +62,7 @@ func createCertTemplate(name, namespace string, notAfter time.Time) (*x509.Certi
 			Organization: []string{organization},
 			CommonName:   commonName,
 		},
-		SignatureAlgorithm:    x509.SHA256WithRSA,
+		SignatureAlgorithm:    x509.PureEd25519,
 		NotBefore:             time.Now(),
 		NotAfter:              notAfter,
 		BasicConstraintsValid: true,
@@ -112,9 +112,9 @@ func createCert(template, parent *x509.Certificate, pub, parentPriv interface{})
 	return
 }
 
-func createCA(ctx context.Context, name, namespace string, notAfter time.Time) (*rsa.PrivateKey, *x509.Certificate, []byte, error) {
+func createCA(ctx context.Context, name, namespace string, notAfter time.Time) (ed25519.PrivateKey, *x509.Certificate, []byte, error) {
 	logger := logging.FromContext(ctx)
-	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		logger.Errorw("error generating random key", zap.Error(err))
 		return nil, nil, nil, err
@@ -126,12 +126,12 @@ func createCA(ctx context.Context, name, namespace string, notAfter time.Time) (
 		return nil, nil, nil, err
 	}
 
-	rootCert, rootCertPEM, err := createCert(rootCertTmpl, rootCertTmpl, &rootKey.PublicKey, rootKey)
+	rootCert, rootCertPEM, err := createCert(rootCertTmpl, rootCertTmpl, publicKey, privateKey)
 	if err != nil {
 		logger.Errorw("error signing the CA cert", zap.Error(err))
 		return nil, nil, nil, err
 	}
-	return rootKey, rootCert, rootCertPEM, nil
+	return privateKey, rootCert, rootCertPEM, nil
 }
 
 // CreateCerts creates and returns a CA certificate and certificate and
@@ -148,7 +148,7 @@ func CreateCerts(ctx context.Context, name, namespace string, notAfter time.Time
 	}
 
 	// Then create the private key for the serving cert
-	servKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		logger.Errorw("error generating random key", zap.Error(err))
 		return nil, nil, nil, err
@@ -160,13 +160,18 @@ func CreateCerts(ctx context.Context, name, namespace string, notAfter time.Time
 	}
 
 	// create a certificate which wraps the server's public key, sign it with the CA private key
-	_, servCertPEM, err := createCert(servCertTemplate, caCertificate, &servKey.PublicKey, caKey)
+	_, servCertPEM, err := createCert(servCertTemplate, caCertificate, publicKey, caKey)
 	if err != nil {
 		logger.Errorw("error signing server certificate template", zap.Error(err))
 		return nil, nil, nil, err
 	}
+	privKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		logger.Errorw("error marshaling private key", zap.Error(err))
+		return nil, nil, nil, err
+	}
 	servKeyPEM := pem.EncodeToMemory(&pem.Block{
-		Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(servKey),
+		Type: "PRIVATE KEY", Bytes: privKeyBytes,
 	})
 	return servKeyPEM, servCertPEM, caCertificatePEM, nil
 }

--- a/webhook/certificates/resources/secret.go
+++ b/webhook/certificates/resources/secret.go
@@ -32,6 +32,8 @@ const (
 	// CACert is the name of the key associated with the certificate of the CA for
 	// the keypair.
 	CACert = "ca-cert.pem"
+
+	oneWeek = 7 * 24 * time.Hour
 )
 
 // MakeSecret synthesizes a Kubernetes Secret object with the keys specified by
@@ -41,7 +43,7 @@ var MakeSecret = MakeSecretInternal
 
 // MakeSecretInternal is only public so MakeSecret can be restored in testing.  Use MakeSecret.
 func MakeSecretInternal(ctx context.Context, name, namespace, serviceName string) (*corev1.Secret, error) {
-	serverKey, serverCert, caCert, err := CreateCerts(ctx, serviceName, namespace, time.Now().AddDate(0, 0, 7))
+	serverKey, serverCert, caCert, err := CreateCerts(ctx, serviceName, namespace, time.Now().Add(oneWeek))
 	if err != nil {
 		return nil, err
 	}

--- a/webhook/certificates/resources/secret.go
+++ b/webhook/certificates/resources/secret.go
@@ -41,7 +41,7 @@ var MakeSecret = MakeSecretInternal
 
 // MakeSecretInternal is only public so MakeSecret can be restored in testing.  Use MakeSecret.
 func MakeSecretInternal(ctx context.Context, name, namespace, serviceName string) (*corev1.Secret, error) {
-	serverKey, serverCert, caCert, err := CreateCerts(ctx, serviceName, namespace, time.Now().AddDate(1, 0, 0))
+	serverKey, serverCert, caCert, err := CreateCerts(ctx, serviceName, namespace, time.Now().AddDate(0, 0, 7))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Webhook uses `ed25519` rather than RSA 2048.
- :broom: Change the expiration of the certificate to seven days and the recreation time to one day before expiration.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement


<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
NONE
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
