### PR TITLE
Try fix TestMetricsExport 

### DIFF
--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -183,6 +183,10 @@ func isNewExporterRequired(newConfig *metricsConfig) bool {
 		return newConfig.collectorAddress != cc.collectorAddress || newConfig.requireSecure != cc.requireSecure
 	}
 
+	if newConfig.backendDestination == prometheus {
+		return newConfig.prometheusHost != cc.prometheusHost || newConfig.prometheusPort != cc.prometheusPort
+	}
+
 	return newConfig.backendDestination == stackdriver && newConfig.stackdriverClientConfig != cc.stackdriverClientConfig
 }
 


### PR DESCRIPTION
TestMetricsExport creates a lot of failures on CI lately. Here is a case where [exporter never got updated](https://storage.googleapis.com/knative-prow/pr-logs/pull/knative_pkg/2082/pull-knative-pkg-unit-tests/1380101339379404800/build-log.txt). This means most likely that a previous test already had the backend set as expected but the port was different than the [one expected later on](https://github.com/knative/pkg/pull/2005#issuecomment-776174080).
I guess this happens only in tests and https://github.com/knative/pkg/issues/1672 is not fixed. 
This fix makes logic about prometheus reconfiguration correct for testing purposes.

/cc @evankanderson 