### PR TITLE
Remove obsolete verbose log message for pre-release

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -72,10 +72,6 @@ func CheckMinimumVersion(versioner discovery.ServerVersionInterface) error {
 
 	// Return error if the current version is less than the minimum version required.
 	if currentVersion.LT(minimumVersion) {
-		if len(currentVersion.Pre) > 0 {
-			return fmt.Errorf("pre-release kubernetes version %q is not compatible, need at least %q (this can be overridden with the env var %q); note pre-release version is smaller than the corresponding release version (e.g. 1.x.y-z < 1.x.y), using 1.x.y-0 as the minimum version is likely to help in this case",
-				currentVersion, minimumVersion, KubernetesMinVersionKey)
-		}
 		return fmt.Errorf("kubernetes version %q is not compatible, need at least %q (this can be overridden with the env var %q)",
 			currentVersion, minimumVersion, KubernetesMinVersionKey)
 	}


### PR DESCRIPTION
The error log was obsoleted by https://github.com/knative/pkg/pull/1944.

As we can see this test case (no error is expected):
https://github.com/knative/pkg/blob/a70bb26767b8d368339a2de6cfe2d30ac2667889/version/version_test.go#L68-L71

pre-release version is __NOT__ smaller than the corresponding release
version anymore.

(I was confused the code says `note pre-release version is smaller than the corresponding release version`
but why the test case passes.)

/kind cleanup