### PR TITLE
Replace reference to obsolete xip.io service

### DIFF
--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -208,7 +208,7 @@ func DefaultErrorRetryChecker(err error) (bool, error) {
 	if isTCPTimeout(err) {
 		return true, fmt.Errorf("retrying for TCP timeout: %w", err)
 	}
-	// Retrying on DNS error, since we may be using xip.io or nip.io in tests.
+	// Retrying on DNS error, since we may be using sslip.io or nip.io in tests.
 	if isDNSError(err) {
 		return true, fmt.Errorf("retrying for DNS error: %w", err)
 	}


### PR DESCRIPTION
Xip.io is no more and we use sslip.io now. Updated the references in serving in https://github.com/knative/serving/pull/11589, updating here to match.