### PR TITLE
Drop Client as it is only used in tests

### DIFF
--- a/webhook/admission_integration_test.go
+++ b/webhook/admission_integration_test.go
@@ -33,6 +33,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/metrics/metricstest"
 	_ "knative.dev/pkg/metrics/testing"
 )
@@ -84,7 +85,7 @@ func TestAdmissionValidResponseForResource(t *testing.T) {
 	if pollErr != nil {
 		t.Fatal("waitForServerAvailable() =", err)
 	}
-	tlsClient, err := createSecureTLSClient(t, wh.Client, &wh.Options)
+	tlsClient, err := createSecureTLSClient(t, kubeclient.Get(ctx), &wh.Options)
 	if err != nil {
 		t.Fatal("createSecureTLSClient() =", err)
 	}
@@ -214,7 +215,7 @@ func TestAdmissionInvalidResponseForResource(t *testing.T) {
 	if pollErr != nil {
 		t.Fatal("waitForServerAvailable() =", err)
 	}
-	tlsClient, err := createSecureTLSClient(t, wh.Client, &wh.Options)
+	tlsClient, err := createSecureTLSClient(t, kubeclient.Get(ctx), &wh.Options)
 	if err != nil {
 		t.Fatal("createSecureTLSClient() =", err)
 	}

--- a/webhook/conversion_integration_test.go
+++ b/webhook/conversion_integration_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	kubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 )
 
 type fixedConversionController struct {
@@ -82,7 +83,7 @@ func TestConversionValidResponse(t *testing.T) {
 	if pollErr != nil {
 		t.Fatal("waitForServerAvailable() =", err)
 	}
-	tlsClient, err := createSecureTLSClient(t, wh.Client, &wh.Options)
+	tlsClient, err := createSecureTLSClient(t, kubeclient.Get(ctx), &wh.Options)
 	if err != nil {
 		t.Fatal("createSecureTLSClient() =", err)
 	}
@@ -171,7 +172,7 @@ func TestConversionInvalidResponse(t *testing.T) {
 	if pollErr != nil {
 		t.Fatal("waitForServerAvailable() =", err)
 	}
-	tlsClient, err := createSecureTLSClient(t, wh.Client, &wh.Options)
+	tlsClient, err := createSecureTLSClient(t, kubeclient.Get(ctx), &wh.Options)
 	if err != nil {
 		t.Fatal("createSecureTLSClient() =", err)
 	}

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -26,14 +26,13 @@ import (
 	"time"
 
 	// Injection stuff
-	kubeclient "knative.dev/pkg/client/injection/kube/client"
+
 	kubeinformerfactory "knative.dev/pkg/injection/clients/namespacedkube/informers/factory"
 	"knative.dev/pkg/network/handlers"
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	admissionv1 "k8s.io/api/admission/v1"
-	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/network"
@@ -78,7 +77,6 @@ const (
 // Webhook implements the external webhook for validation of
 // resources and configuration.
 type Webhook struct {
-	Client  kubernetes.Interface
 	Options Options
 	Logger  *zap.SugaredLogger
 
@@ -106,8 +104,6 @@ func New(
 		}
 	}()
 
-	client := kubeclient.Get(ctx)
-
 	// Injection is too aggressive for this case because by simply linking this
 	// library we force consumers to have secret access.  If we require that one
 	// of the admission controllers' informers *also* require the secret
@@ -132,7 +128,6 @@ func New(
 	syncCtx, cancel := context.WithCancel(context.Background())
 
 	webhook = &Webhook{
-		Client:       client,
 		Options:      *opts,
 		secretlister: secretInformer.Lister(),
 		Logger:       logger,

--- a/webhook/webhook_integration_test.go
+++ b/webhook/webhook_integration_test.go
@@ -71,7 +71,7 @@ func TestMissingContentType(t *testing.T) {
 		t.Fatal("waitForServerAvailable() =", err)
 	}
 
-	tlsClient, err := createSecureTLSClient(t, wh.Client, &wh.Options)
+	tlsClient, err := createSecureTLSClient(t, kubeclient.Get(ctx), &wh.Options)
 	if err != nil {
 		t.Fatal("createSecureTLSClient() =", err)
 	}
@@ -125,7 +125,7 @@ func testEmptyRequestBody(t *testing.T, controller interface{}) {
 		t.Fatal("waitForServerAvailable() =", err)
 	}
 
-	tlsClient, err := createSecureTLSClient(t, wh.Client, &wh.Options)
+	tlsClient, err := createSecureTLSClient(t, kubeclient.Get(ctx), &wh.Options)
 	if err != nil {
 		t.Fatal("createSecureTLSClient() =", err)
 	}


### PR DESCRIPTION
# Changes

/kind cleanup

The client field in the base webhook was only being used by test code, so I removed it and changed the tests to pull the client off of `ctx` themselves.

**Release Note**

N/A

**Docs**

N/A