### PR TITLE
deprecate pkg/ptr in favor of k8s.io/utils/pointer

### DIFF
--- a/depcheck/depcheck_test.go
+++ b/depcheck/depcheck_test.go
@@ -66,7 +66,10 @@ func TestExample(t *testing.T) {
 			"golang.org/x/sync/errgroup",
 		},
 		"knative.dev/pkg/ptr": {
+			"fmt",
+			"reflect",
 			"time",
+			"k8s.io/utils/pointer",
 		},
 	})
 

--- a/ptr/doc.go
+++ b/ptr/doc.go
@@ -15,4 +15,6 @@ limitations under the License.
 */
 
 // Package ptr holds utilities for taking pointer references to values.
+//
+// Deprecated: Use k8s.io/utils/pointer directly.
 package ptr

--- a/ptr/ptr.go
+++ b/ptr/ptr.go
@@ -17,8 +17,9 @@ limitations under the License.
 package ptr
 
 import (
-	"k8s.io/utils/pointer"
 	"time"
+
+	"k8s.io/utils/pointer"
 )
 
 // Int32 is a helper for turning integers into pointers for use in

--- a/ptr/ptr.go
+++ b/ptr/ptr.go
@@ -60,13 +60,13 @@ var String = pointer.StringPtr
 // Duration is a helper for turning time.Duration into pointers for use in
 // API types that want *time.Duration.
 //
-// Deprecated: Use k8s.io/utils/pointer.DurationPtr instead.
+// Deprecated: Use k8s.io/utils/pointer.Duration instead.
 var Duration = pointer.Duration
 
 // Time is a helper for turning a const time.Time into a pointer for use in
 // API types that want *time.Time.
 //
-// Deprecated: Use k8s.io/utils/pointer instead.
+// Deprecated: Will be removed in a future release.
 func Time(t time.Time) *time.Time {
 	return &t
 }

--- a/ptr/ptr.go
+++ b/ptr/ptr.go
@@ -16,52 +16,57 @@ limitations under the License.
 
 package ptr
 
-import "time"
+import (
+	"k8s.io/utils/pointer"
+	"time"
+)
 
 // Int32 is a helper for turning integers into pointers for use in
 // API types that want *int32.
-func Int32(i int32) *int32 {
-	return &i
-}
+//
+// Deprecated: Use k8s.io/utils/pointer.Int32Ptr instead.
+var Int32 = pointer.Int32Ptr
 
 // Int64 is a helper for turning integers into pointers for use in
 // API types that want *int64.
-func Int64(i int64) *int64 {
-	return &i
-}
+//
+// Deprecated: Use k8s.io/utils/pointer.Int64Ptr instead.
+var Int64 = pointer.Int64Ptr
 
 // Float32 is a helper for turning floats into pointers for use in
 // API types that want *float32.
-func Float32(f float32) *float32 {
-	return &f
-}
+//
+// Deprecated: Use k8s.io/utils/pointer.Float32Ptr instead.
+var Float32 = pointer.Float32Ptr
 
 // Float64 is a helper for turning floats into pointers for use in
 // API types that want *float64.
-func Float64(f float64) *float64 {
-	return &f
-}
+//
+// Deprecated: Use k8s.io/utils/pointer.Float64Ptr instead.
+var Float64 = pointer.Float64Ptr
 
 // Bool is a helper for turning bools into pointers for use in
 // API types that want *bool.
-func Bool(b bool) *bool {
-	return &b
-}
+//
+// Deprecated: Use k8s.io/utils/pointer.BoolPtr instead.
+var Bool = pointer.BoolPtr
 
 // String is a helper for turning strings into pointers for use in
 // API types that want *string.
-func String(s string) *string {
-	return &s
-}
+//
+// Deprecated: Use k8s.io/utils/pointer.StringPtr instead.
+var String = pointer.StringPtr
 
 // Duration is a helper for turning time.Duration into pointers for use in
 // API types that want *time.Duration.
-func Duration(t time.Duration) *time.Duration {
-	return &t
-}
+//
+// Deprecated: Use k8s.io/utils/pointer.DurationPtr instead.
+var Duration = pointer.Duration
 
 // Time is a helper for turning a const time.Time into a pointer for use in
-// API types that want *time.Duration.
+// API types that want *time.Time.
+//
+// Deprecated: Use k8s.io/utils/pointer instead.
 func Time(t time.Time) *time.Time {
 	return &t
 }


### PR DESCRIPTION
Mentioned here: https://github.com/knative-sandbox/eventing-rabbitmq/pull/954#discussion_r996188932

`ptr.Time` doesn't have an analogue in k8s-pointer, and it has [a few usages](https://cs.github.com/?scopeName=All+repos&scope=&q=ptr.Time+knative.dev%2Fpkg%2Fptr) that we'll want to get rid of if we proceed with deprecating this package.

/kind cleanup

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Deprecate knative.dev/pkg/ptr in favor of k8s.io/utils/pointer, update funcs to point to those methods
```

cc @dprotaso @vaikas 