### PR TITLE
fix check calls being unreliable

### DIFF
--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -313,8 +313,8 @@ func (sc *SpoofingClient) Check(req *http.Request, inState ResponseChecker, erro
 					return false, nil
 				}
 			}
+			sc.Logf("NOT Retrying %s: %v", req.URL.String(), err)
 		}
-		sc.Logf("NOT Retrying %s: %v", req.URL.String(), err)
 		return true, err
 	})
 

--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -295,12 +295,30 @@ func (sc *SpoofingClient) endpointState(
 	return f(req, inState)
 }
 
-func (sc *SpoofingClient) Check(req *http.Request, inState ResponseChecker) (*Response, error) {
+func (sc *SpoofingClient) Check(req *http.Request, inState ResponseChecker, errorRetryCheckers ...ErrorRetryChecker) (*Response, error) {
+	if len(errorRetryCheckers) == 0 {
+		errorRetryCheckers = []ErrorRetryChecker{DefaultErrorRetryChecker}
+	}
 	traceContext, span := trace.StartSpan(req.Context(), "SpoofingClient-Trace")
 	defer span.End()
-	rawResp, err := sc.Client.Do(req.WithContext(traceContext))
-	if err != nil {
+	var rawResp *http.Response
+	err := wait.PollImmediate(sc.RequestInterval, sc.RequestTimeout, func() (bool, error) {
+		var err error
+		rawResp, err = sc.Client.Do(req.WithContext(traceContext))
+		if err != nil {
+			for _, checker := range errorRetryCheckers {
+				retry, newErr := checker(err)
+				if retry {
+					sc.Logf("Retrying %s: %v", req.URL.String(), newErr)
+					return false, nil
+				}
+			}
+		}
 		sc.Logf("NOT Retrying %s: %v", req.URL.String(), err)
+		return true, err
+	})
+
+	if err != nil {
 		return nil, err
 	}
 	defer rawResp.Body.Close()
@@ -342,7 +360,7 @@ func (sc *SpoofingClient) CheckEndpointState(
 		url,
 		inState,
 		desc,
-		sc.Check,
+		func(req *http.Request, check ResponseChecker) (*Response, error) { return sc.Check(req, check) },
 		"CheckEndpointState",
 		opts...)
 }


### PR DESCRIPTION
Add back `DefaultErrorRetryChecker` into the `CheckEndpointState` calls so it retries for issues caused by the network.

Problem introduced in knative/serving/pull/11680

<!-- Thanks for sending a pull request! -->

