### PR TITLE
Adjust leaderelection defaults

### DIFF
--- a/leaderelection/config.go
+++ b/leaderelection/config.go
@@ -98,9 +98,9 @@ func (c *Config) GetComponentConfig(name string) ComponentConfig {
 func defaultConfig() *Config {
 	return &Config{
 		Buckets:       1,
-		LeaseDuration: 15 * time.Second,
-		RenewDeadline: 10 * time.Second,
-		RetryPeriod:   2 * time.Second,
+		LeaseDuration: 60 * time.Second,
+		RenewDeadline: 40 * time.Second,
+		RetryPeriod:   10 * time.Second,
 	}
 }
 

--- a/leaderelection/doc.go
+++ b/leaderelection/doc.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// LeaderElection provides an interface for controllers implementing using
+// controller injection:
+// https://github.com/knative/pkg/blob/main/injection/README.md
+//
+// Leaderelection uses the context-stuffing mechanism to provide config-driven
+// management of multiple election strategies (currently, using Kubernetes
+// etcd-based election primitives or StatefulSet indexes and counts).
+//
+// For more details, see the original design document:
+// https://docs.google.com/document/d/e/2PACX-1vTh40N-Kk6EPNzYpITiLg8YJk0qZyZv7KgMpcQS72T9Lv_F2PQeGybx4TtH0E1N1aUgLQer7b8u3lDc/pub
+package leaderelection


### PR DESCRIPTION
Fixes: #2383

Also adds documentation for the `leaderelection` package, because I went
looking and found it wasn't there.

Verified that these settings do not seem to interfere with chaos duck integration tests in serving: https://github.com/knative/serving/pull/12499

/assign @mattmoor @dprotaso
