### PR TITLE
Unregister views to avoid slow oom issue during meter cleanup

### DIFF
--- a/metrics/e2e_test.go
+++ b/metrics/e2e_test.go
@@ -195,7 +195,7 @@ func TestMetricsExport(t *testing.T) {
 				return err
 			}
 			// Wait for the webserver to actually start serving metrics
-			return wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (bool, error) {
+			return wait.PollImmediate(10*time.Millisecond, 20*time.Second, func() (bool, error) {
 				resp, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", prometheusPort))
 				return err == nil && resp.StatusCode == http.StatusOK, nil
 			})

--- a/metrics/e2e_test.go
+++ b/metrics/e2e_test.go
@@ -195,7 +195,7 @@ func TestMetricsExport(t *testing.T) {
 				return err
 			}
 			// Wait for the webserver to actually start serving metrics
-			return wait.PollImmediate(10*time.Millisecond, 20*time.Second, func() (bool, error) {
+			return wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (bool, error) {
 				resp, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", prometheusPort))
 				return err == nil && resp.StatusCode == http.StatusOK, nil
 			})

--- a/metrics/resource_view.go
+++ b/metrics/resource_view.go
@@ -87,7 +87,7 @@ func cleanup() {
 	for key, meter := range allMeters.meters {
 		if key != "" && meter.t.Before(expiryCutoff) {
 			flushGivenExporter(meter.e)
-			// make a copy of views to avoid data races
+			// Make a copy of views to avoid data races
 			viewsCopy := copyViews(resourceViews.views)
 			meter.m.Unregister(viewsCopy...)
 			delete(allMeters.meters, key)

--- a/metrics/resource_view.go
+++ b/metrics/resource_view.go
@@ -91,6 +91,7 @@ func cleanup() {
 			viewsCopy := copyViews(resourceViews.views)
 			meter.m.Unregister(viewsCopy...)
 			delete(allMeters.meters, key)
+			meter.m.Stop()
 		}
 	}
 }

--- a/metrics/resource_view.go
+++ b/metrics/resource_view.go
@@ -145,7 +145,7 @@ func RegisterResourceView(views ...*view.View) error {
 	return nil
 }
 
-// UnregisterResourceView is similar to view.Unregiste(), except that it will
+// UnregisterResourceView is similar to view.Unregister(), except that it will
 // unregister the view across all Resources tracked byt he system, rather than
 // simply the default view.
 func UnregisterResourceView(views ...*view.View) {

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -75,6 +75,8 @@ type testExporter struct {
 	id string
 }
 
+func (testExporter) ExportView(viewData *view.Data) {}
+
 func TestSetFactory(t *testing.T) {
 	var oldFactory ResourceExporterFactory
 	func() {
@@ -171,7 +173,7 @@ func TestAllMetersExpiration(t *testing.T) {
 
 	// Expire the second entry
 	fakeClock.Step(9 * time.Minute) // t+12m
-	_ = wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
+	_ = wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
 		// Non-expiring defaultMeter should be available
 		allMeters.lock.Lock()
 		defer allMeters.lock.Unlock()
@@ -235,8 +237,7 @@ func TestIfAllMeterResourcesAreRemoved(t *testing.T) {
 
 	// Expire all meters and views
 	fakeClock.Step(12 * time.Minute) // t+12m
-
-	_ = wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
+	_ = wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
 		// Non-expiring defaultMeter should be available
 		allMeters.lock.Lock()
 		defer allMeters.lock.Unlock()

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -247,16 +247,6 @@ func TestIfAllMeterResourcesAreRemoved(t *testing.T) {
 	if len(allMeters.meters) != 1 {
 		t.Errorf("len(allMeters)=%d, want: 1", len(allMeters.meters))
 	}
-	resourceViews.lock.Lock()
-	for k, meter := range copyAllMeters {
-		for _, mView := range resourceViews.views {
-			// Default meter should be skipped as views are not removed from it during cleanup
-			if k != "" && meter.m.Find(mView.Name) != nil {
-				t.Errorf("Got a view that should be unregistered: %s", mView.Name)
-			}
-		}
-	}
-	resourceViews.lock.Unlock()
 }
 
 func TestResourceAsString(t *testing.T) {

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -196,7 +196,7 @@ func TestIfAllMeterResourcesAreRemoved(t *testing.T) {
 	// Register many resources at once
 	for i := 1; i <= 1000; i++ {
 		res := resource.Resource{Labels: map[string]string{"foo": "bar"}}
-		res.Labels["id"] = fmt.Sprintf("id:%d", i)
+		res.Labels["id"] = fmt.Sprintf("%d", i)
 		_, err := optionForResource(&res)
 		if err != nil {
 			t.Error("Should succeed getting option, instead got error ", err)

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -174,7 +174,7 @@ func TestAllMetersExpiration(t *testing.T) {
 	// Expire the second entry
 	fakeClock.Step(9 * time.Minute) // t+12m
 	_ = wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
-		// Non-expiring defaultMeter should be available
+		// Non-expiring defaultMeter should be available along with the non-expired entry
 		allMeters.lock.Lock()
 		defer allMeters.lock.Unlock()
 		return len(allMeters.meters) == 2, nil

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -196,7 +196,7 @@ func TestIfAllMeterResourcesAreRemoved(t *testing.T) {
 	// Register many resources at once
 	for i := 1; i <= 1000; i++ {
 		res := resource.Resource{Labels: map[string]string{"foo": "bar"}}
-		res.Labels["id"] = string(i)
+		res.Labels["id"] = fmt.Sprintf("id:%d", i)
 		_, err := optionForResource(&res)
 		if err != nil {
 			t.Error("Should succeed getting option, instead got error ", err)

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -173,6 +173,8 @@ func TestAllMetersExpiration(t *testing.T) {
 	fakeClock.Step(9 * time.Minute) // t+12m
 	_ = wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
 		// Non-expiring defaultMeter should be available
+		allMeters.lock.Lock()
+		defer allMeters.lock.Unlock()
 		return len(allMeters.meters) == 2, nil
 	})
 
@@ -236,6 +238,8 @@ func TestIfAllMeterResourcesAreRemoved(t *testing.T) {
 
 	_ = wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
 		// Non-expiring defaultMeter should be available
+		allMeters.lock.Lock()
+		defer allMeters.lock.Unlock()
 		return len(allMeters.meters) == 1, nil
 	})
 


### PR DESCRIPTION
# Changes

- Unregisters views that cause part of https://github.com/knative/serving/issues/10516, details here: https://github.com/knative/serving/issues/10516#issuecomment-770771649
/kind bug

/cc @evankanderson 






