### PR TITLE
Allow Unstructured callback from Defaulting Webhook

### DIFF
--- a/testing/resource.go
+++ b/testing/resource.go
@@ -50,9 +50,9 @@ type ResourceSpec struct {
 	FieldThatsImmutable                      string `json:"fieldThatsImmutable,omitempty"`
 	FieldThatsImmutableWithDefault           string `json:"fieldThatsImmutableWithDefault,omitempty"`
 	FieldForCallbackValidation               string `json:"fieldThatCallbackRejects,omitempty"`
-	FieldForCallbackDefaulting               string `json:"fieldDefaultingCallback,omitempty"`
-	FieldForCallbackDefaultingIsWithinUpdate bool   `json:"fieldForIsWithinUpdate,omitempty"`
-	FieldForCallbackDefaultingUsername       string `json:"FieldForCallbackDefaultingUsername,omitempty"`
+	FieldForCallbackDefaulting               string `json:"fieldForCallbackDefaulting,omitempty"`
+	FieldForCallbackDefaultingIsWithinUpdate bool   `json:"fieldForCallbackDefaultingIsWithinUpdate,omitempty"`
+	FieldForCallbackDefaultingUsername       string `json:"fieldForCallbackDefaultingUsername,omitempty"`
 }
 
 // GetGroupVersionKind returns the GroupVersionKind.

--- a/testing/resource.go
+++ b/testing/resource.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"knative.dev/pkg/apis"
 )
 
@@ -49,11 +50,22 @@ type ResourceSpec struct {
 	FieldThatsImmutable            string `json:"fieldThatsImmutable,omitempty"`
 	FieldThatsImmutableWithDefault string `json:"fieldThatsImmutableWithDefault,omitempty"`
 	FieldForCallbackValidation     string `json:"fieldThatCallbackRejects,omitempty"`
+	FieldForCallbackDefaulting     string `json:"fieldDefaultingCallback,omitempty"`
 }
 
 // GetGroupVersionKind returns the GroupVersionKind.
 func (r *Resource) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Resource")
+}
+
+// GetGroupVersionKindMeta returns the metav1.GroupVersionKind.
+func (r *Resource) GetGroupVersionKindMeta() metav1.GroupVersionKind {
+	gvk := r.GroupVersionKind()
+	return metav1.GroupVersionKind{
+		Group:   gvk.Group,
+		Version: gvk.Version,
+		Kind:    gvk.Kind,
+	}
 }
 
 // GetUntypedSpec returns the spec of the resource.

--- a/testing/resource.go
+++ b/testing/resource.go
@@ -44,13 +44,15 @@ var _ apis.Listable = (*Resource)(nil)
 
 // ResourceSpec represents test resource spec.
 type ResourceSpec struct {
-	FieldWithDefault               string `json:"fieldWithDefault,omitempty"`
-	FieldWithContextDefault        string `json:"fieldWithContextDefault,omitempty"`
-	FieldWithValidation            string `json:"fieldWithValidation,omitempty"`
-	FieldThatsImmutable            string `json:"fieldThatsImmutable,omitempty"`
-	FieldThatsImmutableWithDefault string `json:"fieldThatsImmutableWithDefault,omitempty"`
-	FieldForCallbackValidation     string `json:"fieldThatCallbackRejects,omitempty"`
-	FieldForCallbackDefaulting     string `json:"fieldDefaultingCallback,omitempty"`
+	FieldWithDefault                         string `json:"fieldWithDefault,omitempty"`
+	FieldWithContextDefault                  string `json:"fieldWithContextDefault,omitempty"`
+	FieldWithValidation                      string `json:"fieldWithValidation,omitempty"`
+	FieldThatsImmutable                      string `json:"fieldThatsImmutable,omitempty"`
+	FieldThatsImmutableWithDefault           string `json:"fieldThatsImmutableWithDefault,omitempty"`
+	FieldForCallbackValidation               string `json:"fieldThatCallbackRejects,omitempty"`
+	FieldForCallbackDefaulting               string `json:"fieldDefaultingCallback,omitempty"`
+	FieldForCallbackDefaultingIsWithinUpdate bool   `json:"fieldForIsWithinUpdate,omitempty"`
+	FieldForCallbackDefaultingUsername       string `json:"FieldForCallbackDefaultingUsername,omitempty"`
 }
 
 // GetGroupVersionKind returns the GroupVersionKind.

