### PR TITLE
Allow configuration of threads-per-controller

### DIFF
--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -165,6 +166,14 @@ func toControllerConstructors(namedCtors []injection.NamedControllerConstructor)
 // MainWithContext runs the generic main flow for controllers and
 // webhooks. Use MainWithContext if you do not need to serve webhooks.
 func MainWithContext(ctx context.Context, component string, ctors ...injection.ControllerConstructor) {
+	// Allow configuration of threads per controller
+	if val, ok := os.LookupEnv("K_THREADS_PER_CONTROLLER"); ok {
+		threadsPerController, err := strconv.Atoi(val)
+		if err != nil {
+			log.Fatalf("failed to parse value %q of K_THREADS_PER_CONTROLLER: %v\n", val, err)
+		}
+		controller.DefaultThreadsPerController = threadsPerController
+	}
 
 	// TODO(mattmoor): Remove this once HA is stable.
 	disableHighAvailability := flag.Bool("disable-ha", false,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

The Knative controller infrastructure uses by default two threads per controller. This setting is not configurable in Knative itself while [Tekton allows to configure it](https://github.com/tektoncd/pipeline/blob/v0.38.2/cmd/controller/main.go#L46). [I was playing around with that setting in Knative](https://knative.slack.com/archives/C0186KU7STW/p1659968402805789) and saw massively better numbers to bring Knative up when it reconciles everything in the system.

- :gift: introduce `threads-per-controller` flag to configure the number of go routines per controller

/kind enhancement

**Release Note**

```release-note
You can now provide a `threads-per-controller` command line flag to configure the number of go routines per thread, the default is 2
```

**Docs**

Please let me know if this needs to be documented now given this is "only" in the library and needs to be picked up by the serving repo first.

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->
