### PR TITLE
allow drainer to be reset

### DIFF
--- a/network/handlers/drain.go
+++ b/network/handlers/drain.go
@@ -70,11 +70,10 @@ type Drainer struct {
 	// after Drain is called before it may return.
 	QuietPeriod time.Duration
 
-	// once is used to initialize timer
-	once sync.Once
-
 	// timer is used to orchestrate the drain.
 	timer timer
+
+	ch chan struct{}
 
 	// HealthCheckUAPrefixes are the additional user agent prefixes that trigger the
 	// drainer's health check
@@ -106,7 +105,7 @@ func (d *Drainer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	d.reset()
+	d.resetTimer()
 	d.Inner.ServeHTTP(w, r)
 }
 
@@ -115,19 +114,42 @@ func (d *Drainer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (d *Drainer) Drain() {
 	// Note: until the first caller exits, the others
 	// will wait blocked as well.
-	d.once.Do(func() {
-		t := func() timer {
-			d.Lock()
-			defer d.Unlock()
-			if d.QuietPeriod <= 0 {
-				d.QuietPeriod = network.DefaultDrainTimeout
+	ch := func() chan struct{} {
+		d.Lock()
+		defer d.Unlock()
+		if d.ch != nil {
+			return d.ch
+		}
+
+		if d.QuietPeriod <= 0 {
+			d.QuietPeriod = network.DefaultDrainTimeout
+		}
+
+		timer := newTimer(d.QuietPeriod)
+		ch := make(chan struct{})
+
+		go func() {
+			select {
+			case <-ch:
+				// closed by reset
+			case <-timer.tickChan():
+				close(ch)
 			}
-			d.timer = newTimer(d.QuietPeriod)
-			return d.timer
 		}()
 
-		<-t.tickChan()
-	})
+		d.ch = ch
+		d.timer = timer
+		return ch
+	}()
+
+	<-ch
+}
+
+func drainTimer(tc <-chan time.Time) {
+	select {
+	case <-tc:
+	default:
+	}
 }
 
 // isHealthcheckRequest validates if the request has a user agent that is for healthcheck
@@ -145,8 +167,24 @@ func (d *Drainer) isHealthCheckRequest(r *http.Request) bool {
 	return false
 }
 
+func (d *Drainer) Reset() {
+	d.Lock()
+	defer d.Unlock()
+
+	if d.timer.Stop() {
+		d.timer = nil
+	} else {
+		drainTimer(d.timer.tickChan())
+	}
+
+	if d.ch != nil {
+		close(d.ch)
+		d.ch = nil
+	}
+}
+
 // reset resets the drain timer to the full amount of time.
-func (d *Drainer) reset() {
+func (d *Drainer) resetTimer() {
 	if func() bool {
 		d.RLock()
 		defer d.RUnlock()

--- a/network/handlers/drain.go
+++ b/network/handlers/drain.go
@@ -168,6 +168,8 @@ func (d *Drainer) isHealthCheckRequest(r *http.Request) bool {
 	return false
 }
 
+// Reset interrupts Drain and clears the drainers internal state
+// Thus further calls to Drain will block and wait for the entire QuietPeriod
 func (d *Drainer) Reset() {
 	d.Lock()
 	defer d.Unlock()
@@ -186,7 +188,7 @@ func (d *Drainer) Reset() {
 	}
 }
 
-// reset resets the drain timer to the full amount of time.
+// resetTimer resets the drain timer to the full amount of time.
 func (d *Drainer) resetTimer() {
 	if func() bool {
 		d.RLock()

--- a/network/handlers/drain.go
+++ b/network/handlers/drain.go
@@ -171,10 +171,12 @@ func (d *Drainer) Reset() {
 	d.Lock()
 	defer d.Unlock()
 
-	if d.timer.Stop() {
-		d.timer = nil
-	} else {
-		drainTimer(d.timer.tickChan())
+	if d.timer != nil {
+		if d.timer.Stop() {
+			d.timer = nil
+		} else {
+			drainTimer(d.timer.tickChan())
+		}
 	}
 
 	if d.ch != nil {

--- a/network/handlers/drain.go
+++ b/network/handlers/drain.go
@@ -188,7 +188,6 @@ func (d *Drainer) Reset() {
 	}
 }
 
-// resetTimer resets the drain timer to the full amount of time.
 func (d *Drainer) resetTimer() {
 	if func() bool {
 		d.RLock()

--- a/network/handlers/drain.go
+++ b/network/handlers/drain.go
@@ -73,6 +73,7 @@ type Drainer struct {
 	// timer is used to orchestrate the drain.
 	timer timer
 
+	// used to synchronize callers of Drain and Reset
 	ch chan struct{}
 
 	// HealthCheckUAPrefixes are the additional user agent prefixes that trigger the

--- a/network/handlers/drain_test.go
+++ b/network/handlers/drain_test.go
@@ -526,14 +526,14 @@ func TestReset(t *testing.T) {
 		t.Fatal("Reset didn't unblock second Drain")
 	}
 
-	// Calling reset again shoudl be a noop
+	// Calling reset again should be a noop
 	d.Reset()
 
 	d.QuietPeriod = time.Second / 2
 
 	start := time.Now()
 	d.Drain()
-	duration := time.Now().Sub(start)
+	duration := time.Since(start)
 	diff := d.QuietPeriod - duration
 	if diff < 0 {
 		diff = -diff

--- a/network/handlers/drain_test.go
+++ b/network/handlers/drain_test.go
@@ -539,7 +539,7 @@ func TestReset(t *testing.T) {
 		diff = -diff
 	}
 
-	if diff > 10*time.Millisecond {
+	if diff > 50*time.Millisecond {
 		t.Error("expected to drain to wait QuietPeriod time after reset")
 	}
 }

--- a/network/handlers/drain_test.go
+++ b/network/handlers/drain_test.go
@@ -526,6 +526,9 @@ func TestReset(t *testing.T) {
 		t.Fatal("Reset didn't unblock second Drain")
 	}
 
+	// Calling reset again shoudl be a noop
+	d.Reset()
+
 	d.QuietPeriod = time.Second / 2
 
 	start := time.Now()


### PR DESCRIPTION
Replaces https://github.com/knative/pkg/pull/2491

We need a reset so that downstream for serving to work around containers that are failing their liveness probe see: https://github.com/knative/serving/issues/12571