### PR TITLE
Add possibility to implement a deletion handler in a reconciler.

### DIFF
--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
@@ -212,8 +212,15 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	original, err := getter.Get(s.name)
 
 	if errors.IsNotFound(err) {
-		// The resource may no longer exist, in which case we stop processing.
+		// The resource may no longer exist, in which case we stop processing and call
+		// the ObserveDeletion handler if appropriate.
 		logger.Debugf("Resource %q no longer exists", key)
+		if del, ok := r.reconciler.(reconciler.OnDeletionInterface); ok {
+			return del.ObserveDeletion(ctx, types.NamespacedName{
+				Namespace: s.namespace,
+				Name:      s.name,
+			})
+		}
 		return nil
 	} else if err != nil {
 		return err

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
@@ -212,8 +212,15 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	original, err := getter.Get(s.name)
 
 	if errors.IsNotFound(err) {
-		// The resource may no longer exist, in which case we stop processing.
+		// The resource may no longer exist, in which case we stop processing and call
+		// the ObserveDeletion handler if appropriate.
 		logger.Debugf("Resource %q no longer exists", key)
+		if del, ok := r.reconciler.(reconciler.OnDeletionInterface); ok {
+			return del.ObserveDeletion(ctx, types.NamespacedName{
+				Namespace: s.namespace,
+				Name:      s.name,
+			})
+		}
 		return nil
 	} else if err != nil {
 		return err

--- a/client/injection/kube/reconciler/apps/v1/deployment/reconciler.go
+++ b/client/injection/kube/reconciler/apps/v1/deployment/reconciler.go
@@ -212,8 +212,15 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	original, err := getter.Get(s.name)
 
 	if errors.IsNotFound(err) {
-		// The resource may no longer exist, in which case we stop processing.
+		// The resource may no longer exist, in which case we stop processing and call
+		// the ObserveDeletion handler if appropriate.
 		logger.Debugf("Resource %q no longer exists", key)
+		if del, ok := r.reconciler.(reconciler.OnDeletionInterface); ok {
+			return del.ObserveDeletion(ctx, types.NamespacedName{
+				Namespace: s.namespace,
+				Name:      s.name,
+			})
+		}
 		return nil
 	} else if err != nil {
 		return err

--- a/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
@@ -211,8 +211,15 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	original, err := getter.Get(s.name)
 
 	if errors.IsNotFound(err) {
-		// The resource may no longer exist, in which case we stop processing.
+		// The resource may no longer exist, in which case we stop processing and call
+		// the ObserveDeletion handler if appropriate.
 		logger.Debugf("Resource %q no longer exists", key)
+		if del, ok := r.reconciler.(reconciler.OnDeletionInterface); ok {
+			return del.ObserveDeletion(ctx, types.NamespacedName{
+				Namespace: s.namespace,
+				Name:      s.name,
+			})
+		}
 		return nil
 	} else if err != nil {
 		return err

--- a/client/injection/kube/reconciler/core/v1/secret/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/secret/reconciler.go
@@ -201,8 +201,15 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	original, err := getter.Get(s.name)
 
 	if errors.IsNotFound(err) {
-		// The resource may no longer exist, in which case we stop processing.
+		// The resource may no longer exist, in which case we stop processing and call
+		// the ObserveDeletion handler if appropriate.
 		logger.Debugf("Resource %q no longer exists", key)
+		if del, ok := r.reconciler.(reconciler.OnDeletionInterface); ok {
+			return del.ObserveDeletion(ctx, types.NamespacedName{
+				Namespace: s.namespace,
+				Name:      s.name,
+			})
+		}
 		return nil
 	} else if err != nil {
 		return err

--- a/reconciler/configstore.go
+++ b/reconciler/configstore.go
@@ -1,7 +1,7 @@
 /*
 Copyright 2020 The Knative Authors
 
-Licensed under the Apache License, Veroute.on 2.0 (the "License");
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
@@ -16,9 +16,7 @@ limitations under the License.
 
 package reconciler
 
-import (
-	"context"
-)
+import "context"
 
 // ConfigStore is used to attach the frozen configuration to the context.
 type ConfigStore interface {

--- a/reconciler/configstore.go
+++ b/reconciler/configstore.go
@@ -16,10 +16,26 @@ limitations under the License.
 
 package reconciler
 
-import "context"
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+)
 
 // ConfigStore is used to attach the frozen configuration to the context.
 type ConfigStore interface {
 	// ConfigStore is used to attach the frozen configuration to the context.
 	ToContext(ctx context.Context) context.Context
+}
+
+// OnDeletionInterface defines the strongly typed interface to be implemented by a
+// controller observing a deletion of {{.type|raw}}. Every controller that was active
+// during the deletion of the respective resource is guaranteed to observe this event,
+// leader or not. It's usually used to clear up in-memory state regarding the respective
+// resource. Finalizers should be used to ensure external resources are properly cleaned
+// up.
+type OnDeletionInterface interface {
+	// ObserveDeletion implements custom logic to observe deletion of the respective resource
+	// with the given key.
+	ObserveDeletion(ctx context.Context, key types.NamespacedName) error
 }

--- a/reconciler/configstore.go
+++ b/reconciler/configstore.go
@@ -18,24 +18,10 @@ package reconciler
 
 import (
 	"context"
-
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // ConfigStore is used to attach the frozen configuration to the context.
 type ConfigStore interface {
 	// ConfigStore is used to attach the frozen configuration to the context.
 	ToContext(ctx context.Context) context.Context
-}
-
-// OnDeletionInterface defines the strongly typed interface to be implemented by a
-// controller observing a deletion of {{.type|raw}}. Every controller that was active
-// during the deletion of the respective resource is guaranteed to observe this event,
-// leader or not. It's usually used to clear up in-memory state regarding the respective
-// resource. Finalizers should be used to ensure external resources are properly cleaned
-// up.
-type OnDeletionInterface interface {
-	// ObserveDeletion implements custom logic to observe deletion of the respective resource
-	// with the given key.
-	ObserveDeletion(ctx context.Context, key types.NamespacedName) error
 }

--- a/reconciler/deletion.go
+++ b/reconciler/deletion.go
@@ -23,7 +23,7 @@ import (
 )
 
 // OnDeletionInterface defines the strongly typed interface to be implemented by a
-// controller observing a deletion of {{.type|raw}}. Every controller that was active
+// controller observing a deletion of an object. Every controller that was active
 // during the deletion of the respective resource is guaranteed to observe this event,
 // leader or not. It's usually used to clear up in-memory state regarding the respective
 // resource. Finalizers should be used to ensure external resources are properly cleaned

--- a/reconciler/deletion.go
+++ b/reconciler/deletion.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Veroute.on 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// OnDeletionInterface defines the strongly typed interface to be implemented by a
+// controller observing a deletion of {{.type|raw}}. Every controller that was active
+// during the deletion of the respective resource is guaranteed to observe this event,
+// leader or not. It's usually used to clear up in-memory state regarding the respective
+// resource. Finalizers should be used to ensure external resources are properly cleaned
+// up.
+type OnDeletionInterface interface {
+	// ObserveDeletion implements custom logic to observe deletion of the respective resource
+	// with the given key.
+	ObserveDeletion(ctx context.Context, key types.NamespacedName) error
+}

--- a/reconciler/deletion.go
+++ b/reconciler/deletion.go
@@ -1,7 +1,7 @@
 /*
 Copyright 2021 The Knative Authors
 
-Licensed under the Apache License, Veroute.on 2.0 (the "License");
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

Fixes #2021

# Changes

ObserveFinalizeKind is not guaranteed to be called for every resource
that gets deleted, even if they do have a finalizer. The leader can race
the observers in removing the finalizer so the observers would not even
see the deletion.

Using the OnDelete handler on the informer is equally racy in that it
can trigger the deletion handler while a potential "normal" reconcile is
still in-flight.

This adds an ObserveDeletedKind handler that can be implemented by
reconcilers. The events still go via the workQueue, so proper order and
deduplication is guaranteed. Observation is guaranteed as well. In most
if not all cases, this handler should replace the ObserveFinalizeKind
handler.

Will for example be used in https://github.com/knative-sandbox/net-kourier/issues/448

/assign @n3wscott 
