### PR TITLE
Abstract how our webhook implementations target things.

### DIFF
--- a/webhook/resourcesemantics/validation/controller.go
+++ b/webhook/resourcesemantics/validation/controller.go
@@ -22,7 +22,6 @@ import (
 	// Injection stuff
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	vwhinformer "knative.dev/pkg/client/injection/kube/informers/admissionregistration/v1/validatingwebhookconfiguration"
-	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 
@@ -30,9 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/system"
-	"knative.dev/pkg/webhook"
 	"knative.dev/pkg/webhook/resourcesemantics"
+	"knative.dev/pkg/webhook/targeter"
 )
 
 // NewAdmissionController constructs a reconciler
@@ -44,11 +42,21 @@ func NewAdmissionController(
 	disallowUnknownFields bool,
 	callbacks ...map[schema.GroupVersionKind]Callback,
 ) *controller.Impl {
+	return NewAdmissionControllerFromTargeter(ctx, name, targeter.NewFixed(ctx, path), handlers, wc, disallowUnknownFields, callbacks...)
+}
+
+// NewAdmissionController constructs a reconciler
+func NewAdmissionControllerFromTargeter(
+	ctx context.Context, name string,
+	targeter targeter.Interface,
+	handlers map[schema.GroupVersionKind]resourcesemantics.GenericCRD,
+	wc func(context.Context) context.Context,
+	disallowUnknownFields bool,
+	callbacks ...map[schema.GroupVersionKind]Callback,
+) *controller.Impl {
 
 	client := kubeclient.Get(ctx)
 	vwhInformer := vwhinformer.Get(ctx)
-	secretInformer := secretinformer.Get(ctx)
-	options := webhook.GetOptions(ctx)
 
 	// This not ideal, we are using a variadic argument to effectively make callbacks optional
 	// This allows this addition to be non-breaking to consumers of /pkg
@@ -75,17 +83,16 @@ func NewAdmissionController(
 		key: types.NamespacedName{
 			Name: name,
 		},
-		path:      path,
 		handlers:  handlers,
 		callbacks: unwrappedCallbacks,
 
 		withContext:           wc,
 		disallowUnknownFields: disallowUnknownFields,
-		secretName:            options.SecretName,
 
-		client:       client,
-		vwhlister:    vwhInformer.Lister(),
-		secretlister: secretInformer.Lister(),
+		client:    client,
+		vwhlister: vwhInformer.Lister(),
+
+		targeter: targeter,
 	}
 
 	logger := logging.FromContext(ctx)
@@ -100,13 +107,7 @@ func NewAdmissionController(
 		Handler: controller.HandleAll(c.Enqueue),
 	})
 
-	// Reconcile when the cert bundle changes.
-	secretInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterWithNameAndNamespace(system.Namespace(), wh.secretName),
-		// It doesn't matter what we enqueue because we will always Reconcile
-		// the named VWH resource.
-		Handler: controller.HandleAll(c.Enqueue),
-	})
+	targeter.AddEventHandlers(ctx, c.Enqueue)
 
 	return c
 }

