### PR TITLE
Declare `DefaultErrorRetryChecker` as `ErrorRetryChecker` type

### DIFF
--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -164,7 +164,7 @@ func (sc *SpoofingClient) Do(req *http.Request, errorRetryCheckers ...interface{
 // If no retry checkers are specified `DefaultErrorRetryChecker` will be used.
 func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker, checkers ...interface{}) (*Response, error) {
 	if len(checkers) == 0 {
-		checkers = []interface{}{DefaultErrorRetryChecker}
+		checkers = []interface{}{ErrorRetryChecker(DefaultErrorRetryChecker)}
 	}
 
 	var resp *Response


### PR DESCRIPTION
This patch changes `DefaultErrorRetryChecker` to `ErrorRetryChecker`
type before adding in the interface array.

Without it, the type of DefaultErrorRetryChecker is still `func(error) (bool, error)`.
https://play.golang.org/p/CLlGbwGQeMu

/cc @markusthoemmes 
