### PR TITLE
Fix #2115, allow selective verbs / subresources for webhooks.

### DIFF
--- a/webhook/resourcesemantics/interface.go
+++ b/webhook/resourcesemantics/interface.go
@@ -30,25 +30,21 @@ type GenericCRD interface {
 	runtime.Object
 }
 
-// GenericCRDWithConfig is the interface definition that allows us to perform
-// the generic CRD actions like deciding whether to increment generation and so
-// forth. You can further customiz with SupportedVerbs and SupportedSubResources
-// which
-type GenericCRDWithConfig struct {
-	GenericCRD
+// VerbLimited defines which Verbs you want to have the webhook invoked on.
+type VerbLimited interface {
+	// SupportedVerbs define which operations (verbs) webhook is called on.
+	SupportedVerbs() []admissionregistrationv1.OperationType
+}
 
-	// supportedVerbs are the verbs registered for the callback.
-	// If left empty, configures, Create, Update, and Delete
-	SupportedVerbs []admissionregistrationv1.OperationType
-
-	// supportedSubResources are the subresources that will be registered
+// SubResourceLimited defines which subresources you want to have the webhook
+// invoked on. For example "status", "scale", etc.
+type SubResourceLimited interface {
+	// SupportedSubResources are the subresources that will be registered
 	// for the resource validation.
-	// To get the main resource and status registered (old behaviour), you
-	// leave this empty.
 	// If you wanted to add for example scale validation for Deployments, you'd
 	// do:
 	// []string{"", "/status", "/scale"}
 	// And to get just the main resource, you would do:
 	// []string{""}
-	SupportedSubResources []string
+	SupportedSubResources() []string
 }

--- a/webhook/resourcesemantics/interface.go
+++ b/webhook/resourcesemantics/interface.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcesemantics
 
 import (
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
 )
@@ -27,4 +28,27 @@ type GenericCRD interface {
 	apis.Defaultable
 	apis.Validatable
 	runtime.Object
+}
+
+// GenericCRDWithConfig is the interface definition that allows us to perform
+// the generic CRD actions like deciding whether to increment generation and so
+// forth. You can further customiz with SupportedVerbs and SupportedSubResources
+// which
+type GenericCRDWithConfig struct {
+	GenericCRD
+
+	// supportedVerbs are the verbs registered for the callback.
+	// If left empty, configures, Create, Update, and Delete
+	SupportedVerbs []admissionregistrationv1.OperationType
+
+	// supportedSubResources are the subresources that will be registered
+	// for the resource validation.
+	// To get the main resource and status registered (old behaviour), you
+	// leave this empty.
+	// If you wanted to add for example scale validation for Deployments, you'd
+	// do:
+	// []string{"", "/status", "/scale"}
+	// And to get just the main resource, you would do:
+	// []string{""}
+	SupportedSubResources []string
 }

--- a/webhook/resourcesemantics/validation/controller.go
+++ b/webhook/resourcesemantics/validation/controller.go
@@ -26,7 +26,6 @@ import (
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
@@ -41,7 +40,7 @@ import (
 func NewAdmissionControllerWithConfig(
 	ctx context.Context,
 	name, path string,
-	handlers map[schema.GroupVersionKind]resourcesemantics.GenericCRDWithConfig,
+	handlers map[schema.GroupVersionKind]resourcesemantics.GenericCRD,
 	wc func(context.Context) context.Context,
 	disallowUnknownFields bool,
 	callbacks map[schema.GroupVersionKind]Callback,
@@ -121,10 +120,5 @@ func NewAdmissionController(
 	default:
 		panic("NewAdmissionController may not be called with multiple callback maps")
 	}
-
-	h := make(map[schema.GroupVersionKind]resourcesemantics.GenericCRDWithConfig, len(handlers))
-	for k, v := range handlers {
-		h[k] = resourcesemantics.GenericCRDWithConfig{GenericCRD: v, SupportedVerbs: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update, admissionregistrationv1.Delete}, SupportedSubResources: []string{"", "/status"}}
-	}
-	return NewAdmissionControllerWithConfig(ctx, name, path, h, wc, disallowUnknownFields, unwrappedCallbacks)
+	return NewAdmissionControllerWithConfig(ctx, name, path, handlers, wc, disallowUnknownFields, unwrappedCallbacks)
 }

--- a/webhook/resourcesemantics/validation/reconcile_config.go
+++ b/webhook/resourcesemantics/validation/reconcile_config.go
@@ -105,7 +105,8 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 
 		// If SupportedVerbs has not been given, provide the legacy defaults
 		// of Create, Update, and Delete
-		supportedVerbs := []admissionregistrationv1.OperationType{admissionregistrationv1.Create,
+		supportedVerbs := []admissionregistrationv1.OperationType{
+			admissionregistrationv1.Create,
 			admissionregistrationv1.Update,
 			admissionregistrationv1.Delete,
 		}
@@ -114,13 +115,14 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 			logging.FromContext(ctx).Debugf("Using custom Verbs")
 			supportedVerbs = vl.SupportedVerbs()
 		}
+		logging.FromContext(ctx).Debugf("Registering verbs: %s", supportedVerbs)
+
 		resources := []string{}
 		// If SupportedSubResources has not been given, provide the legacy
 		// defaults of main resource, and status
 		if srl, ok := config.(resourcesemantics.SubResourceLimited); ok {
 			logging.FromContext(ctx).Debugf("Using custom SubResources")
 			for _, subResource := range srl.SupportedSubResources() {
-				logging.FromContext(ctx).Debugf("Adding custom SubResource: %s", subResource)
 				if subResource == "" {
 					// Special case the actual plural if given
 					resources = append(resources, plural)
@@ -131,6 +133,7 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 		} else {
 			resources = append(resources, plural, plural+"/status")
 		}
+		logging.FromContext(ctx).Debugf("Registering SubResources: %s", resources)
 		rules = append(rules, admissionregistrationv1.RuleWithOperations{
 			Operations: supportedVerbs,
 			Rule: admissionregistrationv1.Rule{

--- a/webhook/resourcesemantics/validation/reconcile_config.go
+++ b/webhook/resourcesemantics/validation/reconcile_config.go
@@ -111,14 +111,16 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 		}
 
 		if vl, ok := config.(resourcesemantics.VerbLimited); ok {
+			logging.FromContext(ctx).Debugf("Using custom Verbs")
 			supportedVerbs = vl.SupportedVerbs()
 		}
 		resources := []string{}
 		// If SupportedSubResources has not been given, provide the legacy
 		// defaults of main resource, and status
 		if srl, ok := config.(resourcesemantics.SubResourceLimited); ok {
+			logging.FromContext(ctx).Debugf("Using custom SubResources")
 			for _, subResource := range srl.SupportedSubResources() {
-
+				logging.FromContext(ctx).Debugf("Adding custom SubResource: %s", subResource)
 				if subResource == "" {
 					// Special case the actual plural if given
 					resources = append(resources, plural)
@@ -137,6 +139,10 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 				Resources:   resources,
 			},
 		})
+	}
+
+	for _, r := range rules {
+		logging.FromContext(ctx).Debugf("Rule: %+v", r)
 	}
 
 	// Sort the rules by Group, Version, Kind so that things are deterministically ordered.

--- a/webhook/resourcesemantics/validation/validation_admit.go
+++ b/webhook/resourcesemantics/validation/validation_admit.go
@@ -36,43 +36,16 @@ import (
 var errMissingNewObject = errors.New("the new object may not be nil")
 
 // Callback is a generic function to be called by a consumer of validation
-// To preserve backwards compatibility, it also doubles up as a way to configure
-// which verbs and which subresources are configured in the
-// validatingwebhookconfiguration. For configuring which verbs and subresources
-// should get validated, create the Callback and pass it to
-// NewAdmissionController. If you do not need to do any additional validation
-// you can just have it be nil.
 type Callback struct {
 	// function is the callback to be invoked
-	// You can leave this empty if you just want to configure supportedVerbs
-	// or supportedSubResources
 	function func(ctx context.Context, unstructured *unstructured.Unstructured) error
 
 	// supportedVerbs are the verbs supported for the callback.
-	// The function will only be called on these actions, and other verbs
-	// will not even be registered in the rules.
 	supportedVerbs map[webhook.Operation]struct{}
-
-	// supportedSubResources are the subresources that will be registered
-	// for the callback to be called.
-	// By default 'main' resource and 'status' are filled in. This was
-	// the previous behaviour.
-	// "" string means add the main resource.
-	// To get the previous behaviour explicitly, you would do:
-	// []string{"", "/status"}
-	// If you wanted to add for example scale validation for Deployments, you'd
-	// do:
-	// []string{"", "/status", "/scale"}
-	supportedSubResources []string
 }
 
 // NewCallback creates a new callback function to be invoked on supported verbs.
 func NewCallback(function func(context.Context, *unstructured.Unstructured) error, supportedVerbs ...webhook.Operation) Callback {
-	return NewCallbackWithSubresources(function, []string{"", "/status"}, supportedVerbs...)
-}
-
-// NewCallbackWithSubresources creates a new callback function to be invoked on supported verbs and subresources.
-func NewCallbackWithSubresources(function func(context.Context, *unstructured.Unstructured) error, supportedSubResources []string, supportedVerbs ...webhook.Operation) Callback {
 	m := make(map[webhook.Operation]struct{})
 	for _, op := range supportedVerbs {
 		if _, has := m[op]; has {
@@ -80,7 +53,7 @@ func NewCallbackWithSubresources(function func(context.Context, *unstructured.Un
 		}
 		m[op] = struct{}{}
 	}
-	return Callback{function: function, supportedVerbs: m, supportedSubResources: supportedSubResources}
+	return Callback{function: function, supportedVerbs: m}
 }
 
 var _ webhook.AdmissionController = (*reconciler)(nil)
@@ -234,12 +207,8 @@ func (ac *reconciler) callback(ctx context.Context, req *admissionv1.AdmissionRe
 		return nil
 	}
 
-	// Generically callback if any are provided for the resource and if function
-	// is non nil.
-	// Since the callback might be nil if it's just being used to configure
-	// specific verbs / subresources, check to make sure it's not nil
-	// and skip if it is.
-	if c, ok := ac.callbacks[gvk]; ok && c.function != nil {
+	// Generically callback if any are provided for the resource.
+	if c, ok := ac.callbacks[gvk]; ok {
 		if _, supported := c.supportedVerbs[req.Operation]; supported {
 			unstruct := &unstructured.Unstructured{}
 			if err := json.Unmarshal(toDecode, unstruct); err != nil {

--- a/webhook/resourcesemantics/validation/validation_admit_test.go
+++ b/webhook/resourcesemantics/validation/validation_admit_test.go
@@ -59,27 +59,27 @@ const (
 )
 
 var (
-	handlers = map[schema.GroupVersionKind]resourcesemantics.GenericCRDWithConfig{
+	handlers = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 		{
 			Group:   "pkg.knative.dev",
 			Version: "v1alpha1",
 			Kind:    "Resource",
-		}: resourcesemantics.GenericCRDWithConfig{GenericCRD: &Resource{}},
+		}: &Resource{},
 		{
 			Group:   "pkg.knative.dev",
 			Version: "v1beta1",
 			Kind:    "Resource",
-		}: resourcesemantics.GenericCRDWithConfig{GenericCRD: &Resource{}},
+		}: &Resource{},
 		{
 			Group:   "pkg.knative.dev",
 			Version: "v1alpha1",
 			Kind:    "InnerDefaultResource",
-		}: resourcesemantics.GenericCRDWithConfig{GenericCRD: &InnerDefaultResource{}},
+		}: &InnerDefaultResource{},
 		{
 			Group:   "pkg.knative.io",
 			Version: "v1alpha1",
 			Kind:    "InnerDefaultResource",
-		}: resourcesemantics.GenericCRDWithConfig{GenericCRD: &InnerDefaultResource{}},
+		}: &InnerDefaultResource{},
 	}
 
 	callbacks = map[schema.GroupVersionKind]Callback{

--- a/webhook/resourcesemantics/validation/validation_admit_test.go
+++ b/webhook/resourcesemantics/validation/validation_admit_test.go
@@ -59,27 +59,27 @@ const (
 )
 
 var (
-	handlers = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
+	handlers = map[schema.GroupVersionKind]resourcesemantics.GenericCRDWithConfig{
 		{
 			Group:   "pkg.knative.dev",
 			Version: "v1alpha1",
 			Kind:    "Resource",
-		}: &Resource{},
+		}: resourcesemantics.GenericCRDWithConfig{GenericCRD: &Resource{}},
 		{
 			Group:   "pkg.knative.dev",
 			Version: "v1beta1",
 			Kind:    "Resource",
-		}: &Resource{},
+		}: resourcesemantics.GenericCRDWithConfig{GenericCRD: &Resource{}},
 		{
 			Group:   "pkg.knative.dev",
 			Version: "v1alpha1",
 			Kind:    "InnerDefaultResource",
-		}: &InnerDefaultResource{},
+		}: resourcesemantics.GenericCRDWithConfig{GenericCRD: &InnerDefaultResource{}},
 		{
 			Group:   "pkg.knative.io",
 			Version: "v1alpha1",
 			Kind:    "InnerDefaultResource",
-		}: &InnerDefaultResource{},
+		}: resourcesemantics.GenericCRDWithConfig{GenericCRD: &InnerDefaultResource{}},
 	}
 
 	callbacks = map[schema.GroupVersionKind]Callback{
@@ -645,7 +645,7 @@ func TestNewResourceAdmissionController(t *testing.T) {
 
 	NewAdmissionController(
 		ctx, testResourceValidationName, testResourceValidationPath,
-		handlers,
+		nil,
 		func(ctx context.Context) context.Context {
 			return ctx
 		}, true,
@@ -672,7 +672,7 @@ func TestNewResourceAdmissionControllerDuplicateVerb(t *testing.T) {
 
 	NewAdmissionController(
 		ctx, testResourceValidationName, testResourceValidationPath,
-		handlers,
+		nil,
 		func(ctx context.Context) context.Context {
 			return ctx
 		}, true,
@@ -685,7 +685,7 @@ func newTestResourceAdmissionController(t *testing.T) webhook.AdmissionControlle
 		SecretName: "webhook-secret",
 	})
 
-	c := NewAdmissionController(
+	c := NewAdmissionControllerWithConfig(
 		ctx, testResourceValidationName, testResourceValidationPath,
 		handlers,
 		func(ctx context.Context) context.Context {

--- a/webhook/resourcesemantics/validation/validation_admit_test.go
+++ b/webhook/resourcesemantics/validation/validation_admit_test.go
@@ -645,7 +645,7 @@ func TestNewResourceAdmissionController(t *testing.T) {
 
 	NewAdmissionController(
 		ctx, testResourceValidationName, testResourceValidationPath,
-		nil,
+		handlers,
 		func(ctx context.Context) context.Context {
 			return ctx
 		}, true,
@@ -672,7 +672,7 @@ func TestNewResourceAdmissionControllerDuplicateVerb(t *testing.T) {
 
 	NewAdmissionController(
 		ctx, testResourceValidationName, testResourceValidationPath,
-		nil,
+		handlers,
 		func(ctx context.Context) context.Context {
 			return ctx
 		}, true,


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!-- Thanks for sending a pull request! -->

# Changes
Currently when we create the validatingwebhookconfiguration, there's couple of wonky things with it:
1. Always includes status as a subresource and there are cases where we do not need it (#2115 )
2. Always includes all the verbs in the configuration even though they will later on get filtered, but the call to webhook is still made.

Also the API is widely used so I wanted to investigate what could be a smallest change using what we currently have to make this configurable.

So, the idea is that we have a way to customize additional validation logic via `Callbacks`, so if we utilize that struct we do not have to change the signature, but can piggyback off of it to provide ways to customize the actual webhook configuration without breaking any existing code.

Anyways, wanted to just put the smallest amount of code to see what folks think. obvs, need to write tests, etc. but just wanted to see what folks think before going too much deeper.

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
