### PR TITLE
CmpOpts overrides should be passed through

### DIFF
--- a/reconciler/testing/table.go
+++ b/reconciler/testing/table.go
@@ -387,10 +387,13 @@ func (tt TableTest) Test(t *testing.T, factory Factory) {
 		t.Run(test.Name, func(t *testing.T) {
 			t.Helper()
 			test.Test(t, factory)
+			opts := make([]cmp.Option, 0, len(defaultCmpOpts)+len(test.CmpOpts))
+			opts = append(opts, defaultCmpOpts...)
+			opts = append(opts, test.CmpOpts...)
 			// Validate cached objects do not get soiled after controller loops.
-			if !cmp.Equal(originObjects, test.Objects, defaultCmpOpts...) {
+			if !cmp.Equal(originObjects, test.Objects, opts...) {
 				t.Errorf("Unexpected objects (-want, +got):\n%s",
-					cmp.Diff(originObjects, test.Objects, defaultCmpOpts...))
+					cmp.Diff(originObjects, test.Objects, opts...))
 			}
 		})
 	}


### PR DESCRIPTION
This allows us to pass options to ignore unexpected fields in structs 

/assign @AngeloDanducci @nak3 

/cc @a7i