### PR TITLE
Add IsNum to true when set `-0` to minimumVersion.Pre

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -66,6 +66,7 @@ func CheckMinimumVersion(versioner discovery.ServerVersionInterface) error {
 
 	// If no specific pre-release requirement is set, we default to "-0" to always allow
 	// pre-release versions of the same Major.Minor.Patch version.
+	// Set IsNum to true otherwise currentVersion.LT() below always returns true.
 	if len(minimumVersion.Pre) == 0 {
 		minimumVersion.Pre = []semver.PRVersion{{VersionNum: 0, IsNum: true}}
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -67,7 +67,7 @@ func CheckMinimumVersion(versioner discovery.ServerVersionInterface) error {
 	// If no specific pre-release requirement is set, we default to "-0" to always allow
 	// pre-release versions of the same Major.Minor.Patch version.
 	if len(minimumVersion.Pre) == 0 {
-		minimumVersion.Pre = []semver.PRVersion{{VersionNum: 0}}
+		minimumVersion.Pre = []semver.PRVersion{{VersionNum: 0, IsNum: true}}
 	}
 
 	// Return error if the current version is less than the minimum version required.

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -41,13 +41,16 @@ func TestVersionCheck(t *testing.T) {
 		wantError       bool
 	}{{
 		name:          "greater version (patch)",
-		actualVersion: &testVersioner{version: "v1.20.2"},
+		actualVersion: &testVersioner{version: "v1.20.0"},
 	}, {
 		name:          "greater version (patch), no v",
-		actualVersion: &testVersioner{version: "1.20.2"},
+		actualVersion: &testVersioner{version: "1.20.0"},
 	}, {
 		name:          "greater version (patch), pre-release",
-		actualVersion: &testVersioner{version: "1.20.2-kpn-065dce"},
+		actualVersion: &testVersioner{version: "1.20.0-kpn-065dce"},
+	}, {
+		name:          "greater version (patch), pre-release with build",
+		actualVersion: &testVersioner{version: "1.20.0-1095+9689d22dc3121e-dirty"},
 	}, {
 		name:            "greater version (patch), pre-release, envvar override",
 		actualVersion:   &testVersioner{version: "1.15.11-kpn-065dce"},


### PR DESCRIPTION
This patch adds IsNum to true when set `-0` to minimumVersion.Pre.

For example, the version (`1.20.0-1095+9689d22dc3121e-dirty`) is not compared correctly:

```
2021/09/16 01:33:33 Failed to get k8s version kubernetes version "1.20.0-1095+9689d22dc3121e-dirty" is not compatible, need at least "1.20.0-" (this can be overridden with the env var "KUBERNETES_MIN_VERSION")
```

/cc @markusthoemmes @dprotaso 