### PR TITLE
Update version check comment

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -70,8 +70,7 @@ func CheckMinimumVersion(versioner discovery.ServerVersionInterface) error {
 		minimumVersion.Pre = []semver.PRVersion{{VersionNum: 0}}
 	}
 
-	// Compare returns 1 if the first version is greater than the
-	// second version.
+	// Return error if the current version is less than the minimum version required.
 	if currentVersion.LT(minimumVersion) {
 		if len(currentVersion.Pre) > 0 {
 			return fmt.Errorf("pre-release kubernetes version %q is not compatible, need at least %q (this can be overridden with the env var %q); note pre-release version is smaller than the corresponding release version (e.g. 1.x.y-z < 1.x.y), using 1.x.y-0 as the minimum version is likely to help in this case",


### PR DESCRIPTION
The comment `Compare returns 1` remains since the first implementation.

https://github.com/knative/pkg/commit/80e5f98294faeb254bbc34697932e25f1e896ed6#diff-f6bf0ae0d21c9408c6624174da11dafb369ce306f2cdcea704285d8acc87e19eR49-R53

It is unclear as we no longer check `return 1`. This patch updates the comment.

/kind cleanup