### PR TITLE
Default ConfigMap if ObservabilityConfig is nil

### DIFF
--- a/injection/sharedmain/main_test.go
+++ b/injection/sharedmain/main_test.go
@@ -105,7 +105,7 @@ func TestWithLeaderElectionConfig(t *testing.T) {
 	}
 }
 
-func TextWithObservabilityConfig(t *testing.T) {
+func TestWithObservabilityConfig(t *testing.T) {
 	want := &metrics.ObservabilityConfig{
 		EnableVarLogCollection:  false,
 		LoggingURLTemplate:      "url-template",

--- a/metrics/config_observability.go
+++ b/metrics/config_observability.go
@@ -110,6 +110,9 @@ func defaultConfig() *ObservabilityConfig {
 // NewObservabilityConfigFromConfigMap creates a ObservabilityConfig from the supplied ConfigMap
 func NewObservabilityConfigFromConfigMap(configMap *corev1.ConfigMap) (*ObservabilityConfig, error) {
 	oc := defaultConfig()
+	if configMap == nil {
+		return oc, nil
+	}
 
 	if err := cm.Parse(configMap.Data,
 		cm.AsBool("logging.enable-var-log-collection", &oc.EnableVarLogCollection),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- Defaults the observability config. Currently with [this change](https://github.com/knative/pkg/pull/2610), there is an implicit requirement that `METRICS_DOMAIN` is set which is unexpected for users that have not enabled observability before.

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🐛 Fixes crashing introduced in #2610 

The current build of `knative/pkg` will crash on startup because of [this line](https://github.com/knative/pkg/blob/main/injection/sharedmain/main.go#L118). Rather than introduce a nil-check, we should simply have observability disabled by default (as was the previous behavior) but now accessible from `context.Context`

```console
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x110 pc=0x15c5568]

goroutine 1 [running]:
knative.dev/pkg/metrics.NewObservabilityConfigFromConfigMap(0x0)
        knative.dev/pkg@v0.0.0-20221014164553-b812affa3893/metrics/config_observability.go:114 +0x248
knative.dev/pkg/injection/sharedmain.GetObservabilityConfig({0x2a0e1b8, 0xc00039d170})
        knative.dev/pkg@v0.0.0-20221014164553-b812affa3893/injection/sharedmain/main.go:118 +0x176
knative.dev/pkg/injection/sharedmain.SetupObservabilityOrDie({0x2a0e1b8, 0xc00039d170}, {0x252ef46, 0x7}, 0x24d2f00?, 0xc000312688?)
        knative.dev/pkg@v0.0.0-20221014164553-b812affa3893/injection/sharedmain/main.go:354 +0x5b
knative.dev/pkg/injection/sharedmain.MainWithConfig({0x2a0e1b8, 0xc000831ec0}, {0x252ef46, 0x7}, 0xc000774fc0, {0xc000969ea0, 0x4, 0x4})
        knative.dev/pkg@v0.0.0-20221014164553-b812affa3893/injection/sharedmain/main.go:271 +0x5a6
github.com/aws/karpenter-core/pkg/webhooks.Initialize(0x263aa68)
        github.com/aws/karpenter-core/pkg/webhooks/webhooks.go:93 +0x48a
main.main()
        github.com/aws/karpenter/cmd/webhook/main.go:25 +0x25
```

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Change Observability Config to be Disabled by Default
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
