### PR TITLE
Lookup k8s services to ensure they exist

### DIFF
--- a/resolver/addressable_resolver_test.go
+++ b/resolver/addressable_resolver_test.go
@@ -399,7 +399,7 @@ func TestGetURIDestinationV1(t *testing.T) {
 			wantURI: addressableDNS,
 		}, "happy ref to k8s service": {
 			objects: []runtime.Object{
-				getAddressable(),
+				getAddressableFromKRef(k8sServiceRef()),
 			},
 			dest:    duckv1.Destination{Ref: k8sServiceRef()},
 			wantURI: "http://testsink.testnamespace.svc.cluster.local/",
@@ -511,6 +511,9 @@ func TestGetURIDestinationV1(t *testing.T) {
 		}, "notFound": {
 			dest:    duckv1.Destination{Ref: unaddressableKnativeRef()},
 			wantErr: fmt.Sprintf("%s %q not found", unaddressableResource, unaddressableName),
+		}, "notFound k8s service": {
+			dest:    duckv1.Destination{Ref: k8sServiceRef()},
+			wantErr: fmt.Sprintf("services %q not found", addressableName),
 		}}
 
 	for n, tc := range tests {
@@ -751,5 +754,23 @@ func unaddressableRef() *corev1.ObjectReference {
 		Name:       unaddressableName,
 		APIVersion: unaddressableAPIVersion,
 		Namespace:  testNS,
+	}
+}
+
+func getAddressableFromKRef(ref *duckv1.KReference) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": ref.APIVersion,
+			"kind":       ref.Kind,
+			"metadata": map[string]interface{}{
+				"namespace": ref.Namespace,
+				"name":      ref.Name,
+			},
+			"status": map[string]interface{}{
+				"address": map[string]interface{}{
+					"url": addressableDNS,
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature

- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Fix URIResolver to verify that k8s services exist before returning their URI

/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/knative/eventing/pull/5442

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

```release-note
URIResolver will now error if resolving a k8s service that does not exist
```