### PR TITLE
Support informer filtering in sharedmain

### DIFF
--- a/injection/filtering/informers_util.go
+++ b/injection/filtering/informers_util.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filtering
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"k8s.io/apimachinery/pkg/labels"
+	filteredFactory "knative.dev/pkg/client/injection/kube/informers/factory/filtered"
+)
+
+const (
+	// Label Key/Value pair to be used by Knative controllers implementing filtering
+	KnativeUsedbyKey   = "knative.dev/used-by"
+	KnativeUsedByValue = "true"
+	// Env var to pass the label selectors via a comma separated list eg. k1=v1,k2=v2
+	InformerLabelSelectorsFilterEnv = "INFORMER_LABEL_SELECTORS_FILTER"
+)
+
+// InformersFilterByLabeladds checks if user has set label selectors
+// to be used by filtering informers. Then passes the selectors to the current context so
+// that filtering informer factories can pick up the labels.
+func InformersFilterByLabel(ctx context.Context) context.Context {
+	if labelsStr := os.Getenv(InformerLabelSelectorsFilterEnv); labelsStr != "" {
+		// Validate labels
+		labelsSet, err := labels.ConvertSelectorToLabelsMap(labelsStr)
+		if err != nil {
+			log.Fatal("Error converting label selector string: ", err)
+			return ctx
+		}
+		labelList := make([]string, 0, len(labelsSet))
+		for k, v := range labelsSet {
+			labelList = append(labelList, fmt.Sprintf("%s=%s", k, v))
+		}
+		ctx = filteredFactory.WithSelectors(ctx, labelList...)
+	} else {
+		// Empty selector meant for initializing the factory in paths where filtered factory is imported
+		// eg. sharedmain but no labels are set via the env var. This matches everything.
+		ctx = filteredFactory.WithSelectors(ctx, "")
+	}
+	return ctx
+}
+
+// AddKnativeUsedByLabels adds a predefined label selector to a labels map.
+// It is meant to be used with resource labels maps eg. secret labels.
+func AddKnativeUsedByLabels(objectLabels map[string]string) map[string]string {
+	if objectLabels == nil {
+		objectLabels = map[string]string{}
+	}
+	if labelsStr := os.Getenv(InformerLabelSelectorsFilterEnv); labelsStr != "" {
+		labelsSet, err := labels.ConvertSelectorToLabelsMap(labelsStr)
+		if err != nil {
+			log.Fatal("Error converting label selector string: ", err)
+		}
+		if val, ok := labelsSet[KnativeUsedbyKey]; ok && val == KnativeUsedByValue {
+			objectLabels[KnativeUsedbyKey] = KnativeUsedByValue
+		}
+	}
+	return objectLabels
+}

--- a/injection/filtering/informers_util_default_test.go
+++ b/injection/filtering/informers_util_default_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filtering
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/client-go/rest"
+	secretfilteredfakeinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/filtered/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/factory/filtered/fake"
+	"knative.dev/pkg/injection"
+)
+
+func TestWithoutFilteringInformersSetup(t *testing.T) {
+	t.Setenv("SYSTEM_NAMESPACE", "system")
+	ctx := InformersFilterByLabel(context.Background())
+	ctx, infs := injection.Fake.SetupInformers(ctx, &rest.Config{})
+	if want, got := 1, len(infs); got != want {
+		t.Errorf("SetupInformers() = %d, wanted %d", got, want)
+	}
+	_ = secretfilteredfakeinformer.Get(ctx, "")
+}

--- a/injection/filtering/informers_util_test.go
+++ b/injection/filtering/informers_util_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filtering
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"k8s.io/client-go/rest"
+	secretfilteredfakeinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/filtered/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/factory/filtered/fake"
+	"knative.dev/pkg/injection"
+)
+
+func TestFilteringInformersSetup(t *testing.T) {
+	t.Setenv(InformerLabelSelectorsFilterEnv, fmt.Sprintf("%s=%s, %s=%s", KnativeUsedbyKey, KnativeUsedByValue, "test", "test"))
+	t.Setenv("SYSTEM_NAMESPACE", "system")
+	ctx := InformersFilterByLabel(context.Background())
+	ctx, infs := injection.Fake.SetupInformers(ctx, &rest.Config{})
+	// We have two label selectors so we expect equal number of informers
+	if want, got := 2, len(infs); got != want {
+		t.Errorf("SetupInformers() = %d, wanted %d", got, want)
+	}
+	// Request informers one by one, this should not panic
+	_ = secretfilteredfakeinformer.Get(ctx, fmt.Sprintf("%s=%s", KnativeUsedbyKey, KnativeUsedByValue))
+	_ = secretfilteredfakeinformer.Get(ctx, fmt.Sprintf("%s=%s", "test", "test"))
+}

--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -43,6 +43,7 @@ import (
 	cminformer "knative.dev/pkg/configmap/informer"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
+	"knative.dev/pkg/injection/filtering"
 	"knative.dev/pkg/leaderelection"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
@@ -200,6 +201,7 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 	log.Printf("Registering %d clients", len(injection.Default.GetClients()))
 	log.Printf("Registering %d informer factories", len(injection.Default.GetInformerFactories()))
 	log.Printf("Registering %d informers", len(injection.Default.GetInformers()))
+	log.Printf("Registering %d filtered informers", len(injection.Default.GetFilteredInformers()))
 	log.Printf("Registering %d controllers", len(ctors))
 
 	metrics.MemStatsOrDie(ctx)
@@ -212,6 +214,9 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 	if cfg.Burst == 0 {
 		cfg.Burst = len(ctors) * rest.DefaultBurst
 	}
+
+	// Filter by label if we have to
+	ctx = filtering.InformersFilterByLabel(ctx)
 
 	ctx, startInformers := injection.EnableInjectionOrDie(ctx, cfg)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Defines an env variable to pass a number of label selectors to the informers setup in sharedmain. The informers factories pick up the labels and create one informer per label selector. 
- Defines a label selector: "knative.dev/used-by"="true" to be used in controllers when linking to an informer. This is not required but defines a convention across the ecosystem for filtering.
- Due to the filtered factory import we need to define a default label ("" which matches all resources) 
even in cases we dont use filtering. For more check [here](https://github.com/knative/pkg/tree/main/injection#consuming-informers) for how informers are consumed in this repo.
- This is part of the work for fixing https://github.com/knative/serving/issues/12778 and adding a primitive for filtering resources that could also be used for multi-tenancy reasons.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind 

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Informers filtering is supported via a special env var `INFORMER_LABEL_SELECTORS_FILTER`

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Informers filtering is supported via a special env var `INFORMER_LABEL_SELECTORS_FILTER`. Users can utilize "knative.dev/used-by":true" label selector when linking informers in controller implementation to select related resources only.
If no label is used a default selector is added that has not effect and all resources can be listed.
```
