### PR TITLE
Have the addressable resolver take a tracker.

### DIFF
--- a/resolver/addressable_resolver.go
+++ b/resolver/addressable_resolver.go
@@ -44,12 +44,17 @@ type URIResolver struct {
 	listerFactory func(schema.GroupVersionResource) (cache.GenericLister, error)
 }
 
-// NewURIResolver constructs a new URIResolver with context and a callback
-// for a given listableType (Listable) passed to the URIResolver's tracker.
+// NewURIResolver constructs a new URIResolver with context and a tracker.
+// Deprecated: use NewURIResolverFromTracker instead.
 func NewURIResolver(ctx context.Context, callback func(types.NamespacedName)) *URIResolver {
-	ret := &URIResolver{}
+	return NewURIResolverFromTracker(ctx, tracker.New(callback, controller.GetTrackerLease(ctx)))
+}
 
-	ret.tracker = tracker.New(callback, controller.GetTrackerLease(ctx))
+// NewURIResolverFromTracker constructs a new URIResolver with context and a tracker.
+func NewURIResolverFromTracker(ctx context.Context, t tracker.Interface) *URIResolver {
+	ret := &URIResolver{
+		tracker: t,
+	}
 
 	informerFactory := &pkgapisduck.CachedInformerFactory{
 		Delegate: &pkgapisduck.EnqueueInformerFactory{

--- a/resolver/addressable_resolver_test.go
+++ b/resolver/addressable_resolver_test.go
@@ -35,6 +35,7 @@ import (
 	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	"knative.dev/pkg/resolver"
+	"knative.dev/pkg/tracker"
 )
 
 const (
@@ -353,7 +354,7 @@ func TestGetURIDestinationV1Beta1(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			ctx, _ := fakedynamicclient.With(context.Background(), scheme.Scheme, tc.objects...)
 			ctx = addressable.WithDuck(ctx)
-			r := resolver.NewURIResolver(ctx, func(types.NamespacedName) {})
+			r := resolver.NewURIResolverFromTracker(ctx, tracker.New(func(types.NamespacedName) {}, 0))
 
 			// Run it twice since this should be idempotent. URI Resolver should
 			// not modify the cache's copy.
@@ -538,7 +539,7 @@ func TestGetURIDestinationV1(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			ctx, _ := fakedynamicclient.With(context.Background(), scheme.Scheme, tc.objects...)
 			ctx = addressable.WithDuck(ctx)
-			r := resolver.NewURIResolver(ctx, func(types.NamespacedName) {})
+			r := resolver.NewURIResolverFromTracker(ctx, tracker.New(func(types.NamespacedName) {}, 0))
 
 			// Run it twice since this should be idempotent. URI Resolver should
 			// not modify the cache's copy.
@@ -580,7 +581,7 @@ func TestURIFromObjectReferenceErrors(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			ctx, _ := fakedynamicclient.With(context.Background(), scheme.Scheme, tc.objects...)
 			ctx = addressable.WithDuck(ctx)
-			r := resolver.NewURIResolver(ctx, func(types.NamespacedName) {})
+			r := resolver.NewURIResolverFromTracker(ctx, tracker.New(func(types.NamespacedName) {}, 0))
 
 			// Run it twice since this should be idempotent. URI Resolver should
 			// not modify the cache's copy.


### PR DESCRIPTION
I noticed in a few places downstream that reconcilers were creating both trackers and Addressable resolvers, which seems superfluous.  As part of examining the way we use the tracker, I'm experimenting with changing this to just take a tracker.

/kind cleanup

**Release Note**

```release-note
resolver.NewURIResolver now takes a tracker.Interface instead of a callback.
```

**Docs**

```docs

```
