### PR TITLE
Provide the webhook infrastructure with the raw request context.

### DIFF
--- a/apis/contexts.go
+++ b/apis/contexts.go
@@ -18,6 +18,7 @@ package apis
 
 import (
 	"context"
+	"net/http"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -232,4 +233,23 @@ func WithDryRun(ctx context.Context) context.Context {
 // IsDryRun indicates that this request is in DryRun mode.
 func IsDryRun(ctx context.Context) bool {
 	return ctx.Value(isDryRun{}) != nil
+}
+
+// This is attached to contexts passed to webhook interfaces with
+// additional context from the HTTP request.
+type httpReq struct{}
+
+// WithHTTPRequest associated the HTTP request object the webhook
+// received with the context.
+func WithHTTPRequest(ctx context.Context, r *http.Request) context.Context {
+	return context.WithValue(ctx, httpReq{}, r)
+}
+
+// GetHTTPRequest fetches the raw HTTP request received by the webhook.
+func GetHTTPRequest(ctx context.Context) *http.Request {
+	v := ctx.Value(httpReq{})
+	if v == nil {
+		return nil
+	}
+	return v.(*http.Request)
 }

--- a/apis/contexts_test.go
+++ b/apis/contexts_test.go
@@ -18,6 +18,7 @@ package apis
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -220,5 +221,23 @@ func TestParentMeta(t *testing.T) {
 
 	if got := ParentMeta(ctx); !cmp.Equal(want, got) {
 		t.Errorf("ParentMeta() = %v, wanted %v", got, want)
+	}
+}
+
+func TestGetHTTPRequest(t *testing.T) {
+	ctx := context.Background()
+
+	if got := GetHTTPRequest(ctx); got != nil {
+		t.Errorf("GetHTTPRequest() = %v, wanted %v", got, nil)
+	}
+
+	req, err := http.NewRequest("GET", "https://google.com", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() = %v", err)
+	}
+	ctx = WithHTTPRequest(ctx, req)
+
+	if want, got := req, GetHTTPRequest(ctx); got != want {
+		t.Errorf("GetHTTPRequest() = %v, wanted %v", got, want)
 	}
 }

--- a/webhook/admission.go
+++ b/webhook/admission.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap"
 	admissionv1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
 )
@@ -104,6 +105,7 @@ func admissionHandler(rootLogger *zap.SugaredLogger, stats StatsReporter, c Admi
 			logkey.UserInfo, fmt.Sprint(review.Request.UserInfo))
 
 		ctx := logging.WithLogger(r.Context(), logger)
+		ctx = apis.WithHTTPRequest(ctx, r)
 
 		response := admissionv1.AdmissionReview{
 			// Use the same type meta as the request - this is required by the K8s API

--- a/webhook/admission_integration_test.go
+++ b/webhook/admission_integration_test.go
@@ -33,6 +33,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 	kubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/metrics/metricstest"
 	_ "knative.dev/pkg/metrics/testing"
@@ -50,6 +51,12 @@ func (fac *fixedAdmissionController) Path() string {
 }
 
 func (fac *fixedAdmissionController) Admit(ctx context.Context, req *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+	r := apis.GetHTTPRequest(ctx)
+	if r == nil {
+		panic("nil request!")
+	} else if r.URL.Path != fac.path {
+		panic("wrong path!")
+	}
 	return fac.response
 }
 

--- a/webhook/conversion.go
+++ b/webhook/conversion.go
@@ -24,6 +24,7 @@ import (
 
 	"go.uber.org/zap"
 	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 )
 
@@ -53,6 +54,8 @@ func conversionHandler(rootLogger *zap.SugaredLogger, _ StatsReporter, c Convers
 		)
 
 		ctx := logging.WithLogger(r.Context(), logger)
+		ctx = apis.WithHTTPRequest(ctx, r)
+
 		response := apixv1.ConversionReview{
 			// Use the same type meta as the request - this is required by the K8s API
 			// note: v1beta1 & v1 ConversionReview shapes are identical so even though


### PR DESCRIPTION
Today, we can use `Path()` of `/foo/` (trailing slash) to support prefix-matched webhooks, but unfortunately the request context is lost when `Admit()` or `Convert()` is called.

This ensures that information flows through associated with context for anyone who would like this metadata for additional processing.

/kind enhancement

**Release Note**

```release-note
Webhooks can now access the raw http.Request via `apis.GetHTTPRequest`.
```

**Docs**

```docs

```
