### PR TITLE
add filter label selector for serving fake pod informer factory setup

### DIFF
--- a/reconciler/testing/context.go
+++ b/reconciler/testing/context.go
@@ -39,16 +39,21 @@ import (
 )
 
 // SetupFakeContext sets up the the Context and the fake informers for the tests.
-func SetupFakeContext(t testing.TB) (context.Context, []controller.Informer) {
-	c, _, is := SetupFakeContextWithCancel(t)
+// The optional fs() can be used to edit ctx before the SetupInformer steps
+func SetupFakeContext(t testing.TB, fs ...func(context.Context) context.Context) (context.Context, []controller.Informer) {
+	c, _, is := SetupFakeContextWithCancel(t, fs...)
 	return c, is
 }
 
 // SetupFakeContextWithCancel sets up the the Context and the fake informers for the tests
 // The provided context can be canceled using provided callback.
-func SetupFakeContextWithCancel(t testing.TB) (context.Context, context.CancelFunc, []controller.Informer) {
+// The optional fs() can be used to edit ctx before the SetupInformer steps
+func SetupFakeContextWithCancel(t testing.TB, fs ...func(context.Context) context.Context) (context.Context, context.CancelFunc, []controller.Informer) {
 	ctx, c := context.WithCancel(logtesting.TestContextWithLogger(t))
 	ctx = controller.WithEventRecorder(ctx, record.NewFakeRecorder(1000))
+	for _, f := range fs {
+		ctx = f(ctx)
+	}
 	ctx, is := injection.Fake.SetupInformers(ctx, &rest.Config{})
 	return ctx, c, is
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

/kind bug

Update the faked testing context to facilitate the faked `filterinformaterfactory` setup. 

Without the correct faked context,  the PR https://github.com/knative/serving/pull/10266 always failed with UT by:
```
ok  	knative.dev/serving/pkg/reconciler/autoscaling/hpa/resources	0.080s	coverage: 100.0% of statements
--- FAIL: TestGlobalResyncOnUpdateAutoscalerConfigMap (0.00s)
    logger.go:130: 2021-03-13T01:25:20.733Z	PANIC	fake/fake_filtered_factory.go:47	Unable to fetch labelkey from context.
panic: Unable to fetch labelkey from context. [recovered]
	panic: Unable to fetch labelkey from context.
```