--- a/webhook/targeter/dynamic.go
+++ b/webhook/targeter/dynamic.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package targeter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/controller"
+	nsfactory "knative.dev/pkg/injection/clients/namespacedkube/informers/factory"
+	"knative.dev/pkg/ptr"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
+	certresources "knative.dev/pkg/webhook/certificates/resources"
+)
+
+// DispatchingInterface encapsulates how webhooks that host multiple endpoints
+// target us.
+type DispatchingInterface interface {
+	Interface
+
+	// GetName extracts the name of the resource that we should dispatch to.
+	GetName(ctx context.Context, path string) (string, error)
+}
+
+// NewDynamic returns a DispatchingInterface that handles a path prefix by
+// encoding "names" under that path, and allowing implementations to extract
+// those names to lookup the appropriate handling logic dynamically.
+func NewDynamic(ctx context.Context, path string) DispatchingInterface {
+	options := webhook.GetOptions(ctx)
+	// We rely on something else to have set this up and start it
+	// via injection, typically the cert controller.
+	secretInformer := nsfactory.Get(ctx).Core().V1().Secrets()
+	return &Dynamic{
+		Path:         path,
+		SecretName:   options.SecretName,
+		ServiceName:  options.ServiceName,
+		SecretLister: secretInformer.Lister(),
+	}
+}
+
+// Dynamic is public to make testing easier in other packages.  Code should
+// use NewDynamic to construct Dynamic instances.
+type Dynamic struct {
+	Path         string
+	SecretName   string
+	ServiceName  string
+	SecretLister corelisters.SecretLister
+}
+
+// Assert that Local implements DispatchingInterface
+var _ DispatchingInterface = (*Dynamic)(nil)
+
+// BasePath implements Interface
+func (lt *Dynamic) BasePath() string {
+	return lt.Path
+}
+
+var ErrMissingName = errors.New("the WebhookClientConfig expects context to be infuxed with a name")
+
+// WebhookClientConfig implements Interface
+func (lt *Dynamic) WebhookClientConfig(ctx context.Context) (*admissionregistrationv1.WebhookClientConfig, error) {
+	name := GetName(ctx)
+	if name == "" {
+		return nil, ErrMissingName
+	}
+
+	// Look up the webhook secret, and fetch the CA cert bundle.
+	secret, err := lt.SecretLister.Secrets(system.Namespace()).Get(lt.SecretName)
+	if err != nil {
+		return nil, err
+	}
+	cacert, ok := secret.Data[certresources.CACert]
+	if !ok {
+		return nil, fmt.Errorf("secret %q is missing %q key", lt.SecretName, certresources.CACert)
+	}
+
+	return &admissionregistrationv1.WebhookClientConfig{
+		Service: &admissionregistrationv1.ServiceReference{
+			Namespace: system.Namespace(),
+			Name:      lt.ServiceName,
+			Path:      ptr.String(path.Join(lt.Path, name)),
+		},
+		CABundle: cacert,
+	}, nil
+}
+
+// GetName implements Interface
+func (lt *Dynamic) GetName(ctx context.Context, path string) (string, error) {
+	if !strings.HasPrefix(path, lt.Path) {
+		return "", fmt.Errorf("expected path %q to have prefix %q", path, lt.Path)
+	}
+	return path[len(lt.Path):], nil
+}
+
+// AddEventHandlers implements Interface
+func (lt *Dynamic) AddEventHandlers(ctx context.Context, f func(interface{})) {
+	// We rely on something else to have set this up and start it
+	// via injection, typically the cert controller.
+	secretInformer := nsfactory.Get(ctx).Core().V1().Secrets()
+
+	// Reconcile when the cert bundle changes.
+	secretInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterWithNameAndNamespace(system.Namespace(), lt.SecretName),
+		// It doesn't matter what we enqueue because we will always Reconcile
+		// the named resource.
+		Handler: controller.HandleAll(f),
+	})
+}
+
+type namectx struct{}
+
+// WithName associates a name with the provided context.
+func WithName(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, namectx{}, name)
+}
+
+// GetName extracts a Webhook associated with the provided context.
+func GetName(ctx context.Context) string {
+	untyped := ctx.Value(namectx{})
+	if untyped == nil {
+		return ""
+	}
+	return untyped.(string)
+}

