### PR TITLE
Drop `UserInfo` from logger tagging in webhook.

### DIFF
--- a/webhook/admission.go
+++ b/webhook/admission.go
@@ -102,6 +102,7 @@ func admissionHandler(rootLogger *zap.SugaredLogger, stats StatsReporter, c Admi
 			logkey.Operation, string(review.Request.Operation),
 			logkey.Resource, review.Request.Resource.String(),
 			logkey.SubResource, review.Request.SubResource,
+			logkey.UserInfo, review.Request.UserInfo.Username,
 		)
 
 		ctx := logging.WithLogger(r.Context(), logger)

--- a/webhook/admission.go
+++ b/webhook/admission.go
@@ -102,7 +102,7 @@ func admissionHandler(rootLogger *zap.SugaredLogger, stats StatsReporter, c Admi
 			logkey.Operation, string(review.Request.Operation),
 			logkey.Resource, review.Request.Resource.String(),
 			logkey.SubResource, review.Request.SubResource,
-			logkey.UserInfo, fmt.Sprint(review.Request.UserInfo))
+		)
 
 		ctx := logging.WithLogger(r.Context(), logger)
 		ctx = apis.WithHTTPRequest(ctx, r)


### PR DESCRIPTION
This can get big, and can contain mildly sensitive data that some users don't want showing up in logs.

If we keep this, than we should perhaps restrict what we tag to one of the less unbounded fields (e.g. don't include `Extra`)

/kind cleanup

**Release Note**

```release-note
webhook no longer logs full UserInfo, just the Username field
```

**Docs**

```docs

```


cc @dprotaso @n3wscott 