### PR TITLE
Validate Sink in SourceSpec

### DIFF
--- a/apis/duck/v1/source_types.go
+++ b/apis/duck/v1/source_types.go
@@ -181,9 +181,10 @@ func (s *Source) Validate(ctx context.Context) *apis.FieldError {
 
 func (s *SourceSpec) Validate(ctx context.Context) *apis.FieldError {
 	if s == nil {
-		return nil
+		return apis.ErrMissingField("sink")
 	}
-	return s.CloudEventOverrides.Validate(ctx).ViaField("ceOverrides")
+	return s.Sink.Validate(ctx).ViaField("sink").
+		Also(s.CloudEventOverrides.Validate(ctx).ViaField("ceOverrides"))
 }
 
 func (ceOverrides *CloudEventOverrides) Validate(ctx context.Context) *apis.FieldError {

--- a/apis/duck/v1/source_types.go
+++ b/apis/duck/v1/source_types.go
@@ -181,7 +181,7 @@ func (s *Source) Validate(ctx context.Context) *apis.FieldError {
 
 func (s *SourceSpec) Validate(ctx context.Context) *apis.FieldError {
 	if s == nil {
-		return apis.ErrMissingField("sink")
+		return apis.ErrMissingField("spec")
 	}
 	return s.Sink.Validate(ctx).ViaField("sink").
 		Also(s.CloudEventOverrides.Validate(ctx).ViaField("ceOverrides"))

--- a/apis/duck/v1/source_types_test.go
+++ b/apis/duck/v1/source_types_test.go
@@ -35,20 +35,32 @@ func TestSourceValidate(t *testing.T) {
 	}, {
 		name: "nil source spec validation",
 		src:  &Source{},
-		want: nil,
+		want: apis.ErrGeneric("expected at least one, got none", "spec.sink.ref", "spec.sink.uri"),
 	}, {
 		name: "empty source spec validation",
 		src:  &Source{Spec: SourceSpec{}},
-		want: nil,
+		want: apis.ErrGeneric("expected at least one, got none", "spec.sink.ref", "spec.sink.uri"),
 	}, {
 		name: "empty source ceOverrides extensions validation",
 		src: &Source{Spec: SourceSpec{
+			Sink: Destination{
+				URI: func() *apis.URL {
+					u, _ := apis.ParseURL("https://localhost")
+					return u
+				}(),
+			},
 			CloudEventOverrides: &CloudEventOverrides{Extensions: map[string]string{}},
 		}},
 		want: nil,
 	}, {
 		name: "empty extension name error",
 		src: &Source{Spec: SourceSpec{
+			Sink: Destination{
+				URI: func() *apis.URL {
+					u, _ := apis.ParseURL("https://localhost")
+					return u
+				}(),
+			},
 			CloudEventOverrides: &CloudEventOverrides{Extensions: map[string]string{"": "test"}},
 		}},
 		want: apis.ErrInvalidKeyName(
@@ -59,6 +71,12 @@ func TestSourceValidate(t *testing.T) {
 	}, {
 		name: "long extension key name is valid",
 		src: &Source{Spec: SourceSpec{
+			Sink: Destination{
+				URI: func() *apis.URL {
+					u, _ := apis.ParseURL("https://localhost")
+					return u
+				}(),
+			},
 			CloudEventOverrides: &CloudEventOverrides{
 				Extensions: map[string]string{"nameLongerThan20Characters": "test"},
 			},
@@ -67,6 +85,12 @@ func TestSourceValidate(t *testing.T) {
 	}, {
 		name: "invalid extension name",
 		src: &Source{Spec: SourceSpec{
+			Sink: Destination{
+				URI: func() *apis.URL {
+					u, _ := apis.ParseURL("https://localhost")
+					return u
+				}(),
+			},
 			CloudEventOverrides: &CloudEventOverrides{Extensions: map[string]string{"invalid_name": "test"}},
 		}},
 		want: apis.ErrInvalidKeyName(
@@ -77,6 +101,12 @@ func TestSourceValidate(t *testing.T) {
 	}, {
 		name: "valid extension name",
 		src: &Source{Spec: SourceSpec{
+			Sink: Destination{
+				URI: func() *apis.URL {
+					u, _ := apis.ParseURL("https://localhost")
+					return u
+				}(),
+			},
 			CloudEventOverrides: &CloudEventOverrides{
 				Extensions: map[string]string{"validName": "test"},
 			},


### PR DESCRIPTION
- The `Sink` in `SourceSpec` is required.
- Validate the `sink` field using `Destination.Validate(ctx)`