### PR TITLE
Make URL compatible with controller-gen

### DIFF
--- a/apis/url.go
+++ b/apis/url.go
@@ -27,6 +27,7 @@ import (
 // URL is an alias of url.URL.
 // It has custom json marshal methods that enable it to be used in K8s CRDs
 // such that the CRD resource will have the URL but operator code can can work with url.URL struct
+// +kubebuilder:validation:Type=string
 type URL url.URL
 
 // ParseURL attempts to parse the given string as a URL.


### PR DESCRIPTION
# Changes

- This PR adds kubebuilder marker so CRDs using URL could be
generated with controller-gen.
Same change on VolatileTime: https://github.com/knative/pkg/pull/2104
- Without this marker, any CRD that uses URL fails with error below when using controller-gen
```
controller-gen crd paths="./pkg/apis/sources/v1alpha1/" output:crd:artifacts:config=config/source
/Users/clyu/.gimme/versions/go1.17.darwin.amd64/src/net/url/url.go:359:2: encountered struct field "Scheme" without JSON tag in type "URL"
/Users/clyu/.gimme/versions/go1.17.darwin.amd64/src/net/url/url.go:360:2: encountered struct field "Opaque" without JSON tag in type "URL"
Error: not all generators ran successfully
...
```
- Original issue: [Define schema for rabbitmqsources.sources.knative.dev](https://github.com/knative-sandbox/eventing-rabbitmq/issues/581)
- Related issues: https://github.com/kubernetes-sigs/controller-tools/issues/552, https://github.com/kubernetes-sigs/controller-tools/issues/625

/kind enhancement
