### PR TITLE
resolve cluster domain using env CLUSTER_DOMAIN as a fallback

### DIFF
--- a/network/domain.go
+++ b/network/domain.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	resolverFileName  = "/etc/resolv.conf"
-	defaultDomainName = "cluster.local"
+	resolverFileName    = "/etc/resolv.conf"
+	clusterDomainEnvKey = "CLUSTER_DOMAIN"
+	defaultDomainName   = "cluster.local"
 )
 
 var (
@@ -55,6 +56,7 @@ func GetClusterDomainName() string {
 }
 
 func getClusterDomainName(r io.Reader) string {
+	// First look in the conf file.
 	for scanner := bufio.NewScanner(r); scanner.Scan(); {
 		elements := strings.Split(scanner.Text(), " ")
 		if elements[0] != "search" {
@@ -66,6 +68,12 @@ func getClusterDomainName(r io.Reader) string {
 			}
 		}
 	}
+
+	// Then look in the ENV.
+	if domain := os.Getenv(clusterDomainEnvKey); len(domain) > 0 {
+		return domain
+	}
+
 	// For all abnormal cases return default domain name.
 	return defaultDomainName
 }


### PR DESCRIPTION
# Changes

- :gift: Resolve cluster domain with `CLUSTER_DOMAIN` as a fallback.

/kind enhancement

This will help with tests that are attempting to resolve cluster local urls from outside the cluster, that do not have access to `/etc/resolv.conf` directly. 

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
network.GetServiceHostname and network.GetClusterDomainName now respect the env var CLUSTER_DOMAIN.
```
