### PR TITLE
Bump k8s min k8s version to 1.19

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -32,8 +32,7 @@ const (
 
 	// NOTE: If you are changing this line, please also update the minimum kubernetes
 	// version listed here:
-	// https://github.com/knative/docs/blob/main/docs/install/prerequisites.md#prerequisites
-	// https://github.com/knative/docs/blob/main/docs/install/knative-with-operators.md#prerequisites
+	// https://github.com/knative/docs/blob/mkdocs/docs/snippets/prerequisites.md
 	defaultMinimumVersion = "v1.19.0"
 )
 

--- a/version/version.go
+++ b/version/version.go
@@ -34,7 +34,7 @@ const (
 	// version listed here:
 	// https://github.com/knative/docs/blob/main/docs/install/any-kubernetes-cluster.md#before-you-begin
 	// https://github.com/knative/docs/blob/main/docs/install/knative-with-operators.md#prerequisites
-	defaultMinimumVersion = "v1.18.0"
+	defaultMinimumVersion = "v1.19.0"
 )
 
 func getMinimumVersion() string {

--- a/version/version.go
+++ b/version/version.go
@@ -32,7 +32,7 @@ const (
 
 	// NOTE: If you are changing this line, please also update the minimum kubernetes
 	// version listed here:
-	// https://github.com/knative/docs/blob/main/docs/install/any-kubernetes-cluster.md#before-you-begin
+	// https://github.com/knative/docs/blob/main/docs/install/prerequisites.md#prerequisites
 	// https://github.com/knative/docs/blob/main/docs/install/knative-with-operators.md#prerequisites
 	defaultMinimumVersion = "v1.19.0"
 )

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -41,13 +41,13 @@ func TestVersionCheck(t *testing.T) {
 		wantError       bool
 	}{{
 		name:          "greater version (patch)",
-		actualVersion: &testVersioner{version: "v1.18.2"},
+		actualVersion: &testVersioner{version: "v1.19.2"},
 	}, {
 		name:          "greater version (patch), no v",
-		actualVersion: &testVersioner{version: "1.18.2"},
+		actualVersion: &testVersioner{version: "1.19.2"},
 	}, {
 		name:          "greater version (patch), pre-release",
-		actualVersion: &testVersioner{version: "1.18.2-kpn-065dce"},
+		actualVersion: &testVersioner{version: "1.19.2-kpn-065dce"},
 	}, {
 		name:            "greater version (patch), pre-release, envvar override",
 		actualVersion:   &testVersioner{version: "1.15.11-kpn-065dce"},
@@ -58,16 +58,16 @@ func TestVersionCheck(t *testing.T) {
 		versionOverride: "1.15.11-0",
 	}, {
 		name:          "greater version (minor)",
-		actualVersion: &testVersioner{version: "v1.18.0"},
+		actualVersion: &testVersioner{version: "v1.19.0"},
 	}, {
 		name:          "same version",
-		actualVersion: &testVersioner{version: "v1.18.0"},
+		actualVersion: &testVersioner{version: "v1.19.0"},
 	}, {
 		name:          "same version with build",
-		actualVersion: &testVersioner{version: "v1.18.0+k3s.1"},
+		actualVersion: &testVersioner{version: "v1.19.0+k3s.1"},
 	}, {
 		name:          "same version with pre-release",
-		actualVersion: &testVersioner{version: "v1.18.0-k3s.1"},
+		actualVersion: &testVersioner{version: "v1.19.0-k3s.1"},
 	}, {
 		name:          "smaller version",
 		actualVersion: &testVersioner{version: "v1.14.3"},


### PR DESCRIPTION
This patch bumps min k8s version to 1.19

Doc fixes https://github.com/knative/docs/pull/3804.
Please also see https://github.com/knative/community/blob/main/mechanics/RELEASE-VERSIONING-PRINCIPLES.md#knative-serving-version-table

/cc @dprotaso 