### PR TITLE
Remove unused recorder field

### DIFF
--- a/metrics/config.go
+++ b/metrics/config.go
@@ -84,10 +84,6 @@ type metricsConfig struct {
 	// If duration is less than or equal to zero, it enables the default behavior.
 	reportingPeriod time.Duration
 
-	// recorder provides a hook for performing custom transformations before
-	// writing the metrics to the stats.RecordWithOptions interface.
-	recorder func(context.Context, []stats.Measurement, ...stats.Options) error
-
 	// secret contains credentials for an exporter to use for authentication.
 	secret *corev1.Secret
 
@@ -117,16 +113,13 @@ func (mc *metricsConfig) record(ctx context.Context, mss []stats.Measurement, ro
 		return nil
 	}
 
-	if mc.recorder == nil {
-		opt, err := optionForResource(metricskey.GetResource(ctx))
-		if err != nil {
-			return err
-		}
-		ros = append(ros, opt)
-
-		return stats.RecordWithOptions(ctx, append(ros, stats.WithMeasurements(mss...))...)
+	opt, err := optionForResource(metricskey.GetResource(ctx))
+	if err != nil {
+		return err
 	}
-	return mc.recorder(ctx, mss, ros...)
+	ros = append(ros, opt)
+
+	return stats.RecordWithOptions(ctx, append(ros, stats.WithMeasurements(mss...))...)
 }
 
 func createMetricsConfig(_ context.Context, ops ExporterOptions) (*metricsConfig, error) {

--- a/metrics/config_test.go
+++ b/metrics/config_test.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	. "knative.dev/pkg/logging/testing"
 
@@ -294,7 +293,7 @@ func TestGetMetricsConfig(t *testing.T) {
 			if err != nil {
 				t.Errorf("Wanted valid config %v, got error %v", test.expectedConfig, err)
 			}
-			if diff := cmp.Diff(test.expectedConfig, *mc, cmp.AllowUnexported(*mc), cmpopts.IgnoreTypes(mc.recorder)); diff != "" {
+			if diff := cmp.Diff(test.expectedConfig, *mc, cmp.AllowUnexported(*mc)); diff != "" {
 				t.Errorf("Invalid config (-want +got):\n%s", diff)
 			}
 		})
@@ -388,7 +387,7 @@ func TestGetMetricsConfig_fromEnv(t *testing.T) {
 			if err != nil {
 				t.Errorf("Wanted valid config %v, got error %v", test.expectedConfig, err)
 			}
-			if diff := cmp.Diff(test.expectedConfig, *mc, cmp.AllowUnexported(*mc), cmpopts.IgnoreTypes(mc.recorder)); diff != "" {
+			if diff := cmp.Diff(test.expectedConfig, *mc, cmp.AllowUnexported(*mc)); diff != "" {
 				t.Errorf("Invalid config (-want +got):\n%s", diff)
 			}
 		})
@@ -486,7 +485,7 @@ func TestUpdateExporter(t *testing.T) {
 			if mConfig == oldConfig {
 				t.Error("Expected metrics config change")
 			}
-			if diff := cmp.Diff(test.expectedConfig, *mConfig, cmp.AllowUnexported(*mConfig), cmpopts.IgnoreTypes(mConfig.recorder)); diff != "" {
+			if diff := cmp.Diff(test.expectedConfig, *mConfig, cmp.AllowUnexported(*mConfig)); diff != "" {
 				t.Errorf("Invalid config (-want +got):\n%s", diff)
 			}
 			oldConfig = mConfig
@@ -526,7 +525,7 @@ func TestUpdateExporterFromConfigMapWithOpts(t *testing.T) {
 			if mConfig == oldConfig {
 				t.Error("Expected metrics config change")
 			}
-			if diff := cmp.Diff(test.expectedConfig, *mConfig, cmp.AllowUnexported(*mConfig), cmpopts.IgnoreTypes(mConfig.recorder)); diff != "" {
+			if diff := cmp.Diff(test.expectedConfig, *mConfig, cmp.AllowUnexported(*mConfig)); diff != "" {
 				t.Errorf("Invalid config (-want +got):\n%s", diff)
 			}
 			oldConfig = mConfig


### PR DESCRIPTION
This field of the metricsConfig isn't set anywhere (and isn't exported), so it's doing nothing. Might as well simplify the code a bit by removing it.