### PR TITLE
Use consistent case for "Deprecated" comments

### DIFF
--- a/apis/interfaces.go
+++ b/apis/interfaces.go
@@ -53,7 +53,8 @@ type Listable interface {
 }
 
 // Annotatable indicates that a particular type applies various annotations.
-// DEPRECATED: Use WithUserInfo / GetUserInfo from within SetDefaults instead.
+//
+// Deprecated: Use WithUserInfo / GetUserInfo from within SetDefaults instead.
 // The webhook functionality for this has been turned down, which is why this
 // interface is empty.
 type Annotatable interface{}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -487,7 +487,8 @@ func (c *Impl) RunContext(ctx context.Context, threadiness int) error {
 }
 
 // Run runs the controller.
-// DEPRECATED: Use RunContext instead.
+//
+// Deprecated: Use RunContext instead.
 func (c *Impl) Run(threadiness int, stopCh <-chan struct{}) error {
 	// Create a context that is cancelled when the stopCh is called.
 	ctx, cancel := context.WithCancel(context.Background())

--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -89,7 +89,8 @@ type ExporterOptions struct {
 
 // UpdateExporterFromConfigMap returns a helper func that can be used to update the exporter
 // when a config map is updated.
-// DEPRECATED: Callers should migrate to ConfigMapWatcher.
+//
+// Deprecated: Callers should migrate to ConfigMapWatcher.
 func UpdateExporterFromConfigMap(ctx context.Context, component string, logger *zap.SugaredLogger) func(configMap *corev1.ConfigMap) {
 	return ConfigMapWatcher(ctx, component, nil, logger)
 }

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -99,7 +99,8 @@ func WaitForNewLeaders(ctx context.Context, t *testing.T, client kubernetes.Inte
 }
 
 // WaitForNewLeader waits until the holder of the given lease is different from the previousLeader.
-// DEPRECATED: Use WaitForNewLeaders.
+//
+// Deprecated: Use WaitForNewLeaders.
 func WaitForNewLeader(ctx context.Context, client kubernetes.Interface, lease, namespace, previousLeader string) (string, error) {
 	span := logging.GetEmitableSpan(ctx, "WaitForNewLeader/"+lease)
 	defer span.End()

--- a/tracing/testing/zipkin.go
+++ b/tracing/testing/zipkin.go
@@ -38,6 +38,7 @@ func FakeZipkinExporter() (*recorder.ReporterRecorder, tracing.ConfigOption) {
 	// Create tracer with reporter recorder
 	reporter := recorder.NewReporter()
 	endpoint, _ := openzipkin.NewEndpoint("test", "localhost:1234")
+	//nolint:staticcheck // This is the new endpoint we're asking clients to use.
 	exp := tracing.WithZipkinExporter(func(cfg *config.Config) (zipkinreporter.Reporter, error) {
 		return reporter, nil
 	}, endpoint)

--- a/tracing/zipkin.go
+++ b/tracing/zipkin.go
@@ -29,7 +29,8 @@ import (
 type ZipkinReporterFactory func(*config.Config) (zipkinreporter.Reporter, error)
 
 // WithZipkinExporter returns a config with zipkin enabled.
-// DEPRECATED: This function is the legacy entrypoint and should be replaced with one of:
+//
+// Deprecated: This function is the legacy entrypoint and should be replaced with one of:
 //  - WithExporter() in production code
 //  - testing/FakeZipkinExporter() in test code.
 func WithZipkinExporter(reporterFact ZipkinReporterFactory, endpoint *zipkinmodel.Endpoint) ConfigOption {

--- a/tracker/interface.go
+++ b/tracker/interface.go
@@ -61,7 +61,8 @@ type Reference struct {
 type Interface interface {
 	// Track tells us that "obj" is tracking changes to the
 	// referenced object.
-	// DEPRECATED: use TrackReference
+	//
+	// Deprecated: use TrackReference.
 	Track(ref corev1.ObjectReference, obj interface{}) error
 
 	// Track tells us that "obj" is tracking changes to the


### PR DESCRIPTION
Not the most important thing ever (to say the least), but the canonical prefix to use for `Deprecated:` warnings in godoc is title case (and should be in its own paragraph).

<!-- Thanks for sending a pull request! -->

# Changes

- :broom: make deprecation comments use consistent case.

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind cleanup
