### PR TITLE
Allow global resync & reconcilerImpl informers to be filtered

### DIFF
--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/controller.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/controller.go
@@ -63,6 +63,7 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	lister := customresourcedefinitionInformer.Lister()
 
+	filterFunc := controller.GetFilterFunc(ctx)
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
@@ -71,11 +72,12 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 					return err
 				}
 				for _, elt := range all {
-					// TODO: Consider letting users specify a filter in options.
-					enq(bkt, types.NamespacedName{
-						Namespace: elt.GetNamespace(),
-						Name:      elt.GetName(),
-					})
+					if ok := filterFunc(elt); ok {
+						enq(bkt, types.NamespacedName{
+							Namespace: elt.GetNamespace(),
+							Name:      elt.GetName(),
+						})
+					}
 				}
 				return nil
 			},

--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/controller.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/controller.go
@@ -63,7 +63,7 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	lister := customresourcedefinitionInformer.Lister()
 
-	filterFunc := controller.GetFilterFunc(ctx)
+	filterFunc := controller.DefaultFilterFunc
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
@@ -97,7 +97,12 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		zap.String(logkey.Kind, "apiextensions.k8s.io.CustomResourceDefinition"),
 	)
 
-	impl := controller.NewImpl(rec, logger, ctrTypeName)
+	options := controller.ControllerOptions{
+		Logger:                 logger,
+		WorkQueueName:          ctrTypeName,
+		GlobalResyncFilterFunc: func(o interface{}) bool { return filterFunc(o) },
+	}
+	impl := controller.NewImplFull(rec, options)
 	agentName := defaultControllerAgentName
 
 	// Pass impl to the options. Save any optional results.
@@ -117,6 +122,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.DemoteFunc != nil {
 			rec.DemoteFunc = opts.DemoteFunc
+		}
+		if opts.FilterFunc != nil {
+			filterFunc = opts.FilterFunc
 		}
 	}
 

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/controller.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/controller.go
@@ -63,6 +63,7 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	lister := customresourcedefinitionInformer.Lister()
 
+	filterFunc := controller.GetFilterFunc(ctx)
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
@@ -71,11 +72,12 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 					return err
 				}
 				for _, elt := range all {
-					// TODO: Consider letting users specify a filter in options.
-					enq(bkt, types.NamespacedName{
-						Namespace: elt.GetNamespace(),
-						Name:      elt.GetName(),
-					})
+					if ok := filterFunc(elt); ok {
+						enq(bkt, types.NamespacedName{
+							Namespace: elt.GetNamespace(),
+							Name:      elt.GetName(),
+						})
+					}
 				}
 				return nil
 			},

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/controller.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/controller.go
@@ -63,7 +63,7 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	lister := customresourcedefinitionInformer.Lister()
 
-	filterFunc := controller.GetFilterFunc(ctx)
+	filterFunc := controller.DefaultFilterFunc
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
@@ -97,7 +97,12 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		zap.String(logkey.Kind, "apiextensions.k8s.io.CustomResourceDefinition"),
 	)
 
-	impl := controller.NewImpl(rec, logger, ctrTypeName)
+	options := controller.ControllerOptions{
+		Logger:                 logger,
+		WorkQueueName:          ctrTypeName,
+		GlobalResyncFilterFunc: func(o interface{}) bool { return filterFunc(o) },
+	}
+	impl := controller.NewImplFull(rec, options)
 	agentName := defaultControllerAgentName
 
 	// Pass impl to the options. Save any optional results.
@@ -117,6 +122,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.DemoteFunc != nil {
 			rec.DemoteFunc = opts.DemoteFunc
+		}
+		if opts.FilterFunc != nil {
+			filterFunc = opts.FilterFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/apps/v1/deployment/controller.go
+++ b/client/injection/kube/reconciler/apps/v1/deployment/controller.go
@@ -61,6 +61,7 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	lister := deploymentInformer.Lister()
 
+	filterFunc := controller.GetFilterFunc(ctx)
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
@@ -69,11 +70,12 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 					return err
 				}
 				for _, elt := range all {
-					// TODO: Consider letting users specify a filter in options.
-					enq(bkt, types.NamespacedName{
-						Namespace: elt.GetNamespace(),
-						Name:      elt.GetName(),
-					})
+					if ok := filterFunc(elt); ok {
+						enq(bkt, types.NamespacedName{
+							Namespace: elt.GetNamespace(),
+							Name:      elt.GetName(),
+						})
+					}
 				}
 				return nil
 			},

