### PR TITLE
Add nil checks for Source types validation to be pointer receiver based

### DIFF
--- a/apis/duck/v1/source_types.go
+++ b/apis/duck/v1/source_types.go
@@ -180,13 +180,16 @@ func (s *Source) Validate(ctx context.Context) *apis.FieldError {
 }
 
 func (s *SourceSpec) Validate(ctx context.Context) *apis.FieldError {
-	if s.CloudEventOverrides == nil {
+	if s == nil {
 		return nil
 	}
 	return s.CloudEventOverrides.Validate(ctx).ViaField("ceOverrides")
 }
 
 func (ceOverrides *CloudEventOverrides) Validate(ctx context.Context) *apis.FieldError {
+	if ceOverrides == nil {
+		return nil
+	}
 	for key := range ceOverrides.Extensions {
 		if err := validateExtensionName(key); err != nil {
 			return err.ViaField("extensions")


### PR DESCRIPTION
It's better to have nil checks inside the Validate method of the
type itself instead of the type that holds a field of that type
because this allows using the types in other contexts without
the types that hold a field.

/kind enhancement