### PR TITLE
Allow overriding webhook controller options

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -233,6 +233,17 @@ type ControllerOptions struct { //nolint // for backcompat.
 	Concurrency   int
 }
 
+// NameLogger re-assign ControllerOptions.Logger with a named
+// logger with name ControllerOptions.WorkQueueName.
+func (c *ControllerOptions) NameLogger(ctx context.Context) {
+	if c.Logger == nil {
+		logger := logging.FromContext(ctx)
+		c.Logger = logger.Named(c.WorkQueueName)
+		return
+	}
+	c.Logger = c.Logger.Named(c.WorkQueueName)
+}
+
 // NewContext instantiates an instance of our controller that will feed work to the
 // provided Reconciler as it is enqueued.
 func NewContext(ctx context.Context, r Reconciler, options ControllerOptions) *Impl {

--- a/webhook/context.go
+++ b/webhook/context.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package webhook
 
-import "context"
+import (
+	"context"
+
+	"knative.dev/pkg/controller"
+)
 
 // optionsKey is used as the key for associating information
 // with a context.Context.
@@ -36,4 +40,24 @@ func GetOptions(ctx context.Context) *Options {
 		return nil
 	}
 	return v.(*Options)
+}
+
+// controllerOptions is used as the key for associating information
+// with a context.Context.
+type controllerOptions struct{}
+
+// WithControllerOptions associates a set of controller.ControllerOptions with
+// the returned context.
+func WithControllerOptions(ctx context.Context, options *controller.ControllerOptions) context.Context {
+	return context.WithValue(ctx, controllerOptions{}, options)
+}
+
+// GetControllerOptions retrieves controller.ControllerOptions associated with the
+// given context via WithControllerOptions (above).
+func GetControllerOptions(ctx context.Context) *controller.ControllerOptions {
+	opt := ctx.Value(controllerOptions{})
+	if opt != nil {
+		return opt.(*controller.ControllerOptions)
+	}
+	return nil
 }

--- a/webhook/context_test.go
+++ b/webhook/context_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	"knative.dev/pkg/controller"
+)
+
+func TestWithControllerOptions(t *testing.T) {
+	want := &controller.ControllerOptions{}
+
+	ctx := context.Background()
+	ctx = WithControllerOptions(ctx, want)
+	got := GetControllerOptions(ctx)
+
+	if got != want {
+		t.Fatalf("Want %+v got %+v", want, got)
+	}
+}


### PR DESCRIPTION
Creating 2 defaulting webhooks w1 and w2 inside the same pod
for 2 different mutating webhook configuration manifests
doesn't work since the lease name is based on the hardcoded
queue name DefaultingWebhook. So, we get a single pod competing for
the same lease in 2 separate reconcilers for 2 separate webhooks.

This PR allows overriding `ControllerOptions` for webhooks
so that callers can work around the issue while maintaining
backward compatibility.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Allow overriding webhook controller options

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2418 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Allow overriding webhook controller options
```