### PR TITLE
changeset: allow override the revision through ldflags

### DIFF
--- a/changeset/commit.go
+++ b/changeset/commit.go
@@ -39,7 +39,10 @@ var (
 // The result will have a '-dirty' suffix if the workspace was not clean
 func Get() string {
 	once.Do(func() {
-		rev = get()
+		if rev == "" {
+			rev = get()
+		}
+		// It has been set through ldflags, do nothing
 	})
 
 	return rev

--- a/changeset/commit_test.go
+++ b/changeset/commit_test.go
@@ -73,6 +73,7 @@ func TestGet(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			rev = ""
 			once = sync.Once{}
 			readBuildInfo = func() (info *debug.BuildInfo, ok bool) {
 				return c.info, c.ok


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

# Changes

The main reason for this is to support cases where the `go build` happens on a non git folder but we want to pass a revision anyway.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

/kind enhancement
/cc @imjasonh @dprotaso 

**Release Note**

```release-note
NONE
```

