### PR TITLE
Drop unnecessary list creation from bucketer

### DIFF
--- a/hash/bucketer.go
+++ b/hash/bucketer.go
@@ -98,8 +98,7 @@ func (bs *BucketSet) Owner(key string) string {
 	}
 	bs.mu.RLock()
 	defer bs.mu.RUnlock()
-	l := ChooseSubset(bs.buckets, 1 /*single query wanted*/, key)
-	ret := l.UnsortedList()[0]
+	ret, _ := ChooseSubset(bs.buckets, 1 /*single query wanted*/, key).PopAny()
 	bs.cache.Add(key, ret)
 	return ret
 }

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -35,11 +35,11 @@ func ExampleChooseSubset_selectOne() {
 
 	tasks := sets.NewString("task1", "task2", "task3")
 
-	ret := ChooseSubset(tasks, 1, "my-key1")
-	fmt.Println(ret.UnsortedList()[0])
+	ret, _ := ChooseSubset(tasks, 1, "my-key1").PopAny()
+	fmt.Println(ret)
 
-	ret = ChooseSubset(tasks, 1, "something/another-key")
-	fmt.Println(ret.UnsortedList()[0])
+	ret, _ = ChooseSubset(tasks, 1, "something/another-key").PopAny()
+	fmt.Println(ret)
 	// Output: task3
 	// task2
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

As per title. It's unnecessary to actually create a list of the set to then only return the first element. Since the element's order is random anyway, might as well use `PopAny` in this case.

/assign @julz 