### PR TITLE
add reason for happy condition when use method MarkTrueWithReason

### DIFF
--- a/apis/condition_set.go
+++ b/apis/condition_set.go
@@ -262,7 +262,7 @@ func (r conditionsImpl) MarkTrue(t ConditionType) {
 		Status:   corev1.ConditionTrue,
 		Severity: r.severity(t),
 	})
-	r.recomputeHappiness(t)
+	r.recomputeHappiness(t, "")
 }
 
 // MarkTrueWithReason sets the status of t to true with the reason, and then marks the happy condition to
@@ -276,11 +276,11 @@ func (r conditionsImpl) MarkTrueWithReason(t ConditionType, reason, messageForma
 		Message:  fmt.Sprintf(messageFormat, messageA...),
 		Severity: r.severity(t),
 	})
-	r.recomputeHappiness(t)
+	r.recomputeHappiness(t, reason)
 }
 
 // recomputeHappiness marks the happy condition to true if all other dependents are also true.
-func (r conditionsImpl) recomputeHappiness(t ConditionType) {
+func (r conditionsImpl) recomputeHappiness(t ConditionType,reason string) {
 	if c := r.findUnhappyDependent(); c != nil {
 		// Propagate unhappy dependent to happy condition.
 		r.SetCondition(Condition{
@@ -295,6 +295,7 @@ func (r conditionsImpl) recomputeHappiness(t ConditionType) {
 		r.SetCondition(Condition{
 			Type:     r.happy,
 			Status:   corev1.ConditionTrue,
+			Reason: reason,
 			Severity: r.severity(r.happy),
 		})
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :gift:  add reason for happy condition when use method MarkTrueWithReason


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are:  enhancement

-->
/kind  enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

When user use MarkTrueWithReason to set their condition the happy condition can not be set with reason while I think this is not a good choice. So I hope reason can be  also be set for happy condiition if I use the method MarkTrueWithReason.

<!-- Please include the 'why' behind your changes if no issue exists -->
**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
