### PR TITLE
K8s Service trailing-slash fix in URI resolver  

### DIFF
--- a/resolver/addressable_resolver.go
+++ b/resolver/addressable_resolver.go
@@ -174,7 +174,7 @@ func (r *URIResolver) URIFromObjectReference(ctx context.Context, ref *corev1.Ob
 		url := &apis.URL{
 			Scheme: "http",
 			Host:   network.GetServiceHostname(ref.Name, ref.Namespace),
-			Path:   "/",
+			Path:   "",
 		}
 		return url, nil
 	}

--- a/resolver/addressable_resolver_test.go
+++ b/resolver/addressable_resolver_test.go
@@ -420,7 +420,7 @@ func TestGetURIDestinationV1(t *testing.T) {
 				getAddressableFromKRef(k8sServiceRef()),
 			},
 			dest:    duckv1.Destination{Ref: k8sServiceRef()},
-			wantURI: "http://testsink.testnamespace.svc.cluster.local/",
+			wantURI: "http://testsink.testnamespace.svc.cluster.local",
 		}, "ref with relative uri": {
 			objects: []runtime.Object{
 				getAddressable(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- removes the trailing slash for the resolution of URI from k8s service. Same change in the test file too.
<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # 
The URI resolved for lets say a channel or a knative service does not have the trailing slash. For example, below is the status of a pingsource with a channel as sinkRef:
```
status:
  ceAttributes:
  - source: /apis/v1/namespaces/serverless/pingsources/test-ping-source
    type: dev.knative.sources.ping
  conditions:
  - lastTransitionTime: "2021-07-01T11:20:50Z"
    status: "True"
    type: Deployed
  - lastTransitionTime: "2021-07-01T11:20:50Z"
    status: "True"
    type: Ready
  - lastTransitionTime: "2021-07-01T11:20:50Z"
    status: "True"
    type: SinkProvided
  observedGeneration: 1
  sinkUri: http://my-channel-kn-channel.serverless.svc.cluster.local
  ```
  
Noticed this while working on a component that uses the `status.SinkUri` of eventing sources. Please let me know if for some reason a trailing slash for the resolution of k8s service is intended. 

<!-- Please include the 'why' behind your changes if no issue exists -->

