### PR TITLE
allow the addressable ducktype to act as an ownerref

### DIFF
--- a/apis/duck/v1/addressable_types.go
+++ b/apis/duck/v1/addressable_types.go
@@ -19,6 +19,8 @@ package v1
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/kmeta"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -67,6 +69,7 @@ type AddressStatus struct {
 var (
 	_ apis.Listable         = (*AddressableType)(nil)
 	_ ducktypes.Populatable = (*AddressableType)(nil)
+	_ kmeta.OwnerRefable = (*AddressableType)(nil)
 )
 
 // GetFullType implements duck.Implementable
@@ -95,6 +98,11 @@ func (t *AddressableType) Populate() {
 			},
 		},
 	}
+}
+
+// GetGroupVersionKind implements kmeta.OwnerRefable
+func (t *AddressableType) GetGroupVersionKind() schema.GroupVersionKind {
+	return t.GroupVersionKind()
 }
 
 // GetListType implements apis.Listable

--- a/apis/duck/v1/addressable_types.go
+++ b/apis/duck/v1/addressable_types.go
@@ -19,14 +19,14 @@ package v1
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"knative.dev/pkg/kmeta"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck/ducktypes"
+	"knative.dev/pkg/kmeta"
 )
 
 // +genduck
@@ -69,7 +69,7 @@ type AddressStatus struct {
 var (
 	_ apis.Listable         = (*AddressableType)(nil)
 	_ ducktypes.Populatable = (*AddressableType)(nil)
-	_ kmeta.OwnerRefable = (*AddressableType)(nil)
+	_ kmeta.OwnerRefable    = (*AddressableType)(nil)
 )
 
 // GetFullType implements duck.Implementable


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

-  Add kmeta.OwnerRefable support to AddressableType.

/kind enhancement

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
AddressableType now implements the kmeta.OwnerRefable interface.
```
