### PR TITLE
Implement getter machinery to generically fetch all injected clients

### DIFF
--- a/client/injection/apiextensions/client/client.go
+++ b/client/injection/apiextensions/client/client.go
@@ -29,6 +29,9 @@ import (
 
 func init() {
 	injection.Default.RegisterClient(withClient)
+	injection.Default.RegisterClientFetcher(func(ctx context.Context) interface{} {
+		return Get(ctx)
+	})
 }
 
 // Key is used as the key for associating information with a context.Context.

--- a/client/injection/apiextensions/client/fake/fake.go
+++ b/client/injection/apiextensions/client/fake/fake.go
@@ -31,6 +31,9 @@ import (
 
 func init() {
 	injection.Fake.RegisterClient(withClient)
+	injection.Fake.RegisterClientFetcher(func(ctx context.Context) interface{} {
+		return Get(ctx)
+	})
 }
 
 func withClient(ctx context.Context, cfg *rest.Config) context.Context {

--- a/client/injection/kube/client/client.go
+++ b/client/injection/kube/client/client.go
@@ -29,6 +29,9 @@ import (
 
 func init() {
 	injection.Default.RegisterClient(withClient)
+	injection.Default.RegisterClientFetcher(func(ctx context.Context) interface{} {
+		return Get(ctx)
+	})
 }
 
 // Key is used as the key for associating information with a context.Context.

--- a/client/injection/kube/client/fake/fake.go
+++ b/client/injection/kube/client/fake/fake.go
@@ -31,6 +31,9 @@ import (
 
 func init() {
 	injection.Fake.RegisterClient(withClient)
+	injection.Fake.RegisterClientFetcher(func(ctx context.Context) interface{} {
+		return Get(ctx)
+	})
 }
 
 func withClient(ctx context.Context, cfg *rest.Config) context.Context {

--- a/codegen/cmd/injection-gen/generators/client.go
+++ b/codegen/cmd/injection-gen/generators/client.go
@@ -66,7 +66,11 @@ func (g *clientGenerator) GenerateType(c *generator.Context, t *types.Type, w io
 		"clientSetNewForConfigOrDie": c.Universe.Function(types.Name{Package: g.clientSetPackage, Name: "NewForConfigOrDie"}),
 		"clientSetInterface":         c.Universe.Type(types.Name{Package: g.clientSetPackage, Name: "Interface"}),
 		"injectionRegisterClient":    c.Universe.Function(types.Name{Package: "knative.dev/pkg/injection", Name: "Default.RegisterClient"}),
-		"restConfig":                 c.Universe.Type(types.Name{Package: "k8s.io/client-go/rest", Name: "Config"}),
+		"injectionRegisterClientFetcher": c.Universe.Function(types.Name{
+			Package: "knative.dev/pkg/injection",
+			Name:    "Default.RegisterClientFetcher",
+		}),
+		"restConfig": c.Universe.Type(types.Name{Package: "k8s.io/client-go/rest", Name: "Config"}),
 		"loggingFromContext": c.Universe.Function(types.Name{
 			Package: "knative.dev/pkg/logging",
 			Name:    "FromContext",
@@ -85,6 +89,9 @@ func (g *clientGenerator) GenerateType(c *generator.Context, t *types.Type, w io
 var injectionClient = `
 func init() {
 	{{.injectionRegisterClient|raw}}(withClient)
+	{{.injectionRegisterClientFetcher|raw}}(func(ctx context.Context) interface{} {
+		return Get(ctx)
+	})
 }
 
 // Key is used as the key for associating information with a context.Context.

--- a/codegen/cmd/injection-gen/generators/fake_client.go
+++ b/codegen/cmd/injection-gen/generators/fake_client.go
@@ -71,6 +71,10 @@ func (g *fakeClientGenerator) GenerateType(c *generator.Context, t *types.Type, 
 			Package: "knative.dev/pkg/injection",
 			Name:    "Fake.RegisterClient",
 		}),
+		"injectionRegisterClientFetcher": c.Universe.Function(types.Name{
+			Package: "knative.dev/pkg/injection",
+			Name:    "Fake.RegisterClientFetcher",
+		}),
 		"loggingFromContext": c.Universe.Function(types.Name{
 			Package: "knative.dev/pkg/logging",
 			Name:    "FromContext",
@@ -91,6 +95,9 @@ func (g *fakeClientGenerator) GenerateType(c *generator.Context, t *types.Type, 
 var injectionFakeClient = `
 func init() {
 	{{.injectionRegisterClient|raw}}(withClient)
+	{{.injectionRegisterClientFetcher|raw}}(func(ctx context.Context) interface{} {
+		return Get(ctx)
+	})
 }
 
 func withClient(ctx {{.contextContext|raw}}, cfg *{{.restConfig|raw}}) {{.contextContext|raw}} {

--- a/injection/interface.go
+++ b/injection/interface.go
@@ -36,6 +36,13 @@ type Interface interface {
 	// GetClients fetches all of the registered client injectors.
 	GetClients() []ClientInjector
 
+	// RegisterClientFetcher registers a new callback that fetches a client from
+	// a given context.
+	RegisterClientFetcher(ClientFetcher)
+
+	// FetchAllClients returns all known clients from the given context.
+	FetchAllClients(context.Context) []interface{}
+
 	// RegisterInformerFactory registers a new injector callback for associating
 	// a new informer factory with a context.
 	RegisterInformerFactory(InformerFactoryInjector)
@@ -92,6 +99,7 @@ type impl struct {
 	m sync.RWMutex
 
 	clients           []ClientInjector
+	clientFetchers    []ClientFetcher
 	factories         []InformerFactoryInjector
 	informers         []InformerInjector
 	filteredInformers []FilteredInformersInjector


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

This is a stepping stone towards moer unit test stability around informer usage. See https://github.com/knative/serving/pull/10930 for an end to end example.

In a nutshell, we'd like to be able to fetch all injected clients generically to be able to muck with them and make sure everything is synced when we think it is.

/assign @n3wscott 