### PR TITLE
Allow errors.As to work with reconciler.Events

### DIFF
--- a/reconciler/events.go
+++ b/reconciler/events.go
@@ -87,6 +87,12 @@ func (e *ReconcilerEvent) Is(target error) bool {
 	return errors.Is(err, target)
 }
 
+// As allows ReconcilerEvents to be treated as regular error types.
+func (e *ReconcilerEvent) As(target interface{}) bool {
+	err := fmt.Errorf(e.Format, e.Args...)
+	return errors.As(err, target)
+}
+
 // Error returns the string that is formed by using the format string with the
 // provided args.
 func (e *ReconcilerEvent) Error() string {

--- a/reconciler/events_test.go
+++ b/reconciler/events_test.go
@@ -19,6 +19,7 @@ package reconciler
 import (
 	"errors"
 	"io"
+	"net"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -84,6 +85,13 @@ func TestNew_As(t *testing.T) {
 	}
 	if event.Reason != exampleStatusFailed {
 		t.Error("Mismatched Reason, expected ExampleStatusFailed, got", event.Reason)
+	}
+}
+
+func TestNewWrappedErrors_As(t *testing.T) {
+	err := NewEvent(corev1.EventTypeNormal, exampleStatusFailed, "this is a wrapped error, %w", &net.AddrError{})
+	if netErr := new(net.Error); !EventAs(err, netErr) {
+		t.Error("Event expected to be a wrapped net.AddrError but was not")
 	}
 }
 


### PR DESCRIPTION
# Changes

- :gift: `reconciler.Event`s that wrap errors can be used with the [apimachinery errors package](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/errors), which uses [errors.As](https://github.com/kubernetes/apimachinery/blob/v0.21.0/pkg/api/errors/errors.go#L649-L654) to compare error types.

/kind enhancement

https://github.com/knative/eventing/issues/5146 involves a bug where we are [trying](https://github.com/knative/eventing/blob/7775e372bdc033da163cfb01194785d11a4f7d93/pkg/reconciler/subscription/subscription.go#L120) to ignore `IsNotFound`-type errors in our finalizer, but right now Events can never be used with these apimachinery predicates.

**Release Note**

```release-note
- reconciler.Events can be cast to their underlying error types
```