### PR TITLE
drop deprecated eventing repos

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -38,11 +38,7 @@ jobs:
             org: knative
           - repo: eventing-autoscaler-keda
             org: knative-sandbox
-          - repo: eventing-awssqs
-            org: knative-sandbox
           - repo: eventing-ceph
-            org: knative-sandbox
-          - repo: eventing-couchdb
             org: knative-sandbox
           - repo: eventing-github
             org: knative-sandbox
@@ -53,8 +49,6 @@ jobs:
           - repo: eventing-kafka-broker
             org: knative-sandbox
           - repo: eventing-natss
-            org: knative-sandbox
-          - repo: eventing-prometheus
             org: knative-sandbox
           - repo: eventing-rabbitmq
             org: knative-sandbox


### PR DESCRIPTION
/assign @lionelvillard @ahmetb 

These repos are no longer on the release train