### PR TITLE
Bump k8s min version to v1.18.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -33,7 +33,8 @@ const (
 	// NOTE: If you are changing this line, please also update the minimum kubernetes
 	// version listed here:
 	// https://github.com/knative/docs/blob/main/docs/install/any-kubernetes-cluster.md#before-you-begin
-	defaultMinimumVersion = "v1.17.0"
+	// https://github.com/knative/docs/blob/main/docs/install/knative-with-operators.md#prerequisites
+	defaultMinimumVersion = "v1.18.0"
 )
 
 func getMinimumVersion() string {

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -41,13 +41,13 @@ func TestVersionCheck(t *testing.T) {
 		wantError       bool
 	}{{
 		name:          "greater version (patch)",
-		actualVersion: &testVersioner{version: "v1.17.2"},
+		actualVersion: &testVersioner{version: "v1.18.2"},
 	}, {
 		name:          "greater version (patch), no v",
-		actualVersion: &testVersioner{version: "1.17.2"},
+		actualVersion: &testVersioner{version: "1.18.2"},
 	}, {
 		name:          "greater version (patch), pre-release",
-		actualVersion: &testVersioner{version: "1.17.2-kpn-065dce"},
+		actualVersion: &testVersioner{version: "1.18.2-kpn-065dce"},
 	}, {
 		name:            "greater version (patch), pre-release, envvar override",
 		actualVersion:   &testVersioner{version: "1.15.11-kpn-065dce"},
@@ -61,13 +61,13 @@ func TestVersionCheck(t *testing.T) {
 		actualVersion: &testVersioner{version: "v1.18.0"},
 	}, {
 		name:          "same version",
-		actualVersion: &testVersioner{version: "v1.17.0"},
+		actualVersion: &testVersioner{version: "v1.18.0"},
 	}, {
 		name:          "same version with build",
-		actualVersion: &testVersioner{version: "v1.17.0+k3s.1"},
+		actualVersion: &testVersioner{version: "v1.18.0+k3s.1"},
 	}, {
 		name:          "same version with pre-release",
-		actualVersion: &testVersioner{version: "v1.17.0-k3s.1"},
+		actualVersion: &testVersioner{version: "v1.18.0-k3s.1"},
 	}, {
 		name:          "smaller version",
 		actualVersion: &testVersioner{version: "v1.14.3"},


### PR DESCRIPTION
Minimum version for k8s was v1.18.x since Knative v0.21.x but it was not updated:
https://github.com/knative/community/blob/main/mechanics/RELEASE-VERSIONING-PRINCIPLES.md#knative-serving-version-table

This patch updates it. Note, the doc was already updated.

/cc @dprotaso @evankanderson  @markusthoemmes 