### PR TITLE
Support the webhook serving over non-TLS.

### DIFF
--- a/webhook/helper_test.go
+++ b/webhook/helper_test.go
@@ -228,3 +228,9 @@ func createSecureTLSClient(t *testing.T, kubeClient kubernetes.Interface, acOpts
 		},
 	}, nil
 }
+
+func createNonTLSClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{},
+	}
+}

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -33,7 +33,6 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	admissionv1 "k8s.io/api/admission/v1"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/system"
@@ -50,6 +49,7 @@ type Options struct {
 	// server key/cert are used to serve the webhook and the CA cert
 	// is provided to k8s apiserver during admission controller
 	// registration.
+	// If no SecretName is provided, then the webhook serves without TLS.
 	SecretName string
 
 	// Port where the webhook is served. Per k8s admission
@@ -87,8 +87,10 @@ type Webhook struct {
 	// before shutting down.
 	gracePeriod time.Duration
 
-	mux          http.ServeMux
-	secretlister corelisters.SecretLister
+	mux http.ServeMux
+
+	// The TLS configuration to use for serving (or nil for non-TLS)
+	tlsConfig *tls.Config
 }
 
 // New constructs a Webhook
@@ -103,13 +105,6 @@ func New(
 			err = fmt.Errorf("error creating webhook %v", r)
 		}
 	}()
-
-	// Injection is too aggressive for this case because by simply linking this
-	// library we force consumers to have secret access.  If we require that one
-	// of the admission controllers' informers *also* require the secret
-	// informer, then we can fetch the shared informer factory here and produce
-	// a new secret informer from it.
-	secretInformer := kubeinformerfactory.Get(ctx).Core().V1().Secrets()
 
 	opts := GetOptions(ctx)
 	if opts == nil {
@@ -128,11 +123,51 @@ func New(
 	syncCtx, cancel := context.WithCancel(context.Background())
 
 	webhook = &Webhook{
-		Options:      *opts,
-		secretlister: secretInformer.Lister(),
-		Logger:       logger,
-		synced:       cancel,
-		gracePeriod:  network.DefaultDrainTimeout,
+		Options:     *opts,
+		Logger:      logger,
+		synced:      cancel,
+		gracePeriod: network.DefaultDrainTimeout,
+	}
+
+	if opts.SecretName != "" {
+		// Injection is too aggressive for this case because by simply linking this
+		// library we force consumers to have secret access.  If we require that one
+		// of the admission controllers' informers *also* require the secret
+		// informer, then we can fetch the shared informer factory here and produce
+		// a new secret informer from it.
+		secretInformer := kubeinformerfactory.Get(ctx).Core().V1().Secrets()
+
+		webhook.tlsConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+
+			// If we return (nil, error) the client sees - 'tls: internal error"
+			// If we return (nil, nil) the client sees - 'tls: no certificates configured'
+			//
+			// We'll return (nil, nil) when we don't find a certificate
+			GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+				secret, err := secretInformer.Lister().Secrets(system.Namespace()).Get(opts.SecretName)
+				if err != nil {
+					logger.Errorw("failed to fetch secret", zap.Error(err))
+					return nil, nil
+				}
+
+				serverKey, ok := secret.Data[certresources.ServerKey]
+				if !ok {
+					logger.Warn("server key missing")
+					return nil, nil
+				}
+				serverCert, ok := secret.Data[certresources.ServerCert]
+				if !ok {
+					logger.Warn("server cert missing")
+					return nil, nil
+				}
+				cert, err := tls.X509KeyPair(serverCert, serverKey)
+				if err != nil {
+					return nil, err
+				}
+				return &cert, nil
+			},
+		}
 	}
 
 	webhook.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -176,46 +211,23 @@ func (wh *Webhook) Run(stop <-chan struct{}) error {
 	}
 
 	server := &http.Server{
-		Handler: drainer,
-		Addr:    fmt.Sprint(":", wh.Options.Port),
-		TLSConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-
-			// If we return (nil, error) the client sees - 'tls: internal error"
-			// If we return (nil, nil) the client sees - 'tls: no certificates configured'
-			//
-			// We'll return (nil, nil) when we don't find a certificate
-			GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-				secret, err := wh.secretlister.Secrets(system.Namespace()).Get(wh.Options.SecretName)
-				if err != nil {
-					logger.Errorw("failed to fetch secret", zap.Error(err))
-					return nil, nil
-				}
-
-				serverKey, ok := secret.Data[certresources.ServerKey]
-				if !ok {
-					logger.Warn("server key missing")
-					return nil, nil
-				}
-				serverCert, ok := secret.Data[certresources.ServerCert]
-				if !ok {
-					logger.Warn("server cert missing")
-					return nil, nil
-				}
-				cert, err := tls.X509KeyPair(serverCert, serverKey)
-				if err != nil {
-					return nil, err
-				}
-				return &cert, nil
-			},
-		},
+		Handler:   drainer,
+		Addr:      fmt.Sprint(":", wh.Options.Port),
+		TLSConfig: wh.tlsConfig,
 	}
 
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		if err := server.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			logger.Errorw("ListenAndServeTLS for admission webhook returned error", zap.Error(err))
-			return err
+		if server.TLSConfig != nil {
+			if err := server.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				logger.Errorw("ListenAndServeTLS for admission webhook returned error", zap.Error(err))
+				return err
+			}
+		} else {
+			if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				logger.Errorw("ListenAndServe for admission webhook returned error", zap.Error(err))
+				return err
+			}
 		}
 		return nil
 	})

--- a/webhook/webhook_integration_test.go
+++ b/webhook/webhook_integration_test.go
@@ -205,3 +205,19 @@ func testSetup(t *testing.T, acs ...interface{}) (*Webhook, string, context.Cont
 	resetMetrics()
 	return wh, fmt.Sprintf("0.0.0.0:%d", port), ctx, cancel, nil
 }
+
+func testSetupNoTLS(t *testing.T, acs ...interface{}) (*Webhook, string, context.Context, context.CancelFunc, error) {
+	t.Helper()
+	port, err := newTestPort()
+	if err != nil {
+		return nil, "", nil, nil, err
+	}
+
+	defaultOpts := newDefaultOptions()
+	defaultOpts.SecretName = ""
+	defaultOpts.Port = port
+	ctx, wh, cancel := newNonRunningTestWebhook(t, defaultOpts, acs...)
+
+	resetMetrics()
+	return wh, fmt.Sprintf("0.0.0.0:%d", port), ctx, cancel, nil
+}


### PR DESCRIPTION
# Changes

This reworks the way we setup the TLS Config for the webhook, so that when the `opts.SecretName` is omitted we serve over non-TLS.

/kind enhancement

**Release Note**

N/A

**Docs**

N/A