### PR TITLE
Support istio *List types where Items is an array of pointer types

### DIFF
--- a/codegen/cmd/injection-gen/args/args.go
+++ b/codegen/cmd/injection-gen/args/args.go
@@ -29,6 +29,7 @@ type CustomArgs struct {
 	ExternalVersionsInformersPackage string
 	ListersPackage                   string
 	ForceKinds                       string
+	ListerHasPointerElem             bool
 }
 
 // NewDefaults returns default arguments for the generator.
@@ -45,6 +46,7 @@ func (ca *CustomArgs) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&ca.ExternalVersionsInformersPackage, "external-versions-informers-package", ca.ExternalVersionsInformersPackage, "the full package name for the external versions injection informer to use")
 	fs.StringVar(&ca.ListersPackage, "listers-package", ca.ListersPackage, "the full package name for client listers to use")
 	fs.StringVar(&ca.ForceKinds, "force-genreconciler-kinds", ca.ForceKinds, `force kinds will override the genreconciler tag setting for the given set of kinds, comma separated: "Foo,Bar,Baz"`)
+	fs.BoolVar(&ca.ListerHasPointerElem, "lister-has-pointer-elem", ca.ListerHasPointerElem, "set to true if the List types have an Item array of pointer element types")
 }
 
 // Validate checks the given arguments.

--- a/codegen/cmd/injection-gen/generators/informer.go
+++ b/codegen/cmd/injection-gen/generators/informer.go
@@ -41,6 +41,7 @@ type injectionGenerator struct {
 	injectionClientSetPackage   string
 	clientSetPackage            string
 	listerPkg                   string
+	listerHasPointerElem        bool
 }
 
 var _ generator.Generator = (*injectionGenerator)(nil)
@@ -92,6 +93,7 @@ func (g *injectionGenerator) GenerateType(c *generator.Context, t *types.Type, w
 		"clientSetInterface":               c.Universe.Type(types.Name{Package: g.clientSetPackage, Name: "Interface"}),
 		"resourceLister":                   c.Universe.Type(types.Name{Name: g.typeToGenerate.Name.Name + "Lister", Package: g.listerPkg}),
 		"resourceNamespaceLister":          c.Universe.Type(types.Name{Name: g.typeToGenerate.Name.Name + "NamespaceLister", Package: g.listerPkg}),
+		"listerHasPointerElem":             g.listerHasPointerElem,
 		"groupGoName":                      namer.IC(g.groupGoName),
 		"versionGoName":                    namer.IC(g.groupVersion.Version.String()),
 		"group":                            g.groupVersion.Group.String(),
@@ -226,7 +228,7 @@ func (w *wrapper) List(selector {{ .labelsSelector|raw }}) (ret []*{{ .type|raw 
 		return nil, err
 	}
 	for idx := range lo.Items {
-		ret = append(ret, &lo.Items[idx])
+		ret = append(ret, {{if not .listerHasPointerElem}}&{{end}}lo.Items[idx])
 	}
 	return ret, nil
 }

--- a/codegen/cmd/injection-gen/generators/packages.go
+++ b/codegen/cmd/injection-gen/generators/packages.go
@@ -446,6 +446,7 @@ func versionInformerPackages(basePackage string, groupPkgName string, gv clientg
 					clientSetPackage:            customArgs.VersionedClientSetPackage,
 					injectionClientSetPackage:   filepath.Join(basePackage, "client"),
 					listerPkg:                   listerPackagePath,
+					listerHasPointerElem:        customArgs.ListerHasPointerElem,
 				})
 				return generators
 			},


### PR DESCRIPTION
Generally K8s types have a list type where the 'Items' member is an
array of structs.

ie. https://pkg.go.dev/k8s.io/api@v0.25.3/apps/v1#DeploymentList

```
type DeploymentList struct {
	...
	// Items is the list of Deployments.
	Items []Deployment `json:"items" protobuf:"bytes,2,rep,name=items"`
}
```

Istio is an exception where the list contains pointers to structs

```
type GatewayList struct {
	...
	Items       []*Gateway `json:"items" protobuf:"bytes,2,rep,name=items"`
}
```

To hint that the list types are pointers you can now pass the flag
`--lister-has-pointer-elem`.

Ideally we could infer this info by inspecting the types but
unfortunately the generator doesn't load this information
