### PR TITLE
Fix timeout test on darwin and log dial destination on timeout.

### DIFF
--- a/network/transports.go
+++ b/network/transports.go
@@ -113,7 +113,7 @@ func dialBackOffHelper(ctx context.Context, network, address string, bo wait.Bac
 		return c, nil
 	}
 	elapsed := time.Since(start)
-	return nil, fmt.Errorf("%w after %.2fs", ErrTimeoutDialing, elapsed.Seconds())
+	return nil, fmt.Errorf("%w %s after %.2fs", ErrTimeoutDialing, address, elapsed.Seconds())
 }
 
 func newHTTPTransport(disableKeepAlives, disableCompression bool, maxIdle, maxIdlePerHost int) http.RoundTripper {

--- a/network/transports_test.go
+++ b/network/transports_test.go
@@ -240,7 +240,7 @@ func listenOne() (func(), *net.TCPAddr, error) {
 	if err = syscall.Bind(fd, sa); err != nil {
 		return nil, nil, newTestErr("Unable to bind", err)
 	}
-	if err = syscall.Listen(fd, 0); err != nil {
+	if err = syscall.Listen(fd, 1); err != nil {
 		return nil, nil, newTestErr("Unable to Listen", err)
 	}
 	closer := func() { _ = syscall.Close(fd) }


### PR DESCRIPTION
Fixes: #2502

This adds extra logging so we can determine if a dial timeout like in #2502 was
hitting the expected port.

/assign @cardil
/cc @dprotaso
