### PR TITLE
ValidatesCreates also calls SetDefault if defaultable

### DIFF
--- a/reconciler/testing/reactions.go
+++ b/reconciler/testing/reactions.go
@@ -48,6 +48,12 @@ func InduceFailure(verb, resource string) clientgotesting.ReactionFunc {
 
 func ValidateCreates(ctx context.Context, action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 	got := action.(clientgotesting.CreateAction).GetObject()
+	o, ok := got.(apis.Defaultable)
+	if ok {
+		o.SetDefaults(ctx)
+		got, _ = o.(runtime.Object)
+	}
+
 	obj, ok := got.(apis.Validatable)
 	if !ok {
 		return false, nil, nil


### PR DESCRIPTION
- 🧹 Create validation calls SetDefaults if available.

/kind enhancement

There's a case with Eventing sugar controller where it creates an empty Broker and relies on the defaulting config map to fill in the details. After defaulting the Broker will become valid. The tests were failing when defaulting wasn't called on the newly created Broker object.