--- a/client/injection/kube/reconciler/apps/v1/deployment/controller.go
+++ b/client/injection/kube/reconciler/apps/v1/deployment/controller.go
@@ -61,7 +61,7 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	lister := deploymentInformer.Lister()
 
-	filterFunc := controller.GetFilterFunc(ctx)
+	filterFunc := controller.DefaultFilterFunc
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
@@ -95,7 +95,12 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		zap.String(logkey.Kind, "apps.Deployment"),
 	)
 
-	impl := controller.NewImpl(rec, logger, ctrTypeName)
+	options := controller.ControllerOptions{
+		Logger:                 logger,
+		WorkQueueName:          ctrTypeName,
+		GlobalResyncFilterFunc: func(o interface{}) bool { return filterFunc(o) },
+	}
+	impl := controller.NewImplFull(rec, options)
 	agentName := defaultControllerAgentName
 
 	// Pass impl to the options. Save any optional results.
@@ -115,6 +120,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.DemoteFunc != nil {
 			rec.DemoteFunc = opts.DemoteFunc
+		}
+		if opts.FilterFunc != nil {
+			filterFunc = opts.FilterFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/core/v1/namespace/controller.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/controller.go
@@ -61,6 +61,7 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	lister := namespaceInformer.Lister()
 
+	filterFunc := controller.GetFilterFunc(ctx)
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
@@ -69,11 +70,12 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 					return err
 				}
 				for _, elt := range all {
-					// TODO: Consider letting users specify a filter in options.
-					enq(bkt, types.NamespacedName{
-						Namespace: elt.GetNamespace(),
-						Name:      elt.GetName(),
-					})
+					if ok := filterFunc(elt); ok {
+						enq(bkt, types.NamespacedName{
+							Namespace: elt.GetNamespace(),
+							Name:      elt.GetName(),
+						})
+					}
 				}
 				return nil
 			},

--- a/client/injection/kube/reconciler/core/v1/secret/controller.go
+++ b/client/injection/kube/reconciler/core/v1/secret/controller.go
@@ -61,6 +61,7 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	lister := secretInformer.Lister()
 
+	filterFunc := controller.DefaultFilterFunc
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
@@ -69,11 +70,12 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 					return err
 				}
 				for _, elt := range all {
-					// TODO: Consider letting users specify a filter in options.
-					enq(bkt, types.NamespacedName{
-						Namespace: elt.GetNamespace(),
-						Name:      elt.GetName(),
-					})
+					if ok := filterFunc(elt); ok {
+						enq(bkt, types.NamespacedName{
+							Namespace: elt.GetNamespace(),
+							Name:      elt.GetName(),
+						})
+					}
 				}
 				return nil
 			},
@@ -93,7 +95,12 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		zap.String(logkey.Kind, "core.Secret"),
 	)
 
-	impl := controller.NewImpl(rec, logger, ctrTypeName)
+	options := controller.ControllerOptions{
+		Logger:                 logger,
+		WorkQueueName:          ctrTypeName,
+		GlobalResyncFilterFunc: func(o interface{}) bool { return filterFunc(o) },
+	}
+	impl := controller.NewImplFull(rec, options)
 	agentName := defaultControllerAgentName
 
 	// Pass impl to the options. Save any optional results.
@@ -110,6 +117,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.DemoteFunc != nil {
 			rec.DemoteFunc = opts.DemoteFunc
+		}
+		if opts.FilterFunc != nil {
+			filterFunc = opts.FilterFunc
 		}
 	}
 

--- a/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -140,6 +140,10 @@ func (g *reconcilerControllerGenerator) GenerateType(c *generator.Context, t *ty
 			Package: "knative.dev/pkg/controller",
 			Name:    "OptionsFn",
 		}),
