### PR TITLE
Filter reactor FieldErrors on validation to only error-level alerts.

### DIFF
--- a/reconciler/testing/reactions.go
+++ b/reconciler/testing/reactions.go
@@ -52,7 +52,8 @@ func ValidateCreates(ctx context.Context, action clientgotesting.Action) (handle
 	if !ok {
 		return false, nil, nil
 	}
-	if err := obj.Validate(ctx); err != nil {
+	// Only return error-level errors; warnings should not block API calls.
+	if err := obj.Validate(ctx).Filter(apis.ErrorLevel); err != nil {
 		return true, nil, err
 	}
 	return false, nil, nil
@@ -64,7 +65,8 @@ func ValidateUpdates(ctx context.Context, action clientgotesting.Action) (handle
 	if !ok {
 		return false, nil, nil
 	}
-	if err := obj.Validate(ctx); err != nil {
+	// Only return error-level errors; warnings should not block API calls.
+	if err := obj.Validate(ctx).Filter(apis.ErrorLevel); err != nil {
 		return true, nil, err
 	}
 	return false, nil, nil


### PR DESCRIPTION
See https://github.com/knative/serving/pull/13399#issuecomment-1280033374

When we added warning-level `api.FieldErrors`, we missed filtering the warnings from `ValidateCreates` and `ValidateUpdates`.
For https://github.com/knative/serving/pull/13399, we want to be able to issue warnings on insecure default values for containers, but we don't want to force all our existing tests to use secure default values (and we want to validate that the insecure values will still work for controllers, etc).