--- a/webhook/targeter/dynamic_test.go
+++ b/webhook/targeter/dynamic_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package targeter
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"testing"
+
+	fakesecret "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret/fake"
+	certresources "knative.dev/pkg/webhook/certificates/resources"
+
+	"github.com/google/go-cmp/cmp"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
+
+	. "knative.dev/pkg/reconciler/testing"
+)
+
+func TestDynamic(t *testing.T) {
+	ctx, _ := SetupFakeContext(t)
+
+	ctx = webhook.WithOptions(ctx, webhook.Options{
+		ServiceName: "webhook",
+		SecretName:  "precious",
+	})
+
+	wantBundle := []byte("pem")
+
+	fakesecret.Get(ctx).Informer().GetIndexer().Add(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: system.Namespace(),
+			Name:      "precious",
+		},
+		Data: map[string][]byte{
+			certresources.CACert: wantBundle,
+		},
+	})
+
+	wantBasePath := "/mypath/"
+	l := NewDynamic(ctx, wantBasePath)
+
+	if got, err := l.GetName(ctx, "/otherpath/blah"); err == nil {
+		t.Errorf("GetName() = %q, wanted error", got)
+	}
+
+	l.AddEventHandlers(ctx, func(interface{}) {})
+
+	if gotBasePath := l.BasePath(); gotBasePath != wantBasePath {
+		t.Errorf("BasePath() = %s, wanted %s", gotBasePath, wantBasePath)
+	}
+
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("webhook-%d", i)
+		ctx = WithName(ctx, name)
+
+		got, err := l.WebhookClientConfig(ctx)
+		if err != nil {
+			t.Fatalf("WebhookClientConfig() = %v", err)
+		}
+		want := &admissionregistrationv1.WebhookClientConfig{
+			Service: &admissionregistrationv1.ServiceReference{
+				Namespace: system.Namespace(),
+				Name:      "webhook",
+				Path:      ptr.String(path.Join(wantBasePath, name)),
+			},
+			CABundle: wantBundle,
+		}
+
+		if diff := cmp.Diff(got, want); diff != "" {
+			t.Errorf("WebhookClientConfig (-got, +want) = %s", diff)
+		}
+
+		gotName, err := l.GetName(ctx, *got.Service.Path)
+		if err != nil {
+			t.Fatalf("GetName() = %v", err)
+		}
+		if gotName != name {
+			t.Errorf("GetName() = %q, wanted %q", gotName, name)
+		}
+	}
+}
+
+func TestDynamicMissingNameOnContext(t *testing.T) {
+	ctx, _ := SetupFakeContext(t)
+
+	ctx = webhook.WithOptions(ctx, webhook.Options{
+		ServiceName: "webhook",
+		SecretName:  "not-found",
+	})
+
+	l := NewDynamic(ctx, "/mypath/")
+
+	if _, err := l.WebhookClientConfig(ctx); !errors.Is(err, ErrMissingName) {
+		t.Errorf("WebhookClientConfig() = %v, wanted %v", err, ErrMissingName)
+	}
+}
+
+func TestDynamicMissingSecret(t *testing.T) {
+	ctx, _ := SetupFakeContext(t)
+
+	ctx = webhook.WithOptions(ctx, webhook.Options{
+		ServiceName: "webhook",
+		SecretName:  "not-found",
+	})
+
+	l := NewDynamic(ctx, "/mypath/")
+
+	if cc, err := l.WebhookClientConfig(WithName(ctx, "sally")); err == nil {
+		t.Errorf("WebhookClientConfig() = %+v, wanted error", cc)
+	}
+}
+
+func TestDynamicMalformedSecret(t *testing.T) {
+	ctx, _ := SetupFakeContext(t)
+
+	ctx = webhook.WithOptions(ctx, webhook.Options{
+		ServiceName: "webhook",
+		SecretName:  "precious",
+	})
+
+	fakesecret.Get(ctx).Informer().GetIndexer().Add(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: system.Namespace(),
+			Name:      "precious",
+		},
+		Data: map[string][]byte{
+			"wrong-key": []byte("doesn't matter"),
+		},
+	})
+
+	l := NewDynamic(ctx, "/mypath/")
+
+	if cc, err := l.WebhookClientConfig(WithName(ctx, "bill")); err == nil {
+		t.Errorf("WebhookClientConfig() = %+v, wanted error", cc)
+	}
+}

--- a/webhook/targeter/fixed.go
+++ b/webhook/targeter/fixed.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package targeter
+
+import (
+	"context"
+	"fmt"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/controller"
+	nsfactory "knative.dev/pkg/injection/clients/namespacedkube/informers/factory"
+	"knative.dev/pkg/ptr"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
+	certresources "knative.dev/pkg/webhook/certificates/resources"
+)
+
+// NewFixed returns an Interface that expects us to run on a fixed path local
+// to the cluster.
+func NewFixed(ctx context.Context, path string) Interface {
+	options := webhook.GetOptions(ctx)
+	// We rely on something else to have set this up and start it
+	// via injection, typically the cert controller.
+	secretInformer := nsfactory.Get(ctx).Core().V1().Secrets()
+	return &Fixed{
+		Path:         path,
+		SecretName:   options.SecretName,
+		ServiceName:  options.ServiceName,
+		SecretLister: secretInformer.Lister(),
+	}
+}
+
+// Fixed is public to make testing easier in other packages.  Code should
+// use NewFixed to construct Fixed instances.
+type Fixed struct {
+	Path         string
+	SecretName   string
+	ServiceName  string
+	SecretLister corelisters.SecretLister
+}
+
+// Assert that Fixed implements Interface
+var _ Interface = (*Fixed)(nil)
+
+// BasePath implements Interface
+func (lt *Fixed) BasePath() string {
+	return lt.Path
+}
+
+// WebhookClientConfig implements Interface
+func (lt *Fixed) WebhookClientConfig(ctx context.Context) (*admissionregistrationv1.WebhookClientConfig, error) {
+	// Look up the webhook secret, and fetch the CA cert bundle.
+	secret, err := lt.SecretLister.Secrets(system.Namespace()).Get(lt.SecretName)
+	if err != nil {
+		return nil, err
+	}
+	cacert, ok := secret.Data[certresources.CACert]
+	if !ok {
+		return nil, fmt.Errorf("secret %q is missing %q key", lt.SecretName, certresources.CACert)
+	}
+
+	return &admissionregistrationv1.WebhookClientConfig{
+		Service: &admissionregistrationv1.ServiceReference{
+			Namespace: system.Namespace(),
+			Name:      lt.ServiceName,
+			Path:      ptr.String(lt.Path),
+		},
+		CABundle: cacert,
+	}, nil
+}
+
+// AddEventHandlers implements Interface
+func (lt *Fixed) AddEventHandlers(ctx context.Context, f func(interface{})) {
+	// We rely on something else to have set this up and start it
+	// via injection, typically the cert controller.
+	secretInformer := nsfactory.Get(ctx).Core().V1().Secrets()
+
+	// Reconcile when the cert bundle changes.
+	secretInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterWithNameAndNamespace(system.Namespace(), lt.SecretName),
+		// It doesn't matter what we enqueue because we will always Reconcile
+		// the named resource.
+		Handler: controller.HandleAll(f),
+	})
+}

