### PR TITLE
Sink two codegen passes below loop.

### DIFF
--- a/codegen/cmd/injection-gen/generators/packages.go
+++ b/codegen/cmd/injection-gen/generators/packages.go
@@ -78,12 +78,6 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 			groupGoNames[groupPackageName] = namer.IC(override[0])
 		}
 
-		// Generate the client and fake.
-		packageList = append(packageList, versionClientsPackages(versionPackagePath, boilerplate, customArgs)...)
-
-		// Generate the informer factory and fake.
-		packageList = append(packageList, versionFactoryPackages(versionPackagePath, boilerplate, customArgs)...)
-
 		var typesWithInformers []*types.Type
 		var duckTypes []*types.Type
 		var reconcilerTypes []*types.Type
@@ -134,6 +128,12 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 			packageList = append(packageList, reconcilerPackages(versionPackagePath, groupPackageName, gv, groupGoNames[groupPackageName], boilerplate, reconcilerTypes, customArgs)...)
 		}
 	}
+
+	// Generate the client and fake.
+	packageList = append(packageList, versionClientsPackages(versionPackagePath, boilerplate, customArgs)...)
+
+	// Generate the informer factory and fake.
+	packageList = append(packageList, versionFactoryPackages(versionPackagePath, boilerplate, customArgs)...)
 
 	return packageList
 }


### PR DESCRIPTION
I noticed doing some tinkering that these were running on every iteration, but the inputs don't change.  This sinks the calls to below the loop, and reduces things to a single call for each.

/kind cleanup
/assign @n3wscott 

**Release Note**

```release-note

```

**Docs**

```docs

```