--- a/webhook/resourcesemantics/defaulting/controller.go
+++ b/webhook/resourcesemantics/defaulting/controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
+
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/webhook"
@@ -42,6 +43,7 @@ func NewAdmissionController(
 	handlers map[schema.GroupVersionKind]resourcesemantics.GenericCRD,
 	wc func(context.Context) context.Context,
 	disallowUnknownFields bool,
+	callbacks ...map[schema.GroupVersionKind]Callback,
 ) *controller.Impl {
 
 	client := kubeclient.Get(ctx)
@@ -50,6 +52,19 @@ func NewAdmissionController(
 	options := webhook.GetOptions(ctx)
 
 	key := types.NamespacedName{Name: name}
+
+	// This not ideal, we are using a variadic argument to effectively make callbacks optional
+	// This allows this addition to be non-breaking to consumers of /pkg
+	// TODO: once all sub-repos have adopted this, we might move this back to a traditional param.
+	var unwrappedCallbacks map[schema.GroupVersionKind]Callback
+	switch len(callbacks) {
+	case 0:
+		unwrappedCallbacks = map[schema.GroupVersionKind]Callback{}
+	case 1:
+		unwrappedCallbacks = callbacks[0]
+	default:
+		panic("NewAdmissionController may not be called with multiple callback maps")
+	}
 
 	wh := &reconciler{
 		LeaderAwareFuncs: pkgreconciler.LeaderAwareFuncs{
@@ -60,9 +75,10 @@ func NewAdmissionController(
 			},
 		},
 
-		key:      key,
-		path:     path,
-		handlers: handlers,
+		key:       key,
+		path:      path,
+		handlers:  handlers,
+		callbacks: unwrappedCallbacks,
 
 		withContext:           wc,
 		disallowUnknownFields: disallowUnknownFields,

--- a/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/webhook/resourcesemantics/defaulting/defaulting.go
@@ -25,16 +25,18 @@ import (
 
 	"github.com/gobuffalo/flect"
 	"go.uber.org/zap"
-	jsonpatch "gomodules.xyz/jsonpatch/v2"
+	"gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	admissionlisters "k8s.io/client-go/listers/admissionregistration/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
+
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/controller"
@@ -56,9 +58,10 @@ type reconciler struct {
 	webhook.StatelessAdmissionImpl
 	pkgreconciler.LeaderAwareFuncs
 
-	key      types.NamespacedName
-	path     string
-	handlers map[schema.GroupVersionKind]resourcesemantics.GenericCRD
+	key       types.NamespacedName
+	path      string
+	handlers  map[schema.GroupVersionKind]resourcesemantics.GenericCRD
+	callbacks map[schema.GroupVersionKind]Callback
 
 	withContext func(context.Context) context.Context
 
@@ -68,6 +71,34 @@ type reconciler struct {
 
 	disallowUnknownFields bool
 	secretName            string
+}
+
+// CallbackFunc is the function to be invoked.
+type CallbackFunc func(ctx context.Context, unstructured *unstructured.Unstructured) error
+
+// Callback is a generic function to be called by a consumer of defaulting.
+type Callback struct {
+	// function is the callback to be invoked.
+	function CallbackFunc
+
+	// supportedVerbs are the verbs supported for the callback.
+	// The function will only be called on these actions.
+	supportedVerbs map[webhook.Operation]struct{}
+}
+
+// NewCallback creates a new callback function to be invoked on supported verbs.
+func NewCallback(function func(context.Context, *unstructured.Unstructured) error, supportedVerbs ...webhook.Operation) Callback {
+	if function == nil {
+		panic("expected function, got nil")
+	}
+	m := make(map[webhook.Operation]struct{})
+	for _, op := range supportedVerbs {
+		if _, has := m[op]; has {
+			panic("duplicate verbs not allowed")
+		}
+		m[op] = struct{}{}
+	}
+	return Callback{function: function, supportedVerbs: m}
 }
 
 var _ controller.Reconciler = (*reconciler)(nil)
@@ -231,8 +262,18 @@ func (ac *reconciler) mutate(ctx context.Context, req *admissionv1.AdmissionRequ
 	logger := logging.FromContext(ctx)
 	handler, ok := ac.handlers[gvk]
 	if !ok {
-		logger.Error("Unhandled kind: ", gvk)
-		return nil, fmt.Errorf("unhandled kind: %v", gvk)
+		if _, ok := ac.callbacks[gvk]; !ok {
+			logger.Error("Unhandled kind: ", gvk)
+			return nil, fmt.Errorf("unhandled kind: %v", gvk)
+		}
+		patches, err := ac.callback(ctx, gvk, req, duck.JSONPatch{})
+		if err != nil {
+			logger.Errorw("Failed the callback defaulter", zap.Error(err))
+			// Return the error message as-is to give the defaulter callback
+			// discretion over (our portion of) the message that the user sees.
+			return nil, err
+		}
+		return json.Marshal(patches)
 	}
 
 	// nil values denote absence of `old` (create) or `new` (delete) objects.
@@ -302,6 +343,13 @@ func (ac *reconciler) mutate(ctx context.Context, req *admissionv1.AdmissionRequ
 		return nil, err
 	}
 
+	if patches, err = ac.callback(ctx, gvk, req, patches); err != nil {
+		logger.Errorw("Failed the callback defaulter", zap.Error(err))
+		// Return the error message as-is to give the defaulter callback
+		// discretion over (our portion of) the message that the user sees.
+		return nil, err
+	}
+
 	// None of the validators will accept a nil value for newObj.
 	if newObj == nil {
 		return nil, errMissingNewObject
@@ -327,6 +375,48 @@ func (ac *reconciler) setUserInfoAnnotations(ctx context.Context, patches duck.J
 		return nil, err
 	}
 	return append(patches, patch...), nil
+}
+
+func (ac *reconciler) callback(ctx context.Context, gvk schema.GroupVersionKind, req *admissionv1.AdmissionRequest, patches duck.JSONPatch) (duck.JSONPatch, error) {
+	oldBytes := req.OldObject.Raw
+	newBytes := req.Object.Raw
+
+	// Setup context.
+	if len(oldBytes) != 0 {
+		ctx = apis.WithinUpdate(ctx, oldBytes)
+	} else {
+		ctx = apis.WithinCreate(ctx)
+	}
+
+	// Get callback.
+	callback, ok := ac.callbacks[gvk]
+	if !ok {
+		return patches, nil
+	}
+
+	// Check if request operation is a supported webhook operation.
+	if _, isSupported := callback.supportedVerbs[req.Operation]; !isSupported {
+		return patches, nil
+	}
+
+	before := &unstructured.Unstructured{}
+	after := &unstructured.Unstructured{}
+
+	// Get unstructured object.
+	if err := json.Unmarshal(newBytes, before); err != nil {
+		return nil, fmt.Errorf("cannot decode object: %w", err)
+	}
+	// Copy before in after unstructured objects.
+	before.DeepCopyInto(after)
+
+	// Call callback passing after.
+	if err := callback.function(ctx, after); err != nil {
+		return patches, err
+	}
+
+	// Create patches.
+	patch, err := duck.CreatePatch(before.Object, after.Object)
+	return append(patches, patch...), err
 }
 
 // roundTripPatch generates the JSONPatch that corresponds to round tripping the given bytes through

--- a/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/webhook/resourcesemantics/defaulting/defaulting.go
@@ -93,6 +93,9 @@ func NewCallback(function func(context.Context, *unstructured.Unstructured) erro
 	}
 	m := make(map[webhook.Operation]struct{})
 	for _, op := range supportedVerbs {
+		if op == webhook.Delete {
+			panic("Verb " + webhook.Delete + " not allowed")
+		}
 		if _, has := m[op]; has {
 			panic("duplicate verbs not allowed")
 		}

--- a/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/webhook/resourcesemantics/defaulting/defaulting.go
@@ -171,7 +171,17 @@ func (ac *reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 	logger := logging.FromContext(ctx)
 
 	rules := make([]admissionregistrationv1.RuleWithOperations, 0, len(ac.handlers))
+	gvks := make(map[schema.GroupVersionKind]struct{}, len(ac.handlers)+len(ac.callbacks))
 	for gvk := range ac.handlers {
+		gvks[gvk] = struct{}{}
+	}
+	for gvk := range ac.callbacks {
+		if _, ok := gvks[gvk]; !ok {
+			gvks[gvk] = struct{}{}
+		}
+	}
+
+	for gvk := range gvks {
 		plural := strings.ToLower(flect.Pluralize(gvk.Kind))
 
 		rules = append(rules, admissionregistrationv1.RuleWithOperations{

--- a/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/webhook/resourcesemantics/defaulting/defaulting.go
@@ -433,7 +433,7 @@ func (ac *reconciler) callback(ctx context.Context, gvk schema.GroupVersionKind,
 	}
 
 	if shouldSetUserInfo {
-		setUserInfoAnnotationsUnstructured(ctx, after, before, req)
+		setUserInfoAnnotations(adaptUnstructuredHasSpecCtx(ctx, req), unstructuredHasSpec{after}, req.Resource.Group)
 	}
 
 	// Create patches.

--- a/webhook/resourcesemantics/defaulting/defaulting_test.go
+++ b/webhook/resourcesemantics/defaulting/defaulting_test.go
@@ -410,6 +410,14 @@ func TestAdmitCreates(t *testing.T) {
 			Operation: "add",
 			Path:      "/spec/FieldForCallbackDefaultingUsername",
 			Value:     user1,
+		}, {
+			Operation: "replace",
+			Path:      "/metadata/annotations/pkg.knative.dev~1lastModifier",
+			Value:     user1,
+		}, {
+			Operation: "add",
+			Path:      "/metadata/annotations/pkg.knative.dev~1creator",
+			Value:     user1,
 		}},
 	}}
 
@@ -630,6 +638,10 @@ func TestAdmitUpdatesCallback(t *testing.T) {
 				return req
 			},
 			patches: []jsonpatch.JsonPatchOperation{{
+				Operation: "replace",
+				Path:      "/metadata/annotations/pkg.knative.dev~1lastModifier",
+				Value:     user2,
+			}, {
 				Operation: "replace",
 				Path:      "/spec/fieldDefaultingCallback",
 				Value:     "I'm a default",

--- a/webhook/resourcesemantics/defaulting/defaulting_test.go
+++ b/webhook/resourcesemantics/defaulting/defaulting_test.go
@@ -19,14 +19,19 @@ package defaulting
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	// Injection stuff
 	_ "knative.dev/pkg/client/injection/kube/client/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/admissionregistration/v1/mutatingwebhookconfiguration/fake"
 	_ "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret/fake"
 
-	jsonpatch "gomodules.xyz/jsonpatch/v2"
+	"gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -76,6 +81,29 @@ var (
 			Version: "v1alpha1",
 			Kind:    "InnerDefaultResource",
 		}: &InnerDefaultResource{},
+	}
+
+	callbacks = map[schema.GroupVersionKind]Callback{
+		{
+			Group:   "pkg.knative.dev",
+			Version: "v1alpha1",
+			Kind:    "Resource",
+		}: NewCallback(resourceCallback, webhook.Create, webhook.Update, webhook.Delete),
+		{
+			Group:   "pkg.knative.dev",
+			Version: "v1beta1",
+			Kind:    "Resource",
+		}: NewCallback(resourceCallback, webhook.Create, webhook.Update, webhook.Delete),
+		{
+			Group:   "pkg.knative.dev",
+			Version: "v1beta1",
+			Kind:    "ResourceCallbackDefault",
+		}: NewCallback(resourceCallback, webhook.Create, webhook.Update, webhook.Delete),
+		{
+			Group:   "pkg.knative.dev",
+			Version: "v1beta1",
+			Kind:    "ResourceCallbackDefaultCreate",
+		}: NewCallback(resourceCallback, webhook.Create),
 	}
 
 	initialResourceWebhook = &admissionregistrationv1.MutatingWebhookConfiguration{
@@ -218,10 +246,11 @@ func TestUnknownMetadataFieldSucceeds(t *testing.T) {
 
 func TestAdmitCreates(t *testing.T) {
 	tests := []struct {
-		name      string
-		setup     func(context.Context, *Resource)
-		rejection string
-		patches   []jsonpatch.JsonPatchOperation
+		name              string
+		setup             func(context.Context, *Resource)
+		rejection         string
+		patches           []jsonpatch.JsonPatchOperation
+		createRequestFunc func(ctx context.Context, t *testing.T, r *Resource) *admissionv1.AdmissionRequest
 	}{{
 		name: "test simple creation (alpha, no diff)",
 		setup: func(ctx context.Context, r *Resource) {
@@ -323,6 +352,56 @@ func TestAdmitCreates(t *testing.T) {
 			Path:      "/metadata/annotations/pkg.knative.dev~1creator",
 			Value:     user1,
 		}},
+	}, {
+		name: "test simple creation (callback return error)",
+		setup: func(ctx context.Context, resource *Resource) {
+			resource.Spec.FieldForCallbackDefaulting = "no magic value"
+		},
+		rejection: "no magic value",
+	}, {
+		name: "test simple creation (resource and callback defaults)",
+		setup: func(ctx context.Context, r *Resource) {
+			r.SetDefaults(ctx)
+			r.Spec.FieldForCallbackDefaulting = "magic value"
+			// THIS IS NOT WHO IS CREATING IT, IT IS LIES!
+			r.Annotations = map[string]string{
+				"pkg.knative.dev/lastModifier": user2,
+			}
+		},
+		patches: []jsonpatch.JsonPatchOperation{{
+			Operation: "replace",
+			Path:      "/spec/fieldDefaultingCallback",
+			Value:     "I'm a default",
+		}, {
+			Operation: "replace",
+			Path:      "/metadata/annotations/pkg.knative.dev~1lastModifier",
+			Value:     user1,
+		}, {
+			Operation: "add",
+			Path:      "/metadata/annotations/pkg.knative.dev~1creator",
+			Value:     user1,
+		}},
+	}, {
+		name: "test simple creation (only callback defaults)",
+		setup: func(ctx context.Context, r *Resource) {
+			r.TypeMeta.APIVersion = "pkg.knative.dev/v1beta1"
+			r.TypeMeta.Kind = "ResourceCallbackDefault"
+			r.Spec.FieldForCallbackDefaulting = "magic value"
+			// THIS IS NOT WHO IS CREATING IT, IT LIES!
+			r.Annotations = map[string]string{
+				"pkg.knative.dev/lastModifier": user2,
+			}
+		},
+		createRequestFunc: func(ctx context.Context, t *testing.T, r *Resource) *admissionv1.AdmissionRequest {
+			req := createCreateResource(ctx, t, r)
+			req.Kind = r.GetGroupVersionKindMeta()
+			return req
+		},
+		patches: []jsonpatch.JsonPatchOperation{{
+			Operation: "replace",
+			Path:      "/spec/fieldDefaultingCallback",
+			Value:     "I'm a default",
+		}},
 	}}
 
 	for _, tc := range tests {
@@ -336,7 +415,13 @@ func TestAdmitCreates(t *testing.T) {
 			tc.setup(ctx, r)
 
 			_, ac := newNonRunningTestResourceAdmissionController(t)
-			resp := ac.Admit(ctx, createCreateResource(ctx, t, r))
+			var req *admissionv1.AdmissionRequest
+			if tc.createRequestFunc == nil {
+				req = createCreateResource(ctx, t, r)
+			} else {
+				req = tc.createRequestFunc(ctx, t, r)
+			}
+			resp := ac.Admit(ctx, req)
 
 			if tc.rejection == "" {
 				ExpectAllowed(t, resp)
@@ -370,11 +455,13 @@ func createCreateResource(ctx context.Context, t *testing.T, r *Resource) *admis
 
 func TestAdmitUpdates(t *testing.T) {
 	tests := []struct {
-		name      string
-		setup     func(context.Context, *Resource)
-		mutate    func(context.Context, *Resource)
-		rejection string
-		patches   []jsonpatch.JsonPatchOperation
+		name                     string
+		setup                    func(context.Context, *Resource)
+		mutate                   func(context.Context, *Resource)
+		createResourceFunc       func(name string) *Resource
+		createUpdateResourceFunc func(ctx context.Context, t *testing.T, old, new *Resource) *admissionv1.AdmissionRequest
+		rejection                string
+		patches                  []jsonpatch.JsonPatchOperation
 	}{{
 		name: "test simple update (no diff)",
 		setup: func(ctx context.Context, r *Resource) {
@@ -385,6 +472,71 @@ func TestAdmitUpdates(t *testing.T) {
 			// annotation doesn't change.
 		},
 		patches: []jsonpatch.JsonPatchOperation{},
+	}, {
+		name: "test simple update (callback defaults error)",
+		setup: func(ctx context.Context, r *Resource) {
+			r.SetDefaults(ctx)
+		},
+		mutate: func(ctx context.Context, r *Resource) {
+			r.Spec.FieldForCallbackDefaulting = "no magic value"
+		},
+		rejection: "no magic value",
+	}, {
+		name: "test simple update (callback defaults)",
+		setup: func(ctx context.Context, r *Resource) {
+			r.SetDefaults(ctx)
+		},
+		mutate: func(ctx context.Context, r *Resource) {
+			r.Spec.FieldForCallbackDefaulting = "magic value"
+		},
+		patches: []jsonpatch.JsonPatchOperation{{
+			Operation: "replace",
+			Path:      "/spec/fieldDefaultingCallback",
+			Value:     "I'm a default",
+		}, {
+
+			Operation: "replace",
+			Path:      "/metadata/annotations/pkg.knative.dev~1lastModifier",
+			Value:     user2,
+		}},
+	}, {
+		name: "test simple update (callback defaults only)",
+		setup: func(ctx context.Context, r *Resource) {
+			r.TypeMeta.APIVersion = "pkg.knative.dev/v1beta1"
+			r.TypeMeta.Kind = "ResourceCallbackDefault"
+			r.Spec.FieldForCallbackDefaulting = "magic value"
+			r.SetDefaults(ctx)
+		},
+		mutate: func(ctx context.Context, r *Resource) {
+			r.Spec.FieldForCallbackDefaulting = "magic value"
+		},
+		createUpdateResourceFunc: func(ctx context.Context, t *testing.T, old, new *Resource) *admissionv1.AdmissionRequest {
+			req := createUpdateResource(ctx, t, old, new)
+			req.Kind = new.GetGroupVersionKindMeta()
+			return req
+		},
+		patches: []jsonpatch.JsonPatchOperation{{
+			Operation: "replace",
+			Path:      "/spec/fieldDefaultingCallback",
+			Value:     "I'm a default",
+		}},
+	}, {
+		name: "test simple update (callback defaults only, operation not supported)",
+		setup: func(ctx context.Context, r *Resource) {
+			r.TypeMeta.APIVersion = "pkg.knative.dev/v1beta1"
+			r.TypeMeta.Kind = "ResourceCallbackDefaultCreate"
+			r.Spec.FieldForCallbackDefaulting = "magic value"
+			r.SetDefaults(ctx)
+		},
+		mutate: func(ctx context.Context, r *Resource) {
+			r.Spec.FieldForCallbackDefaulting = "magic value"
+		},
+		createUpdateResourceFunc: func(ctx context.Context, t *testing.T, old, new *Resource) *admissionv1.AdmissionRequest {
+			req := createUpdateResource(ctx, t, old, new)
+			req.Operation = admissionv1.Update
+			req.Kind = new.GetGroupVersionKindMeta()
+			return req
+		},
 	}, {
 		name: "test simple update (update updater annotation)",
 		setup: func(ctx context.Context, r *Resource) {
@@ -428,7 +580,14 @@ func TestAdmitUpdates(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			old := CreateResource("a name")
+			name := "a name"
+
+			var old *Resource
+			if tc.createResourceFunc == nil {
+				old = CreateResource(name)
+			} else {
+				old = tc.createResourceFunc(name)
+			}
 			ctx := TestContextWithLogger(t)
 
 			old.Annotations = map[string]string{
@@ -446,7 +605,15 @@ func TestAdmitUpdates(t *testing.T) {
 			tc.mutate(ctx, new)
 
 			_, ac := newNonRunningTestResourceAdmissionController(t)
-			resp := ac.Admit(ctx, createUpdateResource(ctx, t, old, new))
+
+			var req *admissionv1.AdmissionRequest
+			if tc.createUpdateResourceFunc == nil {
+				req = createUpdateResource(ctx, t, old, new)
+			} else {
+				req = tc.createUpdateResourceFunc(ctx, t, old, new)
+			}
+
+			resp := ac.Admit(ctx, req)
 
 			if tc.rejection == "" {
 				ExpectAllowed(t, resp)
@@ -511,6 +678,10 @@ func TestValidCreateResourceSucceedsWithRoundTripAndDefaultPatch(t *testing.T) {
 func createInnerDefaultResourceWithoutSpec(t *testing.T) []byte {
 	t.Helper()
 	r := InnerDefaultResource{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "InnerDefaultResource",
+			APIVersion: fmt.Sprintf("%s/%s", SchemeGroupVersion.Group, SchemeGroupVersion.Version),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
 			Name:      "a name",
@@ -543,5 +714,27 @@ func newTestResourceAdmissionController(t *testing.T) webhook.AdmissionControlle
 		ctx, testResourceValidationName, testResourceValidationPath,
 		handlers, func(ctx context.Context) context.Context {
 			return ctx
-		}, true).Reconciler.(*reconciler)
+		}, true, callbacks).Reconciler.(*reconciler)
+}
+
+func resourceCallback(_ context.Context, uns *unstructured.Unstructured) error {
+	var resource Resource
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(uns.UnstructuredContent(), &resource); err != nil {
+		return err
+	}
+
+	if resource.Spec.FieldForCallbackDefaulting != "" {
+		if resource.Spec.FieldForCallbackDefaulting != "magic value" {
+			return errors.New(resource.Spec.FieldForCallbackDefaulting)
+		}
+		resource.Spec.FieldForCallbackDefaulting = "I'm a default"
+	}
+
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&resource)
+	if err != nil {
+		return err
+	}
+	uns.Object = u
+
+	return nil
 }

--- a/webhook/resourcesemantics/defaulting/defaulting_test.go
+++ b/webhook/resourcesemantics/defaulting/defaulting_test.go
@@ -371,7 +371,7 @@ func TestAdmitCreates(t *testing.T) {
 		},
 		patches: []jsonpatch.JsonPatchOperation{{
 			Operation: "replace",
-			Path:      "/spec/fieldDefaultingCallback",
+			Path:      "/spec/fieldForCallbackDefaulting",
 			Value:     "I'm a default",
 		}, {
 			Operation: "replace",
@@ -383,7 +383,7 @@ func TestAdmitCreates(t *testing.T) {
 			Value:     user1,
 		}, {
 			Operation: "add",
-			Path:      "/spec/FieldForCallbackDefaultingUsername",
+			Path:      "/spec/fieldForCallbackDefaultingUsername",
 			Value:     user1,
 		}},
 	}, {
@@ -404,11 +404,11 @@ func TestAdmitCreates(t *testing.T) {
 		},
 		patches: []jsonpatch.JsonPatchOperation{{
 			Operation: "replace",
-			Path:      "/spec/fieldDefaultingCallback",
+			Path:      "/spec/fieldForCallbackDefaulting",
 			Value:     "I'm a default",
 		}, {
 			Operation: "add",
-			Path:      "/spec/FieldForCallbackDefaultingUsername",
+			Path:      "/spec/fieldForCallbackDefaultingUsername",
 			Value:     user1,
 		}, {
 			Operation: "replace",
@@ -604,7 +604,7 @@ func TestAdmitUpdatesCallback(t *testing.T) {
 			},
 			patches: []jsonpatch.JsonPatchOperation{{
 				Operation: "replace",
-				Path:      "/spec/fieldDefaultingCallback",
+				Path:      "/spec/fieldForCallbackDefaulting",
 				Value:     "I'm a default",
 			}, {
 
@@ -613,11 +613,11 @@ func TestAdmitUpdatesCallback(t *testing.T) {
 				Value:     user2,
 			}, {
 				Operation: "add",
-				Path:      "/spec/fieldForIsWithinUpdate",
+				Path:      "/spec/fieldForCallbackDefaultingIsWithinUpdate",
 				Value:     true,
 			}, {
 				Operation: "add",
-				Path:      "/spec/FieldForCallbackDefaultingUsername",
+				Path:      "/spec/fieldForCallbackDefaultingUsername",
 				Value:     user2,
 			}},
 			createUpdateResourceFunc: createUpdateResource,
@@ -643,15 +643,15 @@ func TestAdmitUpdatesCallback(t *testing.T) {
 				Value:     user2,
 			}, {
 				Operation: "replace",
-				Path:      "/spec/fieldDefaultingCallback",
+				Path:      "/spec/fieldForCallbackDefaulting",
 				Value:     "I'm a default",
 			}, {
 				Operation: "add",
-				Path:      "/spec/fieldForIsWithinUpdate",
+				Path:      "/spec/fieldForCallbackDefaultingIsWithinUpdate",
 				Value:     true,
 			}, {
 				Operation: "add",
-				Path:      "/spec/FieldForCallbackDefaultingUsername",
+				Path:      "/spec/fieldForCallbackDefaultingUsername",
 				Value:     user2,
 			}},
 		}, {
@@ -681,7 +681,7 @@ func TestAdmitUpdatesCallback(t *testing.T) {
 			},
 			patches: []jsonpatch.JsonPatchOperation{{
 				Operation: "replace",
-				Path:      "/spec/fieldDefaultingCallback",
+				Path:      "/spec/fieldForCallbackDefaulting",
 				Value:     "I'm a default",
 			}, {
 
@@ -690,11 +690,11 @@ func TestAdmitUpdatesCallback(t *testing.T) {
 				Value:     user2,
 			}, {
 				Operation: "add",
-				Path:      "/spec/fieldForIsWithinUpdate",
+				Path:      "/spec/fieldForCallbackDefaultingIsWithinUpdate",
 				Value:     true,
 			}, {
 				Operation: "add",
-				Path:      "/spec/FieldForCallbackDefaultingUsername",
+				Path:      "/spec/fieldForCallbackDefaultingUsername",
 				Value:     user2,
 			}},
 			createUpdateResourceFunc: createUpdateResource,

--- a/webhook/resourcesemantics/defaulting/defaulting_test.go
+++ b/webhook/resourcesemantics/defaulting/defaulting_test.go
@@ -88,17 +88,17 @@ var (
 			Group:   "pkg.knative.dev",
 			Version: "v1alpha1",
 			Kind:    "Resource",
-		}: NewCallback(resourceCallback, webhook.Create, webhook.Update, webhook.Delete),
+		}: NewCallback(resourceCallback, webhook.Create, webhook.Update),
 		{
 			Group:   "pkg.knative.dev",
 			Version: "v1beta1",
 			Kind:    "Resource",
-		}: NewCallback(resourceCallback, webhook.Create, webhook.Update, webhook.Delete),
+		}: NewCallback(resourceCallback, webhook.Create, webhook.Update),
 		{
 			Group:   "pkg.knative.dev",
 			Version: "v1beta1",
 			Kind:    "ResourceCallbackDefault",
-		}: NewCallback(resourceCallback, webhook.Create, webhook.Update, webhook.Delete),
+		}: NewCallback(resourceCallback, webhook.Create, webhook.Update),
 		{
 			Group:   "pkg.knative.dev",
 			Version: "v1beta1",

--- a/webhook/resourcesemantics/defaulting/table_test.go
+++ b/webhook/resourcesemantics/defaulting/table_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientgotesting "k8s.io/client-go/testing"
+
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/ptr"
@@ -90,6 +91,20 @@ func TestReconcile(t *testing.T) {
 			APIGroups:   []string{"pkg.knative.dev"},
 			APIVersions: []string{"v1alpha1"},
 			Resources:   []string{"resources", "resources/status"},
+		},
+	}, {
+		Operations: []admissionregistrationv1.OperationType{"CREATE", "UPDATE"},
+		Rule: admissionregistrationv1.Rule{
+			APIGroups:   []string{"pkg.knative.dev"},
+			APIVersions: []string{"v1beta1"},
+			Resources:   []string{"resourcecallbackdefaultcreates", "resourcecallbackdefaultcreates/status"},
+		},
+	}, {
+		Operations: []admissionregistrationv1.OperationType{"CREATE", "UPDATE"},
+		Rule: admissionregistrationv1.Rule{
+			APIGroups:   []string{"pkg.knative.dev"},
+			APIVersions: []string{"v1beta1"},
+			Resources:   []string{"resourcecallbackdefaults", "resourcecallbackdefaults/status"},
 		},
 	}, {
 		Operations: []admissionregistrationv1.OperationType{"CREATE", "UPDATE"},
@@ -419,7 +434,8 @@ func TestReconcile(t *testing.T) {
 			},
 			path: path,
 
-			handlers: handlers,
+			handlers:  handlers,
+			callbacks: callbacks,
 
 			client:       kubeclient.Get(ctx),
 			mwhlister:    listers.GetMutatingWebhookConfigurationLister(),


### PR DESCRIPTION
Issue #1140

**Proposed Changes**

Allow Defaulting webhook to register generic Unstructured callbacks so that implementers can create generic defaulting logic outside of the APIs package.

This will later be used in Eventing Kafka Broker.

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Allow Unstructured callback from Defaulting Webhook

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind enhancement

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Allow Unstructured callback from Defaulting Webhook
```
