### PR TITLE
Add benchmark for metrics recording

### DIFF
--- a/metrics/record_test.go
+++ b/metrics/record_test.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"go.opencensus.io/tag"
 	"path"
 	"testing"
 
@@ -228,44 +229,81 @@ func TestMeter(t *testing.T) {
 }
 
 func BenchmarkMetricsRecording(b *testing.B) {
-	ctx := context.Background()
+	requestKey := tag.MustNewKey("request")
+	requestStatus := tag.MustNewKey("requestStatus")
+	requestURL := tag.MustNewKey("requestUrl")
+	tagKeys := []tag.Key{requestKey, requestStatus, requestURL}
 	measure1 := stats.Int64("count1", "First counter", stats.UnitDimensionless)
 	measure2 := stats.Int64("count2", "Second counter", stats.UnitDimensionless)
 	v := []*view.View{{
 		Measure:     measure1,
 		Aggregation: view.LastValue(),
+		TagKeys:     tagKeys,
 	}, {
 		Measure:     measure2,
 		Aggregation: view.LastValue(),
+		TagKeys:     tagKeys,
 	}}
-	RegisterResourceView(v...)
+	err := RegisterResourceView(v...)
+	if err != nil {
+		b.Error("Failed to register resource view")
+	}
+	defer UnregisterResourceView(v...)
 	metricsConfig := &metricsConfig{}
 	measurement1 := measure1.M(1000)
 	measurement2 := measure2.M(1)
 	setCurMetricsConfig(metricsConfig)
+	getTagCtx := func() (context.Context, error) {
+		ctx := context.Background()
+		ctx, err := tag.New(
+			ctx,
+			tag.Insert(requestKey, "login"),
+			tag.Insert(requestStatus, "status_ok"),
+			tag.Insert(requestURL, "localhost"),
+		)
+		return ctx, err
+	}
+	if err != nil {
+		b.Error("Failed to create tags")
+	}
 	b.Run("sequential", func(b *testing.B) {
 		for j := 0; j < b.N; j++ {
+			ctx, err := getTagCtx()
+			if err != nil {
+				b.Error("Failed to get context")
+			}
 			Record(ctx, measurement1)
 		}
 	})
 	b.Run("parallel", func(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
+				ctx, err := getTagCtx()
+				if err != nil {
+					b.Error("Failed to get context")
+				}
 				Record(ctx, measurement1)
 			}
 		})
 	})
 	b.Run("sequential-batch", func(b *testing.B) {
 		for j := 0; j < b.N; j++ {
+			ctx, err := getTagCtx()
+			if err != nil {
+				b.Error("Failed to get context")
+			}
 			RecordBatch(ctx, measurement1, measurement2)
 		}
 	})
 	b.Run("parallel-batch", func(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
+				ctx, err := getTagCtx()
+				if err != nil {
+					b.Error("Failed to get context")
+				}
 				RecordBatch(ctx, measurement1, measurement2)
 			}
 		})
 	})
-	UnregisterResourceView(v...)
 }

