### PR TITLE
Update OWNERS_ALIASES to match autogen in community

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,12 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- pkg-approvers
+- technical-oversight-committee
+- dprotaso
+- grantr
+- markusthoemmes
+- mattmoor
+- tcnghia
+- vagababov
+- vaikas
+- n3wscott

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,86 +1,42 @@
 aliases:
-  pkg-approvers:
-  - dprotaso
+  technical-oversight-committee:
   - evankanderson
   - grantr
   - markusthoemmes
-  - mattmoor
-  - tcnghia
-  - vagababov
-  - vaikas
-  - n3wscott
+  - rhuss
 
-  apis-approvers:
-  - mattmoor
-  - vaikas
-  - n3wscott
-  apis-reviewers:
-  - whaught
-
-  apis-duck-approvers:
-  - mattmoor
-  - vaikas
-  apis-duck-reviewers:
-  - whaught
-
-  codegen-approvers:
-  - mattmoor
-  - n3wscott
-  codegen-reviewers:
-  - whaught
-
-  configmap-approvers:
+  pkg-configmap-reviewers:
+  - dprotaso
   - mattmoor
   - mdemirhan
-  - dprotaso
   - vagababov
 
-  controller-approvers:
+  pkg-configmap-writers:
+  - dprotaso
+  - mattmoor
+  - mdemirhan
+  - vagababov
+
+  pkg-controller-reviewers:
   - grantr
   - mattmoor
   - tcnghia
   - vagababov
-  controller-reviewers:
   - whaught
 
-  kflag-approvers:
+  pkg-controller-writers:
+  - grantr
   - mattmoor
-  - vagababov
-
-  kmeta-approvers:
-  - mattmoor
-  - vagababov
-
-  logging-approvers:
-  - mdemirhan
-  - n3wscott
-  - yanweiguo
-
-  metrics-approvers:
-  - mdemirhan
-  - yanweiguo
-
-  network-approvers:
-  - markusthoemmes
   - tcnghia
   - vagababov
 
-  productivity-approvers:
-  - chaodaiG
-  - chizhg
   productivity-reviewers:
-  - chaodaiG
   - coryrc
-  - chizhg
+  - evankanderson
   - steuhs
+  - yt3liu
 
-  source-approvers:
+  productivity-writers:
+  - chizhg
   - n3wscott
-  - vaikas
 
-  webhook-approvers:
-  - dprotaso
-  - mattmoor
-  - tcnghia
-  webhook-reviewers:
-  - whaught

--- a/apis/OWNERS
+++ b/apis/OWNERS
@@ -1,7 +1,9 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- apis-approvers
+- mattmoor
+- vaikas
+- n3wscott
 
 reviewers:
-- apis-reviewers
+- whaught

--- a/apis/duck/OWNERS
+++ b/apis/duck/OWNERS
@@ -1,7 +1,8 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- apis-duck-approvers
+- mattmoor
+- vaikas
 
 reviewers:
-- apis-duck-reviewers
+- whaught

--- a/codegen/OWNERS
+++ b/codegen/OWNERS
@@ -1,7 +1,8 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- codegen-approvers
+- mattmoor
+- n3wscott
 
 reviewers:
-- codegen-reviewers
+- whaught

--- a/configmap/OWNERS
+++ b/configmap/OWNERS
@@ -1,4 +1,6 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- configmap-approvers
+- pkg-configmap-writers
+reviewers:
+- pkg-configmap-reviewers

--- a/controller/OWNERS
+++ b/controller/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- controller-approvers
+- pkg-controller-writers
 
 reviewers:
-- controller-reviewers
+- pkg-controller-reviewers

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- productivity-approvers
+- productivity-writers
 
 reviewers:
 - productivity-reviewers

--- a/hash/OWNERS
+++ b/hash/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- controller-approvers
+- pkg-controller-writers
 
 reviewers:
-- controller-reviewers
+- pkg-controller-reviewers

--- a/kflag/OWNERS
+++ b/kflag/OWNERS
@@ -1,4 +1,5 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- kflag-approvers
+- mattmoor
+- vagababov

--- a/kmeta/OWNERS
+++ b/kmeta/OWNERS
@@ -1,4 +1,5 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- kmeta-approvers
+- mattmoor
+- vagababov

--- a/logging/OWNERS
+++ b/logging/OWNERS
@@ -1,4 +1,6 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- logging-approvers
+- mdemirhan
+- n3wscott
+- yanweiguo

--- a/metrics/OWNERS
+++ b/metrics/OWNERS
@@ -1,4 +1,6 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- metrics-approvers
+- mdemirhan
+- yanweiguo
+

--- a/pool/OWNERS
+++ b/pool/OWNERS
@@ -1,10 +1,10 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- controller-approvers
+- pkg-controller-writers
 
 reviewers:
-- controller-reviewers
+- pkg-controller-reviewers
 
 labels:
 - area/API

--- a/reconciler/OWNERS
+++ b/reconciler/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- controller-approvers
+- pkg-controller-writers
 
 reviewers:
-- controller-reviewers
+- pkg-controller-reviewers

--- a/source/OWNERS
+++ b/source/OWNERS
@@ -1,4 +1,5 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- source-approvers
+- n3wscott
+- vaikas

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- productivity-approvers
+- productivity-writers
 
 reviewers:
 - productivity-reviewers

--- a/tracing/config/OWNERS
+++ b/tracing/config/OWNERS
@@ -1,4 +1,6 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- configmap-approvers
+- pkg-configmap-writers
+reviewers:
+- pkg-configmap-reviewers

--- a/webhook/OWNERS
+++ b/webhook/OWNERS
@@ -1,7 +1,9 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- webhook-approvers
+- dprotaso
+- mattmoor
+- tcnghia
 
 reviewers:
-- webhook-reviewers
+- whaught

--- a/websocket/OWNERS
+++ b/websocket/OWNERS
@@ -1,4 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- network-approvers
+  - markusthoemmes
+  - tcnghia
+  - vagababov
+


### PR DESCRIPTION
See https://github.com/knative/community/pull/552 for the addition of groups/full OWNERS_ALIASES that will be synced.

This is a preparatory PR for landing OWNERS_ALIASES automation across the Knative org (alternative to the CODEOWNERS changes in knative-sandbox).

If this seems to be expanding permissions or otherwise likely to cause a problem, `/hold` this PR and comment here or on https://github.com/knative/community/pull/552.
