### PR TITLE
split warnings. Fix issue: 2581

### DIFF
--- a/webhook/admission.go
+++ b/webhook/admission.go
@@ -133,9 +133,7 @@ func admissionHandler(rootLogger *zap.SugaredLogger, stats StatsReporter, c Admi
 		if reviewResponse.Warnings != nil {
 			cleanedWarnings := make([]string, 0, len(reviewResponse.Warnings))
 			for _, w := range reviewResponse.Warnings {
-				for _, piece := range strings.Split(w, "\n") {
-					cleanedWarnings = append(cleanedWarnings, piece)
-				}
+				cleanedWarnings = append(cleanedWarnings, strings.Split(w, "\n")...)
 			}
 			reviewResponse.Warnings = cleanedWarnings
 		}

--- a/webhook/admission.go
+++ b/webhook/admission.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -123,6 +124,20 @@ func admissionHandler(rootLogger *zap.SugaredLogger, stats StatsReporter, c Admi
 
 		if !reviewResponse.Allowed || reviewResponse.PatchType != nil || response.Response == nil {
 			response.Response = reviewResponse
+		}
+
+		// If warnings contain newlines, which they will do by default if
+		// using Knative apis.FieldError, split them based on newlines
+		// and create a new warning. This is because any control characters
+		// in the warnings will cause the warning to be dropped silently.
+		if reviewResponse.Warnings != nil {
+			cleanedWarnings := make([]string, 0, len(reviewResponse.Warnings))
+			for _, w := range reviewResponse.Warnings {
+				for _, piece := range strings.Split(w, "\n") {
+					cleanedWarnings = append(cleanedWarnings, piece)
+				}
+			}
+			reviewResponse.Warnings = cleanedWarnings
 		}
 		response.Response.UID = review.Request.UID
 


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!-- Thanks for sending a pull request! -->

# Changes
🐛 Fix #2581 

If warnings contain newlines, split on them, and create a new warning for each of them.
<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
* Fixes a bug (#2581) where (most if not all) warnings were silently ignored by k8s apiserver due to having newlines on them.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
