### PR TITLE
Allow configuring bounded staleness for dynamic injection.

### DIFF
--- a/client/injection/apiextensions/informers/apiextensions/v1/customresourcedefinition/customresourcedefinition.go
+++ b/client/injection/apiextensions/informers/apiextensions/v1/customresourcedefinition/customresourcedefinition.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1.CustomResourceDefinitionInformer {
 
 type wrapper struct {
 	client clientset.Interface
+
+	resourceVersion string
 }
 
 var _ v1.CustomResourceDefinitionInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() apiextensionsv1.CustomResourceDefinitionLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apisapiextensionsv1.CustomResourceDefinition, err error) {
 	lo, err := w.client.ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apisapiextensionsv1.Cus
 
 func (w *wrapper) Get(name string) (*apisapiextensionsv1.CustomResourceDefinition, error) {
 	return w.client.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/apiextensions/informers/apiextensions/v1beta1/customresourcedefinition/customresourcedefinition.go
+++ b/client/injection/apiextensions/informers/apiextensions/v1beta1/customresourcedefinition/customresourcedefinition.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.CustomResourceDefinitionInformer {
 
 type wrapper struct {
 	client clientset.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.CustomResourceDefinitionInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() apiextensionsv1beta1.CustomResourceDefinitionLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apisapiextensionsv1beta1.CustomResourceDefinition, err error) {
 	lo, err := w.client.ApiextensionsV1beta1().CustomResourceDefinitions().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apisapiextensionsv1beta
 
 func (w *wrapper) Get(name string) (*apisapiextensionsv1beta1.CustomResourceDefinition, error) {
 	return w.client.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/admissionregistration/v1/mutatingwebhookconfiguration/mutatingwebhookconfiguration.go
+++ b/client/injection/kube/informers/admissionregistration/v1/mutatingwebhookconfiguration/mutatingwebhookconfiguration.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1.MutatingWebhookConfigurationInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1.MutatingWebhookConfigurationInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() admissionregistrationv1.MutatingWebhookConfigurationL
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apiadmissionregistrationv1.MutatingWebhookConfiguration, err error) {
 	lo, err := w.client.AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiadmissionregistratio
 
 func (w *wrapper) Get(name string) (*apiadmissionregistrationv1.MutatingWebhookConfiguration, error) {
 	return w.client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration/mutatingwebhookconfiguration.go
+++ b/client/injection/kube/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration/mutatingwebhookconfiguration.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.MutatingWebhookConfigurationInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.MutatingWebhookConfigurationInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() admissionregistrationv1beta1.MutatingWebhookConfigura
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apiadmissionregistrationv1beta1.MutatingWebhookConfiguration, err error) {
 	lo, err := w.client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiadmissionregistratio
 
 func (w *wrapper) Get(name string) (*apiadmissionregistrationv1beta1.MutatingWebhookConfiguration, error) {
 	return w.client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/admissionregistration/v1beta1/validatingwebhookconfiguration/validatingwebhookconfiguration.go
+++ b/client/injection/kube/informers/admissionregistration/v1beta1/validatingwebhookconfiguration/validatingwebhookconfiguration.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.ValidatingWebhookConfigurationInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.ValidatingWebhookConfigurationInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() admissionregistrationv1beta1.ValidatingWebhookConfigu
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apiadmissionregistrationv1beta1.ValidatingWebhookConfiguration, err error) {
 	lo, err := w.client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiadmissionregistratio
 
 func (w *wrapper) Get(name string) (*apiadmissionregistrationv1beta1.ValidatingWebhookConfiguration, error) {
 	return w.client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/apiserverinternal/v1alpha1/storageversion/storageversion.go
+++ b/client/injection/kube/informers/apiserverinternal/v1alpha1/storageversion/storageversion.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1alpha1.StorageVersionInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1alpha1.StorageVersionInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() apiserverinternalv1alpha1.StorageVersionLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apiapiserverinternalv1alpha1.StorageVersion, err error) {
 	lo, err := w.client.InternalV1alpha1().StorageVersions().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiapiserverinternalv1a
 
 func (w *wrapper) Get(name string) (*apiapiserverinternalv1alpha1.StorageVersion, error) {
 	return w.client.InternalV1alpha1().StorageVersions().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/apps/v1/controllerrevision/controllerrevision.go
+++ b/client/injection/kube/informers/apps/v1/controllerrevision/controllerrevision.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.ControllerRevisionInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() appsv1.ControllerRevisionLister {
 }
 
 func (w *wrapper) ControllerRevisions(namespace string) appsv1.ControllerRevisionNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1.ControllerRevision, err error) {
 	lo, err := w.client.AppsV1().ControllerRevisions(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1.ControllerRev
 
 func (w *wrapper) Get(name string) (*apiappsv1.ControllerRevision, error) {
 	return w.client.AppsV1().ControllerRevisions(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/apps/v1/daemonset/daemonset.go
+++ b/client/injection/kube/informers/apps/v1/daemonset/daemonset.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.DaemonSetInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() appsv1.DaemonSetLister {
 }
 
 func (w *wrapper) DaemonSets(namespace string) appsv1.DaemonSetNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1.DaemonSet, err error) {
 	lo, err := w.client.AppsV1().DaemonSets(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1.DaemonSet, er
 
 func (w *wrapper) Get(name string) (*apiappsv1.DaemonSet, error) {
 	return w.client.AppsV1().DaemonSets(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/apps/v1/deployment/deployment.go
+++ b/client/injection/kube/informers/apps/v1/deployment/deployment.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.DeploymentInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() appsv1.DeploymentLister {
 }
 
 func (w *wrapper) Deployments(namespace string) appsv1.DeploymentNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1.Deployment, err error) {
 	lo, err := w.client.AppsV1().Deployments(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1.Deployment, e
 
 func (w *wrapper) Get(name string) (*apiappsv1.Deployment, error) {
 	return w.client.AppsV1().Deployments(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/apps/v1/replicaset/replicaset.go
+++ b/client/injection/kube/informers/apps/v1/replicaset/replicaset.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.ReplicaSetInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() appsv1.ReplicaSetLister {
 }
 
 func (w *wrapper) ReplicaSets(namespace string) appsv1.ReplicaSetNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1.ReplicaSet, err error) {
 	lo, err := w.client.AppsV1().ReplicaSets(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1.ReplicaSet, e
 
 func (w *wrapper) Get(name string) (*apiappsv1.ReplicaSet, error) {
 	return w.client.AppsV1().ReplicaSets(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/apps/v1/statefulset/statefulset.go
+++ b/client/injection/kube/informers/apps/v1/statefulset/statefulset.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.StatefulSetInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() appsv1.StatefulSetLister {
 }
 
 func (w *wrapper) StatefulSets(namespace string) appsv1.StatefulSetNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1.StatefulSet, err error) {
 	lo, err := w.client.AppsV1().StatefulSets(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1.StatefulSet, 
 
 func (w *wrapper) Get(name string) (*apiappsv1.StatefulSet, error) {
 	return w.client.AppsV1().StatefulSets(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/apps/v1beta1/controllerrevision/controllerrevision.go
+++ b/client/injection/kube/informers/apps/v1beta1/controllerrevision/controllerrevision.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.ControllerRevisionInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() appsv1beta1.ControllerRevisionLister {
 }
 
 func (w *wrapper) ControllerRevisions(namespace string) appsv1beta1.ControllerRevisionNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1beta1.ControllerRevision, err error) {
 	lo, err := w.client.AppsV1beta1().ControllerRevisions(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1beta1.Controll
 
 func (w *wrapper) Get(name string) (*apiappsv1beta1.ControllerRevision, error) {
 	return w.client.AppsV1beta1().ControllerRevisions(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/apps/v1beta1/deployment/deployment.go
+++ b/client/injection/kube/informers/apps/v1beta1/deployment/deployment.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.DeploymentInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() appsv1beta1.DeploymentLister {
 }
 
 func (w *wrapper) Deployments(namespace string) appsv1beta1.DeploymentNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1beta1.Deployment, err error) {
 	lo, err := w.client.AppsV1beta1().Deployments(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1beta1.Deployme
 
 func (w *wrapper) Get(name string) (*apiappsv1beta1.Deployment, error) {
 	return w.client.AppsV1beta1().Deployments(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/apps/v1beta1/statefulset/statefulset.go
+++ b/client/injection/kube/informers/apps/v1beta1/statefulset/statefulset.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.StatefulSetInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() appsv1beta1.StatefulSetLister {
 }
 
 func (w *wrapper) StatefulSets(namespace string) appsv1beta1.StatefulSetNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1beta1.StatefulSet, err error) {
 	lo, err := w.client.AppsV1beta1().StatefulSets(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1beta1.Stateful
 
 func (w *wrapper) Get(name string) (*apiappsv1beta1.StatefulSet, error) {
 	return w.client.AppsV1beta1().StatefulSets(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/apps/v1beta2/controllerrevision/controllerrevision.go
+++ b/client/injection/kube/informers/apps/v1beta2/controllerrevision/controllerrevision.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta2.ControllerRevisionInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() appsv1beta2.ControllerRevisionLister {
 }
 
 func (w *wrapper) ControllerRevisions(namespace string) appsv1beta2.ControllerRevisionNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1beta2.ControllerRevision, err error) {
 	lo, err := w.client.AppsV1beta2().ControllerRevisions(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1beta2.Controll
 
 func (w *wrapper) Get(name string) (*apiappsv1beta2.ControllerRevision, error) {
 	return w.client.AppsV1beta2().ControllerRevisions(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/apps/v1beta2/daemonset/daemonset.go
+++ b/client/injection/kube/informers/apps/v1beta2/daemonset/daemonset.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta2.DaemonSetInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() appsv1beta2.DaemonSetLister {
 }
 
 func (w *wrapper) DaemonSets(namespace string) appsv1beta2.DaemonSetNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1beta2.DaemonSet, err error) {
 	lo, err := w.client.AppsV1beta2().DaemonSets(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1beta2.DaemonSe
 
 func (w *wrapper) Get(name string) (*apiappsv1beta2.DaemonSet, error) {
 	return w.client.AppsV1beta2().DaemonSets(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/apps/v1beta2/deployment/deployment.go
+++ b/client/injection/kube/informers/apps/v1beta2/deployment/deployment.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta2.DeploymentInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() appsv1beta2.DeploymentLister {
 }
 
 func (w *wrapper) Deployments(namespace string) appsv1beta2.DeploymentNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1beta2.Deployment, err error) {
 	lo, err := w.client.AppsV1beta2().Deployments(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1beta2.Deployme
 
 func (w *wrapper) Get(name string) (*apiappsv1beta2.Deployment, error) {
 	return w.client.AppsV1beta2().Deployments(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/apps/v1beta2/replicaset/replicaset.go
+++ b/client/injection/kube/informers/apps/v1beta2/replicaset/replicaset.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta2.ReplicaSetInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() appsv1beta2.ReplicaSetLister {
 }
 
 func (w *wrapper) ReplicaSets(namespace string) appsv1beta2.ReplicaSetNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1beta2.ReplicaSet, err error) {
 	lo, err := w.client.AppsV1beta2().ReplicaSets(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1beta2.ReplicaS
 
 func (w *wrapper) Get(name string) (*apiappsv1beta2.ReplicaSet, error) {
 	return w.client.AppsV1beta2().ReplicaSets(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/apps/v1beta2/statefulset/statefulset.go
+++ b/client/injection/kube/informers/apps/v1beta2/statefulset/statefulset.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta2.StatefulSetInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() appsv1beta2.StatefulSetLister {
 }
 
 func (w *wrapper) StatefulSets(namespace string) appsv1beta2.StatefulSetNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1beta2.StatefulSet, err error) {
 	lo, err := w.client.AppsV1beta2().StatefulSets(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiappsv1beta2.Stateful
 
 func (w *wrapper) Get(name string) (*apiappsv1beta2.StatefulSet, error) {
 	return w.client.AppsV1beta2().StatefulSets(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/autoscaling/v1/horizontalpodautoscaler/horizontalpodautoscaler.go
+++ b/client/injection/kube/informers/autoscaling/v1/horizontalpodautoscaler/horizontalpodautoscaler.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.HorizontalPodAutoscalerInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() autoscalingv1.HorizontalPodAutoscalerLister {
 }
 
 func (w *wrapper) HorizontalPodAutoscalers(namespace string) autoscalingv1.HorizontalPodAutoscalerNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiautoscalingv1.HorizontalPodAutoscaler, err error) {
 	lo, err := w.client.AutoscalingV1().HorizontalPodAutoscalers(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiautoscalingv1.Horizo
 
 func (w *wrapper) Get(name string) (*apiautoscalingv1.HorizontalPodAutoscaler, error) {
 	return w.client.AutoscalingV1().HorizontalPodAutoscalers(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/autoscaling/v2beta2/horizontalpodautoscaler/horizontalpodautoscaler.go
+++ b/client/injection/kube/informers/autoscaling/v2beta2/horizontalpodautoscaler/horizontalpodautoscaler.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v2beta2.HorizontalPodAutoscalerInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() autoscalingv2beta2.HorizontalPodAutoscalerLister {
 }
 
 func (w *wrapper) HorizontalPodAutoscalers(namespace string) autoscalingv2beta2.HorizontalPodAutoscalerNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiautoscalingv2beta2.HorizontalPodAutoscaler, err error) {
 	lo, err := w.client.AutoscalingV2beta2().HorizontalPodAutoscalers(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiautoscalingv2beta2.H
 
 func (w *wrapper) Get(name string) (*apiautoscalingv2beta2.HorizontalPodAutoscaler, error) {
 	return w.client.AutoscalingV2beta2().HorizontalPodAutoscalers(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/batch/v1/cronjob/cronjob.go
+++ b/client/injection/kube/informers/batch/v1/cronjob/cronjob.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.CronJobInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() batchv1.CronJobLister {
 }
 
 func (w *wrapper) CronJobs(namespace string) batchv1.CronJobNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apibatchv1.CronJob, err error) {
 	lo, err := w.client.BatchV1().CronJobs(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apibatchv1.CronJob, err
 
 func (w *wrapper) Get(name string) (*apibatchv1.CronJob, error) {
 	return w.client.BatchV1().CronJobs(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/batch/v1/job/job.go
+++ b/client/injection/kube/informers/batch/v1/job/job.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.JobInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() batchv1.JobLister {
 }
 
 func (w *wrapper) Jobs(namespace string) batchv1.JobNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apibatchv1.Job, err error) {
 	lo, err := w.client.BatchV1().Jobs(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apibatchv1.Job, err err
 
 func (w *wrapper) Get(name string) (*apibatchv1.Job, error) {
 	return w.client.BatchV1().Jobs(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/batch/v1beta1/cronjob/cronjob.go
+++ b/client/injection/kube/informers/batch/v1beta1/cronjob/cronjob.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.CronJobInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() batchv1beta1.CronJobLister {
 }
 
 func (w *wrapper) CronJobs(namespace string) batchv1beta1.CronJobNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apibatchv1beta1.CronJob, err error) {
 	lo, err := w.client.BatchV1beta1().CronJobs(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apibatchv1beta1.CronJob
 
 func (w *wrapper) Get(name string) (*apibatchv1beta1.CronJob, error) {
 	return w.client.BatchV1beta1().CronJobs(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/certificates/v1/certificatesigningrequest/certificatesigningrequest.go
+++ b/client/injection/kube/informers/certificates/v1/certificatesigningrequest/certificatesigningrequest.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1.CertificateSigningRequestInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1.CertificateSigningRequestInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() certificatesv1.CertificateSigningRequestLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apicertificatesv1.CertificateSigningRequest, err error) {
 	lo, err := w.client.CertificatesV1().CertificateSigningRequests().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicertificatesv1.Certi
 
 func (w *wrapper) Get(name string) (*apicertificatesv1.CertificateSigningRequest, error) {
 	return w.client.CertificatesV1().CertificateSigningRequests().Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/certificates/v1beta1/certificatesigningrequest/certificatesigningrequest.go
+++ b/client/injection/kube/informers/certificates/v1beta1/certificatesigningrequest/certificatesigningrequest.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.CertificateSigningRequestInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.CertificateSigningRequestInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() certificatesv1beta1.CertificateSigningRequestLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apicertificatesv1beta1.CertificateSigningRequest, err error) {
 	lo, err := w.client.CertificatesV1beta1().CertificateSigningRequests().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicertificatesv1beta1.
 
 func (w *wrapper) Get(name string) (*apicertificatesv1beta1.CertificateSigningRequest, error) {
 	return w.client.CertificatesV1beta1().CertificateSigningRequests().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/coordination/v1/lease/lease.go
+++ b/client/injection/kube/informers/coordination/v1/lease/lease.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.LeaseInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() coordinationv1.LeaseLister {
 }
 
 func (w *wrapper) Leases(namespace string) coordinationv1.LeaseNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apicoordinationv1.Lease, err error) {
 	lo, err := w.client.CoordinationV1().Leases(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicoordinationv1.Lease
 
 func (w *wrapper) Get(name string) (*apicoordinationv1.Lease, error) {
 	return w.client.CoordinationV1().Leases(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/coordination/v1beta1/lease/lease.go
+++ b/client/injection/kube/informers/coordination/v1beta1/lease/lease.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.LeaseInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() coordinationv1beta1.LeaseLister {
 }
 
 func (w *wrapper) Leases(namespace string) coordinationv1beta1.LeaseNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apicoordinationv1beta1.Lease, err error) {
 	lo, err := w.client.CoordinationV1beta1().Leases(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicoordinationv1beta1.
 
 func (w *wrapper) Get(name string) (*apicoordinationv1beta1.Lease, error) {
 	return w.client.CoordinationV1beta1().Leases(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/core/v1/componentstatus/componentstatus.go
+++ b/client/injection/kube/informers/core/v1/componentstatus/componentstatus.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1.ComponentStatusInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1.ComponentStatusInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() corev1.ComponentStatusLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.ComponentStatus, err error) {
 	lo, err := w.client.CoreV1().ComponentStatuses().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.ComponentStat
 
 func (w *wrapper) Get(name string) (*apicorev1.ComponentStatus, error) {
 	return w.client.CoreV1().ComponentStatuses().Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/core/v1/configmap/configmap.go
+++ b/client/injection/kube/informers/core/v1/configmap/configmap.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.ConfigMapInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() corev1.ConfigMapLister {
 }
 
 func (w *wrapper) ConfigMaps(namespace string) corev1.ConfigMapNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.ConfigMap, err error) {
 	lo, err := w.client.CoreV1().ConfigMaps(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.ConfigMap, er
 
 func (w *wrapper) Get(name string) (*apicorev1.ConfigMap, error) {
 	return w.client.CoreV1().ConfigMaps(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/core/v1/endpoints/endpoints.go
+++ b/client/injection/kube/informers/core/v1/endpoints/endpoints.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.EndpointsInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() corev1.EndpointsLister {
 }
 
 func (w *wrapper) Endpoints(namespace string) corev1.EndpointsNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.Endpoints, err error) {
 	lo, err := w.client.CoreV1().Endpoints(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.Endpoints, er
 
 func (w *wrapper) Get(name string) (*apicorev1.Endpoints, error) {
 	return w.client.CoreV1().Endpoints(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/core/v1/event/event.go
+++ b/client/injection/kube/informers/core/v1/event/event.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.EventInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() corev1.EventLister {
 }
 
 func (w *wrapper) Events(namespace string) corev1.EventNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.Event, err error) {
 	lo, err := w.client.CoreV1().Events(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.Event, err er
 
 func (w *wrapper) Get(name string) (*apicorev1.Event, error) {
 	return w.client.CoreV1().Events(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/core/v1/limitrange/limitrange.go
+++ b/client/injection/kube/informers/core/v1/limitrange/limitrange.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.LimitRangeInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() corev1.LimitRangeLister {
 }
 
 func (w *wrapper) LimitRanges(namespace string) corev1.LimitRangeNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.LimitRange, err error) {
 	lo, err := w.client.CoreV1().LimitRanges(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.LimitRange, e
 
 func (w *wrapper) Get(name string) (*apicorev1.LimitRange, error) {
 	return w.client.CoreV1().LimitRanges(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/core/v1/namespace/namespace.go
+++ b/client/injection/kube/informers/core/v1/namespace/namespace.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1.NamespaceInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1.NamespaceInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() corev1.NamespaceLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.Namespace, err error) {
 	lo, err := w.client.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.Namespace, er
 
 func (w *wrapper) Get(name string) (*apicorev1.Namespace, error) {
 	return w.client.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/core/v1/node/node.go
+++ b/client/injection/kube/informers/core/v1/node/node.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1.NodeInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1.NodeInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() corev1.NodeLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.Node, err error) {
 	lo, err := w.client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.Node, err err
 
 func (w *wrapper) Get(name string) (*apicorev1.Node, error) {
 	return w.client.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/core/v1/persistentvolume/persistentvolume.go
+++ b/client/injection/kube/informers/core/v1/persistentvolume/persistentvolume.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1.PersistentVolumeInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1.PersistentVolumeInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() corev1.PersistentVolumeLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.PersistentVolume, err error) {
 	lo, err := w.client.CoreV1().PersistentVolumes().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.PersistentVol
 
 func (w *wrapper) Get(name string) (*apicorev1.PersistentVolume, error) {
 	return w.client.CoreV1().PersistentVolumes().Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/core/v1/persistentvolumeclaim/persistentvolumeclaim.go
+++ b/client/injection/kube/informers/core/v1/persistentvolumeclaim/persistentvolumeclaim.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.PersistentVolumeClaimInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() corev1.PersistentVolumeClaimLister {
 }
 
 func (w *wrapper) PersistentVolumeClaims(namespace string) corev1.PersistentVolumeClaimNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.PersistentVolumeClaim, err error) {
 	lo, err := w.client.CoreV1().PersistentVolumeClaims(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.PersistentVol
 
 func (w *wrapper) Get(name string) (*apicorev1.PersistentVolumeClaim, error) {
 	return w.client.CoreV1().PersistentVolumeClaims(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/core/v1/pod/pod.go
+++ b/client/injection/kube/informers/core/v1/pod/pod.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.PodInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() corev1.PodLister {
 }
 
 func (w *wrapper) Pods(namespace string) corev1.PodNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.Pod, err error) {
 	lo, err := w.client.CoreV1().Pods(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.Pod, err erro
 
 func (w *wrapper) Get(name string) (*apicorev1.Pod, error) {
 	return w.client.CoreV1().Pods(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/core/v1/podtemplate/podtemplate.go
+++ b/client/injection/kube/informers/core/v1/podtemplate/podtemplate.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.PodTemplateInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() corev1.PodTemplateLister {
 }
 
 func (w *wrapper) PodTemplates(namespace string) corev1.PodTemplateNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.PodTemplate, err error) {
 	lo, err := w.client.CoreV1().PodTemplates(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.PodTemplate, 
 
 func (w *wrapper) Get(name string) (*apicorev1.PodTemplate, error) {
 	return w.client.CoreV1().PodTemplates(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/core/v1/replicationcontroller/replicationcontroller.go
+++ b/client/injection/kube/informers/core/v1/replicationcontroller/replicationcontroller.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.ReplicationControllerInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() corev1.ReplicationControllerLister {
 }
 
 func (w *wrapper) ReplicationControllers(namespace string) corev1.ReplicationControllerNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.ReplicationController, err error) {
 	lo, err := w.client.CoreV1().ReplicationControllers(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.ReplicationCo
 
 func (w *wrapper) Get(name string) (*apicorev1.ReplicationController, error) {
 	return w.client.CoreV1().ReplicationControllers(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/core/v1/resourcequota/resourcequota.go
+++ b/client/injection/kube/informers/core/v1/resourcequota/resourcequota.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.ResourceQuotaInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() corev1.ResourceQuotaLister {
 }
 
 func (w *wrapper) ResourceQuotas(namespace string) corev1.ResourceQuotaNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.ResourceQuota, err error) {
 	lo, err := w.client.CoreV1().ResourceQuotas(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.ResourceQuota
 
 func (w *wrapper) Get(name string) (*apicorev1.ResourceQuota, error) {
 	return w.client.CoreV1().ResourceQuotas(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/core/v1/secret/secret.go
+++ b/client/injection/kube/informers/core/v1/secret/secret.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.SecretInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() corev1.SecretLister {
 }
 
 func (w *wrapper) Secrets(namespace string) corev1.SecretNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.Secret, err error) {
 	lo, err := w.client.CoreV1().Secrets(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.Secret, err e
 
 func (w *wrapper) Get(name string) (*apicorev1.Secret, error) {
 	return w.client.CoreV1().Secrets(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/core/v1/service/service.go
+++ b/client/injection/kube/informers/core/v1/service/service.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.ServiceInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() corev1.ServiceLister {
 }
 
 func (w *wrapper) Services(namespace string) corev1.ServiceNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.Service, err error) {
 	lo, err := w.client.CoreV1().Services(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.Service, err 
 
 func (w *wrapper) Get(name string) (*apicorev1.Service, error) {
 	return w.client.CoreV1().Services(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/core/v1/serviceaccount/serviceaccount.go
+++ b/client/injection/kube/informers/core/v1/serviceaccount/serviceaccount.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.ServiceAccountInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() corev1.ServiceAccountLister {
 }
 
 func (w *wrapper) ServiceAccounts(namespace string) corev1.ServiceAccountNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.ServiceAccount, err error) {
 	lo, err := w.client.CoreV1().ServiceAccounts(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apicorev1.ServiceAccoun
 
 func (w *wrapper) Get(name string) (*apicorev1.ServiceAccount, error) {
 	return w.client.CoreV1().ServiceAccounts(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/discovery/v1/endpointslice/endpointslice.go
+++ b/client/injection/kube/informers/discovery/v1/endpointslice/endpointslice.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.EndpointSliceInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() discoveryv1.EndpointSliceLister {
 }
 
 func (w *wrapper) EndpointSlices(namespace string) discoveryv1.EndpointSliceNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apidiscoveryv1.EndpointSlice, err error) {
 	lo, err := w.client.DiscoveryV1().EndpointSlices(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apidiscoveryv1.Endpoint
 
 func (w *wrapper) Get(name string) (*apidiscoveryv1.EndpointSlice, error) {
 	return w.client.DiscoveryV1().EndpointSlices(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/discovery/v1beta1/endpointslice/endpointslice.go
+++ b/client/injection/kube/informers/discovery/v1beta1/endpointslice/endpointslice.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.EndpointSliceInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() discoveryv1beta1.EndpointSliceLister {
 }
 
 func (w *wrapper) EndpointSlices(namespace string) discoveryv1beta1.EndpointSliceNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apidiscoveryv1beta1.EndpointSlice, err error) {
 	lo, err := w.client.DiscoveryV1beta1().EndpointSlices(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apidiscoveryv1beta1.End
 
 func (w *wrapper) Get(name string) (*apidiscoveryv1beta1.EndpointSlice, error) {
 	return w.client.DiscoveryV1beta1().EndpointSlices(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/events/v1/event/event.go
+++ b/client/injection/kube/informers/events/v1/event/event.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.EventInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() eventsv1.EventLister {
 }
 
 func (w *wrapper) Events(namespace string) eventsv1.EventNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apieventsv1.Event, err error) {
 	lo, err := w.client.EventsV1().Events(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apieventsv1.Event, err 
 
 func (w *wrapper) Get(name string) (*apieventsv1.Event, error) {
 	return w.client.EventsV1().Events(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/events/v1beta1/event/event.go
+++ b/client/injection/kube/informers/events/v1beta1/event/event.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.EventInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() eventsv1beta1.EventLister {
 }
 
 func (w *wrapper) Events(namespace string) eventsv1beta1.EventNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apieventsv1beta1.Event, err error) {
 	lo, err := w.client.EventsV1beta1().Events(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apieventsv1beta1.Event,
 
 func (w *wrapper) Get(name string) (*apieventsv1beta1.Event, error) {
 	return w.client.EventsV1beta1().Events(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/extensions/v1beta1/daemonset/daemonset.go
+++ b/client/injection/kube/informers/extensions/v1beta1/daemonset/daemonset.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.DaemonSetInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() extensionsv1beta1.DaemonSetLister {
 }
 
 func (w *wrapper) DaemonSets(namespace string) extensionsv1beta1.DaemonSetNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiextensionsv1beta1.DaemonSet, err error) {
 	lo, err := w.client.ExtensionsV1beta1().DaemonSets(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiextensionsv1beta1.Da
 
 func (w *wrapper) Get(name string) (*apiextensionsv1beta1.DaemonSet, error) {
 	return w.client.ExtensionsV1beta1().DaemonSets(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/extensions/v1beta1/deployment/deployment.go
+++ b/client/injection/kube/informers/extensions/v1beta1/deployment/deployment.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.DeploymentInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() extensionsv1beta1.DeploymentLister {
 }
 
 func (w *wrapper) Deployments(namespace string) extensionsv1beta1.DeploymentNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiextensionsv1beta1.Deployment, err error) {
 	lo, err := w.client.ExtensionsV1beta1().Deployments(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiextensionsv1beta1.De
 
 func (w *wrapper) Get(name string) (*apiextensionsv1beta1.Deployment, error) {
 	return w.client.ExtensionsV1beta1().Deployments(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/extensions/v1beta1/ingress/ingress.go
+++ b/client/injection/kube/informers/extensions/v1beta1/ingress/ingress.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.IngressInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() extensionsv1beta1.IngressLister {
 }
 
 func (w *wrapper) Ingresses(namespace string) extensionsv1beta1.IngressNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiextensionsv1beta1.Ingress, err error) {
 	lo, err := w.client.ExtensionsV1beta1().Ingresses(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiextensionsv1beta1.In
 
 func (w *wrapper) Get(name string) (*apiextensionsv1beta1.Ingress, error) {
 	return w.client.ExtensionsV1beta1().Ingresses(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/extensions/v1beta1/networkpolicy/networkpolicy.go
+++ b/client/injection/kube/informers/extensions/v1beta1/networkpolicy/networkpolicy.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.NetworkPolicyInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() extensionsv1beta1.NetworkPolicyLister {
 }
 
 func (w *wrapper) NetworkPolicies(namespace string) extensionsv1beta1.NetworkPolicyNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiextensionsv1beta1.NetworkPolicy, err error) {
 	lo, err := w.client.ExtensionsV1beta1().NetworkPolicies(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiextensionsv1beta1.Ne
 
 func (w *wrapper) Get(name string) (*apiextensionsv1beta1.NetworkPolicy, error) {
 	return w.client.ExtensionsV1beta1().NetworkPolicies(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/extensions/v1beta1/podsecuritypolicy/podsecuritypolicy.go
+++ b/client/injection/kube/informers/extensions/v1beta1/podsecuritypolicy/podsecuritypolicy.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.PodSecurityPolicyInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.PodSecurityPolicyInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() extensionsv1beta1.PodSecurityPolicyLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apiextensionsv1beta1.PodSecurityPolicy, err error) {
 	lo, err := w.client.ExtensionsV1beta1().PodSecurityPolicies().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiextensionsv1beta1.Po
 
 func (w *wrapper) Get(name string) (*apiextensionsv1beta1.PodSecurityPolicy, error) {
 	return w.client.ExtensionsV1beta1().PodSecurityPolicies().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/extensions/v1beta1/replicaset/replicaset.go
+++ b/client/injection/kube/informers/extensions/v1beta1/replicaset/replicaset.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.ReplicaSetInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() extensionsv1beta1.ReplicaSetLister {
 }
 
 func (w *wrapper) ReplicaSets(namespace string) extensionsv1beta1.ReplicaSetNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apiextensionsv1beta1.ReplicaSet, err error) {
 	lo, err := w.client.ExtensionsV1beta1().ReplicaSets(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiextensionsv1beta1.Re
 
 func (w *wrapper) Get(name string) (*apiextensionsv1beta1.ReplicaSet, error) {
 	return w.client.ExtensionsV1beta1().ReplicaSets(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/flowcontrol/v1alpha1/flowschema/flowschema.go
+++ b/client/injection/kube/informers/flowcontrol/v1alpha1/flowschema/flowschema.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1alpha1.FlowSchemaInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1alpha1.FlowSchemaInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() flowcontrolv1alpha1.FlowSchemaLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apiflowcontrolv1alpha1.FlowSchema, err error) {
 	lo, err := w.client.FlowcontrolV1alpha1().FlowSchemas().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiflowcontrolv1alpha1.
 
 func (w *wrapper) Get(name string) (*apiflowcontrolv1alpha1.FlowSchema, error) {
 	return w.client.FlowcontrolV1alpha1().FlowSchemas().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/flowcontrol/v1alpha1/prioritylevelconfiguration/prioritylevelconfiguration.go
+++ b/client/injection/kube/informers/flowcontrol/v1alpha1/prioritylevelconfiguration/prioritylevelconfiguration.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1alpha1.PriorityLevelConfigurationInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1alpha1.PriorityLevelConfigurationInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() flowcontrolv1alpha1.PriorityLevelConfigurationLister 
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apiflowcontrolv1alpha1.PriorityLevelConfiguration, err error) {
 	lo, err := w.client.FlowcontrolV1alpha1().PriorityLevelConfigurations().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiflowcontrolv1alpha1.
 
 func (w *wrapper) Get(name string) (*apiflowcontrolv1alpha1.PriorityLevelConfiguration, error) {
 	return w.client.FlowcontrolV1alpha1().PriorityLevelConfigurations().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/flowcontrol/v1beta1/flowschema/flowschema.go
+++ b/client/injection/kube/informers/flowcontrol/v1beta1/flowschema/flowschema.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.FlowSchemaInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.FlowSchemaInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() flowcontrolv1beta1.FlowSchemaLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apiflowcontrolv1beta1.FlowSchema, err error) {
 	lo, err := w.client.FlowcontrolV1beta1().FlowSchemas().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiflowcontrolv1beta1.F
 
 func (w *wrapper) Get(name string) (*apiflowcontrolv1beta1.FlowSchema, error) {
 	return w.client.FlowcontrolV1beta1().FlowSchemas().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/flowcontrol/v1beta1/prioritylevelconfiguration/prioritylevelconfiguration.go
+++ b/client/injection/kube/informers/flowcontrol/v1beta1/prioritylevelconfiguration/prioritylevelconfiguration.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.PriorityLevelConfigurationInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.PriorityLevelConfigurationInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() flowcontrolv1beta1.PriorityLevelConfigurationLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apiflowcontrolv1beta1.PriorityLevelConfiguration, err error) {
 	lo, err := w.client.FlowcontrolV1beta1().PriorityLevelConfigurations().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiflowcontrolv1beta1.P
 
 func (w *wrapper) Get(name string) (*apiflowcontrolv1beta1.PriorityLevelConfiguration, error) {
 	return w.client.FlowcontrolV1beta1().PriorityLevelConfigurations().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/networking/v1/ingress/ingress.go
+++ b/client/injection/kube/informers/networking/v1/ingress/ingress.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.IngressInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() networkingv1.IngressLister {
 }
 
 func (w *wrapper) Ingresses(namespace string) networkingv1.IngressNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apinetworkingv1.Ingress, err error) {
 	lo, err := w.client.NetworkingV1().Ingresses(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apinetworkingv1.Ingress
 
 func (w *wrapper) Get(name string) (*apinetworkingv1.Ingress, error) {
 	return w.client.NetworkingV1().Ingresses(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/networking/v1/ingressclass/ingressclass.go
+++ b/client/injection/kube/informers/networking/v1/ingressclass/ingressclass.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1.IngressClassInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1.IngressClassInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() networkingv1.IngressClassLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apinetworkingv1.IngressClass, err error) {
 	lo, err := w.client.NetworkingV1().IngressClasses().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apinetworkingv1.Ingress
 
 func (w *wrapper) Get(name string) (*apinetworkingv1.IngressClass, error) {
 	return w.client.NetworkingV1().IngressClasses().Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/networking/v1/networkpolicy/networkpolicy.go
+++ b/client/injection/kube/informers/networking/v1/networkpolicy/networkpolicy.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.NetworkPolicyInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() networkingv1.NetworkPolicyLister {
 }
 
 func (w *wrapper) NetworkPolicies(namespace string) networkingv1.NetworkPolicyNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apinetworkingv1.NetworkPolicy, err error) {
 	lo, err := w.client.NetworkingV1().NetworkPolicies(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apinetworkingv1.Network
 
 func (w *wrapper) Get(name string) (*apinetworkingv1.NetworkPolicy, error) {
 	return w.client.NetworkingV1().NetworkPolicies(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/networking/v1beta1/ingress/ingress.go
+++ b/client/injection/kube/informers/networking/v1beta1/ingress/ingress.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.IngressInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() networkingv1beta1.IngressLister {
 }
 
 func (w *wrapper) Ingresses(namespace string) networkingv1beta1.IngressNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apinetworkingv1beta1.Ingress, err error) {
 	lo, err := w.client.NetworkingV1beta1().Ingresses(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apinetworkingv1beta1.In
 
 func (w *wrapper) Get(name string) (*apinetworkingv1beta1.Ingress, error) {
 	return w.client.NetworkingV1beta1().Ingresses(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/networking/v1beta1/ingressclass/ingressclass.go
+++ b/client/injection/kube/informers/networking/v1beta1/ingressclass/ingressclass.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.IngressClassInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.IngressClassInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() networkingv1beta1.IngressClassLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apinetworkingv1beta1.IngressClass, err error) {
 	lo, err := w.client.NetworkingV1beta1().IngressClasses().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apinetworkingv1beta1.In
 
 func (w *wrapper) Get(name string) (*apinetworkingv1beta1.IngressClass, error) {
 	return w.client.NetworkingV1beta1().IngressClasses().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/node/v1/runtimeclass/runtimeclass.go
+++ b/client/injection/kube/informers/node/v1/runtimeclass/runtimeclass.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1.RuntimeClassInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1.RuntimeClassInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() nodev1.RuntimeClassLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apinodev1.RuntimeClass, err error) {
 	lo, err := w.client.NodeV1().RuntimeClasses().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apinodev1.RuntimeClass,
 
 func (w *wrapper) Get(name string) (*apinodev1.RuntimeClass, error) {
 	return w.client.NodeV1().RuntimeClasses().Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/node/v1alpha1/runtimeclass/runtimeclass.go
+++ b/client/injection/kube/informers/node/v1alpha1/runtimeclass/runtimeclass.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1alpha1.RuntimeClassInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1alpha1.RuntimeClassInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() nodev1alpha1.RuntimeClassLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apinodev1alpha1.RuntimeClass, err error) {
 	lo, err := w.client.NodeV1alpha1().RuntimeClasses().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apinodev1alpha1.Runtime
 
 func (w *wrapper) Get(name string) (*apinodev1alpha1.RuntimeClass, error) {
 	return w.client.NodeV1alpha1().RuntimeClasses().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/node/v1beta1/runtimeclass/runtimeclass.go
+++ b/client/injection/kube/informers/node/v1beta1/runtimeclass/runtimeclass.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.RuntimeClassInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.RuntimeClassInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() nodev1beta1.RuntimeClassLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apinodev1beta1.RuntimeClass, err error) {
 	lo, err := w.client.NodeV1beta1().RuntimeClasses().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apinodev1beta1.RuntimeC
 
 func (w *wrapper) Get(name string) (*apinodev1beta1.RuntimeClass, error) {
 	return w.client.NodeV1beta1().RuntimeClasses().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/policy/v1/poddisruptionbudget/poddisruptionbudget.go
+++ b/client/injection/kube/informers/policy/v1/poddisruptionbudget/poddisruptionbudget.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.PodDisruptionBudgetInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() policyv1.PodDisruptionBudgetLister {
 }
 
 func (w *wrapper) PodDisruptionBudgets(namespace string) policyv1.PodDisruptionBudgetNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apipolicyv1.PodDisruptionBudget, err error) {
 	lo, err := w.client.PolicyV1().PodDisruptionBudgets(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apipolicyv1.PodDisrupti
 
 func (w *wrapper) Get(name string) (*apipolicyv1.PodDisruptionBudget, error) {
 	return w.client.PolicyV1().PodDisruptionBudgets(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/policy/v1beta1/poddisruptionbudget/poddisruptionbudget.go
+++ b/client/injection/kube/informers/policy/v1beta1/poddisruptionbudget/poddisruptionbudget.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.PodDisruptionBudgetInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() policyv1beta1.PodDisruptionBudgetLister {
 }
 
 func (w *wrapper) PodDisruptionBudgets(namespace string) policyv1beta1.PodDisruptionBudgetNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apipolicyv1beta1.PodDisruptionBudget, err error) {
 	lo, err := w.client.PolicyV1beta1().PodDisruptionBudgets(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apipolicyv1beta1.PodDis
 
 func (w *wrapper) Get(name string) (*apipolicyv1beta1.PodDisruptionBudget, error) {
 	return w.client.PolicyV1beta1().PodDisruptionBudgets(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/policy/v1beta1/podsecuritypolicy/podsecuritypolicy.go
+++ b/client/injection/kube/informers/policy/v1beta1/podsecuritypolicy/podsecuritypolicy.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.PodSecurityPolicyInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.PodSecurityPolicyInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() policyv1beta1.PodSecurityPolicyLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apipolicyv1beta1.PodSecurityPolicy, err error) {
 	lo, err := w.client.PolicyV1beta1().PodSecurityPolicies().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apipolicyv1beta1.PodSec
 
 func (w *wrapper) Get(name string) (*apipolicyv1beta1.PodSecurityPolicy, error) {
 	return w.client.PolicyV1beta1().PodSecurityPolicies().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/rbac/v1/clusterrole/clusterrole.go
+++ b/client/injection/kube/informers/rbac/v1/clusterrole/clusterrole.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1.ClusterRoleInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1.ClusterRoleInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() rbacv1.ClusterRoleLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1.ClusterRole, err error) {
 	lo, err := w.client.RbacV1().ClusterRoles().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1.ClusterRole, 
 
 func (w *wrapper) Get(name string) (*apirbacv1.ClusterRole, error) {
 	return w.client.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/rbac/v1/clusterrolebinding/clusterrolebinding.go
+++ b/client/injection/kube/informers/rbac/v1/clusterrolebinding/clusterrolebinding.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1.ClusterRoleBindingInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1.ClusterRoleBindingInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() rbacv1.ClusterRoleBindingLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1.ClusterRoleBinding, err error) {
 	lo, err := w.client.RbacV1().ClusterRoleBindings().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1.ClusterRoleBi
 
 func (w *wrapper) Get(name string) (*apirbacv1.ClusterRoleBinding, error) {
 	return w.client.RbacV1().ClusterRoleBindings().Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/rbac/v1/role/role.go
+++ b/client/injection/kube/informers/rbac/v1/role/role.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.RoleInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() rbacv1.RoleLister {
 }
 
 func (w *wrapper) Roles(namespace string) rbacv1.RoleNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1.Role, err error) {
 	lo, err := w.client.RbacV1().Roles(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1.Role, err err
 
 func (w *wrapper) Get(name string) (*apirbacv1.Role, error) {
 	return w.client.RbacV1().Roles(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/rbac/v1/rolebinding/rolebinding.go
+++ b/client/injection/kube/informers/rbac/v1/rolebinding/rolebinding.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1.RoleBindingInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() rbacv1.RoleBindingLister {
 }
 
 func (w *wrapper) RoleBindings(namespace string) rbacv1.RoleBindingNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1.RoleBinding, err error) {
 	lo, err := w.client.RbacV1().RoleBindings(w.namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1.RoleBinding, 
 
 func (w *wrapper) Get(name string) (*apirbacv1.RoleBinding, error) {
 	return w.client.RbacV1().RoleBindings(w.namespace).Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/rbac/v1alpha1/clusterrole/clusterrole.go
+++ b/client/injection/kube/informers/rbac/v1alpha1/clusterrole/clusterrole.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1alpha1.ClusterRoleInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1alpha1.ClusterRoleInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() rbacv1alpha1.ClusterRoleLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1alpha1.ClusterRole, err error) {
 	lo, err := w.client.RbacV1alpha1().ClusterRoles().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1alpha1.Cluster
 
 func (w *wrapper) Get(name string) (*apirbacv1alpha1.ClusterRole, error) {
 	return w.client.RbacV1alpha1().ClusterRoles().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/rbac/v1alpha1/clusterrolebinding/clusterrolebinding.go
+++ b/client/injection/kube/informers/rbac/v1alpha1/clusterrolebinding/clusterrolebinding.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1alpha1.ClusterRoleBindingInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1alpha1.ClusterRoleBindingInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() rbacv1alpha1.ClusterRoleBindingLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1alpha1.ClusterRoleBinding, err error) {
 	lo, err := w.client.RbacV1alpha1().ClusterRoleBindings().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1alpha1.Cluster
 
 func (w *wrapper) Get(name string) (*apirbacv1alpha1.ClusterRoleBinding, error) {
 	return w.client.RbacV1alpha1().ClusterRoleBindings().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/rbac/v1alpha1/role/role.go
+++ b/client/injection/kube/informers/rbac/v1alpha1/role/role.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1alpha1.RoleInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() rbacv1alpha1.RoleLister {
 }
 
 func (w *wrapper) Roles(namespace string) rbacv1alpha1.RoleNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1alpha1.Role, err error) {
 	lo, err := w.client.RbacV1alpha1().Roles(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1alpha1.Role, e
 
 func (w *wrapper) Get(name string) (*apirbacv1alpha1.Role, error) {
 	return w.client.RbacV1alpha1().Roles(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/rbac/v1alpha1/rolebinding/rolebinding.go
+++ b/client/injection/kube/informers/rbac/v1alpha1/rolebinding/rolebinding.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1alpha1.RoleBindingInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() rbacv1alpha1.RoleBindingLister {
 }
 
 func (w *wrapper) RoleBindings(namespace string) rbacv1alpha1.RoleBindingNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1alpha1.RoleBinding, err error) {
 	lo, err := w.client.RbacV1alpha1().RoleBindings(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1alpha1.RoleBin
 
 func (w *wrapper) Get(name string) (*apirbacv1alpha1.RoleBinding, error) {
 	return w.client.RbacV1alpha1().RoleBindings(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/rbac/v1beta1/clusterrole/clusterrole.go
+++ b/client/injection/kube/informers/rbac/v1beta1/clusterrole/clusterrole.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.ClusterRoleInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.ClusterRoleInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() rbacv1beta1.ClusterRoleLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1beta1.ClusterRole, err error) {
 	lo, err := w.client.RbacV1beta1().ClusterRoles().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1beta1.ClusterR
 
 func (w *wrapper) Get(name string) (*apirbacv1beta1.ClusterRole, error) {
 	return w.client.RbacV1beta1().ClusterRoles().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/rbac/v1beta1/clusterrolebinding/clusterrolebinding.go
+++ b/client/injection/kube/informers/rbac/v1beta1/clusterrolebinding/clusterrolebinding.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.ClusterRoleBindingInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.ClusterRoleBindingInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() rbacv1beta1.ClusterRoleBindingLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1beta1.ClusterRoleBinding, err error) {
 	lo, err := w.client.RbacV1beta1().ClusterRoleBindings().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1beta1.ClusterR
 
 func (w *wrapper) Get(name string) (*apirbacv1beta1.ClusterRoleBinding, error) {
 	return w.client.RbacV1beta1().ClusterRoleBindings().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/rbac/v1beta1/role/role.go
+++ b/client/injection/kube/informers/rbac/v1beta1/role/role.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.RoleInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() rbacv1beta1.RoleLister {
 }
 
 func (w *wrapper) Roles(namespace string) rbacv1beta1.RoleNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1beta1.Role, err error) {
 	lo, err := w.client.RbacV1beta1().Roles(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1beta1.Role, er
 
 func (w *wrapper) Get(name string) (*apirbacv1beta1.Role, error) {
 	return w.client.RbacV1beta1().Roles(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/rbac/v1beta1/rolebinding/rolebinding.go
+++ b/client/injection/kube/informers/rbac/v1beta1/rolebinding/rolebinding.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.RoleBindingInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() rbacv1beta1.RoleBindingLister {
 }
 
 func (w *wrapper) RoleBindings(namespace string) rbacv1beta1.RoleBindingNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1beta1.RoleBinding, err error) {
 	lo, err := w.client.RbacV1beta1().RoleBindings(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apirbacv1beta1.RoleBind
 
 func (w *wrapper) Get(name string) (*apirbacv1beta1.RoleBinding, error) {
 	return w.client.RbacV1beta1().RoleBindings(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/scheduling/v1/priorityclass/priorityclass.go
+++ b/client/injection/kube/informers/scheduling/v1/priorityclass/priorityclass.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1.PriorityClassInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1.PriorityClassInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() schedulingv1.PriorityClassLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apischedulingv1.PriorityClass, err error) {
 	lo, err := w.client.SchedulingV1().PriorityClasses().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apischedulingv1.Priorit
 
 func (w *wrapper) Get(name string) (*apischedulingv1.PriorityClass, error) {
 	return w.client.SchedulingV1().PriorityClasses().Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/scheduling/v1alpha1/priorityclass/priorityclass.go
+++ b/client/injection/kube/informers/scheduling/v1alpha1/priorityclass/priorityclass.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1alpha1.PriorityClassInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1alpha1.PriorityClassInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() schedulingv1alpha1.PriorityClassLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apischedulingv1alpha1.PriorityClass, err error) {
 	lo, err := w.client.SchedulingV1alpha1().PriorityClasses().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apischedulingv1alpha1.P
 
 func (w *wrapper) Get(name string) (*apischedulingv1alpha1.PriorityClass, error) {
 	return w.client.SchedulingV1alpha1().PriorityClasses().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/scheduling/v1beta1/priorityclass/priorityclass.go
+++ b/client/injection/kube/informers/scheduling/v1beta1/priorityclass/priorityclass.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.PriorityClassInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.PriorityClassInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() schedulingv1beta1.PriorityClassLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apischedulingv1beta1.PriorityClass, err error) {
 	lo, err := w.client.SchedulingV1beta1().PriorityClasses().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apischedulingv1beta1.Pr
 
 func (w *wrapper) Get(name string) (*apischedulingv1beta1.PriorityClass, error) {
 	return w.client.SchedulingV1beta1().PriorityClasses().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/storage/v1/csidriver/csidriver.go
+++ b/client/injection/kube/informers/storage/v1/csidriver/csidriver.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1.CSIDriverInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1.CSIDriverInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() storagev1.CSIDriverLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1.CSIDriver, err error) {
 	lo, err := w.client.StorageV1().CSIDrivers().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1.CSIDriver,
 
 func (w *wrapper) Get(name string) (*apistoragev1.CSIDriver, error) {
 	return w.client.StorageV1().CSIDrivers().Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/storage/v1/csinode/csinode.go
+++ b/client/injection/kube/informers/storage/v1/csinode/csinode.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1.CSINodeInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1.CSINodeInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() storagev1.CSINodeLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1.CSINode, err error) {
 	lo, err := w.client.StorageV1().CSINodes().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1.CSINode, e
 
 func (w *wrapper) Get(name string) (*apistoragev1.CSINode, error) {
 	return w.client.StorageV1().CSINodes().Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/storage/v1/storageclass/storageclass.go
+++ b/client/injection/kube/informers/storage/v1/storageclass/storageclass.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1.StorageClassInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1.StorageClassInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() storagev1.StorageClassLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1.StorageClass, err error) {
 	lo, err := w.client.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1.StorageCla
 
 func (w *wrapper) Get(name string) (*apistoragev1.StorageClass, error) {
 	return w.client.StorageV1().StorageClasses().Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/storage/v1/volumeattachment/volumeattachment.go
+++ b/client/injection/kube/informers/storage/v1/volumeattachment/volumeattachment.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1.VolumeAttachmentInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1.VolumeAttachmentInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() storagev1.VolumeAttachmentLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1.VolumeAttachment, err error) {
 	lo, err := w.client.StorageV1().VolumeAttachments().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1.VolumeAtta
 
 func (w *wrapper) Get(name string) (*apistoragev1.VolumeAttachment, error) {
 	return w.client.StorageV1().VolumeAttachments().Get(context.TODO(), name, metav1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/storage/v1alpha1/csistoragecapacity/csistoragecapacity.go
+++ b/client/injection/kube/informers/storage/v1alpha1/csistoragecapacity/csistoragecapacity.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1alpha1.CSIStorageCapacityInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() storagev1alpha1.CSIStorageCapacityLister {
 }
 
 func (w *wrapper) CSIStorageCapacities(namespace string) storagev1alpha1.CSIStorageCapacityNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1alpha1.CSIStorageCapacity, err error) {
 	lo, err := w.client.StorageV1alpha1().CSIStorageCapacities(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1alpha1.CSIS
 
 func (w *wrapper) Get(name string) (*apistoragev1alpha1.CSIStorageCapacity, error) {
 	return w.client.StorageV1alpha1().CSIStorageCapacities(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/storage/v1alpha1/volumeattachment/volumeattachment.go
+++ b/client/injection/kube/informers/storage/v1alpha1/volumeattachment/volumeattachment.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1alpha1.VolumeAttachmentInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1alpha1.VolumeAttachmentInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() storagev1alpha1.VolumeAttachmentLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1alpha1.VolumeAttachment, err error) {
 	lo, err := w.client.StorageV1alpha1().VolumeAttachments().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1alpha1.Volu
 
 func (w *wrapper) Get(name string) (*apistoragev1alpha1.VolumeAttachment, error) {
 	return w.client.StorageV1alpha1().VolumeAttachments().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/storage/v1beta1/csidriver/csidriver.go
+++ b/client/injection/kube/informers/storage/v1beta1/csidriver/csidriver.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.CSIDriverInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.CSIDriverInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() storagev1beta1.CSIDriverLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1beta1.CSIDriver, err error) {
 	lo, err := w.client.StorageV1beta1().CSIDrivers().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1beta1.CSIDr
 
 func (w *wrapper) Get(name string) (*apistoragev1beta1.CSIDriver, error) {
 	return w.client.StorageV1beta1().CSIDrivers().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/storage/v1beta1/csinode/csinode.go
+++ b/client/injection/kube/informers/storage/v1beta1/csinode/csinode.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.CSINodeInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.CSINodeInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() storagev1beta1.CSINodeLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1beta1.CSINode, err error) {
 	lo, err := w.client.StorageV1beta1().CSINodes().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1beta1.CSINo
 
 func (w *wrapper) Get(name string) (*apistoragev1beta1.CSINode, error) {
 	return w.client.StorageV1beta1().CSINodes().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/storage/v1beta1/csistoragecapacity/csistoragecapacity.go
+++ b/client/injection/kube/informers/storage/v1beta1/csistoragecapacity/csistoragecapacity.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -68,6 +68,8 @@ type wrapper struct {
 	client kubernetes.Interface
 
 	namespace string
+
+	resourceVersion string
 }
 
 var _ v1beta1.CSIStorageCapacityInformer = (*wrapper)(nil)
@@ -82,13 +84,21 @@ func (w *wrapper) Lister() storagev1beta1.CSIStorageCapacityLister {
 }
 
 func (w *wrapper) CSIStorageCapacities(namespace string) storagev1beta1.CSIStorageCapacityNamespaceLister {
-	return &wrapper{client: w.client, namespace: namespace}
+	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
+}
+
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
 }
 
 func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1beta1.CSIStorageCapacity, err error) {
 	lo, err := w.client.StorageV1beta1().CSIStorageCapacities(w.namespace).List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +111,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1beta1.CSISt
 
 func (w *wrapper) Get(name string) (*apistoragev1beta1.CSIStorageCapacity, error) {
 	return w.client.StorageV1beta1().CSIStorageCapacities(w.namespace).Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/storage/v1beta1/storageclass/storageclass.go
+++ b/client/injection/kube/informers/storage/v1beta1/storageclass/storageclass.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.StorageClassInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.StorageClassInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() storagev1beta1.StorageClassLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1beta1.StorageClass, err error) {
 	lo, err := w.client.StorageV1beta1().StorageClasses().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1beta1.Stora
 
 func (w *wrapper) Get(name string) (*apistoragev1beta1.StorageClass, error) {
 	return w.client.StorageV1beta1().StorageClasses().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/client/injection/kube/informers/storage/v1beta1/volumeattachment/volumeattachment.go
+++ b/client/injection/kube/informers/storage/v1beta1/volumeattachment/volumeattachment.go
@@ -50,7 +50,7 @@ func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 }
 
 func withDynamicInformer(ctx context.Context) context.Context {
-	inf := &wrapper{client: client.Get(ctx)}
+	inf := &wrapper{client: client.Get(ctx), resourceVersion: injection.GetResourceVersion(ctx)}
 	return context.WithValue(ctx, Key{}, inf)
 }
 
@@ -66,6 +66,8 @@ func Get(ctx context.Context) v1beta1.VolumeAttachmentInformer {
 
 type wrapper struct {
 	client kubernetes.Interface
+
+	resourceVersion string
 }
 
 var _ v1beta1.VolumeAttachmentInformer = (*wrapper)(nil)
@@ -79,10 +81,18 @@ func (w *wrapper) Lister() storagev1beta1.VolumeAttachmentLister {
 	return w
 }
 
+// SetResourceVersion allows consumers to adjust the minimum resourceVersion
+// used by the underlying client.  It is not accessible via the standard
+// lister interface, but can be accessed through a user-defined interface and
+// an implementation check e.g. rvs, ok := foo.(ResourceVersionSetter)
+func (w *wrapper) SetResourceVersion(resourceVersion string) {
+	w.resourceVersion = resourceVersion
+}
+
 func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1beta1.VolumeAttachment, err error) {
 	lo, err := w.client.StorageV1beta1().VolumeAttachments().List(context.TODO(), v1.ListOptions{
-		LabelSelector: selector.String(),
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		LabelSelector:   selector.String(),
+		ResourceVersion: w.resourceVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -95,6 +105,6 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apistoragev1beta1.Volum
 
 func (w *wrapper) Get(name string) (*apistoragev1beta1.VolumeAttachment, error) {
 	return w.client.StorageV1beta1().VolumeAttachments().Get(context.TODO(), name, v1.GetOptions{
-		// TODO(mattmoor): Incorporate resourceVersion bounds based on staleness criteria.
+		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/injection/context.go
+++ b/injection/context.go
@@ -66,3 +66,20 @@ func GetConfig(ctx context.Context) *rest.Config {
 	}
 	return value.(*rest.Config)
 }
+
+// rvKey is the key that the resource version is associated with.
+type rvKey struct{}
+
+// WithResourceVersion associates a resource version with the context.
+func WithResourceVersion(ctx context.Context, resourceVersion string) context.Context {
+	return context.WithValue(ctx, rvKey{}, resourceVersion)
+}
+
+// GetResourceVersion gets the resource version associated with the context.
+func GetResourceVersion(ctx context.Context) string {
+	value := ctx.Value(rvKey{})
+	if value == nil {
+		return ""
+	}
+	return value.(string)
+}

--- a/injection/context_test.go
+++ b/injection/context_test.go
@@ -56,3 +56,18 @@ func TestContextConfig(t *testing.T) {
 		t.Errorf("GetConfig() = %v, wanted %v", cfg, want)
 	}
 }
+
+func TestResourceVersion(t *testing.T) {
+	ctx := context.Background()
+
+	if got, want := GetResourceVersion(ctx), ""; got != want {
+		t.Errorf("GetResourceVersion() = %s, wanted %s", got, want)
+	}
+
+	want := "this-is-the-best-version-evar"
+	ctx = WithResourceVersion(ctx, want)
+
+	if got := GetResourceVersion(ctx); got != want {
+		t.Errorf("GetResourceVersion() = %v, wanted %v", got, want)
+	}
+}


### PR DESCRIPTION
Unfortunately the lister interfaces didn't plumb through `ctx` so
this is slightly more complex than I'd have liked.  Instead of
threading the `resourceVersion` (bounded-staleness) through `ctx`
it is stored on the lister implementation.

It is seeded with `injection.WithResourceVersion` (ideally this
would have been all we needed, w/o state), and this state can be
updated by calling `SetResourceVersion`.

The stored `resourceVersion` is passed via `FooOptions` to `Get`
and `List` calls.

Fixes: a long-standing `TODO(mattmoor)`

/kind enhancement

**Release Note**

```release-note
NONE
```

**Docs**

```docs

```
