### PR TITLE
Removing default for KUBECONFIG to enable incluster e2e tests

### DIFF
--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"text/template"
 
-	"k8s.io/client-go/tools/clientcmd"
 	env "knative.dev/pkg/environment"
 	testenv "knative.dev/pkg/test/environment"
 	"knative.dev/pkg/test/logging"
@@ -49,13 +48,6 @@ func initializeFlags() *EnvironmentFlags {
 
 	f.ClientConfig.InitFlags(flag.CommandLine)
 	f.TestClientConfig.InitFlags(flag.CommandLine)
-
-	// We want to do this defaulting for tests only. The flags are reused between tests
-	// and production code and we want to make sure that production code defaults to
-	// the in-cluster config correctly.
-	if f.Kubeconfig == "" {
-		f.Kubeconfig = clientcmd.RecommendedHomeFile
-	}
 
 	return f
 }


### PR DESCRIPTION

# Changes

Removing default setting to KUBECONFIG in e2e flags. This allows e2e testing to be done from inside a Kubernetes Cluster. 

/kind bug 
/kind cleanup


Fixes #2190

closes #2190
