### PR TITLE
🧹 remove defunct markdown linting variable

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -18,10 +18,6 @@
 # It is started by prow for each PR.
 # For convenience, it can also be executed manually.
 
-# Markdown linting failures don't show up properly in Gubernator resulting
-# in a net-negative contributor experience.
-export DISABLE_MD_LINTING=1
-
 export GO111MODULE=on
 
 source $(dirname $0)/../vendor/knative.dev/hack/presubmit-tests.sh


### PR DESCRIPTION
Addresses https://github.com/knative/hack/issues/200

/kind cleanup