### PR TITLE
Add benchmarking for the http tracing handler

### DIFF
--- a/tracing/http_test.go
+++ b/tracing/http_test.go
@@ -41,17 +41,17 @@ func (fw *fakeWriter) Write(data []byte) (int, error) {
 
 func (fw *fakeWriter) WriteHeader(statusCode int) {}
 
-type dummyWriter struct {}
+type benchWriter struct{}
 
-func (dw *dummyWriter) Header() http.Header {
+func (dw *benchWriter) Header() http.Header {
 	return http.Header{}
 }
 
-func (dw *dummyWriter) Write(data []byte) (int, error) {
+func (dw *benchWriter) Write(data []byte) (int, error) {
 	return 0, nil
 }
 
-func (dw *dummyWriter) WriteHeader(statusCode int) {}
+func (dw *benchWriter) WriteHeader(statusCode int) {}
 
 type testHandler struct{}
 
@@ -200,7 +200,7 @@ func BenchmarkSpanMiddleware(b *testing.B) {
 	next := testHandler{}
 	middleware := HTTPSpanMiddleware(&next)
 
-	dw := &dummyWriter{}
+	bw := &benchWriter{}
 
 	req, err := http.NewRequest(http.MethodGet, "http://test.example.com", nil)
 	if err != nil {
@@ -212,14 +212,14 @@ func BenchmarkSpanMiddleware(b *testing.B) {
 
 	b.Run("sequential", func(b *testing.B) {
 		for j := 0; j < b.N; j++ {
-			middleware.ServeHTTP(dw, req)
+			middleware.ServeHTTP(bw, req)
 		}
 	})
 
 	b.Run("parallel", func(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				middleware.ServeHTTP(dw, req)
+				middleware.ServeHTTP(bw, req)
 			}
 		})
 	})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
* Adds a benchmark to be used as a baseline for future changes or migrations. This is helpful especially because tracing happens in several places like activator, queue-proxy. Note that eventing uses [direct calls](https://github.com/knative/eventing/blob/8f35d42544e064783f344538d2957c753e31c820/pkg/broker/ingress/ingress_handler.go#L141-L152) to opencesus lib eg. `trace.StartSpan()` in its event handlers and sets span attributes explicitly in several occasions (this is lighter compared to the handler we benchmark here). I am wondering if we can do the same for Serving as trace.StartSpan() is run anyway as part of the HTTPSpanMiddleware (worth investigating next and use this benchmark to compare changes). Maybe create an optimized handler to be used with activator, queue-proxy? 
Allocations btw seem to be pretty high check bellow. /cc @evankanderson 

```
$ go test   -benchmem -memprofile memprofile.out -cpuprofile profile.out -test.v -test.bench BenchmarkSpanMiddleware -test.run ^$ ./tracing/
goos: linux
goarch: amd64
pkg: knative.dev/pkg/tracing
BenchmarkSpanMiddleware
BenchmarkSpanMiddleware/sequential
BenchmarkSpanMiddleware/sequential-12         	  133786	      9358 ns/op	    6718 B/op	      97 allocs/op
BenchmarkSpanMiddleware/parallel
BenchmarkSpanMiddleware/parallel-12           	  300289	      4129 ns/op	    6586 B/op	      97 allocs/op
PASS
ok  	knative.dev/pkg/tracing	3.025s

```

From sequential execution:
```
Dropped 76 nodes (cum <= 12.05ms)
Showing top 10 nodes out of 142
      flat  flat%   sum%        cum   cum%
     480ms 19.92% 19.92%      910ms 37.76%  runtime.scanobject
     190ms  7.88% 27.80%      190ms  7.88%  runtime.procyield
     160ms  6.64% 34.44%      240ms  9.96%  runtime.findObject
     130ms  5.39% 39.83%      400ms 16.60%  runtime.mallocgc
     110ms  4.56% 44.40%      110ms  4.56%  runtime.pageIndexOf (inline)
      70ms  2.90% 47.30%       70ms  2.90%  runtime.memclrNoHeapPointers
      60ms  2.49% 49.79%       60ms  2.49%  runtime.memmove
      60ms  2.49% 52.28%       70ms  2.90%  runtime.spanOf
      50ms  2.07% 54.36%      170ms  7.05%  runtime.greyobject
      50ms  2.07% 56.43%       80ms  3.32%  runtime.heapBitsSetType
```
It means that for the most part there is gc work going on here. Let's check gc allocation:
```
Dropped 11 nodes (cum <= 63402)
Showing top 10 nodes out of 75
      flat  flat%   sum%        cum   cum%
   1327148 10.47% 10.47%    1327148 10.47%  go.opencensus.io/tag.Upsert
    819212  6.46% 16.93%    2306801 18.19%  go.opencensus.io/trace.(*span).copyToCappedAttributes
    699082  5.51% 22.44%     699082  5.51%  container/list.(*List).insertValue (inline)
    654138  5.16% 27.60%    1353220 10.67%  github.com/golang/groupcache/lru.(*Cache).Add
    546149  4.31% 31.90%    1043150  8.23%  go.opencensus.io/trace.newLruMap
    524333  4.13% 36.04%     622638  4.91%  contrib.go.opencensus.io/exporter/zipkin.zipkinSpan
    466960  3.68% 39.72%    1618794 12.77%  go.opencensus.io/plugin/ochttp.(*trackingResponseWriter).end.func1
    447849  3.53% 43.25%     447849  3.53%  context.WithValue
    400255  3.16% 46.41%    2726550 21.50%  go.opencensus.io/plugin/ochttp.(*Handler).startStats
    382302  3.01% 49.43%     382302  3.01%  go.opencensus.io/tag.newMap (inline)
```
By digging into [startStats](https://github.com/census-instrumentation/opencensus-go/blob/de37041b23a4ac17ac695473ec3876c40a4b65f8/plugin/ochttp/server.go#L149) I see that similar to the findings in [metrics benchmarking](https://github.com/knative/pkg/pull/2052#issuecomment-795296071), mutators and other tag/attributes manipulation cause significant overhead.