### PR TITLE
Make --ingressendpoint configurable via env

### DIFF
--- a/test/ingress/ingress.go
+++ b/test/ingress/ingress.go
@@ -53,6 +53,13 @@ func GetIngressEndpoint(ctx context.Context, kubeClientset kubernetes.Interface,
 		return "", nil, err
 	}
 
+	// Check an environment variable first
+	if endpointOverrideFromEnv := os.Getenv("INGRESS_ENDPOINT"); endpointOverrideFromEnv != "" {
+		// an override should be used over the env
+		if endpointOverride == "" {
+			endpointOverride = endpointOverrideFromEnv
+		}
+	}
 	// If an override is provided, use it
 	if endpointOverride != "" {
 		return endpointOverride, func(port string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Check an environment variable `$INGRESS_ENDPOINT` for the test option `--ingressendpoint` before the override check at `test/ingress/ingress.go` 

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/knative/serving/issues/11294

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
