### PR TITLE
Drop several deprecated APIs

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -233,19 +233,6 @@ type ControllerOptions struct { //nolint // for backcompat.
 	Concurrency   int
 }
 
-// NewImpl instantiates an instance of our controller that will feed work to the
-// provided Reconciler as it is enqueued.
-// Deprecated: use NewImplFull.
-func NewImpl(r Reconciler, logger *zap.SugaredLogger, workQueueName string) *Impl {
-	return NewImplFull(r, ControllerOptions{WorkQueueName: workQueueName, Logger: logger})
-}
-
-// NewImplFull accepts the full set of options available to all controllers.
-// Deprecated: use NewContext instead.
-func NewImplFull(r Reconciler, options ControllerOptions) *Impl {
-	return NewContext(context.TODO(), r, options)
-}
-
 // NewContext instantiates an instance of our controller that will feed work to the
 // provided Reconciler as it is enqueued.
 func NewContext(ctx context.Context, r Reconciler, options ControllerOptions) *Impl {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -715,7 +715,7 @@ func TestEnqueue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var rl workqueue.RateLimiter = testRateLimiter{t, 100 * time.Millisecond}
-			impl := NewImplFull(&nopReconciler{}, ControllerOptions{WorkQueueName: "Testing", Logger: TestLogger(t), RateLimiter: rl})
+			impl := NewContext(context.TODO(), &nopReconciler{}, ControllerOptions{WorkQueueName: "Testing", Logger: TestLogger(t), RateLimiter: rl})
 			test.work(impl)
 
 			impl.WorkQueue().ShutDown()
@@ -751,7 +751,7 @@ func pollQ(q workqueue.RateLimitingInterface, sig chan int) func() (bool, error)
 }
 
 func TestEnqueueAfter(t *testing.T) {
-	impl := NewImplFull(&nopReconciler{}, ControllerOptions{
+	impl := NewContext(context.TODO(), &nopReconciler{}, ControllerOptions{
 		Logger:        TestLogger(t),
 		WorkQueueName: "Testing",
 		Reporter:      &FakeStatsReporter{},
@@ -818,7 +818,7 @@ func TestEnqueueAfter(t *testing.T) {
 }
 
 func TestEnqueueKeyAfter(t *testing.T) {
-	impl := NewImplFull(&nopReconciler{}, ControllerOptions{
+	impl := NewContext(context.TODO(), &nopReconciler{}, ControllerOptions{
 		Logger:        TestLogger(t),
 		WorkQueueName: "Testing",
 		Reporter:      &FakeStatsReporter{},
@@ -880,7 +880,7 @@ func (cr *CountingReconciler) Reconcile(context.Context, string) error {
 
 func TestStartAndShutdown(t *testing.T) {
 	r := &CountingReconciler{}
-	impl := NewImplFull(&nopReconciler{}, ControllerOptions{
+	impl := NewContext(context.TODO(), &nopReconciler{}, ControllerOptions{
 		Logger:        TestLogger(t),
 		WorkQueueName: "Testing",
 		Reporter:      &FakeStatsReporter{},
@@ -950,7 +950,7 @@ func TestStartAndShutdownWithLeaderAwareNoElection(t *testing.T) {
 			},
 		},
 	}
-	impl := NewImplFull(r, ControllerOptions{
+	impl := NewContext(context.TODO(), r, ControllerOptions{
 		Logger:        TestLogger(t),
 		WorkQueueName: "Testing",
 		Reporter:      &FakeStatsReporter{},
@@ -1022,7 +1022,7 @@ func TestStartAndShutdownWithLeaderAwareWithLostElection(t *testing.T) {
 		},
 	)
 
-	impl := NewImplFull(&nopReconciler{}, ControllerOptions{
+	impl := NewContext(context.TODO(), &nopReconciler{}, ControllerOptions{
 		Logger:        TestLogger(t),
 		WorkQueueName: "Testing",
 		Reporter:      &FakeStatsReporter{},
@@ -1066,7 +1066,7 @@ func TestStartAndShutdownWithLeaderAwareWithLostElection(t *testing.T) {
 func TestStartAndShutdownWithWork(t *testing.T) {
 	r := &CountingReconciler{}
 	reporter := &FakeStatsReporter{}
-	impl := NewImplFull(r, ControllerOptions{
+	impl := NewContext(context.TODO(), r, ControllerOptions{
 		Logger:        TestLogger(t),
 		WorkQueueName: "Testing",
 		Reporter:      reporter,
@@ -1170,7 +1170,7 @@ func TestStartAndShutdownWithErroringWork(t *testing.T) {
 
 	item := types.NamespacedName{Namespace: "", Name: "bar"}
 
-	impl := NewImplFull(&errorReconciler{}, ControllerOptions{
+	impl := NewContext(context.TODO(), &errorReconciler{}, ControllerOptions{
 		Logger:        TestLogger(t),
 		WorkQueueName: "Testing",
 		Reporter:      &FakeStatsReporter{},
@@ -1229,7 +1229,7 @@ func (er *permanentErrorReconciler) Reconcile(context.Context, string) error {
 func TestStartAndShutdownWithPermanentErroringWork(t *testing.T) {
 	r := &permanentErrorReconciler{}
 	reporter := &FakeStatsReporter{}
-	impl := NewImplFull(r, ControllerOptions{
+	impl := NewContext(context.TODO(), r, ControllerOptions{
 		Logger:        TestLogger(t),
 		WorkQueueName: "Testing",
 		Reporter:      reporter,
@@ -1297,7 +1297,7 @@ func TestStartAndShutdownWithRequeuingWork(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			r := &requeueAfterReconciler{duration: test.duration}
 			reporter := &FakeStatsReporter{}
-			impl := NewImplFull(r, ControllerOptions{
+			impl := NewContext(context.TODO(), r, ControllerOptions{
 				Logger:        TestLogger(t),
 				WorkQueueName: "Testing",
 				Reporter:      reporter,
@@ -1396,7 +1396,7 @@ func (*fakeStore) List() []interface{} {
 
 func TestImplGlobalResync(t *testing.T) {
 	r := &CountingReconciler{}
-	impl := NewImplFull(r, ControllerOptions{
+	impl := NewContext(context.TODO(), r, ControllerOptions{
 		Logger:        TestLogger(t),
 		WorkQueueName: "Testing",
 		Reporter:      &FakeStatsReporter{},

--- a/resolver/addressable_resolver.go
+++ b/resolver/addressable_resolver.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
 	"knative.dev/pkg/controller"
@@ -47,12 +46,6 @@ type URIResolver struct {
 	tracker       tracker.Interface
 	listerFactory func(schema.GroupVersionResource) (cache.GenericLister, error)
 	resolvers     []RefResolverFunc
-}
-
-// NewURIResolver constructs a new URIResolver with context, a tracker and an optional list of custom resolvers.
-// Deprecated: use NewURIResolverFromTracker instead.
-func NewURIResolver(ctx context.Context, callback func(types.NamespacedName), resolvers ...RefResolverFunc) *URIResolver {
-	return NewURIResolverFromTracker(ctx, tracker.New(callback, controller.GetTrackerLease(ctx)), resolvers...)
 }
 
 // NewURIResolverFromTracker constructs a new URIResolver with context, a tracker and an optional list of custom resolvers.


### PR DESCRIPTION
# Changes

/kind cleanup

**Release Note**

```release-note
Drop deprecated addressable resolver constructor.
Drop deprecated controller.New* constructors.
```

**Docs**

```docs

```
