### PR TITLE
Log metrics/logging init messages at debug level

### DIFF
--- a/logging/config.go
+++ b/logging/config.go
@@ -114,8 +114,8 @@ func newLoggerFromConfig(configJSON, levelOverride string, opts []zap.Option) (*
 		return nil, zap.AtomicLevel{}, err
 	}
 
-	logger.Info("Successfully created the logger.")
-	logger.Info("Logging level set to: " + loggingCfg.Level.String())
+	logger.Debug("Successfully created the logger.")
+	logger.Debug("Logging level set to: " + loggingCfg.Level.String())
 	return logger, loggingCfg.Level, nil
 }
 

--- a/metrics/metrics_worker.go
+++ b/metrics/metrics_worker.go
@@ -73,7 +73,7 @@ func (cmd *updateMetricsConfigWithExporter) handleCommand(w *metricsWorker) {
 	ctx := cmd.ctx
 	logger := logging.FromContext(ctx)
 	if isNewExporterRequired(cmd.newConfig) {
-		logger.Info("Flushing the existing exporter before setting up the new exporter.")
+		logger.Debug("Flushing the existing exporter before setting up the new exporter.")
 		flushGivenExporter(curMetricsExporter)
 		e, f, err := newMetricsExporter(cmd.newConfig, logger)
 		if err != nil {
@@ -88,7 +88,7 @@ func (cmd *updateMetricsConfigWithExporter) handleCommand(w *metricsWorker) {
 			cmd.done <- err
 			return
 		}
-		logger.Infof("Successfully updated the metrics exporter; old config: %v; new config %v", existingConfig, cmd.newConfig)
+		logger.Debugf("Successfully updated the metrics exporter; old config: %v; new config %v", existingConfig, cmd.newConfig)
 	}
 	setCurMetricsConfigUnlocked(cmd.newConfig)
 	cmd.done <- nil

--- a/metrics/prometheus_exporter.go
+++ b/metrics/prometheus_exporter.go
@@ -48,7 +48,7 @@ func newPrometheusExporter(config *metricsConfig, logger *zap.SugaredLogger) (vi
 		logger.Errorw("Failed to create the Prometheus exporter.", zap.Error(err))
 		return nil, nil, err
 	}
-	logger.Infof("Created Prometheus exporter with config: %v. Start the server for Prometheus exporter.", config)
+	logger.Debugf("Created Prometheus exporter with config: %v. Start the server for Prometheus exporter.", config)
 	// Start the server for Prometheus scraping
 	go func() {
 		srv := startNewPromSrv(e, config.prometheusHost, config.prometheusPort)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Log metrics/logging init messages at `debug` level instead of `info`

After analyzing the logs emitted by our Knative Services, we realized that 90% of them were these 5 log entries related to the initialization of the metrics exporter and logger, over and over again.
I believe that silence is golden for this kind of setup operations, especially when the logger and metrics exporter aren't part of the business logic of the application that's running inside those services.
Regular scaling of these applications (including to 0) makes this "issue" even more visible.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Initialization messages related to loggers and metric exporters are now logged at the `debug` level
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
