### PR TITLE
make METRICS_DOMAIN optional when backend is not OpenCensus

### DIFF
--- a/metrics/config.go
+++ b/metrics/config.go
@@ -124,12 +124,7 @@ func (mc *metricsConfig) record(ctx context.Context, mss []stats.Measurement, ro
 
 func createMetricsConfig(_ context.Context, ops ExporterOptions) (*metricsConfig, error) {
 	var mc metricsConfig
-
-	if ops.Domain == "" {
-		return nil, errors.New("metrics domain cannot be empty")
-	}
 	mc.domain = ops.Domain
-
 	if ops.Component == "" {
 		return nil, errors.New("metrics component name cannot be empty")
 	}
@@ -159,6 +154,9 @@ func createMetricsConfig(_ context.Context, ops ExporterOptions) (*metricsConfig
 
 	switch mc.backendDestination {
 	case openCensus:
+		if ops.Domain == "" {
+			return nil, errors.New("metrics domain cannot be empty")
+		}
 		mc.collectorAddress = ops.ConfigMap[collectorAddressKey]
 		if isSecure := ops.ConfigMap[collectorSecureKey]; isSecure != "" {
 			var err error
@@ -221,22 +219,7 @@ func Domain() string {
 	if domain := os.Getenv(DomainEnv); domain != "" {
 		return domain
 	}
-
-	panic(fmt.Sprintf(`The environment variable %q is not set
-
-If this is a process running on Kubernetes, then it should be specifying
-this via:
-
-  env:
-  - name: %s
-    value: knative.dev/some-repository
-
-If this is a Go unit test consuming metric.Domain() then it should add the
-following import:
-
-import (
-	_ "knative.dev/pkg/metrics/testing"
-)`, DomainEnv, DomainEnv))
+	return ""
 }
 
 // prometheusPort returns the TCP port number configured via the environment

--- a/metrics/config_test.go
+++ b/metrics/config_test.go
@@ -61,7 +61,7 @@ var (
 		name: "emptyDomain",
 		ops: ExporterOptions{
 			ConfigMap: map[string]string{
-				BackendDestinationKey: string(prometheus),
+				BackendDestinationKey: string(openCensus),
 			},
 			Component: testComponent,
 		},


### PR DESCRIPTION
Related to https://github.com/knative/pkg/pull/2614

We currently panic when `METRICS_DOMAIN` isn't set but this setting is only needed when using OpenCensus
