### PR TITLE
Allow tracking Cluster-scoped resources.

### DIFF
--- a/tracker/enqueue.go
+++ b/tracker/enqueue.go
@@ -95,7 +95,10 @@ func (i *impl) TrackReference(ref Reference, obj interface{}) error {
 	invalidFields := map[string][]string{
 		"APIVersion": validation.IsQualifiedName(ref.APIVersion),
 		"Kind":       validation.IsCIdentifier(ref.Kind),
-		"Namespace":  validation.IsDNS1123Label(ref.Namespace),
+	}
+	// Allow namespace to be empty for cluster-scoped references.
+	if ref.Namespace != "" {
+		invalidFields["Namespace"] = validation.IsDNS1123Label(ref.Namespace)
 	}
 	var selector labels.Selector
 	fieldErrors := []string{}

--- a/tracker/enqueue_test.go
+++ b/tracker/enqueue_test.go
@@ -334,15 +334,6 @@ func TestBadObjectReferences(t *testing.T) {
 		},
 		match: "Kind",
 	}, {
-		name: "Missing Namespace",
-		objRef: corev1.ObjectReference{
-			APIVersion: "build.knative.dev/v1alpha1",
-			Kind:       "Build",
-			// Namespace: "default",
-			Name: "kaniko",
-		},
-		match: "Namespace",
-	}, {
 		name: "Capital in Namespace",
 		objRef: corev1.ObjectReference{
 			APIVersion: "build.knative.dev/v1alpha1",
@@ -395,7 +386,7 @@ func TestBadObjectReferences(t *testing.T) {
 			// Namespace:  "default",
 			// Name:      "kaniko",
 		},
-		match: "\nAPIVersion:.*\nKind:.*\nNamespace:",
+		match: "\nAPIVersion:.*\nKind:",
 	}}
 
 	for _, test := range tests {
@@ -434,7 +425,7 @@ func TestBadReferences(t *testing.T) {
 	}{{
 		name:   "Missing All",
 		objRef: Reference{},
-		match:  "\nAPIVersion:.*\nKind:.*\nNamespace:",
+		match:  "\nAPIVersion:.*\nKind:",
 	}, {
 		name: "Name and Selector",
 		objRef: Reference{


### PR DESCRIPTION
Previously we required namespace to be non-empty, but it never is for Cluster-scoped resources.

This change elides validation for missing namespaces, assuming cluster-scoping.

/kind enhancement

**Release Note**

```release-note
tracker now supports Cluster-scoped resources.
```

**Docs**
```docs

```
