### PR TITLE
Add `NewProxyAutoTLSTransport` and `DialTLSWithBackOff` to support TLS proxy

### DIFF
--- a/network/h2c.go
+++ b/network/h2c.go
@@ -54,3 +54,16 @@ func newH2CTransport(disableCompression bool) http.RoundTripper {
 		},
 	}
 }
+
+// newH2Transport constructs a neew H2 transport. That transport will handles HTTPS traffic
+// with TLS config.
+func newH2Transport(disableCompression bool, tlsConf *tls.Config) http.RoundTripper {
+	return &http2.Transport{
+		DisableCompression: disableCompression,
+		DialTLS: func(netw, addr string, tlsConf *tls.Config) (net.Conn, error) {
+			return DialTLSWithBackOff(context.Background(),
+				netw, addr, tlsConf)
+		},
+		TLSClientConfig: tlsConf,
+	}
+}

--- a/network/transports.go
+++ b/network/transports.go
@@ -18,6 +18,7 @@ package network
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -63,11 +64,21 @@ var DialWithBackOff = NewBackoffDialer(backOffTemplate)
 // between tries.
 func NewBackoffDialer(backoffConfig wait.Backoff) func(context.Context, string, string) (net.Conn, error) {
 	return func(ctx context.Context, network, address string) (net.Conn, error) {
-		return dialBackOffHelper(ctx, network, address, backoffConfig, sleepTO)
+		return dialBackOffHelper(ctx, network, address, backoffConfig, sleepTO, nil)
 	}
 }
 
