### PR TITLE
Updates boilerplate action to use go v1.18

### DIFF
--- a/.github/workflows/knative-boilerplate.yaml
+++ b/.github/workflows/knative-boilerplate.yaml
@@ -42,10 +42,10 @@ jobs:
 
     steps:
 
-      - name: Set up Go 1.17.x
+      - name: Set up Go 1.18.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
         id: go
 
       - name: Check out code


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

# Changes

Uses go v1.18 in the boilerplate action (same as the others)