--- a/webhook/targeter/fixed_test.go
+++ b/webhook/targeter/fixed_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package targeter
+
+import (
+	"testing"
+
+	fakesecret "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret/fake"
+	certresources "knative.dev/pkg/webhook/certificates/resources"
+
+	"github.com/google/go-cmp/cmp"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
+
+	. "knative.dev/pkg/reconciler/testing"
+)
+
+func TestFixed(t *testing.T) {
+	ctx, _ := SetupFakeContext(t)
+
+	ctx = webhook.WithOptions(ctx, webhook.Options{
+		ServiceName: "webhook",
+		SecretName:  "precious",
+	})
+
+	wantBundle := []byte("pem")
+
+	fakesecret.Get(ctx).Informer().GetIndexer().Add(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: system.Namespace(),
+			Name:      "precious",
+		},
+		Data: map[string][]byte{
+			certresources.CACert: wantBundle,
+		},
+	})
+
+	wantBasePath := "/mypath"
+	l := NewFixed(ctx, wantBasePath)
+
+	l.AddEventHandlers(ctx, func(interface{}) {})
+
+	if gotBasePath := l.BasePath(); gotBasePath != wantBasePath {
+		t.Errorf("BasePath() = %s, wanted %s", gotBasePath, wantBasePath)
+	}
+
+	got, err := l.WebhookClientConfig(ctx)
+	if err != nil {
+		t.Fatalf("WebhookClientConfig() = %v", err)
+	}
+	want := &admissionregistrationv1.WebhookClientConfig{
+		Service: &admissionregistrationv1.ServiceReference{
+			Namespace: system.Namespace(),
+			Name:      "webhook",
+			Path:      ptr.String(wantBasePath),
+		},
+		CABundle: wantBundle,
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("WebhookClientConfig (-got, +want) = %s", diff)
+	}
+}
+
+func TestFixedMissingSecret(t *testing.T) {
+	ctx, _ := SetupFakeContext(t)
+
+	ctx = webhook.WithOptions(ctx, webhook.Options{
+		ServiceName: "webhook",
+		SecretName:  "not-found",
+	})
+
+	l := NewFixed(ctx, "/mypath")
+
+	if cc, err := l.WebhookClientConfig(ctx); err == nil {
+		t.Errorf("WebhookClientConfig() = %+v, wanted error", cc)
+	}
+}
+
+func TestFixedMalformedSecret(t *testing.T) {
+	ctx, _ := SetupFakeContext(t)
+
+	ctx = webhook.WithOptions(ctx, webhook.Options{
+		ServiceName: "webhook",
+		SecretName:  "precious",
+	})
+
+	fakesecret.Get(ctx).Informer().GetIndexer().Add(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: system.Namespace(),
+			Name:      "precious",
+		},
+		Data: map[string][]byte{
+			"wrong-key": []byte("doesn't matter"),
+		},
+	})
+
+	l := NewFixed(ctx, "/mypath")
+
+	if cc, err := l.WebhookClientConfig(ctx); err == nil {
+		t.Errorf("WebhookClientConfig() = %+v, wanted error", cc)
+	}
+}

