### PR TITLE
Trim the space in configmap/registriesSkippingTagResolving's url. (#2…

### DIFF
--- a/configmap/parse.go
+++ b/configmap/parse.go
@@ -141,7 +141,11 @@ func AsDuration(key string, target *time.Duration) ParseFunc {
 func AsStringSet(key string, target *sets.String) ParseFunc {
 	return func(data map[string]string) error {
 		if raw, ok := data[key]; ok {
-			*target = sets.NewString(strings.Split(raw, ",")...)
+			splitted := strings.Split(raw, ",")
+			for i, v := range splitted {
+				splitted[i] = strings.TrimSpace(v)
+			}
+			*target = sets.NewString(splitted...)
 		}
 		return nil
 	}

--- a/configmap/parse_test.go
+++ b/configmap/parse_test.go
@@ -61,7 +61,7 @@ func TestParse(t *testing.T) {
 			"test-int":      "4",
 			"test-float64":  "1.0",
 			"test-duration": "1m",
-			"test-set":      "a,b,c",
+			"test-set":      "a,b,c, d",
 			"test-quantity": "500m",
 
 			"test-namespaced-name":          "some-namespace/some-name",
@@ -76,7 +76,7 @@ func TestParse(t *testing.T) {
 			f64:    1.0,
 			i:      4,
 			dur:    time.Minute,
-			set:    sets.NewString("a", "b", "c"),
+			set:    sets.NewString("a", "b", "c", "d"),
 			qua:    &fiveHundredM,
 			nsn: types.NamespacedName{
 				Name:      "some-name",


### PR DESCRIPTION
# Changes

🎁 Trim the space in configmap/registriesSkippingTagResolving's url. Because many develpers do like "a.com, b.com", it's easy to have this mistake.

Related to https://github.com/knative/pkg/issues/2229
Related PR