### PR TITLE
Allow setting DisableCompression in NewAutoTransport

### DIFF
--- a/network/h2c.go
+++ b/network/h2c.go
@@ -41,8 +41,13 @@ func NewServer(addr string, h http.Handler) *http.Server {
 // to explicitly allow h2c (http2 without TLS) transport.
 // See https://github.com/golang/go/issues/14141 for more details.
 func NewH2CTransport() http.RoundTripper {
+	return newH2CTransport(false)
+}
+
+func newH2CTransport(disableCompression bool) http.RoundTripper {
 	return &http2.Transport{
-		AllowHTTP: true,
+		AllowHTTP:          true,
+		DisableCompression: disableCompression,
 		DialTLS: func(netw, addr string, _ *tls.Config) (net.Conn, error) {
 			return DialWithBackOff(context.Background(),
 				netw, addr)


### PR DESCRIPTION
Fixes #2006.

Go's http client helpfully adds an "Accept-Encoding: gzip" header if not
already present, and unzips the response if it did so. While this is
often the right thing to do, it is not the right thing to do if we're
reverse proxying since (a) it means we add a header to the request the
client didn't actually ask for (b) it means we end up uncompressing
things in the proxy, which e.g. for activator/QP is not what we want.

/kind enhancement
<!-- Thanks for sending a pull request! -->

# Changes


<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 


- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Add `NewProxyAutoTransport` which is an auto-transport with DisableCompression=true set on the underlying transports.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Adds NewProxyAutoTransport(), this method returns a transport which automatically selects between HTTP and H2c, and which is suitable for use by reverse proxies. Specifically it sets DisableCompression=true on the underlying transports.
```

/assign @vagababov @markusthoemmes 