-func dialBackOffHelper(ctx context.Context, network, address string, bo wait.Backoff, sleep time.Duration) (net.Conn, error) {
+// DialTLSWithBackOff is same with DialWithBackOff but takes tls config.
+var DialTLSWithBackOff = NewTLSBackoffDialer(backOffTemplate)
+
+// NewTLSBackoffDialer is same with NewBackoffDialer but takes tls config.
+func NewTLSBackoffDialer(backoffConfig wait.Backoff) func(context.Context, string, string, *tls.Config) (net.Conn, error) {
+	return func(ctx context.Context, network, address string, tlsConf *tls.Config) (net.Conn, error) {
+		return dialBackOffHelper(ctx, network, address, backoffConfig, sleepTO, tlsConf)
+	}
+}
+
+func dialBackOffHelper(ctx context.Context, network, address string, bo wait.Backoff, sleep time.Duration, tlsConf *tls.Config) (net.Conn, error) {
 	dialer := &net.Dialer{
 		Timeout:   bo.Duration, // Initial duration.
 		KeepAlive: 5 * time.Second,
@@ -75,7 +86,15 @@ func dialBackOffHelper(ctx context.Context, network, address string, bo wait.Bac
 	}
 	start := time.Now()
 	for {
-		c, err := dialer.DialContext(ctx, network, address)
+		var (
+			c   net.Conn
+			err error
+		)
+		if tlsConf == nil {
+			c, err = dialer.DialContext(ctx, network, address)
+		} else {
+			c, err = tls.DialWithDialer(dialer, network, address, tlsConf)
+		}
 		if err != nil {
 			var errNet net.Error
 			if errors.As(err, &errNet) && errNet.Timeout() {
@@ -105,12 +124,32 @@ func newHTTPTransport(disableKeepAlives, disableCompression bool, maxIdle, maxId
 	return transport
 }
 
+func newHTTPSTransport(disableKeepAlives, disableCompression bool, maxIdle, maxIdlePerHost int, tlsConf *tls.Config) http.RoundTripper {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = DialWithBackOff
+	transport.DisableKeepAlives = disableKeepAlives
+	transport.MaxIdleConns = maxIdle
+	transport.MaxIdleConnsPerHost = maxIdlePerHost
+	transport.ForceAttemptHTTP2 = false
+	transport.DisableCompression = disableCompression
+
+	transport.TLSClientConfig = tlsConf
+	return transport
+}
+
 // NewProberTransport creates a RoundTripper that is useful for probing,
 // since it will not cache connections.
 func NewProberTransport() http.RoundTripper {
 	return newAutoTransport(
 		newHTTPTransport(true /*disable keep-alives*/, false /*disable auto-compression*/, 0, 0 /*no caching*/),
 		NewH2CTransport())
+}
+
+// NewProxyAutoTLSTransport is same with NewProxyAutoTransport but it has tls.Config to create HTTPS request.
+func NewProxyAutoTLSTransport(maxIdle, maxIdlePerHost int, tlsConf *tls.Config) http.RoundTripper {
+	return newAutoTransport(
+		newHTTPSTransport(false /*disable keep-alives*/, true /*disable auto-compression*/, maxIdle, maxIdlePerHost, tlsConf),
+		newH2Transport(true /*disable auto-compression*/, tlsConf))
 }
 
 // NewAutoTransport creates a RoundTripper that can use appropriate transport

--- a/network/transports.go
+++ b/network/transports.go
@@ -46,7 +46,7 @@ func newAutoTransport(v1, v2 http.RoundTripper) http.RoundTripper {
 	})
 }
 
-const sleepTO = 30 * time.Millisecond
+const sleep = 30 * time.Millisecond
 
 var backOffTemplate = wait.Backoff{
 	Duration: 50 * time.Millisecond,
@@ -64,7 +64,7 @@ var DialWithBackOff = NewBackoffDialer(backOffTemplate)
 // between tries.
 func NewBackoffDialer(backoffConfig wait.Backoff) func(context.Context, string, string) (net.Conn, error) {
 	return func(ctx context.Context, network, address string) (net.Conn, error) {
-		return dialBackOffHelper(ctx, network, address, backoffConfig, sleepTO, nil)
+		return dialBackOffHelper(ctx, network, address, backoffConfig, nil)
 	}
 }
 
@@ -74,11 +74,11 @@ var DialTLSWithBackOff = NewTLSBackoffDialer(backOffTemplate)
 // NewTLSBackoffDialer is same with NewBackoffDialer but takes tls config.
 func NewTLSBackoffDialer(backoffConfig wait.Backoff) func(context.Context, string, string, *tls.Config) (net.Conn, error) {
 	return func(ctx context.Context, network, address string, tlsConf *tls.Config) (net.Conn, error) {
-		return dialBackOffHelper(ctx, network, address, backoffConfig, sleepTO, tlsConf)
+		return dialBackOffHelper(ctx, network, address, backoffConfig, tlsConf)
 	}
 }
 
-func dialBackOffHelper(ctx context.Context, network, address string, bo wait.Backoff, sleep time.Duration, tlsConf *tls.Config) (net.Conn, error) {
+func dialBackOffHelper(ctx context.Context, network, address string, bo wait.Backoff, tlsConf *tls.Config) (net.Conn, error) {
 	dialer := &net.Dialer{
 		Timeout:   bo.Duration, // Initial duration.
 		KeepAlive: 5 * time.Second,

--- a/network/transports_test.go
+++ b/network/transports_test.go
@@ -82,7 +82,7 @@ func TestDialWithBackoff(t *testing.T) {
 	bo.Steps = 2
 
 	// Timeout. Use special testing IP address.
-	c, err = dialBackOffHelper(context.Background(), "tcp4", "198.18.0.254:8888", bo, sleepTO, nil)
+	c, err = dialBackOffHelper(context.Background(), "tcp4", "198.18.0.254:8888", bo, nil)
 	if err == nil {
 		c.Close()
 		t.Error("Unexpected success dialing")
@@ -120,7 +120,7 @@ func TestDialTLSWithBackoff(t *testing.T) {
 	bo.Steps = 2
 
 	// Timeout. Use special testing IP address.
-	c, err = dialBackOffHelper(context.Background(), "tcp4", "198.18.0.254:8888", bo, sleepTO, tlsConf)
+	c, err = dialBackOffHelper(context.Background(), "tcp4", "198.18.0.254:8888", bo, tlsConf)
 	if err == nil {
 		c.Close()
 		t.Error("Unexpected success dialing")


### PR DESCRIPTION
Part of: https://github.com/knative/serving/issues/12503
PoC: https://github.com/knative/serving/pull/12815

This patch `NewProxyAutoTLSTransport` which is `NewProxyAutoTransport + TLS config.
Current proxy does not support TLS but it needs for https://github.com/knative/serving/issues/12503.

`DialTLSWithBackOff` is also `DialWithBackOff` + TLS config. It needs
`newH2Transport` which handles HTTP2 with TLS.

/cc @evankanderson @skonto @rhuss 