### PR TITLE
Avoid double-resyncs without leader election.

### DIFF
--- a/leaderelection/context.go
+++ b/leaderelection/context.go
@@ -94,7 +94,11 @@ func BuildElector(ctx context.Context, la reconciler.LeaderAware, queueName stri
 	return &unopposedElector{
 		la:  la,
 		bkt: reconciler.UniversalBucket(),
-		enq: enq,
+		// The UniversalBucket owns everything, so there is never a need to
+		// enqueue things (no possible state change).  We pass nil here to
+		// avoid filling the queue for an extra resynce at startup along
+		// this path.
+		enq: nil,
 	}, nil
 }
 

--- a/reconciler/leader.go
+++ b/reconciler/leader.go
@@ -97,7 +97,7 @@ func (laf *LeaderAwareFuncs) Promote(b Bucket, enq func(Bucket, types.Namespaced
 		laf.buckets[b.Name()] = b
 	}()
 
-	if promote := laf.PromoteFunc; promote != nil {
+	if promote := laf.PromoteFunc; promote != nil && enq != nil {
 		return promote(b, enq)
 	}
 	return nil

--- a/reconciler/leader_test.go
+++ b/reconciler/leader_test.go
@@ -42,6 +42,11 @@ func TestLeaderAwareFuncs(t *testing.T) {
 	}
 
 	laf.PromoteFunc = func(bkt Bucket, gotFunc func(Bucket, types.NamespacedName)) error {
+		if gotFunc == nil {
+			t.Error("PromoteFunc should not be called with nil gotFunc")
+			return nil
+		}
+
 		gotFunc(bkt, wantKey)
 		if !called {
 			t.Error("gotFunc didn't call wantFunc!")
@@ -79,4 +84,7 @@ func TestLeaderAwareFuncs(t *testing.T) {
 	if laf.IsLeaderFor(wantKey) {
 		t.Error("IsLeaderFor() = true, wanted false")
 	}
+
+	// We should elide calls with a nil enq
+	laf.Promote(wantBkt, nil)
 }


### PR DESCRIPTION
tl;dr Without leader election enabled, we've been suffering from double resyncs, this fixes that.

Essentially when the informers are started, prior to starting the controllers, they fill the controller's workqueue with ~the world.  Once we start the controllers, the leader election code calls `Promote` on a `Bucket` so that it starts processing them as their leader, and then is requeues every key that falls into that `Bucket`.

When leader election is disabled, we use the `UniversalBucket`, which always owns everything.  This means that the first pass through the workqueue was already hitting every key, so re-enqueuing every key results in superfluous processing of those keys.

This change makes the `LeaderAwareFuncs` elide the call to `PromoteFunc` when the `enq` function passed is `nil`, and makes the `unopposedElector` have a `nil` `enq` field when we explicitly pass it the `UniversalBucket` because leader election is disabled.

/kind cleanup

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
