### PR TITLE
Take pointer to map in AsOptionalMap for consistency

### DIFF
--- a/configmap/parse.go
+++ b/configmap/parse.go
@@ -247,15 +247,19 @@ func Parse(data map[string]string, parsers ...ParseFunc) error {
 
 // AsOptionalMap parses the data into the target as a map[string]string, if it exists.
 // The map is represented as a list of key-value pairs with a common prefix.
-func AsOptionalMap(prefix string, target **map[string]string) ParseFunc {
+func AsOptionalMap(prefix string, target *map[string]string) ParseFunc {
+	if target == nil {
+		panic("target cannot be nil")
+	}
+
 	return func(data map[string]string) error {
 		for k, v := range data {
 			if strings.HasPrefix(k, prefix) && len(k) > len(prefix)+1 {
 				if *target == nil {
 					m := make(map[string]string, 2)
-					*target = &m
+					*target = m
 				}
-				(**target)[k[len(prefix)+1: /* remove dot `.` */]] = v
+				(*target)[k[len(prefix)+1: /* remove dot `.` */]] = v
 			}
 		}
 		return nil

--- a/configmap/parse.go
+++ b/configmap/parse.go
@@ -247,11 +247,15 @@ func Parse(data map[string]string, parsers ...ParseFunc) error {
 
 // AsOptionalMap parses the data into the target as a map[string]string, if it exists.
 // The map is represented as a list of key-value pairs with a common prefix.
-func AsOptionalMap(prefix string, target map[string]string) ParseFunc {
+func AsOptionalMap(prefix string, target **map[string]string) ParseFunc {
 	return func(data map[string]string) error {
 		for k, v := range data {
 			if strings.HasPrefix(k, prefix) && len(k) > len(prefix)+1 {
-				target[k[len(prefix)+1: /* remove dot `.` */]] = v
+				if *target == nil {
+					m := make(map[string]string, 2)
+					*target = &m
+				}
+				(**target)[k[len(prefix)+1: /* remove dot `.` */]] = v
 			}
 		}
 		return nil

--- a/configmap/parse.go
+++ b/configmap/parse.go
@@ -245,9 +245,9 @@ func Parse(data map[string]string, parsers ...ParseFunc) error {
 	return nil
 }
 
-// AsOptionalMap parses the data into the target as a map[string]string, if it exists.
+// CollectMapEntriesWithPrefix parses the data into the target as a map[string]string, if it exists.
 // The map is represented as a list of key-value pairs with a common prefix.
-func AsOptionalMap(prefix string, target *map[string]string) ParseFunc {
+func CollectMapEntriesWithPrefix(prefix string, target *map[string]string) ParseFunc {
 	if target == nil {
 		panic("target cannot be nil")
 	}

--- a/configmap/parse_test.go
+++ b/configmap/parse_test.go
@@ -43,7 +43,7 @@ type testConfig struct {
 	nsn  types.NamespacedName
 	onsn *types.NamespacedName
 
-	dict map[string]string
+	dict *map[string]string
 }
 
 func TestParse(t *testing.T) {
@@ -76,9 +76,6 @@ func TestParse(t *testing.T) {
 			"test-dict.k":  "v",
 			"test-dict.k1": "v1",
 		},
-		conf: testConfig{
-			dict: map[string]string{},
-		},
 		want: testConfig{
 			str:    "foo.bar",
 			toggle: true,
@@ -100,7 +97,7 @@ func TestParse(t *testing.T) {
 				Name:      "some-other-name",
 				Namespace: "some-other-namespace",
 			},
-			dict: map[string]string{
+			dict: &map[string]string{
 				"k":  "v",
 				"k1": "v1",
 			},
@@ -218,13 +215,13 @@ func TestParse(t *testing.T) {
 				AsQuantity("test-quantity", &test.conf.qua),
 				AsNamespacedName("test-namespaced-name", &test.conf.nsn),
 				AsOptionalNamespacedName("test-optional-namespaced-name", &test.conf.onsn),
-				AsOptionalMap("test-dict", test.conf.dict),
+				AsOptionalMap("test-dict", &test.conf.dict),
 			); (err == nil) == test.expectErr {
 				t.Fatal("Failed to parse data:", err)
 			}
 
-			if !cmp.Equal(test.conf, test.want, cmp.AllowUnexported(testConfig{})) {
-				t.Fatalf("parsed = %v, want %v", test.conf, test.want)
+			if diff := cmp.Diff(test.want, test.conf, cmp.AllowUnexported(testConfig{})); diff != "" {
+				t.Fatal("(-want, +got)", diff)
 			}
 		})
 	}

--- a/configmap/parse_test.go
+++ b/configmap/parse_test.go
@@ -215,7 +215,7 @@ func TestParse(t *testing.T) {
 				AsQuantity("test-quantity", &test.conf.qua),
 				AsNamespacedName("test-namespaced-name", &test.conf.nsn),
 				AsOptionalNamespacedName("test-optional-namespaced-name", &test.conf.onsn),
-				AsOptionalMap("test-dict", &test.conf.dict),
+				CollectMapEntriesWithPrefix("test-dict", &test.conf.dict),
 			); (err == nil) == test.expectErr {
 				t.Fatal("Failed to parse data:", err)
 			}

--- a/configmap/parse_test.go
+++ b/configmap/parse_test.go
@@ -43,7 +43,7 @@ type testConfig struct {
 	nsn  types.NamespacedName
 	onsn *types.NamespacedName
 
-	dict *map[string]string
+	dict map[string]string
 }
 
 func TestParse(t *testing.T) {
@@ -97,7 +97,7 @@ func TestParse(t *testing.T) {
 				Name:      "some-other-name",
 				Namespace: "some-other-namespace",
 			},
-			dict: &map[string]string{
+			dict: map[string]string{
 				"k":  "v",
 				"k1": "v1",
 			},

--- a/leaderelection/config.go
+++ b/leaderelection/config.go
@@ -57,7 +57,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 
 		cm.AsUint32("buckets", &config.Buckets),
 
-		cm.AsOptionalMap("map-lease-prefix", &config.LeaseNamesPrefixMapping),
+		cm.CollectMapEntriesWithPrefix("map-lease-prefix", &config.LeaseNamesPrefixMapping),
 	); err != nil {
 		return nil, err
 	}

--- a/leaderelection/config.go
+++ b/leaderelection/config.go
@@ -85,21 +85,18 @@ type Config struct {
 	LeaseDuration           time.Duration
 	RenewDeadline           time.Duration
 	RetryPeriod             time.Duration
-	LeaseNamesPrefixMapping *map[string]string
+	LeaseNamesPrefixMapping map[string]string
 }
 
 func (c *Config) GetComponentConfig(name string) ComponentConfig {
-	cc := ComponentConfig{
-		Component:     name,
-		Buckets:       c.Buckets,
-		LeaseDuration: c.LeaseDuration,
-		RenewDeadline: c.RenewDeadline,
-		RetryPeriod:   c.RetryPeriod,
+	return ComponentConfig{
+		Component:               name,
+		Buckets:                 c.Buckets,
+		LeaseDuration:           c.LeaseDuration,
+		RenewDeadline:           c.RenewDeadline,
+		RetryPeriod:             c.RetryPeriod,
+		LeaseNamesPrefixMapping: c.LeaseNamesPrefixMapping,
 	}
-	if c.LeaseNamesPrefixMapping != nil {
-		cc.LeaseNamesPrefixMapping = *c.LeaseNamesPrefixMapping
-	}
-	return cc
 }
 
 func defaultConfig() *Config {

--- a/leaderelection/config.go
+++ b/leaderelection/config.go
@@ -57,7 +57,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 
 		cm.AsUint32("buckets", &config.Buckets),
 
-		cm.AsOptionalMap("map-lease-prefix", config.LeaseNamesPrefixMapping),
+		cm.AsOptionalMap("map-lease-prefix", &config.LeaseNamesPrefixMapping),
 	); err != nil {
 		return nil, err
 	}
@@ -85,27 +85,29 @@ type Config struct {
 	LeaseDuration           time.Duration
 	RenewDeadline           time.Duration
 	RetryPeriod             time.Duration
-	LeaseNamesPrefixMapping map[string]string
+	LeaseNamesPrefixMapping *map[string]string
 }
 
 func (c *Config) GetComponentConfig(name string) ComponentConfig {
-	return ComponentConfig{
-		Component:               name,
-		Buckets:                 c.Buckets,
-		LeaseDuration:           c.LeaseDuration,
-		RenewDeadline:           c.RenewDeadline,
-		RetryPeriod:             c.RetryPeriod,
-		LeaseNamesPrefixMapping: c.LeaseNamesPrefixMapping,
+	cc := ComponentConfig{
+		Component:     name,
+		Buckets:       c.Buckets,
+		LeaseDuration: c.LeaseDuration,
+		RenewDeadline: c.RenewDeadline,
+		RetryPeriod:   c.RetryPeriod,
 	}
+	if c.LeaseNamesPrefixMapping != nil {
+		cc.LeaseNamesPrefixMapping = *c.LeaseNamesPrefixMapping
+	}
+	return cc
 }
 
 func defaultConfig() *Config {
 	return &Config{
-		Buckets:                 1,
-		LeaseDuration:           60 * time.Second,
-		RenewDeadline:           40 * time.Second,
-		RetryPeriod:             10 * time.Second,
-		LeaseNamesPrefixMapping: make(map[string]string),
+		Buckets:       1,
+		LeaseDuration: 60 * time.Second,
+		RenewDeadline: 40 * time.Second,
+		RetryPeriod:   10 * time.Second,
 	}
 }
 

--- a/leaderelection/config_test.go
+++ b/leaderelection/config_test.go
@@ -199,7 +199,7 @@ func TestNewConfigFromMap(t *testing.T) {
 			LeaseDuration: 15 * time.Second,
 			RenewDeadline: 40 * time.Second,
 			RetryPeriod:   10 * time.Second,
-			LeaseNamesPrefixMapping: &map[string]string{
+			LeaseNamesPrefixMapping: map[string]string{
 				"reconciler": "reconciler1",
 			},
 		},

--- a/leaderelection/config_test.go
+++ b/leaderelection/config_test.go
@@ -38,11 +38,10 @@ const (
 
 func okConfig() *Config {
 	return &Config{
-		Buckets:                 1,
-		LeaseDuration:           15 * time.Second,
-		RenewDeadline:           10 * time.Second,
-		RetryPeriod:             2 * time.Second,
-		LeaseNamesPrefixMapping: map[string]string{},
+		Buckets:       1,
+		LeaseDuration: 15 * time.Second,
+		RenewDeadline: 10 * time.Second,
+		RetryPeriod:   2 * time.Second,
 	}
 }
 
@@ -123,11 +122,10 @@ func TestNewConfigMapFromData(t *testing.T) {
 			"buckets":       "5",
 		},
 		expected: &Config{
-			Buckets:                 5,
-			LeaseDuration:           2 * time.Second,
-			RenewDeadline:           3 * time.Second,
-			RetryPeriod:             4 * time.Second,
-			LeaseNamesPrefixMapping: map[string]string{},
+			Buckets:       5,
+			LeaseDuration: 2 * time.Second,
+			RenewDeadline: 3 * time.Second,
+			RetryPeriod:   4 * time.Second,
 		},
 	}, {
 		name: "prioritize new keys",
@@ -141,11 +139,10 @@ func TestNewConfigMapFromData(t *testing.T) {
 			"buckets":        "7",
 		},
 		expected: &Config{
-			Buckets:                 7,
-			LeaseDuration:           1 * time.Second,
-			RenewDeadline:           2 * time.Second,
-			RetryPeriod:             3 * time.Second,
-			LeaseNamesPrefixMapping: map[string]string{},
+			Buckets:       7,
+			LeaseDuration: 1 * time.Second,
+			RenewDeadline: 2 * time.Second,
+			RetryPeriod:   3 * time.Second,
 		},
 	}}
 
@@ -185,11 +182,10 @@ func TestNewConfigFromMap(t *testing.T) {
 			"buckets":        "5",
 		},
 		want: Config{
-			Buckets:                 5,
-			LeaseDuration:           15 * time.Second,
-			RenewDeadline:           40 * time.Second,
-			RetryPeriod:             10 * time.Second,
-			LeaseNamesPrefixMapping: map[string]string{},
+			Buckets:       5,
+			LeaseDuration: 15 * time.Second,
+			RenewDeadline: 40 * time.Second,
+			RetryPeriod:   10 * time.Second,
 		},
 	}, {
 		name: "ok config, prefix map",
@@ -203,7 +199,7 @@ func TestNewConfigFromMap(t *testing.T) {
 			LeaseDuration: 15 * time.Second,
 			RenewDeadline: 40 * time.Second,
 			RetryPeriod:   10 * time.Second,
-			LeaseNamesPrefixMapping: map[string]string{
+			LeaseNamesPrefixMapping: &map[string]string{
 				"reconciler": "reconciler1",
 			},
 		},


### PR DESCRIPTION
- Other `As*` functions take pointers.
- This avoids having to initialize the map passed to the function

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>