### PR TITLE
Add retry checker for DNS failure from Ingress

### DIFF
--- a/test/spoof/error_checks.go
+++ b/test/spoof/error_checks.go
@@ -21,6 +21,7 @@ package spoof
 import (
 	"errors"
 	"net"
+	"net/http"
 	"strings"
 )
 
@@ -61,4 +62,9 @@ func isConnectionReset(err error) bool {
 
 func isNoRouteToHostError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "connect: no route to host")
+}
+
+func isResponseDNSError(resp *Response) bool {
+	// no such host with 502 is sent back from istio-ingressgateway when it fails to resolve domain.
+	return resp.StatusCode == http.StatusBadGateway && strings.Contains(string(resp.Body), "no such host")
 }


### PR DESCRIPTION
This patch fixes the recent flake in `service_to_service_test.go` on Kind/Istio.
istio-ingressgateway returns 502 with no such host error when it fails to resolve the cluster domain.

/cc @markusthoemmes 