### PR TITLE
SpanTree and TestSpanTree for tracing tests

### DIFF
--- a/test/tracing/traces.go
+++ b/test/tracing/traces.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/openzipkin/zipkin-go/model"
+)
+
+// hostSuffix is an optional suffix that might appear at the end of hostnames.
+// We supplement matches with this to allow matches for:
+//    foo.bar
+// to match all of:
+//    foo.bar
+//    foo.bar.svc
+//    foo.bar.svc.cluster.local
+// It's hardly perfect, but requires the suffix to start with the delimiter '.'
+// and then match anything prior to the path starting, e.g. '/'
+const HostSuffix = "[.][^/]+"
+
+// PrettyPrintTrace pretty prints a Trace.
+func PrettyPrintTrace(trace []model.SpanModel) string {
+	b, _ := json.Marshal(trace)
+	return string(b)
+}
+
+// SpanTree is the tree of Spans representation of a Trace.
+type SpanTree struct {
+	Root     bool
+	Span     model.SpanModel
+	Children []SpanTree
+}
+
+func (t SpanTree) String() string {
+	b, _ := json.MarshalIndent(t, "", "  ")
+	return string(b)
+}
+
+type SpanMatcher struct {
+	Kind                     *model.Kind               `json:"a_Kind,omitempty"`
+	LocalEndpointServiceName string                    `json:"b_Name,omitempty"`
+	Tags                     map[string]*regexp.Regexp `json:"c_Tags,omitempty"`
+}
+
+type SpanMatcherOption func(*SpanMatcher)
+
+func WithLocalEndpointServiceName(s string) SpanMatcherOption {
+	return func(m *SpanMatcher) {
+		m.LocalEndpointServiceName = s
+	}
+}
+
+func WithHTTPHostAndPath(host, path string) SpanMatcherOption {
+	return func(m *SpanMatcher) {
+		m.Tags["http.host"] = regexp.MustCompile("^" + regexp.QuoteMeta(host) + HostSuffix + "$")
+		m.Tags["http.path"] = regexp.MustCompile("^" + regexp.QuoteMeta(path) + "$")
+	}
+}
+
+func WithHTTPURL(host, path string) SpanMatcherOption {
+	return func(m *SpanMatcher) {
+		m.Tags["http.url"] = regexp.MustCompile("^http://" + regexp.QuoteMeta(host) + HostSuffix + regexp.QuoteMeta(path) + "$")
+	}
+}
+
+func (m *SpanMatcher) MatchesSpan(span *model.SpanModel) error {
+	if m == nil {
+		return nil
+	}
+	if m.Kind != nil {
+		if *m.Kind != span.Kind {
+			return fmt.Errorf("mismatched kind: got %q, want %q", span.Kind, *m.Kind)
+		}
+	}
+	if m.LocalEndpointServiceName != "" {
+		if span.LocalEndpoint == nil {
+			return errors.New("missing local endpoint")
+		}
+		if m.LocalEndpointServiceName != span.LocalEndpoint.ServiceName {
+			return fmt.Errorf("mismatched LocalEndpoint ServiceName: got %q, want %q", span.LocalEndpoint.ServiceName, m.LocalEndpointServiceName)
+		}
+	}
+	for k, v := range m.Tags {
+		if t := span.Tags[k]; !v.MatchString(t) {
+			return fmt.Errorf("unexpected tag %s: got %q, want %q", k, t, v)
+		}
+	}
+	return nil
+}
+
+func MatchSpan(kind model.Kind, opts ...SpanMatcherOption) *SpanMatcher {
+	m := &SpanMatcher{
+		Kind: &kind,
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+func MatchHTTPSpanWithCode(kind model.Kind, statusCode int, opts ...SpanMatcherOption) *SpanMatcher {
+	return MatchSpan(kind, WithCode(statusCode))
+}
+
+func WithCode(statusCode int) SpanMatcherOption {
+	return func(m *SpanMatcher) {
+		m.Tags = map[string]*regexp.Regexp{
+			"http.method":      regexp.MustCompile("^" + http.MethodPost + "$"),
+			"http.status_code": regexp.MustCompile("^" + strconv.Itoa(statusCode) + "$"),
+		}
+	}
+}
+
+func MatchHTTPSpanNoReply(kind model.Kind, opts ...SpanMatcherOption) *SpanMatcher {
+	return MatchHTTPSpanWithCode(kind, 202, opts...)
+}
+
+func MatchHTTPSpanWithReply(kind model.Kind, opts ...SpanMatcherOption) *SpanMatcher {
+	return MatchHTTPSpanWithCode(kind, 200, opts...)
+}
+
+// TestSpanTree is the expected version of SpanTree used for assertions in testing.
+//
+// The JSON names of the fields are weird because we want a specific order when pretty printing
+// JSON. The JSON will be printed in alphabetical order, so we are imposing a certain order by
+// prefixing the keys with a specific letter. The letter has no mean other than ordering.
+type TestSpanTree struct {
+	Note     string         `json:"a_Note,omitempty"`
+	Span     *SpanMatcher   `json:"c_Span"`
+	Children []TestSpanTree `json:"z_Children,omitempty"`
+}
+
+func (tt TestSpanTree) String() string {
+	b, _ := json.MarshalIndent(tt, "", "  ")
+	return string(b)
+}
+
+// GetTraceTree converts a set slice of spans into a SpanTree.
+func GetTraceTree(trace []model.SpanModel) (*SpanTree, error) {
+	var roots []model.SpanModel
+	parents := map[model.ID][]model.SpanModel{}
+	for _, span := range trace {
+		if span.ParentID != nil {
+			parents[*span.ParentID] = append(parents[*span.ParentID], span)
+		} else {
+			roots = append(roots, span)
+		}
+	}
+
+	if len(roots) == 0 {
+		return nil, fmt.Errorf("no root spans found in the trace: Original: %v", PrettyPrintTrace(trace))
+	}
+
+	children, err := getChildren(parents, roots)
+	if err != nil {
+		return nil, fmt.Errorf("could not create span tree for %v: %v", PrettyPrintTrace(trace), err)
+	}
+
+	if len(parents) != 0 {
+		return nil, fmt.Errorf("left over spans after generating the SpanTree: %v. Original: %v", parents, PrettyPrintTrace(trace))
+	}
+	tree := SpanTree{
+		Root:     true,
+		Children: children,
+	}
+	return &tree, nil
+}
+
+func getChildren(parents map[model.ID][]model.SpanModel, current []model.SpanModel) ([]SpanTree, error) {
+	children := make([]SpanTree, 0, len(current))
+	for _, span := range current {
+		grandchildren, err := getChildren(parents, parents[span.ID])
+		if err != nil {
+			return children, err
+		}
+		children = append(children, SpanTree{
+			Span:     span,
+			Children: grandchildren,
+		})
+		delete(parents, span.ID)
+	}
+
+	return children, nil
+}
+
+// MatchesSubtree checks to see if this TestSpanTree matches a subtree
+// of the actual SpanTree. It is intended to be used for assertions
+// while testing. Returns the set of possible subtree matches with the
+// corresponding set of unmatched siblings.
+func (tt TestSpanTree) MatchesSubtree(t *testing.T, actual *SpanTree) (matches [][]SpanTree) {
+	if t != nil {
+		t.Helper()
+		t.Logf("attempting to match test tree %v against %v", tt, actual)
+	}
+	if err := tt.Span.MatchesSpan(&actual.Span); err == nil {
+		if t != nil {
+			t.Logf("%v matches span %v, matching children", tt.Span, actual.Span)
+		}
+		// Tree roots match; check children.
+		if err := matchesSubtrees(t, tt.Children, actual.Children); err == nil {
+			// A matching root leaves no unmatched siblings.
+			matches = append(matches, nil)
+		}
+	} else if t != nil {
+		t.Logf("%v does not match span %v: %v", tt.Span, actual.Span, err)
+	}
+	// Recursively match children.
+	for i, child := range actual.Children {
+		for _, childMatch := range tt.MatchesSubtree(t, &child) {
+			// Append unmatched children to child results.
+			childMatch = append(childMatch, actual.Children[:i]...)
+			childMatch = append(childMatch, actual.Children[i+1:]...)
+			matches = append(matches, childMatch)
+		}
+	}
+	return
+}
+
+// matchesSubtrees checks for a match of each TestSpanTree with a
+// subtree of a distinct actual SpanTree.
+func matchesSubtrees(t *testing.T, ts []TestSpanTree, as []SpanTree) error {
+	if t != nil {
+		t.Helper()
+		t.Logf("attempting to match test trees %v against %v", ts, as)
+	}
+	if len(ts) == 0 {
+		return nil
+	}
+	tt := ts[0]
+	for j, a := range as {
+		// If there is no error, then it matched successfully.
+		for _, match := range tt.MatchesSubtree(t, &a) {
+			asNew := make([]SpanTree, 0, len(as)-1+len(match))
+			asNew = append(asNew, as[:j]...)
+			asNew = append(asNew, as[j+1:]...)
+			asNew = append(asNew, match...)
+			if err := matchesSubtrees(t, ts[1:], asNew); err == nil {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("unmatched span trees. want: %s got %s", ts, as)
+}

--- a/test/tracing/traces.go
+++ b/test/tracing/traces.go
@@ -174,7 +174,7 @@ func GetTraceTree(trace []model.SpanModel) (*SpanTree, error) {
 
 	children, err := getChildren(parents, roots)
 	if err != nil {
-		return nil, fmt.Errorf("could not create span tree for %v: %v", PrettyPrintTrace(trace), err)
+		return nil, fmt.Errorf("could not create span tree for %v: %w", PrettyPrintTrace(trace), err)
 	}
 
 	if len(parents) != 0 {

--- a/test/tracing/traces_test.go
+++ b/test/tracing/traces_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Google LLC.
+Copyright 2022 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/tracing/traces_test.go
+++ b/test/tracing/traces_test.go
@@ -1,0 +1,680 @@
+/*
+Copyright 2020 Google LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/openzipkin/zipkin-go/model"
+)
+
+var (
+	serverKind = model.Server
+	clientKind = model.Client
+)
+
+type SpanCase struct {
+	Span        *model.SpanModel
+	ShouldMatch bool
+}
+
+func TestSpanMatcher(t *testing.T) {
+	t.Parallel()
+	tcs := []struct {
+		Name    string
+		Matcher *SpanMatcher
+		Spans   []SpanCase
+	}{{
+		Name:    "empty matcher",
+		Matcher: &SpanMatcher{},
+		Spans: []SpanCase{{
+			Span:        &model.SpanModel{},
+			ShouldMatch: true,
+		}, {
+			Span: &model.SpanModel{
+				Kind: model.Server,
+				LocalEndpoint: &model.Endpoint{
+					ServiceName: "test-service-name",
+				},
+				Tags: map[string]string{
+					"test-tag":  "test-tag-value",
+					"other-tag": "other-tag-value",
+				},
+			},
+			ShouldMatch: true,
+		}},
+	}, {
+		Name: "kind matcher",
+		Matcher: &SpanMatcher{
+			Kind: &serverKind,
+		},
+		Spans: []SpanCase{{
+			Span:        &model.SpanModel{},
+			ShouldMatch: false,
+		}, {
+			Span: &model.SpanModel{
+				Kind: model.Server,
+			},
+			ShouldMatch: true,
+		}, {
+			Span: &model.SpanModel{
+				Kind: model.Client,
+			},
+			ShouldMatch: false,
+		}, {
+			Span: &model.SpanModel{
+				Kind: model.Server,
+				LocalEndpoint: &model.Endpoint{
+					ServiceName: "test-service-name",
+				},
+				Tags: map[string]string{
+					"test-tag":  "test-tag-value",
+					"other-tag": "other-tag-value",
+				},
+			},
+			ShouldMatch: true,
+		}},
+	}, {
+		Name: "local endpoint service name matcher",
+		Matcher: &SpanMatcher{
+			LocalEndpointServiceName: "test-service-name",
+		},
+		Spans: []SpanCase{{
+			Span:        &model.SpanModel{},
+			ShouldMatch: false,
+		}, {
+			Span: &model.SpanModel{
+				LocalEndpoint: &model.Endpoint{
+					ServiceName: "test-service-name",
+				},
+			},
+			ShouldMatch: true,
+		}, {
+			Span: &model.SpanModel{
+				LocalEndpoint: &model.Endpoint{
+					ServiceName: "other-service-name",
+				},
+			},
+			ShouldMatch: false,
+		}, {
+			Span: &model.SpanModel{
+				Kind: model.Server,
+				LocalEndpoint: &model.Endpoint{
+					ServiceName: "test-service-name",
+				},
+				Tags: map[string]string{
+					"test-tag":  "test-tag-value",
+					"other-tag": "other-tag-value",
+				},
+			},
+			ShouldMatch: true,
+		}},
+	}, {
+		Name: "tag matcher",
+		Matcher: &SpanMatcher{
+			Tags: map[string]*regexp.Regexp{
+				"test-tag": regexp.MustCompile("^test-tag-value$"),
+			},
+		},
+		Spans: []SpanCase{{
+			Span:        &model.SpanModel{},
+			ShouldMatch: false,
+		}, {
+			Span: &model.SpanModel{
+				Tags: map[string]string{
+					"test-tag": "test-tag-value",
+				},
+			},
+			ShouldMatch: true,
+		}, {
+			Span: &model.SpanModel{
+				Tags: map[string]string{
+					"test-tag": "other-tag-value",
+				},
+			},
+			ShouldMatch: false,
+		}, {
+			Span: &model.SpanModel{
+				Tags: map[string]string{
+					"other-tag": "test-tag-value",
+				},
+			},
+			ShouldMatch: false,
+		}, {
+			Span: &model.SpanModel{
+				Kind: model.Server,
+				LocalEndpoint: &model.Endpoint{
+					ServiceName: "test-service-name",
+				},
+				Tags: map[string]string{
+					"test-tag":  "test-tag-value",
+					"other-tag": "other-tag-value",
+				},
+			},
+			ShouldMatch: true,
+		}},
+	}}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			tc := tc
+			t.Parallel()
+			for _, sc := range tc.Spans {
+				if err := tc.Matcher.MatchesSpan(sc.Span); err != nil && sc.ShouldMatch {
+					t.Errorf("expected matcher %v to match span %v but got %v", tc.Matcher, sc.Span, err)
+				} else if err == nil && !sc.ShouldMatch {
+					t.Errorf("expected matcher %v not to match span %v but got match", tc.Matcher, sc.Span)
+				}
+
+			}
+		})
+	}
+}
+
+type SpanTreeCase struct {
+	SpanTree    *SpanTree
+	ShouldMatch bool
+}
+
+func TestMatchesSubtree(t *testing.T) {
+	t.Parallel()
+	tcs := []struct {
+		Name         string
+		TestSpanTree *TestSpanTree
+		SpanTrees    []SpanTreeCase
+	}{{
+		Name:         "empty test tree",
+		TestSpanTree: &TestSpanTree{},
+		SpanTrees: []SpanTreeCase{{
+			SpanTree:    &SpanTree{},
+			ShouldMatch: true,
+		}, {
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+				Children: []SpanTree{{
+					Span: model.SpanModel{
+						Kind: model.Client,
+					},
+				}, {
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"test-tag": "test-tag-value",
+						},
+					},
+				}},
+			},
+			ShouldMatch: true,
+		}},
+	}, {
+		Name: "single node",
+		TestSpanTree: &TestSpanTree{
+			Span: &SpanMatcher{
+				Kind: &serverKind,
+			},
+		},
+		SpanTrees: []SpanTreeCase{{
+			SpanTree:    &SpanTree{},
+			ShouldMatch: false,
+		}, {
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+			},
+			ShouldMatch: true,
+		}, {
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Client,
+				},
+			},
+			ShouldMatch: false,
+		}, {
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Client,
+				},
+				Children: []SpanTree{{
+					Span: model.SpanModel{
+						Kind: model.Server,
+					},
+				}},
+			},
+			ShouldMatch: true,
+		}},
+	}, {
+		Name: "single child",
+		TestSpanTree: &TestSpanTree{
+			Span: &SpanMatcher{
+				Kind: &serverKind,
+			},
+			Children: []TestSpanTree{{
+				Span: &SpanMatcher{
+					Kind: &clientKind,
+				},
+			}},
+		},
+		SpanTrees: []SpanTreeCase{{
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+				Children: []SpanTree{{
+					Span: model.SpanModel{
+						Kind: model.Client,
+					},
+				}},
+			},
+			ShouldMatch: true,
+		}, {
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Client,
+				},
+				Children: []SpanTree{{
+					Span: model.SpanModel{
+						Kind: model.Server,
+					},
+				}},
+			},
+			ShouldMatch: false,
+		}, {
+			SpanTree: &SpanTree{
+				Children: []SpanTree{{
+					Span: model.SpanModel{
+						Kind: model.Server,
+					},
+					Children: []SpanTree{{
+						Span: model.SpanModel{
+							Kind: model.Client,
+						},
+					}},
+				}},
+			},
+			ShouldMatch: true,
+		}, {
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+				Children: []SpanTree{{
+					Children: []SpanTree{{
+						Span: model.SpanModel{
+							Kind: model.Client,
+						},
+					}},
+				}},
+			},
+			ShouldMatch: true,
+		}, {
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+				Children: []SpanTree{{
+					Span: model.SpanModel{
+						Kind: model.Client,
+					},
+					Children: []SpanTree{{}},
+				}},
+			},
+			ShouldMatch: true,
+		}, {
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+				Children: []SpanTree{{
+					Span: model.SpanModel{
+						Kind: model.Client,
+					},
+				}, {}},
+			},
+			ShouldMatch: true,
+		}},
+	}, {
+		Name: "two children",
+		TestSpanTree: &TestSpanTree{
+			Span: &SpanMatcher{
+				Kind: &serverKind,
+			},
+			Children: []TestSpanTree{{
+				Span: &SpanMatcher{
+					Tags: map[string]*regexp.Regexp{
+						"child": regexp.MustCompile("^a$"),
+					},
+				},
+			}, {
+				Span: &SpanMatcher{
+					Tags: map[string]*regexp.Regexp{
+						"child": regexp.MustCompile("^b$"),
+					},
+				},
+			}},
+		},
+		SpanTrees: []SpanTreeCase{{
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+				Children: []SpanTree{{
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"child": "a",
+						},
+					},
+				}, {
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"child": "b",
+						},
+					},
+				}},
+			},
+			ShouldMatch: true,
+		}, {
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+				Children: []SpanTree{{
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"child": "b",
+						},
+					},
+				}, {
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"child": "a",
+						},
+					},
+				}},
+			},
+			ShouldMatch: true,
+		}, {
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+				Children: []SpanTree{{
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"child": "a",
+						},
+					},
+				}, {
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"child": "a",
+						},
+					},
+				}},
+			},
+			ShouldMatch: false,
+		}, {
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+				Children: []SpanTree{{
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"child": "a",
+						},
+					},
+					Children: []SpanTree{{
+						Span: model.SpanModel{
+							Tags: map[string]string{
+								"child": "b",
+							},
+						},
+					}},
+				}},
+			},
+			ShouldMatch: false,
+		}, {
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+				Children: []SpanTree{{
+					// This span is a red-herring. Although it matches child 'a',
+					// it cannot be used as match for 'a' in a complete sub-tree
+					// match since it is a parent of child 'b'. The matcher must
+					// therefore look for alternative matches for 'a' by recursing
+					// into its children.
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"child": "a",
+						},
+					},
+					Children: []SpanTree{{
+						Span: model.SpanModel{
+							Tags: map[string]string{
+								"child": "a",
+							},
+						},
+					}, {
+						Span: model.SpanModel{
+							Tags: map[string]string{
+								"child": "b",
+							},
+						},
+					}},
+				}},
+			},
+			ShouldMatch: true,
+		}, {
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+				Children: []SpanTree{{
+					Children: []SpanTree{{
+						Span: model.SpanModel{
+							Tags: map[string]string{
+								"child": "a",
+							},
+						},
+					}, {
+						Span: model.SpanModel{
+							Tags: map[string]string{
+								"child": "b",
+							},
+						},
+					}},
+				}},
+			},
+			ShouldMatch: true,
+		}},
+	}, {
+		Name: "two identical children",
+		TestSpanTree: &TestSpanTree{
+			Span: &SpanMatcher{
+				Kind: &serverKind,
+			},
+			Children: []TestSpanTree{{
+				Span: &SpanMatcher{
+					Tags: map[string]*regexp.Regexp{
+						"child": regexp.MustCompile("^a$"),
+					},
+				},
+			}, {
+				Span: &SpanMatcher{
+					Tags: map[string]*regexp.Regexp{
+						"child": regexp.MustCompile("^a$"),
+					},
+				},
+			}},
+		},
+		SpanTrees: []SpanTreeCase{{
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+				Children: []SpanTree{{
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"child": "a",
+						},
+					},
+				}, {
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"child": "b",
+						},
+					},
+				}},
+			},
+			ShouldMatch: false,
+		}, {
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+				Children: []SpanTree{{
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"child": "a",
+						},
+					},
+				}},
+			},
+			ShouldMatch: false,
+		}, {
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+				Children: []SpanTree{{
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"child": "a",
+						},
+					},
+				}, {
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"child": "a",
+						},
+					},
+				}},
+			},
+			ShouldMatch: true,
+		}},
+	}, {
+		Name: "three children",
+		TestSpanTree: &TestSpanTree{
+			Span: &SpanMatcher{
+				Kind: &serverKind,
+			},
+			Children: []TestSpanTree{{
+				Span: &SpanMatcher{
+					Tags: map[string]*regexp.Regexp{
+						"child": regexp.MustCompile("^a$"),
+					},
+				},
+			}, {
+				Span: &SpanMatcher{
+					Tags: map[string]*regexp.Regexp{
+						"child": regexp.MustCompile("^b$"),
+					},
+				},
+			}, {
+				Span: &SpanMatcher{
+					Tags: map[string]*regexp.Regexp{
+						"child": regexp.MustCompile("^c$"),
+					},
+				},
+			}},
+		},
+		SpanTrees: []SpanTreeCase{{
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+				Children: []SpanTree{{
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"child": "a",
+						},
+					},
+				}, {
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"child": "b",
+						},
+					},
+				}, {
+					Span: model.SpanModel{
+						Tags: map[string]string{
+							"child": "c",
+						},
+					},
+				}},
+			},
+			ShouldMatch: true,
+		}, {
+			SpanTree: &SpanTree{
+				Span: model.SpanModel{
+					Kind: model.Server,
+				},
+				Children: []SpanTree{{
+					Children: []SpanTree{{
+						Span: model.SpanModel{
+							Tags: map[string]string{
+								"child": "a",
+							},
+						},
+					}, {
+						Span: model.SpanModel{
+							Tags: map[string]string{
+								"child": "b",
+							},
+						},
+					}},
+				}, {
+					Children: []SpanTree{{
+						Span: model.SpanModel{
+							Tags: map[string]string{
+								"child": "c",
+							},
+						},
+					}},
+				}},
+			},
+			ShouldMatch: true,
+		}},
+	},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			tc := tc
+			t.Parallel()
+			for _, stc := range tc.SpanTrees {
+				if matches := tc.TestSpanTree.MatchesSubtree(t, stc.SpanTree); len(matches) == 0 && stc.ShouldMatch {
+					t.Errorf("expected test tree %v to match span tree %v", tc.TestSpanTree, stc.SpanTree)
+				} else if len(matches) > 0 && !stc.ShouldMatch {
+					t.Errorf("expected test tree %v not to match span tree %v but got matches %v", tc.TestSpanTree, stc.SpanTree, matches)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a copy of
https://github.com/knative/eventing/blob/main/test/conformance/helpers/tracing/traces.go
with slight changes:

* Split WithHTTPHostAndPath into WithHTTPHostAndPath and WithHTTPURL.
The first one adds http.host and http.path. The second one adds
http.url. This separation allows using one or the other regardless of
Kind (Client/Server/etc.)

* MatchHTTPSpanNoReply now passes the options to the underlying
MatchHTTPSpanWithCode in the same was as MatchHTTPSpanWithReply

* Created more generic functions WithCode and MatchSpan

The whole diff can be seen here: https://pastebin.com/35Vx6e8w

Migrating this file from knative/eventing because it will be used in eventing-kafka-broker as well [in this PR](https://github.com/knative-sandbox/eventing-kafka-broker/pull/2369). 

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
-->

:gift:

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
