### PR TITLE
Print proper warning logs from API warnings

### DIFF
--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -167,6 +167,10 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 	logger, atomicLevel := SetupLoggerOrDie(ctx, component)
 	defer flush(logger)
 	ctx = logging.WithLogger(ctx, logger)
+
+	// Override client-go's warning handler to give us nicely printed warnings.
+	rest.SetDefaultWarningHandler(&logging.WarningHandler{Logger: logger})
+
 	profilingHandler := profiling.NewHandler(logger, false)
 	profilingServer := profiling.NewServer(profilingHandler)
 

--- a/logging/warning_handler.go
+++ b/logging/warning_handler.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import "go.uber.org/zap"
+
+// WarningHandler is a warning handler to forward client-go's warning logs into a zap logger.
+type WarningHandler struct {
+	Logger *zap.SugaredLogger
+}
+
+func (h *WarningHandler) HandleWarningHeader(code int, agent string, message string) {
+	// This condition is copied from K8s' default WarningLogger.
+	if code != 299 || len(message) == 0 {
+		return
+	}
+
+	h.Logger.Warn("API Warning: " + message)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Instead of writing to client-go's own `klog`, this writes API warnings (see https://kubernetes.io/blog/2020/09/03/warnings/) into the respective zap logger, so they'll be "proper" warnings in the log as well, which should make them easier to catch.

/assign @dprotaso @julz 
