### PR TITLE
This implements the EventExpansion needed to emit K8s events.

### DIFF
--- a/client/injection/kube/client/client_expansion.go
+++ b/client/injection/kube/client/client_expansion.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	context "context"
+	fmt "fmt"
 
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	restclient "k8s.io/client-go/rest"
 )
 
@@ -38,28 +40,70 @@ func (*wrapCoreV1ServiceImpl) ProxyGet(string, string, string, string, map[strin
 	panic("NYI")
 }
 
-func (*wrapEventsV1beta1EventImpl) CreateWithEventNamespace(*eventsv1beta1.Event) (*eventsv1beta1.Event, error) {
-	panic("NYI")
+func (e *wrapEventsV1beta1EventImpl) CreateWithEventNamespace(event *eventsv1beta1.Event) (*eventsv1beta1.Event, error) {
+	if e.namespace != "" && event.Namespace != e.namespace {
+		return nil, fmt.Errorf("can't create an event with namespace '%v' in namespace '%v'", event.Namespace, e.namespace)
+	}
+	ne := &wrapEventsV1beta1EventImpl{
+		dyn:       e.dyn,
+		namespace: event.Namespace,
+	}
+	return ne.Create(context.TODO(), event, metav1.CreateOptions{})
 }
 
-func (*wrapEventsV1beta1EventImpl) UpdateWithEventNamespace(*eventsv1beta1.Event) (*eventsv1beta1.Event, error) {
-	panic("NYI")
+func (e *wrapEventsV1beta1EventImpl) UpdateWithEventNamespace(event *eventsv1beta1.Event) (*eventsv1beta1.Event, error) {
+	if e.namespace != "" && event.Namespace != e.namespace {
+		return nil, fmt.Errorf("can't update an event with namespace '%v' in namespace '%v'", event.Namespace, e.namespace)
+	}
+	ne := &wrapEventsV1beta1EventImpl{
+		dyn:       e.dyn,
+		namespace: event.Namespace,
+	}
+	return ne.Update(context.TODO(), event, metav1.UpdateOptions{})
 }
 
-func (*wrapEventsV1beta1EventImpl) PatchWithEventNamespace(*eventsv1beta1.Event, []byte) (*eventsv1beta1.Event, error) {
-	panic("NYI")
+func (e *wrapEventsV1beta1EventImpl) PatchWithEventNamespace(event *eventsv1beta1.Event, bytes []byte) (*eventsv1beta1.Event, error) {
+	if e.namespace != "" && event.Namespace != e.namespace {
+		return nil, fmt.Errorf("can't patch an event with namespace '%v' in namespace '%v'", event.Namespace, e.namespace)
+	}
+	ne := &wrapEventsV1beta1EventImpl{
+		dyn:       e.dyn,
+		namespace: event.Namespace,
+	}
+	return ne.Patch(context.TODO(), event.Name, types.StrategicMergePatchType, bytes, metav1.PatchOptions{})
 }
 
-func (*wrapCoreV1EventImpl) CreateWithEventNamespace(*corev1.Event) (*corev1.Event, error) {
-	panic("NYI")
+func (e *wrapCoreV1EventImpl) CreateWithEventNamespace(event *corev1.Event) (*corev1.Event, error) {
+	if e.namespace != "" && event.Namespace != e.namespace {
+		return nil, fmt.Errorf("can't create an event with namespace '%v' in namespace '%v'", event.Namespace, e.namespace)
+	}
+	ne := &wrapCoreV1EventImpl{
+		dyn:       e.dyn,
+		namespace: event.Namespace,
+	}
+	return ne.Create(context.TODO(), event, metav1.CreateOptions{})
 }
 
-func (*wrapCoreV1EventImpl) UpdateWithEventNamespace(*corev1.Event) (*corev1.Event, error) {
-	panic("NYI")
+func (e *wrapCoreV1EventImpl) UpdateWithEventNamespace(event *corev1.Event) (*corev1.Event, error) {
+	if e.namespace != "" && event.Namespace != e.namespace {
+		return nil, fmt.Errorf("can't update an event with namespace '%v' in namespace '%v'", event.Namespace, e.namespace)
+	}
+	ne := &wrapCoreV1EventImpl{
+		dyn:       e.dyn,
+		namespace: event.Namespace,
+	}
+	return ne.Update(context.TODO(), event, metav1.UpdateOptions{})
 }
 
-func (*wrapCoreV1EventImpl) PatchWithEventNamespace(*corev1.Event, []byte) (*corev1.Event, error) {
-	panic("NYI")
+func (e *wrapCoreV1EventImpl) PatchWithEventNamespace(event *corev1.Event, bytes []byte) (*corev1.Event, error) {
+	if e.namespace != "" && event.Namespace != e.namespace {
+		return nil, fmt.Errorf("can't patch an event with namespace '%v' in namespace '%v'", event.Namespace, e.namespace)
+	}
+	ne := &wrapCoreV1EventImpl{
+		dyn:       e.dyn,
+		namespace: event.Namespace,
+	}
+	return ne.Patch(context.TODO(), event.Name, types.StrategicMergePatchType, bytes, metav1.PatchOptions{})
 }
 
 func (*wrapCoreV1EventImpl) Search(*runtime.Scheme, runtime.Object) (*corev1.EventList, error) {


### PR DESCRIPTION
With this change, I was able to pass some downstream e2e tests that check for event emission with this path enabled, which previously failed.

The relevant hand-rolled bits in Kubernetes client-go is here: https://github.com/kubernetes/client-go/blob/35bf219cc60981cdf318b711e2630cc05e0a83e5/kubernetes/typed/core/v1/event_expansion.go#L49

I opted to avoid copy/pasting the generated code, and instead used a trick that let me call into the generated code.

Going through this exercise also (likely) uncovered a Kubernetes bug: https://github.com/kubernetes/kubernetes/issues/104495

/kind enhancement
/assign @n3wscott 

**Release Note**

```release-note

```

**Docs**

```docs

```
