### PR TITLE
Escape path before returning it in a response

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"html"
 	"net/http"
 	"time"
 
@@ -140,7 +141,7 @@ func New(
 	}
 
 	webhook.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, fmt.Sprint("no controller registered for: ", r.URL.Path), http.StatusBadRequest)
+		http.Error(w, fmt.Sprint("no controller registered for: ", html.EscapeString(r.URL.Path)), http.StatusBadRequest)
 	})
 
 	for _, controller := range controllers {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Fixes https://github.com/knative/pkg/security/code-scanning/5?query=ref%3Arefs%2Fheads%2Fmain

Yet again not likely anything that would actively harm us, seeing as the webhook is exclusively called via the K8s APIServer and I doubt this'd ever be an issue, but if it makes the scanner happy :)

/assign @vagababov @julz 