### PR TITLE
Tidy helper to avoid need for nosec comment

### DIFF
--- a/test/monitoring/monitoring.go
+++ b/test/monitoring/monitoring.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -75,9 +74,7 @@ func Cleanup(pid int) error {
 // PortForward sets up local port forward to the pod specified by the "app" label in the given namespace
 func PortForward(logf logging.FormatLogger, podList *v1.PodList, localPort, remotePort int, namespace string) (int, error) {
 	podName := podList.Items[0].Name
-	portFwdCmd := fmt.Sprintf("kubectl port-forward %s %d:%d -n %s", podName, localPort, remotePort, namespace)
-	portFwdProcess, err := executeCmdBackground(logf, portFwdCmd)
-
+	portFwdProcess, err := executeCmdBackground(logf, "kubectl", "port-forward", podName, fmt.Sprintf("%d:%d", localPort, remotePort), "-n", namespace)
 	if err != nil {
 		return 0, fmt.Errorf("failed to port forward: %w", err)
 	}
@@ -86,12 +83,10 @@ func PortForward(logf logging.FormatLogger, podList *v1.PodList, localPort, remo
 	return portFwdProcess.Pid, nil
 }
 
-// RunBackground starts a background process and returns the Process if succeed
-func executeCmdBackground(logf logging.FormatLogger, format string, args ...interface{}) (*os.Process, error) {
-	cmd := fmt.Sprintf(format, args...)
+// executeCmdBackground starts a background process and returns the Process if succeed
+func executeCmdBackground(logf logging.FormatLogger, cmd string, args ...string) (*os.Process, error) {
 	logf("Executing command: %s", cmd)
-	parts := strings.Split(cmd, " ")
-	c := exec.Command(parts[0], parts[1:]...) // #nosec
+	c := exec.Command(cmd, args...)
 	if err := c.Start(); err != nil {
 		return nil, fmt.Errorf("%s command failed: %w", cmd, err)
 	}


### PR DESCRIPTION
Currently we fmt.Sprintf a command string only to immediately split it
back in to args, which causes gosec to complain about unsanitised inputs
to exec.Command. Refactoring this to directly pass an args array is
clearer, more secure, and avoids needing the nosec comment.