### PR TITLE
Add CheckEndpointState method to SpoofingClient

### DIFF
--- a/test/request.go
+++ b/test/request.go
@@ -84,8 +84,6 @@ func EventuallyMatchesBody(expected string) spoof.ResponseChecker {
 	}
 }
 
-type endpointStateCallable = func(ctx context.Context, u *url.URL, inState spoof.ResponseChecker, desc string, r ...spoof.RequestOption) (*spoof.Response, error)
-
 // WaitForEndpointState will poll an endpoint until inState indicates the state is achieved,
 // or default timeout is reached.
 // If resolvableDomain is false, it will use kubeClientset to look up the ingress and spoof
@@ -96,24 +94,13 @@ func WaitForEndpointState(
 	ctx context.Context,
 	kubeClient kubernetes.Interface,
 	logf logging.FormatLogger,
-	u *url.URL,
+	url *url.URL,
 	inState spoof.ResponseChecker,
 	desc string,
 	resolvable bool,
 	opts ...interface{}) (*spoof.Response, error) {
-	return endpointStateWithTimeout(
-		ctx,
-		kubeClient,
-		logf,
-		u,
-		inState,
-		desc,
-		resolvable,
-		Flags.SpoofRequestTimeout,
-		func(client *spoof.SpoofingClient) endpointStateCallable {
-			return client.WaitForEndpointState
-		},
-		opts...)
+	return WaitForEndpointStateWithTimeout(ctx, kubeClient, logf, url, inState,
+		desc, resolvable, Flags.SpoofRequestTimeout, opts...)
 }
 
 // WaitForEndpointStateWithTimeout will poll an endpoint until inState indicates the state is achieved