+		"controllerGetFilterFunc": c.Universe.Type(types.Name{
+			Package: "knative.dev/pkg/controller",
+			Name:    "GetFilterFunc",
+		}),
 		"contextContext": c.Universe.Type(types.Name{
 			Package: "context",
 			Name:    "Context",
@@ -217,6 +221,7 @@ func NewImpl(ctx {{.contextContext|raw}}, r Interface{{if .hasClass}}, classValu
 
 	lister := {{.type|lowercaseSingular}}Informer.Lister()
 
+	filterFunc := {{.controllerGetFilterFunc|raw}}(ctx)
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: {{.reconcilerLeaderAwareFuncs|raw}}{
 			PromoteFunc: func(bkt {{.reconcilerBucket|raw}}, enq func({{.reconcilerBucket|raw}}, {{.typesNamespacedName|raw}})) error {
@@ -225,11 +230,12 @@ func NewImpl(ctx {{.contextContext|raw}}, r Interface{{if .hasClass}}, classValu
 					return err
 				}
 				for _, elt := range all {
-					// TODO: Consider letting users specify a filter in options.
-					enq(bkt, {{.typesNamespacedName|raw}}{
-						Namespace: elt.GetNamespace(),
-						Name: elt.GetName(),
-					})
+					if ok := filterFunc(elt); ok {
+						enq(bkt, {{.typesNamespacedName|raw}}{
+							Namespace: elt.GetNamespace(),
+							Name: elt.GetName(),
+						})
+					}
 				}
 				return nil
 			},

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1628,7 +1628,7 @@ func TestFilteredGlobalResync(t *testing.T) {
 		filterFunc: func(interface{}) bool { return false },
 	}, {
 		name:       "always true",
-		filterFunc: alwaysTrue,
+		filterFunc: DefaultFilterFunc,
 		wantQueue:  []types.NamespacedName{{Namespace: "foo", Name: "bar"}, {Namespace: "bar", Name: "foo"}, {Namespace: "fizz", Name: "buzz"}},
 	}, {
 		name: "filter namespace foo",

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1617,3 +1617,53 @@ func TestGetEventRecorder(t *testing.T) {
 		t.Error("GetEventRecorder() = nil, wanted non-nil")
 	}
 }
+
+func TestFilteredGlobalResync(t *testing.T) {
+	tests := []struct {
+		name       string
+		filterFunc FilterFunc
+		wantQueue  []types.NamespacedName
+	}{{
+		name:       "do nothing",
+		filterFunc: func(interface{}) bool { return false },
+	}, {
+		name:       "always true",
+		filterFunc: alwaysTrue,
+		wantQueue:  []types.NamespacedName{{Namespace: "foo", Name: "bar"}, {Namespace: "bar", Name: "foo"}, {Namespace: "fizz", Name: "buzz"}},
+	}, {
+		name: "filter namespace foo",
+		filterFunc: func(obj interface{}) bool {
+			if mo, ok := obj.(metav1.Object); ok {
+				if mo.GetNamespace() == "foo" {
+					return true
+				}
+			}
+			return false
+		},
+		wantQueue: []types.NamespacedName{{Namespace: "foo", Name: "bar"}},
+	}, {
+		name: "filter object named foo",
+		filterFunc: func(obj interface{}) bool {
+			if mo, ok := obj.(metav1.Object); ok {
+				if mo.GetName() == "foo" {
+					return true
+				}
+			}
+			return false
+		},
+		wantQueue: []types.NamespacedName{{Namespace: "bar", Name: "foo"}},
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			impl := NewImplFull(&nopReconciler{}, ControllerOptions{WorkQueueName: "FilteredTesting", Logger: TestLogger(t), GlobalResyncFilterFunc: test.filterFunc})
+			impl.GlobalResync(&fakeInformer{})
+
+			impl.WorkQueue().ShutDown()
+			gotQueue := drainWorkQueue(impl.WorkQueue())
+
+			if diff := cmp.Diff(test.wantQueue, gotQueue); diff != "" {
+				t.Error("unexpected queue (-want +got):", diff)
+			}
+		})
+	}
+}

--- a/controller/options.go
+++ b/controller/options.go
@@ -41,6 +41,9 @@ type Options struct {
 
 	// Concurrency - The number of workers to use when processing the controller's workqueue.
 	Concurrency int
+
+	// FilterFunc filters the objects that are enqueued when a global resync is triggered.
+	FilterFunc FilterFunc
 }
 
 // OptionsFn is a callback method signature that accepts an Impl and returns


### PR DESCRIPTION
# Changes

A revised implementation of #2170 and #1909, updated and now using options as per @mattmoor's [ancient code review](https://github.com/knative/pkg/pull/1909/files#r530448985).

Also switched our reconcilers to use `controller.NewImplFull` since `NewImpl` is deprecated, and this makes setting the `GlobalResyncFilterFunc` easier too.

This came up again because of https://github.com/knative/eventing/issues/5543, so looking to reintroduce @lberk's changes.

/cc @markusthoemmes 