### PR TITLE
Add ability to filter objects on injection controller promotion

### DIFF
--- a/controller/options.go
+++ b/controller/options.go
@@ -38,6 +38,9 @@ type Options struct {
 
 	// DemoteFunc configures the demote function this reconciler uses
 	DemoteFunc func(b reconciler.Bucket)
+
+	// PromoteFilterFunc filters the objects that are enqueued when the reconciler is promoted to leader.
+	PromoteFilterFunc func(obj interface{}) bool
 }
 
 // OptionsFn is a callback method signature that accepts an Impl and returns


### PR DESCRIPTION
Currently we enqueue every object with no way to filter, which causes problems for eventing's source controller which reconciles duck CRDs.

ref: https://github.com/knative/eventing/issues/5543