### PR TITLE
Define a global for `reconciler.DefaultTimeout`.

### DIFF
--- a/reconciler/reconcile_common.go
+++ b/reconciler/reconcile_common.go
@@ -30,6 +30,11 @@ import (
 
 const failedGenerationBump = "NewObservedGenFailure"
 
+// DefaultTimeout is used in some downstream reconcilers to put a context
+// deadline on reconciliation.  It is a variable so that it can be exposed by
+// entrypoints as a flag, e.g. via flag.DurationVar
+var DefaultTimeout = 30 * time.Second
+
 const (
 	// DoReconcileKind is the function name for reconciling the resource (as a leader).
 	DoReconcileKind = "ReconcileKind"


### PR DESCRIPTION
Serving currently uses a fixed constant for the context timeout on reconciliation, which is causing some bad interactions with certain policy webhooks.

Based on feedback on https://github.com/knative/serving/pull/13323 I am hoisting this into a shared variable, so that folks can turn it into a flag, so it is configurable.

```release-note

```

```docs

```

/assign @vaikas 