--- a/metrics/record_test.go
+++ b/metrics/record_test.go
@@ -19,7 +19,6 @@ package metrics
 import (
 	"context"
 	"fmt"
-	"go.opencensus.io/tag"
 	"path"
 	"testing"
 
@@ -30,6 +29,7 @@ import (
 	"go.opencensus.io/resource"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 )
 
 type cases struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

* Adds a benchmark to be used as a baseline for future changes or migrations.
This is helpful especially because metrics reporting happens in many places and after some user request eg. [eventing](https://github.com/knative/eventing/blob/149ebe660b60f43975fba414034a7c90682e8804/pkg/adapter/v2/cloudevents.go#L120).
/cc @evankanderson 
I used this benchmark to compare with branch release-0.20. Results are bellow.
Possibly due to our change in #2031 moving to a channel implementation we add some overhead ~1ms but for overloaded
pods with many goroutines things get better (I will compare in the future with using atomic values) probably due to [this](https://stackoverflow.com/questions/57562606/why-does-sync-mutex-largely-drop-performance-when-goroutine-contention-is-more-t).
It would be nice numbers to be validated independently (or percentage diffs).

**main**
```
$go test -run=^$ -test.v -test.benchmem=true -test.bench=^BenchmarkMetricsRecording$ ./metrics/ 
goos: linux
goarch: amd64
pkg: knative.dev/pkg/metrics
BenchmarkMetricsRecording
BenchmarkMetricsRecording/sequential
BenchmarkMetricsRecording/sequential-12         	  716590	      2110 ns/op	     368 B/op	       9 allocs/op
BenchmarkMetricsRecording/parallel
BenchmarkMetricsRecording/parallel-12           	  356906	      3212 ns/op	     368 B/op	       9 allocs/op
BenchmarkMetricsRecording/sequential-batch
BenchmarkMetricsRecording/sequential-batch-12   	  568777	      2252 ns/op	     400 B/op	       9 allocs/op
BenchmarkMetricsRecording/parallel-batch
BenchmarkMetricsRecording/parallel-batch-12     	  295448	      3850 ns/op	     400 B/op	       9 allocs/op
PASS
ok  	knative.dev/pkg/metrics	6.185s


$ go test -run=^$ -test.v -test.benchmem=true -cpu=3000 -test.bench=^BenchmarkMetricsRecording$ ./metrics/ 
goos: linux
goarch: amd64
pkg: knative.dev/pkg/metrics
BenchmarkMetricsRecording
BenchmarkMetricsRecording/sequential
BenchmarkMetricsRecording/sequential-3000         	  540606	      1984 ns/op	     368 B/op	       9 allocs/op
BenchmarkMetricsRecording/parallel
BenchmarkMetricsRecording/parallel-3000           	  379110	      3114 ns/op	     369 B/op	       9 allocs/op
BenchmarkMetricsRecording/sequential-batch
BenchmarkMetricsRecording/sequential-batch-3000   	  519412	      2420 ns/op	     400 B/op	       9 allocs/op
BenchmarkMetricsRecording/parallel-batch
BenchmarkMetricsRecording/parallel-batch-3000     	  350462	      3914 ns/op	     401 B/op	       9 allocs/op
PASS
ok  	knative.dev/pkg/metrics	5.516s


$ go test -run=^$ -test.v -test.benchmem=true -cpu=15000 -test.bench=^BenchmarkMetricsRecording$ ./metrics/ 
goos: linux
goarch: amd64
pkg: knative.dev/pkg/metrics
BenchmarkMetricsRecording
BenchmarkMetricsRecording/sequential
BenchmarkMetricsRecording/sequential-15000         	  826749	      2125 ns/op	     368 B/op	       9 allocs/op
BenchmarkMetricsRecording/parallel
BenchmarkMetricsRecording/parallel-15000           	  267745	      3974 ns/op	     374 B/op	       9 allocs/op
BenchmarkMetricsRecording/sequential-batch
BenchmarkMetricsRecording/sequential-batch-15000   	  433729	      2634 ns/op	     400 B/op	       9 allocs/op
BenchmarkMetricsRecording/parallel-batch
BenchmarkMetricsRecording/parallel-batch-15000     	  279043	      4349 ns/op	     405 B/op	       9 allocs/op
PASS
ok  	knative.dev/pkg/metrics	13.112s

```
**release-0.20**
```
$ go test -run=^$ -test.v -test.benchmem=true -test.bench=^BenchmarkMetricsRecording$ ./metrics/ 
goos: linux
goarch: amd64
pkg: knative.dev/pkg/metrics
BenchmarkMetricsRecording
BenchmarkMetricsRecording/sequential
BenchmarkMetricsRecording/sequential-12         	  891790	      1182 ns/op	     264 B/op	       7 allocs/op
BenchmarkMetricsRecording/parallel
BenchmarkMetricsRecording/parallel-12           	 1000000	      1176 ns/op	     264 B/op	       7 allocs/op
BenchmarkMetricsRecording/sequential-batch
BenchmarkMetricsRecording/sequential-batch-12   	  891654	      1240 ns/op	     296 B/op	       7 allocs/op
BenchmarkMetricsRecording/parallel-batch
BenchmarkMetricsRecording/parallel-batch-12     	 1000000	      1360 ns/op	     296 B/op	       7 allocs/op
PASS
ok  	knative.dev/pkg/metrics	4.809s

$ go test -run=^$ -test.v -test.benchmem=true -cpu=3000 -test.bench=^BenchmarkMetricsRecording$ ./metrics/ 
goos: linux
goarch: amd64
pkg: knative.dev/pkg/metrics
BenchmarkMetricsRecording
BenchmarkMetricsRecording/sequential
BenchmarkMetricsRecording/sequential-3000         	 1000000	      1268 ns/op	     264 B/op	       7 allocs/op
BenchmarkMetricsRecording/parallel
BenchmarkMetricsRecording/parallel-3000           	  556707	      2501 ns/op	     265 B/op	       7 allocs/op
BenchmarkMetricsRecording/sequential-batch
BenchmarkMetricsRecording/sequential-batch-3000   	  955573	      1591 ns/op	     296 B/op	       7 allocs/op
BenchmarkMetricsRecording/parallel-batch
BenchmarkMetricsRecording/parallel-batch-3000     	  425730	      2701 ns/op	     296 B/op	       7 allocs/op
PASS
ok  	knative.dev/pkg/metrics	8.039s


$ go test -run=^$ -test.v -test.benchmem=true -cpu=15000 -test.bench=^BenchmarkMetricsRecording$ ./metrics/ 
goos: linux
goarch: amd64
pkg: knative.dev/pkg/metrics
BenchmarkMetricsRecording
BenchmarkMetricsRecording/sequential
BenchmarkMetricsRecording/sequential-15000         	 1000000	      1501 ns/op	     264 B/op	       7 allocs/op
BenchmarkMetricsRecording/parallel
BenchmarkMetricsRecording/parallel-15000           	   87499	     12933 ns/op	     298 B/op	       7 allocs/op
BenchmarkMetricsRecording/sequential-batch
BenchmarkMetricsRecording/sequential-batch-15000   	  956638	      1524 ns/op	     296 B/op	       7 allocs/op
BenchmarkMetricsRecording/parallel-batch
BenchmarkMetricsRecording/parallel-batch-15000     	   26812	     55237 ns/op	     424 B/op	       8 allocs/op
PASS
ok  	knative.dev/pkg/metrics	13.983s
```



