### PR TITLE
Build downstream tests with go 1.17

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -78,10 +78,10 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
     steps:
-    - name: Set up Go 1.16.x
+    - name: Set up Go 1.17.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.x
+        go-version: 1.17.x
 
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
As per title. Some of them have started failing because of a type mismatch caused by Golang 1.16 vs 1.17.

/assign @julz 