### PR TITLE
Deprecate ReadOnlyFinalizer interface over OnDeletionInterface

### DIFF
--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
@@ -77,11 +77,13 @@ type ReadOnlyInterface interface {
 // controller finalizing v1.CustomResourceDefinition if they want to process tombstoned resources
 // even when they are not the leader.  Due to the nature of how finalizers are handled
 // there are no guarantees that this will be called.
-// DEPRECATED: Use reconciler.OnDeletionInterface instead.
+//
+// Deprecated: Use reconciler.OnDeletionInterface instead.
 type ReadOnlyFinalizer interface {
 	// ObserveFinalizeKind implements custom logic to observe the final state of v1.CustomResourceDefinition.
 	// This method should not write to the API.
-	// DEPRECATED: Use reconciler.ObserveDeletion instead.
+	//
+	// Deprecated: Use reconciler.ObserveDeletion instead.
 	ObserveFinalizeKind(ctx context.Context, o *v1.CustomResourceDefinition) reconciler.Event
 }
 

--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
@@ -77,9 +77,11 @@ type ReadOnlyInterface interface {
 // controller finalizing v1.CustomResourceDefinition if they want to process tombstoned resources
 // even when they are not the leader.  Due to the nature of how finalizers are handled
 // there are no guarantees that this will be called.
+// DEPRECATED: Use reconciler.OnDeletionInterface instead.
 type ReadOnlyFinalizer interface {
 	// ObserveFinalizeKind implements custom logic to observe the final state of v1.CustomResourceDefinition.
 	// This method should not write to the API.
+	// DEPRECATED: Use reconciler.ObserveDeletion instead.
 	ObserveFinalizeKind(ctx context.Context, o *v1.CustomResourceDefinition) reconciler.Event
 }
 
@@ -132,7 +134,6 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client client
 	if _, ok := r.(reconciler.LeaderAware); ok {
 		logger.Fatalf("%T implements the incorrect LeaderAware interface. Promote() should not take an argument as genreconciler handles the enqueuing automatically.", r)
 	}
-	// TODO: Consider validating when folks implement ReadOnlyFinalizer, but not Finalizer.
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
@@ -77,9 +77,11 @@ type ReadOnlyInterface interface {
 // controller finalizing v1beta1.CustomResourceDefinition if they want to process tombstoned resources
 // even when they are not the leader.  Due to the nature of how finalizers are handled
 // there are no guarantees that this will be called.
+// DEPRECATED: Use reconciler.OnDeletionInterface instead.
 type ReadOnlyFinalizer interface {
 	// ObserveFinalizeKind implements custom logic to observe the final state of v1beta1.CustomResourceDefinition.
 	// This method should not write to the API.
+	// DEPRECATED: Use reconciler.ObserveDeletion instead.
 	ObserveFinalizeKind(ctx context.Context, o *v1beta1.CustomResourceDefinition) reconciler.Event
 }
 
@@ -132,7 +134,6 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client client
 	if _, ok := r.(reconciler.LeaderAware); ok {
 		logger.Fatalf("%T implements the incorrect LeaderAware interface. Promote() should not take an argument as genreconciler handles the enqueuing automatically.", r)
 	}
-	// TODO: Consider validating when folks implement ReadOnlyFinalizer, but not Finalizer.
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
@@ -77,11 +77,13 @@ type ReadOnlyInterface interface {
 // controller finalizing v1beta1.CustomResourceDefinition if they want to process tombstoned resources
 // even when they are not the leader.  Due to the nature of how finalizers are handled
 // there are no guarantees that this will be called.
-// DEPRECATED: Use reconciler.OnDeletionInterface instead.
+//
+// Deprecated: Use reconciler.OnDeletionInterface instead.
 type ReadOnlyFinalizer interface {
 	// ObserveFinalizeKind implements custom logic to observe the final state of v1beta1.CustomResourceDefinition.
 	// This method should not write to the API.
-	// DEPRECATED: Use reconciler.ObserveDeletion instead.
+	//
+	// Deprecated: Use reconciler.ObserveDeletion instead.
 	ObserveFinalizeKind(ctx context.Context, o *v1beta1.CustomResourceDefinition) reconciler.Event
 }
 

--- a/client/injection/kube/reconciler/apps/v1/deployment/reconciler.go
+++ b/client/injection/kube/reconciler/apps/v1/deployment/reconciler.go
@@ -77,9 +77,11 @@ type ReadOnlyInterface interface {
 // controller finalizing v1.Deployment if they want to process tombstoned resources
 // even when they are not the leader.  Due to the nature of how finalizers are handled
 // there are no guarantees that this will be called.
+// DEPRECATED: Use reconciler.OnDeletionInterface instead.
 type ReadOnlyFinalizer interface {
 	// ObserveFinalizeKind implements custom logic to observe the final state of v1.Deployment.
 	// This method should not write to the API.
+	// DEPRECATED: Use reconciler.ObserveDeletion instead.
 	ObserveFinalizeKind(ctx context.Context, o *v1.Deployment) reconciler.Event
 }
 
@@ -132,7 +134,6 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client kubern
 	if _, ok := r.(reconciler.LeaderAware); ok {
 		logger.Fatalf("%T implements the incorrect LeaderAware interface. Promote() should not take an argument as genreconciler handles the enqueuing automatically.", r)
 	}
-	// TODO: Consider validating when folks implement ReadOnlyFinalizer, but not Finalizer.
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{

--- a/client/injection/kube/reconciler/apps/v1/deployment/reconciler.go
+++ b/client/injection/kube/reconciler/apps/v1/deployment/reconciler.go
@@ -77,11 +77,13 @@ type ReadOnlyInterface interface {
 // controller finalizing v1.Deployment if they want to process tombstoned resources
 // even when they are not the leader.  Due to the nature of how finalizers are handled
 // there are no guarantees that this will be called.
-// DEPRECATED: Use reconciler.OnDeletionInterface instead.
+//
+// Deprecated: Use reconciler.OnDeletionInterface instead.
 type ReadOnlyFinalizer interface {
 	// ObserveFinalizeKind implements custom logic to observe the final state of v1.Deployment.
 	// This method should not write to the API.
-	// DEPRECATED: Use reconciler.ObserveDeletion instead.
+	//
+	// Deprecated: Use reconciler.ObserveDeletion instead.
 	ObserveFinalizeKind(ctx context.Context, o *v1.Deployment) reconciler.Event
 }
 

--- a/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
@@ -76,11 +76,13 @@ type ReadOnlyInterface interface {
 // controller finalizing v1.Namespace if they want to process tombstoned resources
 // even when they are not the leader.  Due to the nature of how finalizers are handled
 // there are no guarantees that this will be called.
-// DEPRECATED: Use reconciler.OnDeletionInterface instead.
+//
+// Deprecated: Use reconciler.OnDeletionInterface instead.
 type ReadOnlyFinalizer interface {
 	// ObserveFinalizeKind implements custom logic to observe the final state of v1.Namespace.
 	// This method should not write to the API.
-	// DEPRECATED: Use reconciler.ObserveDeletion instead.
+	//
+	// Deprecated: Use reconciler.ObserveDeletion instead.
 	ObserveFinalizeKind(ctx context.Context, o *v1.Namespace) reconciler.Event
 }
 

--- a/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
@@ -76,9 +76,11 @@ type ReadOnlyInterface interface {
 // controller finalizing v1.Namespace if they want to process tombstoned resources
 // even when they are not the leader.  Due to the nature of how finalizers are handled
 // there are no guarantees that this will be called.
+// DEPRECATED: Use reconciler.OnDeletionInterface instead.
 type ReadOnlyFinalizer interface {
 	// ObserveFinalizeKind implements custom logic to observe the final state of v1.Namespace.
 	// This method should not write to the API.
+	// DEPRECATED: Use reconciler.ObserveDeletion instead.
 	ObserveFinalizeKind(ctx context.Context, o *v1.Namespace) reconciler.Event
 }
 
@@ -131,7 +133,6 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client kubern
 	if _, ok := r.(reconciler.LeaderAware); ok {
 		logger.Fatalf("%T implements the incorrect LeaderAware interface. Promote() should not take an argument as genreconciler handles the enqueuing automatically.", r)
 	}
-	// TODO: Consider validating when folks implement ReadOnlyFinalizer, but not Finalizer.
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{

--- a/client/injection/kube/reconciler/core/v1/secret/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/secret/reconciler.go
@@ -74,9 +74,11 @@ type ReadOnlyInterface interface {
 // controller finalizing v1.Secret if they want to process tombstoned resources
 // even when they are not the leader.  Due to the nature of how finalizers are handled
 // there are no guarantees that this will be called.
+// DEPRECATED: Use reconciler.OnDeletionInterface instead.
 type ReadOnlyFinalizer interface {
 	// ObserveFinalizeKind implements custom logic to observe the final state of v1.Secret.
 	// This method should not write to the API.
+	// DEPRECATED: Use reconciler.ObserveDeletion instead.
 	ObserveFinalizeKind(ctx context.Context, o *v1.Secret) reconciler.Event
 }
 
@@ -125,7 +127,6 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client kubern
 	if _, ok := r.(reconciler.LeaderAware); ok {
 		logger.Fatalf("%T implements the incorrect LeaderAware interface. Promote() should not take an argument as genreconciler handles the enqueuing automatically.", r)
 	}
-	// TODO: Consider validating when folks implement ReadOnlyFinalizer, but not Finalizer.
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{

--- a/client/injection/kube/reconciler/core/v1/secret/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/secret/reconciler.go
@@ -74,11 +74,13 @@ type ReadOnlyInterface interface {
 // controller finalizing v1.Secret if they want to process tombstoned resources
 // even when they are not the leader.  Due to the nature of how finalizers are handled
 // there are no guarantees that this will be called.
-// DEPRECATED: Use reconciler.OnDeletionInterface instead.
+//
+// Deprecated: Use reconciler.OnDeletionInterface instead.
 type ReadOnlyFinalizer interface {
 	// ObserveFinalizeKind implements custom logic to observe the final state of v1.Secret.
 	// This method should not write to the API.
-	// DEPRECATED: Use reconciler.ObserveDeletion instead.
+	//
+	// Deprecated: Use reconciler.ObserveDeletion instead.
 	ObserveFinalizeKind(ctx context.Context, o *v1.Secret) reconciler.Event
 }
 

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -268,11 +268,13 @@ type ReadOnlyInterface interface {
 // controller finalizing {{.type|raw}} if they want to process tombstoned resources
 // even when they are not the leader.  Due to the nature of how finalizers are handled
 // there are no guarantees that this will be called.
-// DEPRECATED: Use reconciler.OnDeletionInterface instead.
+//
+// Deprecated: Use reconciler.OnDeletionInterface instead.
 type ReadOnlyFinalizer interface {
 	// ObserveFinalizeKind implements custom logic to observe the final state of {{.type|raw}}.
 	// This method should not write to the API.
-	// DEPRECATED: Use reconciler.ObserveDeletion instead.
+	//
+	// Deprecated: Use reconciler.ObserveDeletion instead.
 	ObserveFinalizeKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}}
 }
 

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -268,9 +268,11 @@ type ReadOnlyInterface interface {
 // controller finalizing {{.type|raw}} if they want to process tombstoned resources
 // even when they are not the leader.  Due to the nature of how finalizers are handled
 // there are no guarantees that this will be called.
+// DEPRECATED: Use reconciler.OnDeletionInterface instead.
 type ReadOnlyFinalizer interface {
 	// ObserveFinalizeKind implements custom logic to observe the final state of {{.type|raw}}.
 	// This method should not write to the API.
+	// DEPRECATED: Use reconciler.ObserveDeletion instead.
 	ObserveFinalizeKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}}
 }
 
@@ -332,7 +334,6 @@ func NewReconciler(ctx {{.contextContext|raw}}, logger *{{.zapSugaredLogger|raw}
 	if _, ok := r.({{.reconcilerLeaderAware|raw}}); ok {
 		logger.Fatalf("%T implements the incorrect LeaderAware interface. Promote() should not take an argument as genreconciler handles the enqueuing automatically.", r)
 	}
-	// TODO: Consider validating when folks implement ReadOnlyFinalizer, but not Finalizer.
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: {{.reconcilerLeaderAwareFuncs|raw}}{

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
@@ -81,10 +81,6 @@ func (g *reconcilerReconcilerStubGenerator) GenerateType(c *generator.Context, t
 			Package: g.reconcilerPkg,
 			Name:    "ReadOnlyInterface",
 		}),
-		"reconcilerReadOnlyFinalizer": c.Universe.Type(types.Name{
-			Package: g.reconcilerPkg,
-			Name:    "ReadOnlyFinalizer",
-		}),
 		"corev1EventTypeNormal": c.Universe.Type(types.Name{
 			Package: "k8s.io/api/core/v1",
 			Name:    "EventTypeNormal",
@@ -124,11 +120,6 @@ var _ {{.reconcilerInterface|raw}} = (*Reconciler)(nil)
 // Implement this to observe resources even when we are not the leader.
 //var _ {{.reconcilerReadOnlyInterface|raw}} = (*Reconciler)(nil)
 
-// Optionally check that our Reconciler implements ReadOnlyFinalizer
-// Implement this to observe tombstoned resources even when we are not
-// the leader (best effort).
-//var _ {{.reconcilerReadOnlyFinalizer|raw}} = (*Reconciler)(nil)
-
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
 	{{if not .isKRShaped}}// TODO: use this if the resource implements InitializeConditions.
@@ -156,10 +147,4 @@ func (r *Reconciler) ReconcileKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}
 // 	// TODO: add custom observation logic here.
 // 	return nil
 // }
-
-// Optionally, use ObserveFinalizeKind to observe resources being finalized when we are no the leader.
-//func (r *Reconciler) ObserveFinalizeKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
-// 	// TODO: add custom observation logic here.
-//	return nil
-//}
 `


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

We've determined `ReadOnlyFinalizer` to be unsafe a while ago and hence introduced the (supposed to be safe) alternative `OnDeletionInterface`. We should nudge people to use the latter and completely fade out the former.

Note: Neither knative nor sandbox nor Tekton is using ReadOnlyFinalizer anymore, so we might also think about "just" dropping it.

/kind deprecation

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Deprecate ReadOnlyFinalizer interface over OnDeletionInterface.
```

/assign @julz @n3wscott 