### PR TITLE
Bump golangci-lint timeout to 10m for github actions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  timeout: 5m
+  timeout: 10m
 
   skip-dirs:
     - client


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

I had a least two PRs where this failed the Lint action. Sometimes, GH Actions are veeeeery slow.

/assign @julz 