### PR TITLE
Retry 'no route to host' errors by default

### DIFF
--- a/test/spoof/error_checks.go
+++ b/test/spoof/error_checks.go
@@ -58,3 +58,7 @@ func isConnectionRefused(err error) bool {
 func isConnectionReset(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "connection reset by peer")
 }
+
+func isNoRouteToHostError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "connect: no route to host")
+}

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -223,6 +223,11 @@ func DefaultErrorRetryChecker(err error) (bool, error) {
 	if errors.Is(err, io.EOF) {
 		return true, fmt.Errorf("retrying for: %w", err)
 	}
+	// No route to host errors are in the same category as connection refused errors and
+	// are usuallt transient.
+	if isNoRouteToHostError(err) {
+		return true, fmt.Errorf("retrying for 'no route to host' error: %w", err)
+	}
 	return false, err
 }
 

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -224,7 +224,7 @@ func DefaultErrorRetryChecker(err error) (bool, error) {
 		return true, fmt.Errorf("retrying for: %w", err)
 	}
 	// No route to host errors are in the same category as connection refused errors and
-	// are usuallt transient.
+	// are usually transient.
 	if isNoRouteToHostError(err) {
 		return true, fmt.Errorf("retrying for 'no route to host' error: %w", err)
 	}


### PR DESCRIPTION
As seen in net-kourier nightlies like https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-sandbox-net-kourier-nightly-release/1412336305043410944.

Things started failing with no changes done whatsoever. Upon investigation, it turned out that the test runner's Linux version was bumped from 4.19 to 5.4. The working theory is, that the error handling in the TCP stack changes slightly so that errors that would've been reported as "connection refused" (which we already retry) are now reported as "no route to host", which we might want to retry as well.

/assign @dprotaso 