### PR TITLE
adds WithNamespace ability to contexts

### DIFF
--- a/apis/contexts.go
+++ b/apis/contexts.go
@@ -141,6 +141,22 @@ func IsWithinParent(ctx context.Context) bool {
 	return ok
 }
 
+type namespaceKey struct{}
+// WithNamespace attaches the request's namespace. Intended to be used
+// where defaulting depends on the namespace (eventing channels, brokers)
+// and the client may not provide it in the resource ObjectMeta
+func WithNamespace(ctx context.Context, ns string) context.Context {
+	return context.WithValue(ctx, namespaceKey{}, ns)
+}
+
+func GetNamespace(ctx context.Context) string {
+	if ns, ok := ctx.Value(namespaceKey{}).(string); ok {
+		return ns
+	}
+
+	return ""
+}
+
 // ParentMeta accesses the ObjectMeta of the enclosing parent resource
 // from the context.  See WithinParent for how to attach the parent's
 // ObjectMeta to the context.

--- a/apis/contexts_test.go
+++ b/apis/contexts_test.go
@@ -241,3 +241,18 @@ func TestGetHTTPRequest(t *testing.T) {
 		t.Errorf("GetHTTPRequest() = %v, wanted %v", got, want)
 	}
 }
+
+func TestGetNamespace(t *testing.T) {
+	ctx := context.Background()
+
+	if got := GetNamespace(ctx); got != "" {
+		t.Errorf("GetNamespace() = \"%v\", wanted \"\"", got)
+	}
+
+	ns := "some-namespace"
+	ctx = WithNamespace(ctx, ns)
+
+	if want, got := ns, GetNamespace(ctx); got != want {
+		t.Errorf("GetNamespace() = \"%v\", wanted \"%v\"", got, want)
+	}
+}

--- a/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/webhook/resourcesemantics/defaulting/defaulting.go
@@ -288,7 +288,7 @@ func (ac *reconciler) mutate(ctx context.Context, req *admissionv1.AdmissionRequ
 		ctx = apis.WithinCreate(ctx)
 	}
 	ctx = apis.WithUserInfo(ctx, &req.UserInfo)
-
+	ctx = apis.WithNamespace(ctx, req.Namespace)
 	// Default the new object.
 	if patches, err = setDefaults(ctx, patches, newObj); err != nil {
 		logger.Errorw("Failed the resource specific defaulter", zap.Error(err))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :bug: Fixes issue where namespace can be misrepresented in the context. Depending on the client, namespace may not be present in the metadata. With these changes, we attach the namespace directly from the incoming request. 

/kind bug

Fixes part of the issue raised in knative/eventing: [#4514](https://github.com/knative/eventing/issues/4514)

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
