### PR TITLE
:bug: Preallocate free ports before running network tests

### DIFF
--- a/network/support_test.go
+++ b/network/support_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import "net/http"
+
+func NewRoundTripperAutoTransport(v1, v2 http.RoundTripper) http.RoundTripper {
+	return newAutoTransport(v1, v2)
+}


### PR DESCRIPTION
# Changes

- :bug: Preallocate free ports before running network tests

/kind bug

Fixes #2502