### PR TITLE
Replace golint with revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,9 +10,9 @@ linters:
   enable:
     - asciicheck
     - errorlint
-    - golint
     - gosec
     - prealloc
+    - revive
     - stylecheck
     - unconvert
     - unparam

--- a/apis/duck/v1beta1/destination.go
+++ b/apis/duck/v1beta1/destination.go
@@ -136,10 +136,7 @@ func (dest *Destination) GetRef() *corev1.ObjectReference {
 	if dest.Ref != nil {
 		return dest.Ref
 	}
-	if ref := dest.deprecatedObjectReference(); ref != nil {
-		return ref
-	}
-	return nil
+	return dest.deprecatedObjectReference()
 }
 
 func validateDestinationRef(ref corev1.ObjectReference) *apis.FieldError {

--- a/leaderelection/chaosduck/main.go
+++ b/leaderelection/chaosduck/main.go
@@ -47,8 +47,8 @@ type components map[string]sets.String
 var (
 	disabledComponents      kflag.StringSet
 	disabledComponentsRegex kflag.StringSet
-	tributePeriod           time.Duration = 20 * time.Second
-	tributeFactor                         = 2.0
+	tributePeriod           = 20 * time.Second
+	tributeFactor           = 2.0
 )
 
 func init() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

See https://groups.google.com/g/golang-nuts/c/rCP70Aq_tBc/m/8QHp6_cqBgAJ
as towards golint's deprecation. revive is supposed to be a drop-in
replacement.

/assign @julz 