### PR TITLE
Add length limit for the generated names used in tests

### DIFF
--- a/test/helpers/name.go
+++ b/test/helpers/name.go
@@ -26,11 +26,12 @@ import (
 )
 
 const (
-	letterBytes    = "abcdefghijklmnopqrstuvwxyz"
-	randSuffixLen  = 8
-	sep            = '-'
-	sepS           = "-"
-	testNamePrefix = "Test"
+	letterBytes     = "abcdefghijklmnopqrstuvwxyz"
+	randSuffixLen   = 8
+	nameLengthLimit = 50
+	sep             = '-'
+	sepS            = "-"
+	testNamePrefix  = "Test"
 )
 
 func init() {
@@ -52,7 +53,14 @@ func ObjectPrefixForTest(t named) string {
 
 // ObjectNameForTest generates a random object name based on the test name.
 func ObjectNameForTest(t named) string {
-	return kmeta.ChildName(ObjectPrefixForTest(t), string(sep)+RandomString())
+	prefix := ObjectPrefixForTest(t)
+	suffix := string(sep) + RandomString()
+	limit := nameLengthLimit - len(suffix)
+	if len(prefix) < limit {
+		limit = len(prefix)
+	}
+
+	return kmeta.ChildName(prefix[:limit], suffix)
 }
 
 // AppendRandomString will generate a random string that begins with prefix.

--- a/test/helpers/name.go
+++ b/test/helpers/name.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 	"time"
 	"unicode"
-
-	"knative.dev/pkg/kmeta"
 )
 
 const (
@@ -60,7 +58,7 @@ func ObjectNameForTest(t named) string {
 		limit = len(prefix)
 	}
 
-	return kmeta.ChildName(prefix[:limit], suffix)
+	return prefix[:limit] + suffix
 }
 
 // AppendRandomString will generate a random string that begins with prefix.

--- a/test/helpers/name_test.go
+++ b/test/helpers/name_test.go
@@ -85,7 +85,7 @@ func TestObjectNameForTest(t *testing.T) {
 		{testNamed{name: "Foo-bar"}, "foo-bar-"},
 		{testNamed{name: "with_underscore"}, "with-underscore-"},
 		{testNamed{name: "WithHTTP"}, "with-http-"},
-		{testNamed{name: "ANameExceedingTheLimitLenght-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "a-name-exceeding-the-limit-lenght-aaaaaaa-"},
+		{testNamed{name: "ANameExceedingTheLimitLength-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "a-name-exceeding-the-limit-length-aaaaaaa-"},
 	}
 	for _, v := range testCases {
 		actual := ObjectNameForTest(&v.input)

--- a/test/helpers/name_test.go
+++ b/test/helpers/name_test.go
@@ -18,6 +18,7 @@ package helpers
 
 import (
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -73,4 +74,31 @@ func TestGetBaseFuncName(t *testing.T) {
 			t.Fatalf("Expect %q but actual is %q", v.expected, actual)
 		}
 	}
+}
+
+func TestObjectNameForTest(t *testing.T) {
+	testCases := []struct {
+		input          testNamed
+		expectedPrefix string
+	}{
+		{testNamed{name: "TestFooBar"}, "foo-bar-"},
+		{testNamed{name: "Foo-bar"}, "foo-bar-"},
+		{testNamed{name: "with_underscore"}, "with-underscore-"},
+		{testNamed{name: "WithHTTP"}, "with-http-"},
+		{testNamed{name: "ANameExceedingTheLimitLenght-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "a-name-exceeding-the-limit-lenght-aaaaaaa-"},
+	}
+	for _, v := range testCases {
+		actual := ObjectNameForTest(&v.input)
+		if !strings.HasPrefix(actual, v.expectedPrefix) {
+			t.Fatalf("Expect prefix %q but actual is %q", v.expectedPrefix, actual)
+		}
+	}
+}
+
+type testNamed struct {
+	name string
+}
+
+func (n *testNamed) Name() string {
+	return n.name
 }


### PR DESCRIPTION
`ObjectNameForTest` is used to generate names for objects (like service) used in tests. It calls `kmeta.ChildName` which allows max name length is 63 (supported by k8s). However some non-k8s implementation has a smaller limit than k8s.

This PR proposes to limit the length of generated name to 50, which is sufficient in knative tests. 