@@ -122,7 +109,7 @@ func WaitForEndpointState(
 // the domain in the request headers, otherwise it will make the request directly to domain.
 // desc will be used to name the metric that is emitted to track how long it took for the
 // domain to get into the state checked by inState.  Commas in `desc` must be escaped.
-func endpointStateWithTimeout(
+func WaitForEndpointStateWithTimeout(
 	ctx context.Context,
 	kubeClient kubernetes.Interface,
 	logf logging.FormatLogger,
@@ -131,7 +118,21 @@ func endpointStateWithTimeout(
 	desc string,
 	resolvable bool,
 	timeout time.Duration,
-	f func(*spoof.SpoofingClient) endpointStateCallable,
+	opts ...interface{}) (*spoof.Response, error) {
+
+	return waitForEndpointStateWithTimeout(ctx, kubeClient, logf, url, inState, desc, resolvable, timeout, true, opts)
+}
+
+func waitForEndpointStateWithTimeout(
+	ctx context.Context,
+	kubeClient kubernetes.Interface,
+	logf logging.FormatLogger,
+	url *url.URL,
+	inState spoof.ResponseChecker,
+	desc string,
+	resolvable bool,
+	timeout time.Duration,
+	wait bool,
 	opts ...interface{}) (*spoof.Response, error) {
 
 	var tOpts []spoof.TransportOption
@@ -152,30 +153,22 @@ func endpointStateWithTimeout(
 	}
 	client.RequestTimeout = timeout
 
-	return f(client)(ctx, url, inState, desc, rOpts...)
+	if wait {
+		return client.WaitForEndpointState(ctx, url, inState, desc, rOpts...)
+	}
+	return client.CheckEndpointState(ctx, url, inState, desc, rOpts...)
 }
 
 func CheckEndpointState(
 	ctx context.Context,
 	kubeClient kubernetes.Interface,
 	logf logging.FormatLogger,
-	u *url.URL,
+	url *url.URL,
 	inState spoof.ResponseChecker,
 	desc string,
 	resolvable bool,
 	opts ...interface{},
 ) (*spoof.Response, error) {
-	return endpointStateWithTimeout(
-		ctx,
-		kubeClient,
-		logf,
-		u,
-		inState,
-		desc,
-		resolvable,
-		Flags.SpoofRequestTimeout,
-		func(client *spoof.SpoofingClient) endpointStateCallable {
-			return client.CheckEndpointState
-		},
-		opts...)
+	return waitForEndpointStateWithTimeout(ctx, kubeClient, logf, url, inState,
+		desc, resolvable, Flags.SpoofRequestTimeout, false, opts...)
 }

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -313,13 +313,16 @@ func (sc *SpoofingClient) Check(req *http.Request, inState ResponseChecker) (*Re
 		Body:       body,
 	}
 	ok, err := inState(resp)
+
+	sc.logZipkinTrace(resp)
+
 	if err != nil {
 		return resp, fmt.Errorf("response: %s did not pass checks: %w", resp, err)
 	}
 	if ok {
-		sc.logZipkinTrace(resp)
 		return resp, nil
 	}
+
 	return nil, err
 }
 

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -254,7 +254,25 @@ func (sc *SpoofingClient) WaitForEndpointState(
 	desc string,
 	opts ...RequestOption) (*Response, error) {
 
-	defer logging.GetEmitableSpan(ctx, "WaitForEndpointState/"+desc).End()
+	return sc.endpointState(
+		ctx,
+		url,
+		inState,
+		desc,
+		func(req *http.Request, check ResponseChecker) (*Response, error) { return sc.Poll(req, check) },
+		"WaitForEndpointState",
+		opts...)
+}
+
+func (sc *SpoofingClient) endpointState(
+	ctx context.Context,
+	url *url.URL,
+	inState ResponseChecker,
+	desc string,
+	f func(*http.Request, ResponseChecker) (*Response, error),
+	logName string,
+	opts ...RequestOption) (*Response, error) {
+	defer logging.GetEmitableSpan(ctx, logName+"/"+desc).End()
 
 	if url.Scheme == "" || url.Host == "" {
 		return nil, fmt.Errorf("invalid URL: %q", url.String())
@@ -269,5 +287,54 @@ func (sc *SpoofingClient) WaitForEndpointState(
 		opt(req)
 	}
 
-	return sc.Poll(req, inState)
+	return f(req, inState)
+}
+
+func (sc *SpoofingClient) Check(req *http.Request, inState ResponseChecker) (*Response, error) {
+	traceContext, span := trace.StartSpan(req.Context(), "SpoofingClient-Trace")
+	defer span.End()
+	rawResp, err := sc.Client.Do(req.WithContext(traceContext))
+	if err != nil {
+		sc.Logf("NOT Retrying %s: %v", req.URL.String(), err)
+		return nil, err
+	}
+	defer rawResp.Body.Close()
+
+	body, err := ioutil.ReadAll(rawResp.Body)
+	if err != nil {
+		return nil, err
+	}
+	rawResp.Header.Add(zipkin.ZipkinTraceIDHeader, span.SpanContext().TraceID.String())
+
+	resp := &Response{
+		Status:     rawResp.Status,
+		StatusCode: rawResp.StatusCode,
+		Header:     rawResp.Header,
+		Body:       body,
+	}
+	ok, err := inState(resp)
+	if err != nil {
+		return resp, fmt.Errorf("response: %s did not pass checks: %w", resp, err)
+	}
+	if ok {
+		sc.logZipkinTrace(resp)
+		return resp, nil
+	}
+	return nil, err
+}
+
+func (sc *SpoofingClient) CheckEndpointState(
+	ctx context.Context,
+	url *url.URL,
+	inState ResponseChecker,
+	desc string,
+	opts ...RequestOption) (*Response, error) {
+	return sc.endpointState(
+		ctx,
+		url,
+		inState,
+		desc,
+		sc.Check,
+		"CheckEndpointState",
+		opts...)
 }

--- a/test/spoof_test.go
+++ b/test/spoof_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// spoof contains logic to make polling HTTP requests against an endpoint with optional host spoofing.
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/client/injection/kube/client/fake"
+	"knative.dev/pkg/test/spoof"
+)
+
+type fakeTransport struct{}
+
+func (ft *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		Status:     "200 ok",
+		StatusCode: 200,
+		Header:     http.Header{},
+		Body:       http.NoBody,
+	}, nil
+}
+
+type countCalls struct {
+	calls int32
+}
+
+func (c *countCalls) count(rc spoof.ResponseChecker) spoof.ResponseChecker {
+	return func(resp *spoof.Response) (done bool, err error) {
+		c.calls++
+		return rc(resp)
+	}
+}
+
+func TestSpoofingClient_CheckEndpointState(t *testing.T) {
+	ingress := &corev1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "istio-ingressgateway",
+			Namespace: "istio-system",
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{
+						Hostname: "host",
+					},
+				},
+			},
+		},
+	}
+	type args struct {
+		url     *url.URL
+		inState spoof.ResponseChecker
+		desc    string
+		opts    []RequestOption
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantErr   bool
+		wantCalls int32
+	}{{
+		name: "Non matching response doesn't trigger a second check",
+		args: args{
+			url: &url.URL{
+				Host:   "fake.knative.net",
+				Scheme: "http",
+			},
+			inState: func(resp *spoof.Response) (done bool, err error) {
+				return false, nil
+			},
+		},
+		wantErr:   false,
+		wantCalls: 1,
+	}, {
+		name: "Error response doesn't trigger a second check",
+		args: args{
+			url: &url.URL{
+				Host:   "fake.knative.net",
+				Scheme: "http",
+			},
+			inState: func(resp *spoof.Response) (done bool, err error) {
+				return false, fmt.Errorf("response error")
+			},
+		},
+		wantErr:   true,
+		wantCalls: 1,
+	}, {
+		name: "OK response doesn't trigger a second check",
+		args: args{
+			url: &url.URL{
+				Host:   "fake.knative.net",
+				Scheme: "http",
+			},
+			inState: func(resp *spoof.Response) (done bool, err error) {
+				return true, nil
+			},
+		},
+		wantErr:   false,
+		wantCalls: 1,
+	}}
+	for _, tt := range tests {
+		_, fKlient := fake.With(context.TODO(), ingress)
+		t.Run(tt.name, func(t *testing.T) {
+			sc, err := NewSpoofingClient(
+				context.TODO(),
+				fKlient,
+				t.Logf,
+				"some.svc.knative.dev",
+				false,
+			)
+			if err != nil {
+				t.Fatalf("Spoofing client not created: %v", err)
+			}
+			sc.Client = &http.Client{
+				Transport: &fakeTransport{},
+			}
+			counter := countCalls{}
+			_, err = sc.CheckEndpointState(context.TODO(), tt.args.url, counter.count(tt.args.inState), tt.args.desc, tt.args.opts...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SpoofingClient.CheckEndpointState() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if counter.calls != tt.wantCalls {
+				t.Errorf("Expected ResponseChecker to be invoked %d time but got invoked %d", tt.wantCalls, counter.calls)
+			}
+		})
+	}
+}


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- New method `CheckEndpointState` just for checking an endpoint's response

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind api-change

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of knative/serving#1178

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
No changes to the existing WaitForEndpointState method, these changes don't fix knative/serving#1178 but help change the way some assertions work in serving e2e tests
```
