### PR TITLE
Make VolatileTime compatible with controller-gen

### DIFF
--- a/apis/volatile_time.go
+++ b/apis/volatile_time.go
@@ -28,6 +28,8 @@ import (
 // Thus differing VolatileTime values are not considered different.
 // Note, go-cmp will still return inequality, see unit test if you
 // need this behavior for go-cmp.
+//
+// +kubebuilder:validation:Type=string
 type VolatileTime struct {
 	Inner metav1.Time `json:",inline"`
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

This fixes https://github.com/kubernetes-sigs/controller-tools/issues/533 and is part of the ongoing work to try to use `controller-tools` for our own schema gen.

/assign @julz @vagababov @n3wscott 