### PR TITLE
Enable the image template to fetch values from env

### DIFF
--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -22,6 +22,8 @@ package test
 import (
 	"bytes"
 	"flag"
+	"os"
+	"strings"
 	"text/template"
 
 	"k8s.io/client-go/tools/clientcmd"
@@ -68,7 +70,13 @@ func SetupLoggingFlags() {
 
 // ImagePath is a helper function to transform an image name into an image reference that can be pulled.
 func ImagePath(name string) string {
-	tpl, err := template.New("image").Parse(Flags.ImageTemplate)
+	tpl, err := template.New("image").Funcs(template.FuncMap{
+		"toEnvKey": func(in string) string {
+			underscores := strings.ReplaceAll(in, "-", "_")
+			return strings.ToUpper(underscores)
+		},
+		"fromEnv": os.Getenv,
+	}).Parse(Flags.ImageTemplate)
 	if err != nil {
 		panic("could not parse image template: " + err.Error())
 	}


### PR DESCRIPTION
Yeah, this looks a little weird, I know.

My use-case is this: Our CI system wants me to define clear dependencies on images it builds (the images are not built via `ko` but via a mechanism in said CI system). The CI system then publishes the built images pullref (sha based) into an environment variable of my choice.

By allowing the functions in this PR, this enables me to fetch these pullrefs from env via a template like

```
{{with $name := .Name}}{{ fromEnv (toEnvKey (printf "KNATIVE_SERVING_TEST_%s" $name)) }}{{end}}
```

:tada: 

/assign @dprotaso @n3wscott 