### PR TITLE
[release-0.24] when testing downstream use the correct release branch

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -80,18 +80,33 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.16.x
+
     - name: Install Dependencies
       run: |
         go get github.com/google/go-licenses
-    - name: Checkout Upstream
+
+    - name: Check out code
       uses: actions/checkout@v2
       with:
+        fetch-depth: 0
         path: ./src/knative.dev/${{ github.event.repository.name }}
+
+    - name: Merge upstream
+      if: github.event_name == 'pull_request'
+      shell: bash
+      working-directory: ./src/knative.dev/${{ github.event.repository.name }}
+      run: |
+         git remote add upstream https://github.com/${{ github.repository }}.git
+         git fetch upstream ${{ github.base_ref }}
+         git pull --no-rebase --no-commit upstream ${{ github.base_ref }}
+
     - name: Checkout Downstream
       uses: actions/checkout@v2
       with:
+        ref: ${{ github.base_ref }}
         repository: ${{ matrix.org }}/${{ matrix.repo }}
         path: ./src/knative.dev/${{ matrix.repo }}
+
     - name: Test Downstream
       uses: knative-sandbox/actions-downstream-test@v1
       with:


### PR DESCRIPTION
Verifies - https://github.com/knative/pkg/pull/2265

and useful for this supported release branch