### PR TITLE
add flag to disable test cleanup in e2e tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -125,6 +125,7 @@ Tests importing [`knative.dev/pkg/test`](#test-library) recognize these flags:
 - [`--dockerrepo`](#specifying-docker-repo)
 - [`--tag`](#specifying-tag)
 - [`--imagetemplate`](#specifying-image-template)
+- [`--nocleanup`](#nocleanup)
 
 ### Specifying kubeconfig
 
@@ -208,6 +209,14 @@ reference to an image from the test. Defaults to
 
 ```bash
 go test ./test --imagetemplate {{.Repository}}/{{.Name}}:{{.Tag}}
+```
+
+### Nocleanup
+
+The `--nocleanup` argument lets you preserve resources created by the end-to-end tests to assist with debugging.
+
+```bash
+go test ./test --nocleanup
 ```
 
 ---

--- a/test/flags/e2e_flags.go
+++ b/test/flags/e2e_flags.go
@@ -35,6 +35,7 @@ type TestEnvironment struct {
 	Tag                  string        // Tag for test images
 	SpoofRequestInterval time.Duration // SpoofRequestInterval is the interval between requests in SpoofingClient
 	SpoofRequestTimeout  time.Duration // SpoofRequestTimeout is the timeout for polling requests in SpoofingClient
+	NoCleanup            bool          // Do not delete test resources, to assist with debugging
 }
 
 var f *TestEnvironment
@@ -69,6 +70,8 @@ func InitFlags(flagset *flag.FlagSet) {
 		"Provide the uri of the docker repo you have uploaded the test image to using `uploadtestimage.sh`. Defaults to $KO_DOCKER_REPO")
 
 	flagset.StringVar(&f.Tag, "tag", "latest", "Provide the version tag for the test images.")
+
+	flagset.BoolVar(&f.NoCleanup, "nocleanup", false, "Do not delete resources after running tests.")
 }
 
 // Flags returns the command line flags or defaults for settings in the user's


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- add `--nocleanup` flag to disable test cleanup in e2e tests

/kind enhancement

This is in support of [Serving Issue 10001](https://github.com/knative/serving/issues/10001). The flag created here will be used to enable the functionality in the Serving repo.

```release-note
Add a `--nocleanup` flag to allow users to disable test cleanup when running e2e tests locally 
```

**Docs**

```docs
- [Usage]: https://github.com/knative/pkg/blob/add-nocleanup-flag/test/README.md#nocleanup
```
(note that the above link won't be valid until this is merged -- prior to that, text can be viewed [here](https://github.com/psschwei/pkg/blob/add-nocleanup-flag/test/README.md#nocleanup). 