### PR TITLE
Add ability to filter objects on injection controller promotion

### DIFF
--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/controller.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/controller.go
@@ -63,6 +63,8 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	lister := customresourcedefinitionInformer.Lister()
 
+	var promoteFilterFunc func(obj interface{}) bool
+
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
@@ -71,7 +73,11 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 					return err
 				}
 				for _, elt := range all {
-					// TODO: Consider letting users specify a filter in options.
+					if promoteFilterFunc != nil {
+						if ok := promoteFilterFunc(elt); !ok {
+							continue
+						}
+					}
 					enq(bkt, types.NamespacedName{
 						Namespace: elt.GetNamespace(),
 						Name:      elt.GetName(),
@@ -115,6 +121,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.DemoteFunc != nil {
 			rec.DemoteFunc = opts.DemoteFunc
+		}
+		if opts.PromoteFilterFunc != nil {
+			promoteFilterFunc = opts.PromoteFilterFunc
 		}
 	}
 

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/controller.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/controller.go
@@ -63,6 +63,8 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	lister := customresourcedefinitionInformer.Lister()
 
+	var promoteFilterFunc func(obj interface{}) bool
+
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
@@ -71,7 +73,11 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 					return err
 				}
 				for _, elt := range all {
-					// TODO: Consider letting users specify a filter in options.
+					if promoteFilterFunc != nil {
+						if ok := promoteFilterFunc(elt); !ok {
+							continue
+						}
+					}
 					enq(bkt, types.NamespacedName{
 						Namespace: elt.GetNamespace(),
 						Name:      elt.GetName(),
@@ -115,6 +121,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.DemoteFunc != nil {
 			rec.DemoteFunc = opts.DemoteFunc
+		}
+		if opts.PromoteFilterFunc != nil {
+			promoteFilterFunc = opts.PromoteFilterFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/apps/v1/deployment/controller.go
+++ b/client/injection/kube/reconciler/apps/v1/deployment/controller.go
@@ -61,6 +61,8 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	lister := deploymentInformer.Lister()
 
+	var promoteFilterFunc func(obj interface{}) bool
+
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
@@ -69,7 +71,11 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 					return err
 				}
 				for _, elt := range all {
-					// TODO: Consider letting users specify a filter in options.
+					if promoteFilterFunc != nil {
+						if ok := promoteFilterFunc(elt); !ok {
+							continue
+						}
+					}
 					enq(bkt, types.NamespacedName{
 						Namespace: elt.GetNamespace(),
 						Name:      elt.GetName(),
@@ -113,6 +119,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.DemoteFunc != nil {
 			rec.DemoteFunc = opts.DemoteFunc
+		}
+		if opts.PromoteFilterFunc != nil {
+			promoteFilterFunc = opts.PromoteFilterFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/core/v1/secret/controller.go
+++ b/client/injection/kube/reconciler/core/v1/secret/controller.go
@@ -61,6 +61,8 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	lister := secretInformer.Lister()
 
+	var promoteFilterFunc func(obj interface{}) bool
+
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
@@ -69,7 +71,11 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 					return err
 				}
 				for _, elt := range all {
-					// TODO: Consider letting users specify a filter in options.
+					if promoteFilterFunc != nil {
+						if ok := promoteFilterFunc(elt); !ok {
+							continue
+						}
+					}
 					enq(bkt, types.NamespacedName{
 						Namespace: elt.GetNamespace(),
 						Name:      elt.GetName(),
@@ -110,6 +116,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.DemoteFunc != nil {
 			rec.DemoteFunc = opts.DemoteFunc
+		}
+		if opts.PromoteFilterFunc != nil {
+			promoteFilterFunc = opts.PromoteFilterFunc
 		}
 	}
 

--- a/controller/options.go
+++ b/controller/options.go
@@ -41,6 +41,11 @@ type Options struct {
 
 	// Concurrency - The number of workers to use when processing the controller's workqueue.
 	Concurrency int
+
+	// PromoteFilterFunc filters the objects that are enqueued when the reconciler is promoted to leader.
+	// Objects that pass the filter (return true) will be reconciled when a new leader is promoted.
+	// If no filter is specified, all objects will be reconciled.
+	PromoteFilterFunc func(obj interface{}) bool
 }
 
 // OptionsFn is a callback method signature that accepts an Impl and returns

--- a/injection/README.md
+++ b/injection/README.md
@@ -388,6 +388,28 @@ impl := kindreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Op
 })
 ```
 
+### Filtering on controller promotion
+
+The generated controllers implement the
+[LeaderAwareFuncs](https://github.com/knative/pkg/blob/main/reconciler/leader.go#L66-L72)
+interface to support HA controller deployments. When a generated controller is
+promoted, by default it will trigger [a re-reconcile of every resource it
+manages](https://github.com/knative/pkg/blob/main/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/controller.go#L68-L81).
+To filter which objects get reconciled, pass a `PromoteFilterFunc` to the
+controller's constructor:
+
+```go
+kindreconciler "knative.dev/<repo>/pkg/client/injection/reconciler/<clientgroup>/<version>/<resource>"
+pkgreconciler "knative.dev/pkg/reconciler"
+...
+impl := kindreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
+	return controller.Options{
+		PromoteFilterFunc: pkgreconciler.LabelFilterFunc("mylabel", "myvalue", false),
+	}
+})
+```
+
+
 ### Artifacts
 
 The artifacts are targeted to the configured `client/injection` directory:


### PR DESCRIPTION
Currently we enqueue every object with no way to filter, which causes problems for eventing's source controller which reconciles duck CRDs.

I decided that since I didn't have justification for the changes in #2176 that I would feel better not making them. If we come up with a reason we need to support filtering `GlobalResync` from the constructor rather than just by using `FilteredGlobalResync` we can revisit that later.

ref: knative/eventing#5543

