### PR TITLE
Move IsKProbe to drainer, since it's the only place it's used

### DIFF
--- a/network/handlers/drain.go
+++ b/network/handlers/drain.go
@@ -90,7 +90,7 @@ func (d *Drainer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	if network.IsKProbe(r) {
+	if isKProbe(r) {
 		if d.draining() {
 			http.Error(w, "shutting down", http.StatusServiceUnavailable)
 		} else {
@@ -145,4 +145,9 @@ func (d *Drainer) draining() bool {
 	d.RLock()
 	defer d.RUnlock()
 	return d.timer != nil
+}
+
+// isKProbe returns true if the request is a knatvie probe.
+func isKProbe(r *http.Request) bool {
+	return r.Header.Get(network.ProbeHeaderName) == network.ProbeHeaderValue
 }

--- a/network/handlers/drain_test.go
+++ b/network/handlers/drain_test.go
@@ -384,3 +384,36 @@ func TestIsKProbe(t *testing.T) {
 		t.Error("Not a knative probe but counted as such")
 	}
 }
+
+func TestServeKProbe(t *testing.T) {
+	var (
+		kprobehash = "hash"
+		kprobe     = &http.Request{
+			Header: http.Header{
+				network.ProbeHeaderName: []string{network.ProbeHeaderValue},
+				network.HashHeaderName:  []string{kprobehash},
+			},
+		}
+		kprobeerr = &http.Request{
+			Header: http.Header{
+				network.ProbeHeaderName: []string{network.ProbeHeaderValue},
+			},
+		}
+	)
+
+	resp := httptest.NewRecorder()
+	serveKProbe(resp, kprobe)
+	if got, want := resp.Code, http.StatusOK; got != want {
+		t.Errorf("Probe status = %d, wanted %d", got, want)
+	}
+
+	if got, want := resp.Header().Get(network.HashHeaderName), kprobehash; got != want {
+		t.Errorf("KProbe hash = %s, wanted %s", got, want)
+	}
+
+	resp = httptest.NewRecorder()
+	serveKProbe(resp, kprobeerr)
+	if got, want := resp.Code, http.StatusBadRequest; got != want {
+		t.Errorf("Probe status = %d, wanted %d", got, want)
+	}
+}

--- a/network/handlers/drain_test.go
+++ b/network/handlers/drain_test.go
@@ -362,3 +362,25 @@ func TestHealthCheck(t *testing.T) {
 		t.Errorf("Probe status = %d, wanted %d", got, want)
 	}
 }
+
+func TestIsKProbe(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/", nil)
+	if err != nil {
+		t.Fatal("Error building request:", err)
+	}
+	if isKProbe(req) {
+		t.Error("Not a knative probe but counted as such")
+	}
+	req.Header.Set(network.ProbeHeaderName, network.ProbeHeaderValue)
+	if !isKProbe(req) {
+		t.Error("knative probe but not counted as such")
+	}
+	req.Header.Del(network.ProbeHeaderName)
+	if isKProbe(req) {
+		t.Error("Not a knative probe but counted as such")
+	}
+	req.Header.Set(network.ProbeHeaderName, "no matter")
+	if isKProbe(req) {
+		t.Error("Not a knative probe but counted as such")
+	}
+}

--- a/network/network.go
+++ b/network/network.go
@@ -69,11 +69,6 @@ func IsKubeletProbe(r *http.Request) bool {
 		r.Header.Get(KubeletProbeHeaderName) != ""
 }
 
-// IsKProbe returns true if the request is a knatvie probe.
-func IsKProbe(r *http.Request) bool {
-	return r.Header.Get(ProbeHeaderName) == ProbeHeaderValue
-}
-
 // ServeKProbe serve KProbe requests.
 func ServeKProbe(w http.ResponseWriter, r *http.Request) {
 	hh := r.Header.Get(HashHeaderName)

--- a/network/network.go
+++ b/network/network.go
@@ -17,7 +17,6 @@ limitations under the License.
 package network
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -67,15 +66,4 @@ const (
 func IsKubeletProbe(r *http.Request) bool {
 	return strings.HasPrefix(r.Header.Get(UserAgentKey), KubeProbeUAPrefix) ||
 		r.Header.Get(KubeletProbeHeaderName) != ""
-}
-
-// ServeKProbe serve KProbe requests.
-func ServeKProbe(w http.ResponseWriter, r *http.Request) {
-	hh := r.Header.Get(HashHeaderName)
-	if hh == "" {
-		http.Error(w, fmt.Sprintf("a probe request must contain a non-empty %q header", HashHeaderName), http.StatusBadRequest)
-		return
-	}
-	w.Header().Set(HashHeaderName, hh)
-	w.WriteHeader(http.StatusOK)
 }

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -44,28 +44,6 @@ func TestIsKubeletProbe(t *testing.T) {
 	}
 }
 
-func TestIsKnativeProbe(t *testing.T) {
-	req, err := http.NewRequest(http.MethodGet, "http://example.com/", nil)
-	if err != nil {
-		t.Fatal("Error building request:", err)
-	}
-	if IsKProbe(req) {
-		t.Error("Not a knative probe but counted as such")
-	}
-	req.Header.Set(ProbeHeaderName, ProbeHeaderValue)
-	if !IsKProbe(req) {
-		t.Error("knative probe but not counted as such")
-	}
-	req.Header.Del(ProbeHeaderName)
-	if IsKProbe(req) {
-		t.Error("Not a knative probe but counted as such")
-	}
-	req.Header.Set(ProbeHeaderName, "no matter")
-	if IsKProbe(req) {
-		t.Error("Not a knative probe but counted as such")
-	}
-}
-
 func TestServeKProbe(t *testing.T) {
 	var (
 		kprobehash = "hash"

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -18,7 +18,6 @@ package network
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"testing"
 )
 
@@ -41,38 +40,5 @@ func TestIsKubeletProbe(t *testing.T) {
 	req.Header.Set(KubeletProbeHeaderName, "no matter")
 	if !IsKubeletProbe(req) {
 		t.Error("kubelet probe but not counted as such")
-	}
-}
-
-func TestServeKProbe(t *testing.T) {
-	var (
-		kprobehash = "hash"
-		kprobe     = &http.Request{
-			Header: http.Header{
-				ProbeHeaderName: []string{ProbeHeaderValue},
-				HashHeaderName:  []string{kprobehash},
-			},
-		}
-		kprobeerr = &http.Request{
-			Header: http.Header{
-				ProbeHeaderName: []string{ProbeHeaderValue},
-			},
-		}
-	)
-
-	resp := httptest.NewRecorder()
-	ServeKProbe(resp, kprobe)
-	if got, want := resp.Code, http.StatusOK; got != want {
-		t.Errorf("Probe status = %d, wanted %d", got, want)
-	}
-
-	if got, want := resp.Header().Get(HashHeaderName), kprobehash; got != want {
-		t.Errorf("KProbe hash = %s, wanted %s", got, want)
-	}
-
-	resp = httptest.NewRecorder()
-	ServeKProbe(resp, kprobeerr)
-	if got, want := resp.Code, http.StatusBadRequest; got != want {
-		t.Errorf("Probe status = %d, wanted %d", got, want)
 	}
 }


### PR DESCRIPTION
And hide it, since no need to export it, if nobody's going to use it.

🧹 

 /assign @tcnghia 