--- a/webhook/targeter/targeter.go
+++ b/webhook/targeter/targeter.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package targeter
+
+import (
+	"context"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// Interface encapsulates how webhooks target us.
+type Interface interface {
+	// BasePath returns the base path on which we serve.
+	// If the path ends in a '/' then it will receive requests for all paths
+	// with that prefix.
+	// If the path does not end in a '/' then it will match exactly this path.
+	BasePath() string
+
+	// WebhookClientConfig returns the targeting config for this webhook.
+	// The path in the configured WebhookClientConfig should match, or have a
+	// prefix matching the value returned by BasePath above.
+	WebhookClientConfig(context.Context) (*admissionregistrationv1.WebhookClientConfig, error)
+
+	// AddEventHandler registers informer events as needed by this Interface
+	AddEventHandlers(context.Context, func(interface{}))
+}
+
+// SwitchClientConfig converts an admission webhook config to an API extension
+// webhook config.  These are effectively type aliases, but Kubernetes redefines
+// the type for unknown reasons.
+func SwitchClientConfig(in *admissionregistrationv1.WebhookClientConfig) *apixv1.WebhookClientConfig {
+	out := &apixv1.WebhookClientConfig{
+		URL:      in.URL,
+		CABundle: in.CABundle,
+	}
+	if in.Service != nil {
+		out.Service = &apixv1.ServiceReference{
+			Namespace: in.Service.Namespace,
+			Name:      in.Service.Name,
+			Path:      in.Service.Path,
+			Port:      in.Service.Port,
+		}
+	}
+	return out
+}

--- a/webhook/targeter/targeter_test.go
+++ b/webhook/targeter/targeter_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package targeter
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"knative.dev/pkg/ptr"
+	"knative.dev/pkg/system"
+	_ "knative.dev/pkg/system/testing"
+	"knative.dev/pkg/test/helpers"
+)
+
+func TestSwitchClientConfigLocal(t *testing.T) {
+	name := helpers.ObjectNameForTest(t)
+	bundle := []byte("pem")
+
+	got := SwitchClientConfig(&admissionregistrationv1.WebhookClientConfig{
+		Service: &admissionregistrationv1.ServiceReference{
+			Namespace: system.Namespace(),
+			Name:      name,
+			Path:      ptr.String("/local/path/here"),
+		},
+		CABundle: bundle,
+	})
+
+	want := &apixv1.WebhookClientConfig{
+		Service: &apixv1.ServiceReference{
+			Namespace: system.Namespace(),
+			Name:      name,
+			Path:      ptr.String("/local/path/here"),
+		},
+		CABundle: bundle,
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("SwitchClientConfig(-got, +want) = %s", diff)
+	}
+}
+
+func TestSwitchClientConfigURL(t *testing.T) {
+	got := SwitchClientConfig(&admissionregistrationv1.WebhookClientConfig{
+		URL: ptr.String("https://google.com"),
+	})
+
+	want := &apixv1.WebhookClientConfig{
+		URL: ptr.String("https://google.com"),
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("SwitchClientConfig(-got, +want) = %s", diff)
+	}
+}


### PR DESCRIPTION
This change introduces a `targeter.Interface` abstraction that we've been
using downstream to abstract the core logic of webhooks from the details
of how delivery to them is handled.

The most immediate benefit of this refactoring is that each of our webhooks
no longer needs direct knowledge of `caBundle` and the secret logic, which
is consolidated in the provided implementations.  So for examples, folks
could now provide an implementation of `targeter.Interface` that receives
its `caBundle` information in a wholly different way (e.g. mounted from the
filesystem).

This encapsulation of how the `WebhookClientConfig` is produced also enables
folks to produce these configurations in more imaginative ways. For example,
I have included an implementation that allows folks to host a webhook with a
`BasePath()`, produce configs for "names" under this `BasePath()` and
then extract the "name" being handled when receiving a webhook request.

This encapsulation also lets folks produce `WebhookClientConfig` blocks that
don't even need `caBundle` and leverage `URL` blocks, if they are hosting
things with public-CA TLS-terminated endpoints (e.g. as a `ksvc`).

<!-- Thanks for sending a pull request! -->

# Changes

- :broom: Update or clean up current behavior
/kind cleanup

**Release Note**

```release-note

```

**Docs**

```docs

```
