### PR TITLE
:bug: `TestDialWithBackoff` work without special environment

### DIFF
--- a/network/transports.go
+++ b/network/transports.go
@@ -55,6 +55,9 @@ var backOffTemplate = wait.Backoff{
 	Steps:    15,
 }
 
+// ErrTimeoutDialing when the timeout is reached after set amount of time.
+var ErrTimeoutDialing = errors.New("timed out dialing")
+
 // DialWithBackOff executes `net.Dialer.DialContext()` with exponentially increasing
 // dial timeouts. In addition it sleeps with random jitter between tries.
 var DialWithBackOff = NewBackoffDialer(backOffTemplate)
@@ -110,7 +113,7 @@ func dialBackOffHelper(ctx context.Context, network, address string, bo wait.Bac
 		return c, nil
 	}
 	elapsed := time.Since(start)
-	return nil, fmt.Errorf("timed out dialing after %.2fs", elapsed.Seconds())
+	return nil, fmt.Errorf("%w after %.2fs", ErrTimeoutDialing, elapsed.Seconds())
 }
 
 func newHTTPTransport(disableKeepAlives, disableCompression bool, maxIdle, maxIdlePerHost int) http.RoundTripper {


### PR DESCRIPTION
# Changes

- :bug: `TestDialWithBackoff` work without special environment

/kind bug

Fixes #2401 