### PR TITLE
introduce new case convention for leader election config map

### DIFF
--- a/leaderelection/config.go
+++ b/leaderelection/config.go
@@ -46,9 +46,14 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 	config := defaultConfig()
 
 	if err := cm.Parse(data,
+		// Parse legacy keys first
 		cm.AsDuration("leaseDuration", &config.LeaseDuration),
 		cm.AsDuration("renewDeadline", &config.RenewDeadline),
 		cm.AsDuration("retryPeriod", &config.RetryPeriod),
+
+		cm.AsDuration("lease-duration", &config.LeaseDuration),
+		cm.AsDuration("renew-deadline", &config.RenewDeadline),
+		cm.AsDuration("retry-period", &config.RetryPeriod),
 
 		cm.AsUint32("buckets", &config.Buckets),
 	); err != nil {


### PR DESCRIPTION
Part of https://github.com/knative/serving/issues/7300

Majority of serving uses lowercase-hyphens - ie. some-property over
someProperty

This changes the leader election config map parsing to support formats
and to prioritize the lowercase-hyphen case