### PR TITLE
Avoid second lister fetch during finalizer reconciliation.

### DIFF
--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/reconciler.go
@@ -335,23 +335,14 @@ func (r *reconcilerImpl) updateStatus(ctx context.Context, existing *v1.CustomRe
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.CustomResourceDefinition) (*v1.CustomResourceDefinition, error) {
-
-	getter := r.Lister
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.CustomResourceDefinition, desiredFinalizers sets.String) (*v1.CustomResourceDefinition, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -408,10 +399,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.CustomResourceDefinition, reconcileEvent reconciler.Event) (*v1.CustomResourceDefinition, error) {
@@ -435,8 +424,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.Custom
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
@@ -335,23 +335,14 @@ func (r *reconcilerImpl) updateStatus(ctx context.Context, existing *v1beta1.Cus
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1beta1.CustomResourceDefinition) (*v1beta1.CustomResourceDefinition, error) {
-
-	getter := r.Lister
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1beta1.CustomResourceDefinition, desiredFinalizers sets.String) (*v1beta1.CustomResourceDefinition, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -408,10 +399,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1beta1.CustomResourceDefinition, reconcileEvent reconciler.Event) (*v1beta1.CustomResourceDefinition, error) {
@@ -435,8 +424,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1beta1.C
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/kube/reconciler/admissionregistration/v1/mutatingwebhookconfiguration/reconciler.go
+++ b/client/injection/kube/reconciler/admissionregistration/v1/mutatingwebhookconfiguration/reconciler.go
@@ -271,23 +271,14 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.MutatingWebhookConfiguration) (*v1.MutatingWebhookConfiguration, error) {
-
-	getter := r.Lister
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.MutatingWebhookConfiguration, desiredFinalizers sets.String) (*v1.MutatingWebhookConfiguration, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -344,10 +335,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.MutatingWebhookConfiguration, reconcileEvent reconciler.Event) (*v1.MutatingWebhookConfiguration, error) {
@@ -371,8 +360,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.Mutati
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/kube/reconciler/admissionregistration/v1/validatingwebhookconfiguration/reconciler.go
+++ b/client/injection/kube/reconciler/admissionregistration/v1/validatingwebhookconfiguration/reconciler.go
@@ -271,23 +271,14 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.ValidatingWebhookConfiguration) (*v1.ValidatingWebhookConfiguration, error) {
-
-	getter := r.Lister
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.ValidatingWebhookConfiguration, desiredFinalizers sets.String) (*v1.ValidatingWebhookConfiguration, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -344,10 +335,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.ValidatingWebhookConfiguration, reconcileEvent reconciler.Event) (*v1.ValidatingWebhookConfiguration, error) {
@@ -371,8 +360,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.Valida
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/kube/reconciler/admissionregistration/v1beta1/mutatingwebhookconfiguration/reconciler.go
+++ b/client/injection/kube/reconciler/admissionregistration/v1beta1/mutatingwebhookconfiguration/reconciler.go
@@ -271,23 +271,14 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1beta1.MutatingWebhookConfiguration) (*v1beta1.MutatingWebhookConfiguration, error) {
-
-	getter := r.Lister
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1beta1.MutatingWebhookConfiguration, desiredFinalizers sets.String) (*v1beta1.MutatingWebhookConfiguration, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -344,10 +335,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1beta1.MutatingWebhookConfiguration, reconcileEvent reconciler.Event) (*v1beta1.MutatingWebhookConfiguration, error) {
@@ -371,8 +360,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1beta1.M
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/kube/reconciler/admissionregistration/v1beta1/validatingwebhookconfiguration/reconciler.go
+++ b/client/injection/kube/reconciler/admissionregistration/v1beta1/validatingwebhookconfiguration/reconciler.go
@@ -271,23 +271,14 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1beta1.ValidatingWebhookConfiguration) (*v1beta1.ValidatingWebhookConfiguration, error) {
-
-	getter := r.Lister
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1beta1.ValidatingWebhookConfiguration, desiredFinalizers sets.String) (*v1beta1.ValidatingWebhookConfiguration, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -344,10 +335,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1beta1.ValidatingWebhookConfiguration, reconcileEvent reconciler.Event) (*v1beta1.ValidatingWebhookConfiguration, error) {
@@ -371,8 +360,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1beta1.V
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/kube/reconciler/apps/v1/deployment/reconciler.go
+++ b/client/injection/kube/reconciler/apps/v1/deployment/reconciler.go
@@ -335,23 +335,14 @@ func (r *reconcilerImpl) updateStatus(ctx context.Context, existing *v1.Deployme
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.Deployment) (*v1.Deployment, error) {
-
-	getter := r.Lister.Deployments(resource.Namespace)
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.Deployment, desiredFinalizers sets.String) (*v1.Deployment, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -408,10 +399,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.Deployment, reconcileEvent reconciler.Event) (*v1.Deployment, error) {
@@ -435,8 +424,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.Deploy
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/kube/reconciler/apps/v1beta1/deployment/reconciler.go
+++ b/client/injection/kube/reconciler/apps/v1beta1/deployment/reconciler.go
@@ -335,23 +335,14 @@ func (r *reconcilerImpl) updateStatus(ctx context.Context, existing *v1beta1.Dep
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1beta1.Deployment) (*v1beta1.Deployment, error) {
-
-	getter := r.Lister.Deployments(resource.Namespace)
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1beta1.Deployment, desiredFinalizers sets.String) (*v1beta1.Deployment, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -408,10 +399,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1beta1.Deployment, reconcileEvent reconciler.Event) (*v1beta1.Deployment, error) {
@@ -435,8 +424,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1beta1.D
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/kube/reconciler/apps/v1beta2/deployment/reconciler.go
+++ b/client/injection/kube/reconciler/apps/v1beta2/deployment/reconciler.go
@@ -335,23 +335,14 @@ func (r *reconcilerImpl) updateStatus(ctx context.Context, existing *v1beta2.Dep
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1beta2.Deployment) (*v1beta2.Deployment, error) {
-
-	getter := r.Lister.Deployments(resource.Namespace)
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1beta2.Deployment, desiredFinalizers sets.String) (*v1beta2.Deployment, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -408,10 +399,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1beta2.Deployment, reconcileEvent reconciler.Event) (*v1beta2.Deployment, error) {
@@ -435,8 +424,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1beta2.D
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/kube/reconciler/batch/v1/cronjob/reconciler.go
+++ b/client/injection/kube/reconciler/batch/v1/cronjob/reconciler.go
@@ -335,23 +335,14 @@ func (r *reconcilerImpl) updateStatus(ctx context.Context, existing *v1.CronJob,
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.CronJob) (*v1.CronJob, error) {
-
-	getter := r.Lister.CronJobs(resource.Namespace)
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.CronJob, desiredFinalizers sets.String) (*v1.CronJob, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -408,10 +399,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.CronJob, reconcileEvent reconciler.Event) (*v1.CronJob, error) {
@@ -435,8 +424,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.CronJo
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/kube/reconciler/batch/v1beta1/cronjob/reconciler.go
+++ b/client/injection/kube/reconciler/batch/v1beta1/cronjob/reconciler.go
@@ -335,23 +335,14 @@ func (r *reconcilerImpl) updateStatus(ctx context.Context, existing *v1beta1.Cro
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1beta1.CronJob) (*v1beta1.CronJob, error) {
-
-	getter := r.Lister.CronJobs(resource.Namespace)
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1beta1.CronJob, desiredFinalizers sets.String) (*v1beta1.CronJob, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -408,10 +399,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1beta1.CronJob, reconcileEvent reconciler.Event) (*v1beta1.CronJob, error) {
@@ -435,8 +424,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1beta1.C
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/kube/reconciler/core/v1/configmap/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/configmap/reconciler.go
@@ -270,23 +270,14 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.ConfigMap) (*v1.ConfigMap, error) {
-
-	getter := r.Lister.ConfigMaps(resource.Namespace)
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.ConfigMap, desiredFinalizers sets.String) (*v1.ConfigMap, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -343,10 +334,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.ConfigMap, reconcileEvent reconciler.Event) (*v1.ConfigMap, error) {
@@ -370,8 +359,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.Config
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/kube/reconciler/core/v1/node/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/node/reconciler.go
@@ -334,23 +334,14 @@ func (r *reconcilerImpl) updateStatus(ctx context.Context, existing *v1.Node, de
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.Node) (*v1.Node, error) {
-
-	getter := r.Lister
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.Node, desiredFinalizers sets.String) (*v1.Node, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -407,10 +398,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.Node, reconcileEvent reconciler.Event) (*v1.Node, error) {
@@ -434,8 +423,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.Node, 
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/kube/reconciler/core/v1/pod/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/pod/reconciler.go
@@ -334,23 +334,14 @@ func (r *reconcilerImpl) updateStatus(ctx context.Context, existing *v1.Pod, des
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.Pod) (*v1.Pod, error) {
-
-	getter := r.Lister.Pods(resource.Namespace)
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.Pod, desiredFinalizers sets.String) (*v1.Pod, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -407,10 +398,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.Pod, reconcileEvent reconciler.Event) (*v1.Pod, error) {
@@ -434,8 +423,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.Pod, r
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/kube/reconciler/core/v1/secret/reconciler.go
+++ b/client/injection/kube/reconciler/core/v1/secret/reconciler.go
@@ -270,23 +270,14 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.Secret) (*v1.Secret, error) {
-
-	getter := r.Lister.Secrets(resource.Namespace)
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.Secret, desiredFinalizers sets.String) (*v1.Secret, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -343,10 +334,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.Secret, reconcileEvent reconciler.Event) (*v1.Secret, error) {
@@ -370,8 +359,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.Secret
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/kube/reconciler/extensions/v1beta1/deployment/reconciler.go
+++ b/client/injection/kube/reconciler/extensions/v1beta1/deployment/reconciler.go
@@ -335,23 +335,14 @@ func (r *reconcilerImpl) updateStatus(ctx context.Context, existing *v1beta1.Dep
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1beta1.Deployment) (*v1beta1.Deployment, error) {
-
-	getter := r.Lister.Deployments(resource.Namespace)
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1beta1.Deployment, desiredFinalizers sets.String) (*v1beta1.Deployment, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -408,10 +399,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1beta1.Deployment, reconcileEvent reconciler.Event) (*v1beta1.Deployment, error) {
@@ -435,8 +424,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1beta1.D
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/kube/reconciler/extensions/v1beta1/networkpolicy/reconciler.go
+++ b/client/injection/kube/reconciler/extensions/v1beta1/networkpolicy/reconciler.go
@@ -335,23 +335,14 @@ func (r *reconcilerImpl) updateStatus(ctx context.Context, existing *v1beta1.Net
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1beta1.NetworkPolicy) (*v1beta1.NetworkPolicy, error) {
-
-	getter := r.Lister.NetworkPolicies(resource.Namespace)
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1beta1.NetworkPolicy, desiredFinalizers sets.String) (*v1beta1.NetworkPolicy, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -408,10 +399,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1beta1.NetworkPolicy, reconcileEvent reconciler.Event) (*v1beta1.NetworkPolicy, error) {
@@ -435,8 +424,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1beta1.N
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/client/injection/kube/reconciler/networking/v1/networkpolicy/reconciler.go
+++ b/client/injection/kube/reconciler/networking/v1/networkpolicy/reconciler.go
@@ -335,23 +335,14 @@ func (r *reconcilerImpl) updateStatus(ctx context.Context, existing *v1.NetworkP
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.NetworkPolicy) (*v1.NetworkPolicy, error) {
-
-	getter := r.Lister.NetworkPolicies(resource.Namespace)
-
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.NetworkPolicy, desiredFinalizers sets.String) (*v1.NetworkPolicy, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	desiredFinalizers := sets.NewString(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -408,10 +399,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.NetworkPolicy, reconcileEvent reconciler.Event) (*v1.NetworkPolicy, error) {
@@ -435,8 +424,6 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.Networ
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }

--- a/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -154,6 +154,10 @@ func (g *reconcilerReconcilerGenerator) GenerateType(c *generator.Context, t *ty
 			Package: "k8s.io/apimachinery/pkg/util/sets",
 			Name:    "NewString",
 		}),
+		"setsString": c.Universe.Type(types.Name{
+			Package: "k8s.io/apimachinery/pkg/util/sets",
+			Name:    "String",
+		}),
 		"controllerOptions": c.Universe.Type(types.Name{
 			Package: "knative.dev/pkg/controller",
 			Name:    "Options",
@@ -597,25 +601,14 @@ var reconcilerFinalizerFactory = `
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx {{.contextContext|raw}}, resource *{{.type|raw}}) (*{{.type|raw}}, error) {
-	{{if .nonNamespaced}}
-	getter := r.Lister
-	{{else}}
-	getter := r.Lister.{{.type|apiGroup}}(resource.Namespace)
-	{{end}}
-	actual, err := getter.Get(resource.Name)
-	if err != nil {
-		return resource, err
-	}
-
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx {{.contextContext|raw}}, resource *{{.type|raw}}, desiredFinalizers {{.setsString|raw}}) (*{{.type|raw}}, error) {
 	// Don't modify the informers copy.
-	existing := actual.DeepCopy()
+	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
 	existingFinalizers := {{.setsNewString|raw}}(existing.Finalizers...)
-	desiredFinalizers := {{.setsNewString|raw}}(resource.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -675,10 +668,8 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx {{.contextContext|raw}}, re
 		finalizers.Insert(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 func (r *reconcilerImpl) clearFinalizer(ctx {{.contextContext|raw}}, resource *{{.type|raw}}, reconcileEvent {{.reconcilerEvent|raw}}) (*{{.type|raw}}, error) {
@@ -702,10 +693,8 @@ func (r *reconcilerImpl) clearFinalizer(ctx {{.contextContext|raw}}, resource *{
 		finalizers.Delete(r.finalizerName)
 	}
 
-	resource.Finalizers = finalizers.List()
-
 	// Synchronize the finalizers filtered by r.finalizerName.
-	return r.updateFinalizersFiltered(ctx, resource)
+	return r.updateFinalizersFiltered(ctx, resource, finalizers)
 }
 
 `


### PR DESCRIPTION
I noticed that the finalizer manipulation code was performing a second fetch of the resource from the lister cache to determine the differences in finalizers when the finalizers are being modify immediately above each callsite.

This changes both call sites to simply pass through the "desired finalizers" as a new parameter (instead of assigning them), which lets us use the unmodified resource and avoid the redundant lister cache fetch.

- :broom: Update or clean up current behavior

/kind cleanup

**Release Note**

```release-note
Eliminate a redundant lister cache fetch in the knative reconciler codegen.
```

**Docs**

```docs

```

cc @vaikas @dprotaso @tcnghia 