### PR TITLE
Feature: Implement `Apply` codegen.

### DIFF
--- a/client/injection/kube/client/client.go
+++ b/client/injection/kube/client/client.go
@@ -171,6 +171,7 @@ import (
 	injection "knative.dev/pkg/injection"
 	dynamicclient "knative.dev/pkg/injection/clients/dynamicclient"
 	logging "knative.dev/pkg/logging"
+	ptr "knative.dev/pkg/ptr"
 )
 
 func init() {
@@ -260,11 +261,43 @@ type wrapAdmissionregistrationV1MutatingWebhookConfigurationImpl struct {
 var _ typedadmissionregistrationv1.MutatingWebhookConfigurationInterface = (*wrapAdmissionregistrationV1MutatingWebhookConfigurationImpl)(nil)
 
 func (w *wrapAdmissionregistrationV1MutatingWebhookConfigurationImpl) Apply(ctx context.Context, in *v1.MutatingWebhookConfigurationApplyConfiguration, opts metav1.ApplyOptions) (result *admissionregistrationv1.MutatingWebhookConfiguration, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("MutatingWebhookConfiguration")
+
+	in.APIVersion = ptr.String("admissionregistration.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &admissionregistrationv1.MutatingWebhookConfiguration{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAdmissionregistrationV1MutatingWebhookConfigurationImpl) ApplyStatus(ctx context.Context, in *v1.MutatingWebhookConfigurationApplyConfiguration, opts metav1.ApplyOptions) (result *admissionregistrationv1.MutatingWebhookConfiguration, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("MutatingWebhookConfiguration")
+
+	in.APIVersion = ptr.String("admissionregistration.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &admissionregistrationv1.MutatingWebhookConfiguration{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAdmissionregistrationV1MutatingWebhookConfigurationImpl) Create(ctx context.Context, in *admissionregistrationv1.MutatingWebhookConfiguration, opts metav1.CreateOptions) (*admissionregistrationv1.MutatingWebhookConfiguration, error) {
@@ -395,11 +428,43 @@ type wrapAdmissionregistrationV1ValidatingWebhookConfigurationImpl struct {
 var _ typedadmissionregistrationv1.ValidatingWebhookConfigurationInterface = (*wrapAdmissionregistrationV1ValidatingWebhookConfigurationImpl)(nil)
 
 func (w *wrapAdmissionregistrationV1ValidatingWebhookConfigurationImpl) Apply(ctx context.Context, in *v1.ValidatingWebhookConfigurationApplyConfiguration, opts metav1.ApplyOptions) (result *admissionregistrationv1.ValidatingWebhookConfiguration, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ValidatingWebhookConfiguration")
+
+	in.APIVersion = ptr.String("admissionregistration.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAdmissionregistrationV1ValidatingWebhookConfigurationImpl) ApplyStatus(ctx context.Context, in *v1.ValidatingWebhookConfigurationApplyConfiguration, opts metav1.ApplyOptions) (result *admissionregistrationv1.ValidatingWebhookConfiguration, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ValidatingWebhookConfiguration")
+
+	in.APIVersion = ptr.String("admissionregistration.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAdmissionregistrationV1ValidatingWebhookConfigurationImpl) Create(ctx context.Context, in *admissionregistrationv1.ValidatingWebhookConfiguration, opts metav1.CreateOptions) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
@@ -545,11 +610,43 @@ type wrapAdmissionregistrationV1beta1MutatingWebhookConfigurationImpl struct {
 var _ typedadmissionregistrationv1beta1.MutatingWebhookConfigurationInterface = (*wrapAdmissionregistrationV1beta1MutatingWebhookConfigurationImpl)(nil)
 
 func (w *wrapAdmissionregistrationV1beta1MutatingWebhookConfigurationImpl) Apply(ctx context.Context, in *v1beta1.MutatingWebhookConfigurationApplyConfiguration, opts metav1.ApplyOptions) (result *admissionregistrationv1beta1.MutatingWebhookConfiguration, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("MutatingWebhookConfiguration")
+
+	in.APIVersion = ptr.String("admissionregistration.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &admissionregistrationv1beta1.MutatingWebhookConfiguration{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAdmissionregistrationV1beta1MutatingWebhookConfigurationImpl) ApplyStatus(ctx context.Context, in *v1beta1.MutatingWebhookConfigurationApplyConfiguration, opts metav1.ApplyOptions) (result *admissionregistrationv1beta1.MutatingWebhookConfiguration, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("MutatingWebhookConfiguration")
+
+	in.APIVersion = ptr.String("admissionregistration.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &admissionregistrationv1beta1.MutatingWebhookConfiguration{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAdmissionregistrationV1beta1MutatingWebhookConfigurationImpl) Create(ctx context.Context, in *admissionregistrationv1beta1.MutatingWebhookConfiguration, opts metav1.CreateOptions) (*admissionregistrationv1beta1.MutatingWebhookConfiguration, error) {
@@ -680,11 +777,43 @@ type wrapAdmissionregistrationV1beta1ValidatingWebhookConfigurationImpl struct {
 var _ typedadmissionregistrationv1beta1.ValidatingWebhookConfigurationInterface = (*wrapAdmissionregistrationV1beta1ValidatingWebhookConfigurationImpl)(nil)
 
 func (w *wrapAdmissionregistrationV1beta1ValidatingWebhookConfigurationImpl) Apply(ctx context.Context, in *v1beta1.ValidatingWebhookConfigurationApplyConfiguration, opts metav1.ApplyOptions) (result *admissionregistrationv1beta1.ValidatingWebhookConfiguration, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ValidatingWebhookConfiguration")
+
+	in.APIVersion = ptr.String("admissionregistration.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &admissionregistrationv1beta1.ValidatingWebhookConfiguration{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAdmissionregistrationV1beta1ValidatingWebhookConfigurationImpl) ApplyStatus(ctx context.Context, in *v1beta1.ValidatingWebhookConfigurationApplyConfiguration, opts metav1.ApplyOptions) (result *admissionregistrationv1beta1.ValidatingWebhookConfiguration, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ValidatingWebhookConfiguration")
+
+	in.APIVersion = ptr.String("admissionregistration.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &admissionregistrationv1beta1.ValidatingWebhookConfiguration{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAdmissionregistrationV1beta1ValidatingWebhookConfigurationImpl) Create(ctx context.Context, in *admissionregistrationv1beta1.ValidatingWebhookConfiguration, opts metav1.CreateOptions) (*admissionregistrationv1beta1.ValidatingWebhookConfiguration, error) {
@@ -830,11 +959,43 @@ type wrapInternalV1alpha1StorageVersionImpl struct {
 var _ typedinternalv1alpha1.StorageVersionInterface = (*wrapInternalV1alpha1StorageVersionImpl)(nil)
 
 func (w *wrapInternalV1alpha1StorageVersionImpl) Apply(ctx context.Context, in *v1alpha1.StorageVersionApplyConfiguration, opts metav1.ApplyOptions) (result *apiserverinternalv1alpha1.StorageVersion, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("StorageVersion")
+
+	in.APIVersion = ptr.String("internal.apiserver.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiserverinternalv1alpha1.StorageVersion{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapInternalV1alpha1StorageVersionImpl) ApplyStatus(ctx context.Context, in *v1alpha1.StorageVersionApplyConfiguration, opts metav1.ApplyOptions) (result *apiserverinternalv1alpha1.StorageVersion, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("StorageVersion")
+
+	in.APIVersion = ptr.String("internal.apiserver.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiserverinternalv1alpha1.StorageVersion{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapInternalV1alpha1StorageVersionImpl) Create(ctx context.Context, in *apiserverinternalv1alpha1.StorageVersion, opts metav1.CreateOptions) (*apiserverinternalv1alpha1.StorageVersion, error) {
@@ -984,11 +1145,43 @@ type wrapAppsV1ControllerRevisionImpl struct {
 var _ typedappsv1.ControllerRevisionInterface = (*wrapAppsV1ControllerRevisionImpl)(nil)
 
 func (w *wrapAppsV1ControllerRevisionImpl) Apply(ctx context.Context, in *appsv1.ControllerRevisionApplyConfiguration, opts metav1.ApplyOptions) (result *apiappsv1.ControllerRevision, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ControllerRevision")
+
+	in.APIVersion = ptr.String("apps/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiappsv1.ControllerRevision{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1ControllerRevisionImpl) ApplyStatus(ctx context.Context, in *appsv1.ControllerRevisionApplyConfiguration, opts metav1.ApplyOptions) (result *apiappsv1.ControllerRevision, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ControllerRevision")
+
+	in.APIVersion = ptr.String("apps/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiappsv1.ControllerRevision{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1ControllerRevisionImpl) Create(ctx context.Context, in *apiappsv1.ControllerRevision, opts metav1.CreateOptions) (*apiappsv1.ControllerRevision, error) {
@@ -1123,11 +1316,43 @@ type wrapAppsV1DaemonSetImpl struct {
 var _ typedappsv1.DaemonSetInterface = (*wrapAppsV1DaemonSetImpl)(nil)
 
 func (w *wrapAppsV1DaemonSetImpl) Apply(ctx context.Context, in *appsv1.DaemonSetApplyConfiguration, opts metav1.ApplyOptions) (result *apiappsv1.DaemonSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("DaemonSet")
+
+	in.APIVersion = ptr.String("apps/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiappsv1.DaemonSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1DaemonSetImpl) ApplyStatus(ctx context.Context, in *appsv1.DaemonSetApplyConfiguration, opts metav1.ApplyOptions) (result *apiappsv1.DaemonSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("DaemonSet")
+
+	in.APIVersion = ptr.String("apps/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiappsv1.DaemonSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1DaemonSetImpl) Create(ctx context.Context, in *apiappsv1.DaemonSet, opts metav1.CreateOptions) (*apiappsv1.DaemonSet, error) {
@@ -1262,11 +1487,43 @@ type wrapAppsV1DeploymentImpl struct {
 var _ typedappsv1.DeploymentInterface = (*wrapAppsV1DeploymentImpl)(nil)
 
 func (w *wrapAppsV1DeploymentImpl) Apply(ctx context.Context, in *appsv1.DeploymentApplyConfiguration, opts metav1.ApplyOptions) (result *apiappsv1.Deployment, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Deployment")
+
+	in.APIVersion = ptr.String("apps/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiappsv1.Deployment{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1DeploymentImpl) ApplyStatus(ctx context.Context, in *appsv1.DeploymentApplyConfiguration, opts metav1.ApplyOptions) (result *apiappsv1.Deployment, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Deployment")
+
+	in.APIVersion = ptr.String("apps/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiappsv1.Deployment{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1DeploymentImpl) Create(ctx context.Context, in *apiappsv1.Deployment, opts metav1.CreateOptions) (*apiappsv1.Deployment, error) {
@@ -1413,11 +1670,43 @@ type wrapAppsV1ReplicaSetImpl struct {
 var _ typedappsv1.ReplicaSetInterface = (*wrapAppsV1ReplicaSetImpl)(nil)
 
 func (w *wrapAppsV1ReplicaSetImpl) Apply(ctx context.Context, in *appsv1.ReplicaSetApplyConfiguration, opts metav1.ApplyOptions) (result *apiappsv1.ReplicaSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ReplicaSet")
+
+	in.APIVersion = ptr.String("apps/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiappsv1.ReplicaSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1ReplicaSetImpl) ApplyStatus(ctx context.Context, in *appsv1.ReplicaSetApplyConfiguration, opts metav1.ApplyOptions) (result *apiappsv1.ReplicaSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ReplicaSet")
+
+	in.APIVersion = ptr.String("apps/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiappsv1.ReplicaSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1ReplicaSetImpl) Create(ctx context.Context, in *apiappsv1.ReplicaSet, opts metav1.CreateOptions) (*apiappsv1.ReplicaSet, error) {
@@ -1564,11 +1853,43 @@ type wrapAppsV1StatefulSetImpl struct {
 var _ typedappsv1.StatefulSetInterface = (*wrapAppsV1StatefulSetImpl)(nil)
 
 func (w *wrapAppsV1StatefulSetImpl) Apply(ctx context.Context, in *appsv1.StatefulSetApplyConfiguration, opts metav1.ApplyOptions) (result *apiappsv1.StatefulSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("StatefulSet")
+
+	in.APIVersion = ptr.String("apps/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiappsv1.StatefulSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1StatefulSetImpl) ApplyStatus(ctx context.Context, in *appsv1.StatefulSetApplyConfiguration, opts metav1.ApplyOptions) (result *apiappsv1.StatefulSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("StatefulSet")
+
+	in.APIVersion = ptr.String("apps/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiappsv1.StatefulSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1StatefulSetImpl) Create(ctx context.Context, in *apiappsv1.StatefulSet, opts metav1.CreateOptions) (*apiappsv1.StatefulSet, error) {
@@ -1730,11 +2051,43 @@ type wrapAppsV1beta1ControllerRevisionImpl struct {
 var _ typedappsv1beta1.ControllerRevisionInterface = (*wrapAppsV1beta1ControllerRevisionImpl)(nil)
 
 func (w *wrapAppsV1beta1ControllerRevisionImpl) Apply(ctx context.Context, in *appsv1beta1.ControllerRevisionApplyConfiguration, opts metav1.ApplyOptions) (result *apiappsv1beta1.ControllerRevision, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ControllerRevision")
+
+	in.APIVersion = ptr.String("apps/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiappsv1beta1.ControllerRevision{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1beta1ControllerRevisionImpl) ApplyStatus(ctx context.Context, in *appsv1beta1.ControllerRevisionApplyConfiguration, opts metav1.ApplyOptions) (result *apiappsv1beta1.ControllerRevision, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ControllerRevision")
+
+	in.APIVersion = ptr.String("apps/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiappsv1beta1.ControllerRevision{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1beta1ControllerRevisionImpl) Create(ctx context.Context, in *apiappsv1beta1.ControllerRevision, opts metav1.CreateOptions) (*apiappsv1beta1.ControllerRevision, error) {
@@ -1869,11 +2222,43 @@ type wrapAppsV1beta1DeploymentImpl struct {
 var _ typedappsv1beta1.DeploymentInterface = (*wrapAppsV1beta1DeploymentImpl)(nil)
 
 func (w *wrapAppsV1beta1DeploymentImpl) Apply(ctx context.Context, in *appsv1beta1.DeploymentApplyConfiguration, opts metav1.ApplyOptions) (result *apiappsv1beta1.Deployment, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Deployment")
+
+	in.APIVersion = ptr.String("apps/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiappsv1beta1.Deployment{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1beta1DeploymentImpl) ApplyStatus(ctx context.Context, in *appsv1beta1.DeploymentApplyConfiguration, opts metav1.ApplyOptions) (result *apiappsv1beta1.Deployment, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Deployment")
+
+	in.APIVersion = ptr.String("apps/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiappsv1beta1.Deployment{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1beta1DeploymentImpl) Create(ctx context.Context, in *apiappsv1beta1.Deployment, opts metav1.CreateOptions) (*apiappsv1beta1.Deployment, error) {
@@ -2008,11 +2393,43 @@ type wrapAppsV1beta1StatefulSetImpl struct {
 var _ typedappsv1beta1.StatefulSetInterface = (*wrapAppsV1beta1StatefulSetImpl)(nil)
 
 func (w *wrapAppsV1beta1StatefulSetImpl) Apply(ctx context.Context, in *appsv1beta1.StatefulSetApplyConfiguration, opts metav1.ApplyOptions) (result *apiappsv1beta1.StatefulSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("StatefulSet")
+
+	in.APIVersion = ptr.String("apps/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiappsv1beta1.StatefulSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1beta1StatefulSetImpl) ApplyStatus(ctx context.Context, in *appsv1beta1.StatefulSetApplyConfiguration, opts metav1.ApplyOptions) (result *apiappsv1beta1.StatefulSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("StatefulSet")
+
+	in.APIVersion = ptr.String("apps/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiappsv1beta1.StatefulSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1beta1StatefulSetImpl) Create(ctx context.Context, in *apiappsv1beta1.StatefulSet, opts metav1.CreateOptions) (*apiappsv1beta1.StatefulSet, error) {
@@ -2162,11 +2579,43 @@ type wrapAppsV1beta2ControllerRevisionImpl struct {
 var _ typedappsv1beta2.ControllerRevisionInterface = (*wrapAppsV1beta2ControllerRevisionImpl)(nil)
 
 func (w *wrapAppsV1beta2ControllerRevisionImpl) Apply(ctx context.Context, in *v1beta2.ControllerRevisionApplyConfiguration, opts metav1.ApplyOptions) (result *appsv1beta2.ControllerRevision, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ControllerRevision")
+
+	in.APIVersion = ptr.String("apps/v1beta2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &appsv1beta2.ControllerRevision{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1beta2ControllerRevisionImpl) ApplyStatus(ctx context.Context, in *v1beta2.ControllerRevisionApplyConfiguration, opts metav1.ApplyOptions) (result *appsv1beta2.ControllerRevision, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ControllerRevision")
+
+	in.APIVersion = ptr.String("apps/v1beta2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &appsv1beta2.ControllerRevision{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1beta2ControllerRevisionImpl) Create(ctx context.Context, in *appsv1beta2.ControllerRevision, opts metav1.CreateOptions) (*appsv1beta2.ControllerRevision, error) {
@@ -2301,11 +2750,43 @@ type wrapAppsV1beta2DaemonSetImpl struct {
 var _ typedappsv1beta2.DaemonSetInterface = (*wrapAppsV1beta2DaemonSetImpl)(nil)
 
 func (w *wrapAppsV1beta2DaemonSetImpl) Apply(ctx context.Context, in *v1beta2.DaemonSetApplyConfiguration, opts metav1.ApplyOptions) (result *appsv1beta2.DaemonSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("DaemonSet")
+
+	in.APIVersion = ptr.String("apps/v1beta2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &appsv1beta2.DaemonSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1beta2DaemonSetImpl) ApplyStatus(ctx context.Context, in *v1beta2.DaemonSetApplyConfiguration, opts metav1.ApplyOptions) (result *appsv1beta2.DaemonSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("DaemonSet")
+
+	in.APIVersion = ptr.String("apps/v1beta2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &appsv1beta2.DaemonSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1beta2DaemonSetImpl) Create(ctx context.Context, in *appsv1beta2.DaemonSet, opts metav1.CreateOptions) (*appsv1beta2.DaemonSet, error) {
@@ -2440,11 +2921,43 @@ type wrapAppsV1beta2DeploymentImpl struct {
 var _ typedappsv1beta2.DeploymentInterface = (*wrapAppsV1beta2DeploymentImpl)(nil)
 
 func (w *wrapAppsV1beta2DeploymentImpl) Apply(ctx context.Context, in *v1beta2.DeploymentApplyConfiguration, opts metav1.ApplyOptions) (result *appsv1beta2.Deployment, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Deployment")
+
+	in.APIVersion = ptr.String("apps/v1beta2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &appsv1beta2.Deployment{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1beta2DeploymentImpl) ApplyStatus(ctx context.Context, in *v1beta2.DeploymentApplyConfiguration, opts metav1.ApplyOptions) (result *appsv1beta2.Deployment, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Deployment")
+
+	in.APIVersion = ptr.String("apps/v1beta2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &appsv1beta2.Deployment{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1beta2DeploymentImpl) Create(ctx context.Context, in *appsv1beta2.Deployment, opts metav1.CreateOptions) (*appsv1beta2.Deployment, error) {
@@ -2579,11 +3092,43 @@ type wrapAppsV1beta2ReplicaSetImpl struct {
 var _ typedappsv1beta2.ReplicaSetInterface = (*wrapAppsV1beta2ReplicaSetImpl)(nil)
 
 func (w *wrapAppsV1beta2ReplicaSetImpl) Apply(ctx context.Context, in *v1beta2.ReplicaSetApplyConfiguration, opts metav1.ApplyOptions) (result *appsv1beta2.ReplicaSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ReplicaSet")
+
+	in.APIVersion = ptr.String("apps/v1beta2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &appsv1beta2.ReplicaSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1beta2ReplicaSetImpl) ApplyStatus(ctx context.Context, in *v1beta2.ReplicaSetApplyConfiguration, opts metav1.ApplyOptions) (result *appsv1beta2.ReplicaSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ReplicaSet")
+
+	in.APIVersion = ptr.String("apps/v1beta2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &appsv1beta2.ReplicaSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1beta2ReplicaSetImpl) Create(ctx context.Context, in *appsv1beta2.ReplicaSet, opts metav1.CreateOptions) (*appsv1beta2.ReplicaSet, error) {
@@ -2718,11 +3263,43 @@ type wrapAppsV1beta2StatefulSetImpl struct {
 var _ typedappsv1beta2.StatefulSetInterface = (*wrapAppsV1beta2StatefulSetImpl)(nil)
 
 func (w *wrapAppsV1beta2StatefulSetImpl) Apply(ctx context.Context, in *v1beta2.StatefulSetApplyConfiguration, opts metav1.ApplyOptions) (result *appsv1beta2.StatefulSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("StatefulSet")
+
+	in.APIVersion = ptr.String("apps/v1beta2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &appsv1beta2.StatefulSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1beta2StatefulSetImpl) ApplyStatus(ctx context.Context, in *v1beta2.StatefulSetApplyConfiguration, opts metav1.ApplyOptions) (result *appsv1beta2.StatefulSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("StatefulSet")
+
+	in.APIVersion = ptr.String("apps/v1beta2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &appsv1beta2.StatefulSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAppsV1beta2StatefulSetImpl) Create(ctx context.Context, in *appsv1beta2.StatefulSet, opts metav1.CreateOptions) (*appsv1beta2.StatefulSet, error) {
@@ -3322,11 +3899,43 @@ type wrapAutoscalingV1HorizontalPodAutoscalerImpl struct {
 var _ typedautoscalingv1.HorizontalPodAutoscalerInterface = (*wrapAutoscalingV1HorizontalPodAutoscalerImpl)(nil)
 
 func (w *wrapAutoscalingV1HorizontalPodAutoscalerImpl) Apply(ctx context.Context, in *applyconfigurationsautoscalingv1.HorizontalPodAutoscalerApplyConfiguration, opts metav1.ApplyOptions) (result *autoscalingv1.HorizontalPodAutoscaler, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("HorizontalPodAutoscaler")
+
+	in.APIVersion = ptr.String("autoscaling/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &autoscalingv1.HorizontalPodAutoscaler{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAutoscalingV1HorizontalPodAutoscalerImpl) ApplyStatus(ctx context.Context, in *applyconfigurationsautoscalingv1.HorizontalPodAutoscalerApplyConfiguration, opts metav1.ApplyOptions) (result *autoscalingv1.HorizontalPodAutoscaler, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("HorizontalPodAutoscaler")
+
+	in.APIVersion = ptr.String("autoscaling/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &autoscalingv1.HorizontalPodAutoscaler{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAutoscalingV1HorizontalPodAutoscalerImpl) Create(ctx context.Context, in *autoscalingv1.HorizontalPodAutoscaler, opts metav1.CreateOptions) (*autoscalingv1.HorizontalPodAutoscaler, error) {
@@ -3476,11 +4085,43 @@ type wrapAutoscalingV2HorizontalPodAutoscalerImpl struct {
 var _ typedautoscalingv2.HorizontalPodAutoscalerInterface = (*wrapAutoscalingV2HorizontalPodAutoscalerImpl)(nil)
 
 func (w *wrapAutoscalingV2HorizontalPodAutoscalerImpl) Apply(ctx context.Context, in *v2.HorizontalPodAutoscalerApplyConfiguration, opts metav1.ApplyOptions) (result *autoscalingv2.HorizontalPodAutoscaler, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("HorizontalPodAutoscaler")
+
+	in.APIVersion = ptr.String("autoscaling/v2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &autoscalingv2.HorizontalPodAutoscaler{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAutoscalingV2HorizontalPodAutoscalerImpl) ApplyStatus(ctx context.Context, in *v2.HorizontalPodAutoscalerApplyConfiguration, opts metav1.ApplyOptions) (result *autoscalingv2.HorizontalPodAutoscaler, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("HorizontalPodAutoscaler")
+
+	in.APIVersion = ptr.String("autoscaling/v2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &autoscalingv2.HorizontalPodAutoscaler{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAutoscalingV2HorizontalPodAutoscalerImpl) Create(ctx context.Context, in *autoscalingv2.HorizontalPodAutoscaler, opts metav1.CreateOptions) (*autoscalingv2.HorizontalPodAutoscaler, error) {
@@ -3630,11 +4271,43 @@ type wrapAutoscalingV2beta1HorizontalPodAutoscalerImpl struct {
 var _ typedautoscalingv2beta1.HorizontalPodAutoscalerInterface = (*wrapAutoscalingV2beta1HorizontalPodAutoscalerImpl)(nil)
 
 func (w *wrapAutoscalingV2beta1HorizontalPodAutoscalerImpl) Apply(ctx context.Context, in *v2beta1.HorizontalPodAutoscalerApplyConfiguration, opts metav1.ApplyOptions) (result *autoscalingv2beta1.HorizontalPodAutoscaler, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("HorizontalPodAutoscaler")
+
+	in.APIVersion = ptr.String("autoscaling/v2beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &autoscalingv2beta1.HorizontalPodAutoscaler{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAutoscalingV2beta1HorizontalPodAutoscalerImpl) ApplyStatus(ctx context.Context, in *v2beta1.HorizontalPodAutoscalerApplyConfiguration, opts metav1.ApplyOptions) (result *autoscalingv2beta1.HorizontalPodAutoscaler, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("HorizontalPodAutoscaler")
+
+	in.APIVersion = ptr.String("autoscaling/v2beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &autoscalingv2beta1.HorizontalPodAutoscaler{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAutoscalingV2beta1HorizontalPodAutoscalerImpl) Create(ctx context.Context, in *autoscalingv2beta1.HorizontalPodAutoscaler, opts metav1.CreateOptions) (*autoscalingv2beta1.HorizontalPodAutoscaler, error) {
@@ -3784,11 +4457,43 @@ type wrapAutoscalingV2beta2HorizontalPodAutoscalerImpl struct {
 var _ typedautoscalingv2beta2.HorizontalPodAutoscalerInterface = (*wrapAutoscalingV2beta2HorizontalPodAutoscalerImpl)(nil)
 
 func (w *wrapAutoscalingV2beta2HorizontalPodAutoscalerImpl) Apply(ctx context.Context, in *v2beta2.HorizontalPodAutoscalerApplyConfiguration, opts metav1.ApplyOptions) (result *autoscalingv2beta2.HorizontalPodAutoscaler, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("HorizontalPodAutoscaler")
+
+	in.APIVersion = ptr.String("autoscaling/v2beta2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAutoscalingV2beta2HorizontalPodAutoscalerImpl) ApplyStatus(ctx context.Context, in *v2beta2.HorizontalPodAutoscalerApplyConfiguration, opts metav1.ApplyOptions) (result *autoscalingv2beta2.HorizontalPodAutoscaler, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("HorizontalPodAutoscaler")
+
+	in.APIVersion = ptr.String("autoscaling/v2beta2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapAutoscalingV2beta2HorizontalPodAutoscalerImpl) Create(ctx context.Context, in *autoscalingv2beta2.HorizontalPodAutoscaler, opts metav1.CreateOptions) (*autoscalingv2beta2.HorizontalPodAutoscaler, error) {
@@ -3938,11 +4643,43 @@ type wrapBatchV1CronJobImpl struct {
 var _ typedbatchv1.CronJobInterface = (*wrapBatchV1CronJobImpl)(nil)
 
 func (w *wrapBatchV1CronJobImpl) Apply(ctx context.Context, in *batchv1.CronJobApplyConfiguration, opts metav1.ApplyOptions) (result *apibatchv1.CronJob, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CronJob")
+
+	in.APIVersion = ptr.String("batch/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apibatchv1.CronJob{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapBatchV1CronJobImpl) ApplyStatus(ctx context.Context, in *batchv1.CronJobApplyConfiguration, opts metav1.ApplyOptions) (result *apibatchv1.CronJob, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CronJob")
+
+	in.APIVersion = ptr.String("batch/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apibatchv1.CronJob{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapBatchV1CronJobImpl) Create(ctx context.Context, in *apibatchv1.CronJob, opts metav1.CreateOptions) (*apibatchv1.CronJob, error) {
@@ -4077,11 +4814,43 @@ type wrapBatchV1JobImpl struct {
 var _ typedbatchv1.JobInterface = (*wrapBatchV1JobImpl)(nil)
 
 func (w *wrapBatchV1JobImpl) Apply(ctx context.Context, in *batchv1.JobApplyConfiguration, opts metav1.ApplyOptions) (result *apibatchv1.Job, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Job")
+
+	in.APIVersion = ptr.String("batch/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apibatchv1.Job{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapBatchV1JobImpl) ApplyStatus(ctx context.Context, in *batchv1.JobApplyConfiguration, opts metav1.ApplyOptions) (result *apibatchv1.Job, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Job")
+
+	in.APIVersion = ptr.String("batch/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apibatchv1.Job{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapBatchV1JobImpl) Create(ctx context.Context, in *apibatchv1.Job, opts metav1.CreateOptions) (*apibatchv1.Job, error) {
@@ -4231,11 +5000,43 @@ type wrapBatchV1beta1CronJobImpl struct {
 var _ typedbatchv1beta1.CronJobInterface = (*wrapBatchV1beta1CronJobImpl)(nil)
 
 func (w *wrapBatchV1beta1CronJobImpl) Apply(ctx context.Context, in *batchv1beta1.CronJobApplyConfiguration, opts metav1.ApplyOptions) (result *apibatchv1beta1.CronJob, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CronJob")
+
+	in.APIVersion = ptr.String("batch/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apibatchv1beta1.CronJob{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapBatchV1beta1CronJobImpl) ApplyStatus(ctx context.Context, in *batchv1beta1.CronJobApplyConfiguration, opts metav1.ApplyOptions) (result *apibatchv1beta1.CronJob, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CronJob")
+
+	in.APIVersion = ptr.String("batch/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apibatchv1beta1.CronJob{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapBatchV1beta1CronJobImpl) Create(ctx context.Context, in *apibatchv1beta1.CronJob, opts metav1.CreateOptions) (*apibatchv1beta1.CronJob, error) {
@@ -4381,11 +5182,43 @@ type wrapCertificatesV1CertificateSigningRequestImpl struct {
 var _ typedcertificatesv1.CertificateSigningRequestInterface = (*wrapCertificatesV1CertificateSigningRequestImpl)(nil)
 
 func (w *wrapCertificatesV1CertificateSigningRequestImpl) Apply(ctx context.Context, in *certificatesv1.CertificateSigningRequestApplyConfiguration, opts metav1.ApplyOptions) (result *apicertificatesv1.CertificateSigningRequest, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CertificateSigningRequest")
+
+	in.APIVersion = ptr.String("certificates.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicertificatesv1.CertificateSigningRequest{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCertificatesV1CertificateSigningRequestImpl) ApplyStatus(ctx context.Context, in *certificatesv1.CertificateSigningRequestApplyConfiguration, opts metav1.ApplyOptions) (result *apicertificatesv1.CertificateSigningRequest, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CertificateSigningRequest")
+
+	in.APIVersion = ptr.String("certificates.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicertificatesv1.CertificateSigningRequest{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCertificatesV1CertificateSigningRequestImpl) Create(ctx context.Context, in *apicertificatesv1.CertificateSigningRequest, opts metav1.CreateOptions) (*apicertificatesv1.CertificateSigningRequest, error) {
@@ -4535,11 +5368,43 @@ type wrapCertificatesV1beta1CertificateSigningRequestImpl struct {
 var _ typedcertificatesv1beta1.CertificateSigningRequestInterface = (*wrapCertificatesV1beta1CertificateSigningRequestImpl)(nil)
 
 func (w *wrapCertificatesV1beta1CertificateSigningRequestImpl) Apply(ctx context.Context, in *certificatesv1beta1.CertificateSigningRequestApplyConfiguration, opts metav1.ApplyOptions) (result *apicertificatesv1beta1.CertificateSigningRequest, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CertificateSigningRequest")
+
+	in.APIVersion = ptr.String("certificates.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicertificatesv1beta1.CertificateSigningRequest{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCertificatesV1beta1CertificateSigningRequestImpl) ApplyStatus(ctx context.Context, in *certificatesv1beta1.CertificateSigningRequestApplyConfiguration, opts metav1.ApplyOptions) (result *apicertificatesv1beta1.CertificateSigningRequest, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CertificateSigningRequest")
+
+	in.APIVersion = ptr.String("certificates.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicertificatesv1beta1.CertificateSigningRequest{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCertificatesV1beta1CertificateSigningRequestImpl) Create(ctx context.Context, in *apicertificatesv1beta1.CertificateSigningRequest, opts metav1.CreateOptions) (*apicertificatesv1beta1.CertificateSigningRequest, error) {
@@ -4689,11 +5554,43 @@ type wrapCoordinationV1LeaseImpl struct {
 var _ typedcoordinationv1.LeaseInterface = (*wrapCoordinationV1LeaseImpl)(nil)
 
 func (w *wrapCoordinationV1LeaseImpl) Apply(ctx context.Context, in *coordinationv1.LeaseApplyConfiguration, opts metav1.ApplyOptions) (result *apicoordinationv1.Lease, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Lease")
+
+	in.APIVersion = ptr.String("coordination.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicoordinationv1.Lease{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoordinationV1LeaseImpl) ApplyStatus(ctx context.Context, in *coordinationv1.LeaseApplyConfiguration, opts metav1.ApplyOptions) (result *apicoordinationv1.Lease, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Lease")
+
+	in.APIVersion = ptr.String("coordination.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicoordinationv1.Lease{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoordinationV1LeaseImpl) Create(ctx context.Context, in *apicoordinationv1.Lease, opts metav1.CreateOptions) (*apicoordinationv1.Lease, error) {
@@ -4843,11 +5740,43 @@ type wrapCoordinationV1beta1LeaseImpl struct {
 var _ typedcoordinationv1beta1.LeaseInterface = (*wrapCoordinationV1beta1LeaseImpl)(nil)
 
 func (w *wrapCoordinationV1beta1LeaseImpl) Apply(ctx context.Context, in *coordinationv1beta1.LeaseApplyConfiguration, opts metav1.ApplyOptions) (result *apicoordinationv1beta1.Lease, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Lease")
+
+	in.APIVersion = ptr.String("coordination.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicoordinationv1beta1.Lease{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoordinationV1beta1LeaseImpl) ApplyStatus(ctx context.Context, in *coordinationv1beta1.LeaseApplyConfiguration, opts metav1.ApplyOptions) (result *apicoordinationv1beta1.Lease, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Lease")
+
+	in.APIVersion = ptr.String("coordination.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicoordinationv1beta1.Lease{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoordinationV1beta1LeaseImpl) Create(ctx context.Context, in *apicoordinationv1beta1.Lease, opts metav1.CreateOptions) (*apicoordinationv1beta1.Lease, error) {
@@ -4993,11 +5922,43 @@ type wrapCoreV1ComponentStatusImpl struct {
 var _ typedcorev1.ComponentStatusInterface = (*wrapCoreV1ComponentStatusImpl)(nil)
 
 func (w *wrapCoreV1ComponentStatusImpl) Apply(ctx context.Context, in *corev1.ComponentStatusApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.ComponentStatus, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ComponentStatus")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.ComponentStatus{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1ComponentStatusImpl) ApplyStatus(ctx context.Context, in *corev1.ComponentStatusApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.ComponentStatus, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ComponentStatus")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.ComponentStatus{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1ComponentStatusImpl) Create(ctx context.Context, in *apicorev1.ComponentStatus, opts metav1.CreateOptions) (*apicorev1.ComponentStatus, error) {
@@ -5132,11 +6093,43 @@ type wrapCoreV1ConfigMapImpl struct {
 var _ typedcorev1.ConfigMapInterface = (*wrapCoreV1ConfigMapImpl)(nil)
 
 func (w *wrapCoreV1ConfigMapImpl) Apply(ctx context.Context, in *corev1.ConfigMapApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.ConfigMap, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ConfigMap")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.ConfigMap{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1ConfigMapImpl) ApplyStatus(ctx context.Context, in *corev1.ConfigMapApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.ConfigMap, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ConfigMap")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.ConfigMap{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1ConfigMapImpl) Create(ctx context.Context, in *apicorev1.ConfigMap, opts metav1.CreateOptions) (*apicorev1.ConfigMap, error) {
@@ -5271,11 +6264,43 @@ type wrapCoreV1EndpointsImpl struct {
 var _ typedcorev1.EndpointsInterface = (*wrapCoreV1EndpointsImpl)(nil)
 
 func (w *wrapCoreV1EndpointsImpl) Apply(ctx context.Context, in *corev1.EndpointsApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.Endpoints, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Endpoints")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.Endpoints{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1EndpointsImpl) ApplyStatus(ctx context.Context, in *corev1.EndpointsApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.Endpoints, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Endpoints")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.Endpoints{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1EndpointsImpl) Create(ctx context.Context, in *apicorev1.Endpoints, opts metav1.CreateOptions) (*apicorev1.Endpoints, error) {
@@ -5410,11 +6435,43 @@ type wrapCoreV1EventImpl struct {
 var _ typedcorev1.EventInterface = (*wrapCoreV1EventImpl)(nil)
 
 func (w *wrapCoreV1EventImpl) Apply(ctx context.Context, in *corev1.EventApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.Event, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Event")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.Event{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1EventImpl) ApplyStatus(ctx context.Context, in *corev1.EventApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.Event, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Event")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.Event{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1EventImpl) Create(ctx context.Context, in *apicorev1.Event, opts metav1.CreateOptions) (*apicorev1.Event, error) {
@@ -5549,11 +6606,43 @@ type wrapCoreV1LimitRangeImpl struct {
 var _ typedcorev1.LimitRangeInterface = (*wrapCoreV1LimitRangeImpl)(nil)
 
 func (w *wrapCoreV1LimitRangeImpl) Apply(ctx context.Context, in *corev1.LimitRangeApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.LimitRange, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("LimitRange")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.LimitRange{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1LimitRangeImpl) ApplyStatus(ctx context.Context, in *corev1.LimitRangeApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.LimitRange, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("LimitRange")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.LimitRange{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1LimitRangeImpl) Create(ctx context.Context, in *apicorev1.LimitRange, opts metav1.CreateOptions) (*apicorev1.LimitRange, error) {
@@ -5684,11 +6773,43 @@ type wrapCoreV1NamespaceImpl struct {
 var _ typedcorev1.NamespaceInterface = (*wrapCoreV1NamespaceImpl)(nil)
 
 func (w *wrapCoreV1NamespaceImpl) Apply(ctx context.Context, in *corev1.NamespaceApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.Namespace, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Namespace")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.Namespace{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1NamespaceImpl) ApplyStatus(ctx context.Context, in *corev1.NamespaceApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.Namespace, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Namespace")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.Namespace{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1NamespaceImpl) Create(ctx context.Context, in *apicorev1.Namespace, opts metav1.CreateOptions) (*apicorev1.Namespace, error) {
@@ -5815,11 +6936,43 @@ type wrapCoreV1NodeImpl struct {
 var _ typedcorev1.NodeInterface = (*wrapCoreV1NodeImpl)(nil)
 
 func (w *wrapCoreV1NodeImpl) Apply(ctx context.Context, in *corev1.NodeApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.Node, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Node")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.Node{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1NodeImpl) ApplyStatus(ctx context.Context, in *corev1.NodeApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.Node, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Node")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.Node{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1NodeImpl) Create(ctx context.Context, in *apicorev1.Node, opts metav1.CreateOptions) (*apicorev1.Node, error) {
@@ -5950,11 +7103,43 @@ type wrapCoreV1PersistentVolumeImpl struct {
 var _ typedcorev1.PersistentVolumeInterface = (*wrapCoreV1PersistentVolumeImpl)(nil)
 
 func (w *wrapCoreV1PersistentVolumeImpl) Apply(ctx context.Context, in *corev1.PersistentVolumeApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.PersistentVolume, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PersistentVolume")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.PersistentVolume{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1PersistentVolumeImpl) ApplyStatus(ctx context.Context, in *corev1.PersistentVolumeApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.PersistentVolume, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PersistentVolume")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.PersistentVolume{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1PersistentVolumeImpl) Create(ctx context.Context, in *apicorev1.PersistentVolume, opts metav1.CreateOptions) (*apicorev1.PersistentVolume, error) {
@@ -6089,11 +7274,43 @@ type wrapCoreV1PersistentVolumeClaimImpl struct {
 var _ typedcorev1.PersistentVolumeClaimInterface = (*wrapCoreV1PersistentVolumeClaimImpl)(nil)
 
 func (w *wrapCoreV1PersistentVolumeClaimImpl) Apply(ctx context.Context, in *corev1.PersistentVolumeClaimApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.PersistentVolumeClaim, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PersistentVolumeClaim")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.PersistentVolumeClaim{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1PersistentVolumeClaimImpl) ApplyStatus(ctx context.Context, in *corev1.PersistentVolumeClaimApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.PersistentVolumeClaim, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PersistentVolumeClaim")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.PersistentVolumeClaim{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1PersistentVolumeClaimImpl) Create(ctx context.Context, in *apicorev1.PersistentVolumeClaim, opts metav1.CreateOptions) (*apicorev1.PersistentVolumeClaim, error) {
@@ -6228,11 +7445,43 @@ type wrapCoreV1PodImpl struct {
 var _ typedcorev1.PodInterface = (*wrapCoreV1PodImpl)(nil)
 
 func (w *wrapCoreV1PodImpl) Apply(ctx context.Context, in *corev1.PodApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.Pod, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Pod")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.Pod{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1PodImpl) ApplyStatus(ctx context.Context, in *corev1.PodApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.Pod, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Pod")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.Pod{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1PodImpl) Create(ctx context.Context, in *apicorev1.Pod, opts metav1.CreateOptions) (*apicorev1.Pod, error) {
@@ -6371,11 +7620,43 @@ type wrapCoreV1PodTemplateImpl struct {
 var _ typedcorev1.PodTemplateInterface = (*wrapCoreV1PodTemplateImpl)(nil)
 
 func (w *wrapCoreV1PodTemplateImpl) Apply(ctx context.Context, in *corev1.PodTemplateApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.PodTemplate, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PodTemplate")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.PodTemplate{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1PodTemplateImpl) ApplyStatus(ctx context.Context, in *corev1.PodTemplateApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.PodTemplate, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PodTemplate")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.PodTemplate{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1PodTemplateImpl) Create(ctx context.Context, in *apicorev1.PodTemplate, opts metav1.CreateOptions) (*apicorev1.PodTemplate, error) {
@@ -6510,11 +7791,43 @@ type wrapCoreV1ReplicationControllerImpl struct {
 var _ typedcorev1.ReplicationControllerInterface = (*wrapCoreV1ReplicationControllerImpl)(nil)
 
 func (w *wrapCoreV1ReplicationControllerImpl) Apply(ctx context.Context, in *corev1.ReplicationControllerApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.ReplicationController, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ReplicationController")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.ReplicationController{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1ReplicationControllerImpl) ApplyStatus(ctx context.Context, in *corev1.ReplicationControllerApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.ReplicationController, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ReplicationController")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.ReplicationController{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1ReplicationControllerImpl) Create(ctx context.Context, in *apicorev1.ReplicationController, opts metav1.CreateOptions) (*apicorev1.ReplicationController, error) {
@@ -6657,11 +7970,43 @@ type wrapCoreV1ResourceQuotaImpl struct {
 var _ typedcorev1.ResourceQuotaInterface = (*wrapCoreV1ResourceQuotaImpl)(nil)
 
 func (w *wrapCoreV1ResourceQuotaImpl) Apply(ctx context.Context, in *corev1.ResourceQuotaApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.ResourceQuota, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ResourceQuota")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.ResourceQuota{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1ResourceQuotaImpl) ApplyStatus(ctx context.Context, in *corev1.ResourceQuotaApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.ResourceQuota, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ResourceQuota")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.ResourceQuota{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1ResourceQuotaImpl) Create(ctx context.Context, in *apicorev1.ResourceQuota, opts metav1.CreateOptions) (*apicorev1.ResourceQuota, error) {
@@ -6796,11 +8141,43 @@ type wrapCoreV1SecretImpl struct {
 var _ typedcorev1.SecretInterface = (*wrapCoreV1SecretImpl)(nil)
 
 func (w *wrapCoreV1SecretImpl) Apply(ctx context.Context, in *corev1.SecretApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.Secret, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Secret")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.Secret{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1SecretImpl) ApplyStatus(ctx context.Context, in *corev1.SecretApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.Secret, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Secret")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.Secret{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1SecretImpl) Create(ctx context.Context, in *apicorev1.Secret, opts metav1.CreateOptions) (*apicorev1.Secret, error) {
@@ -6935,11 +8312,43 @@ type wrapCoreV1ServiceImpl struct {
 var _ typedcorev1.ServiceInterface = (*wrapCoreV1ServiceImpl)(nil)
 
 func (w *wrapCoreV1ServiceImpl) Apply(ctx context.Context, in *corev1.ServiceApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.Service, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Service")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.Service{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1ServiceImpl) ApplyStatus(ctx context.Context, in *corev1.ServiceApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.Service, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Service")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.Service{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1ServiceImpl) Create(ctx context.Context, in *apicorev1.Service, opts metav1.CreateOptions) (*apicorev1.Service, error) {
@@ -7070,11 +8479,43 @@ type wrapCoreV1ServiceAccountImpl struct {
 var _ typedcorev1.ServiceAccountInterface = (*wrapCoreV1ServiceAccountImpl)(nil)
 
 func (w *wrapCoreV1ServiceAccountImpl) Apply(ctx context.Context, in *corev1.ServiceAccountApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.ServiceAccount, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ServiceAccount")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.ServiceAccount{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1ServiceAccountImpl) ApplyStatus(ctx context.Context, in *corev1.ServiceAccountApplyConfiguration, opts metav1.ApplyOptions) (result *apicorev1.ServiceAccount, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ServiceAccount")
+
+	in.APIVersion = ptr.String("v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apicorev1.ServiceAccount{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapCoreV1ServiceAccountImpl) Create(ctx context.Context, in *apicorev1.ServiceAccount, opts metav1.CreateOptions) (*apicorev1.ServiceAccount, error) {
@@ -7228,11 +8669,43 @@ type wrapDiscoveryV1EndpointSliceImpl struct {
 var _ typeddiscoveryv1.EndpointSliceInterface = (*wrapDiscoveryV1EndpointSliceImpl)(nil)
 
 func (w *wrapDiscoveryV1EndpointSliceImpl) Apply(ctx context.Context, in *discoveryv1.EndpointSliceApplyConfiguration, opts metav1.ApplyOptions) (result *apidiscoveryv1.EndpointSlice, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("EndpointSlice")
+
+	in.APIVersion = ptr.String("discovery.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apidiscoveryv1.EndpointSlice{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapDiscoveryV1EndpointSliceImpl) ApplyStatus(ctx context.Context, in *discoveryv1.EndpointSliceApplyConfiguration, opts metav1.ApplyOptions) (result *apidiscoveryv1.EndpointSlice, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("EndpointSlice")
+
+	in.APIVersion = ptr.String("discovery.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apidiscoveryv1.EndpointSlice{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapDiscoveryV1EndpointSliceImpl) Create(ctx context.Context, in *apidiscoveryv1.EndpointSlice, opts metav1.CreateOptions) (*apidiscoveryv1.EndpointSlice, error) {
@@ -7382,11 +8855,43 @@ type wrapDiscoveryV1beta1EndpointSliceImpl struct {
 var _ typeddiscoveryv1beta1.EndpointSliceInterface = (*wrapDiscoveryV1beta1EndpointSliceImpl)(nil)
 
 func (w *wrapDiscoveryV1beta1EndpointSliceImpl) Apply(ctx context.Context, in *discoveryv1beta1.EndpointSliceApplyConfiguration, opts metav1.ApplyOptions) (result *apidiscoveryv1beta1.EndpointSlice, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("EndpointSlice")
+
+	in.APIVersion = ptr.String("discovery.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apidiscoveryv1beta1.EndpointSlice{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapDiscoveryV1beta1EndpointSliceImpl) ApplyStatus(ctx context.Context, in *discoveryv1beta1.EndpointSliceApplyConfiguration, opts metav1.ApplyOptions) (result *apidiscoveryv1beta1.EndpointSlice, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("EndpointSlice")
+
+	in.APIVersion = ptr.String("discovery.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apidiscoveryv1beta1.EndpointSlice{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapDiscoveryV1beta1EndpointSliceImpl) Create(ctx context.Context, in *apidiscoveryv1beta1.EndpointSlice, opts metav1.CreateOptions) (*apidiscoveryv1beta1.EndpointSlice, error) {
@@ -7536,11 +9041,43 @@ type wrapEventsV1EventImpl struct {
 var _ typedeventsv1.EventInterface = (*wrapEventsV1EventImpl)(nil)
 
 func (w *wrapEventsV1EventImpl) Apply(ctx context.Context, in *eventsv1.EventApplyConfiguration, opts metav1.ApplyOptions) (result *apieventsv1.Event, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Event")
+
+	in.APIVersion = ptr.String("events.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apieventsv1.Event{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapEventsV1EventImpl) ApplyStatus(ctx context.Context, in *eventsv1.EventApplyConfiguration, opts metav1.ApplyOptions) (result *apieventsv1.Event, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Event")
+
+	in.APIVersion = ptr.String("events.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apieventsv1.Event{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapEventsV1EventImpl) Create(ctx context.Context, in *apieventsv1.Event, opts metav1.CreateOptions) (*apieventsv1.Event, error) {
@@ -7690,11 +9227,43 @@ type wrapEventsV1beta1EventImpl struct {
 var _ typedeventsv1beta1.EventInterface = (*wrapEventsV1beta1EventImpl)(nil)
 
 func (w *wrapEventsV1beta1EventImpl) Apply(ctx context.Context, in *eventsv1beta1.EventApplyConfiguration, opts metav1.ApplyOptions) (result *apieventsv1beta1.Event, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Event")
+
+	in.APIVersion = ptr.String("events.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apieventsv1beta1.Event{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapEventsV1beta1EventImpl) ApplyStatus(ctx context.Context, in *eventsv1beta1.EventApplyConfiguration, opts metav1.ApplyOptions) (result *apieventsv1beta1.Event, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Event")
+
+	in.APIVersion = ptr.String("events.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apieventsv1beta1.Event{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapEventsV1beta1EventImpl) Create(ctx context.Context, in *apieventsv1beta1.Event, opts metav1.CreateOptions) (*apieventsv1beta1.Event, error) {
@@ -7844,11 +9413,43 @@ type wrapExtensionsV1beta1DaemonSetImpl struct {
 var _ typedextensionsv1beta1.DaemonSetInterface = (*wrapExtensionsV1beta1DaemonSetImpl)(nil)
 
 func (w *wrapExtensionsV1beta1DaemonSetImpl) Apply(ctx context.Context, in *extensionsv1beta1.DaemonSetApplyConfiguration, opts metav1.ApplyOptions) (result *apiextensionsv1beta1.DaemonSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("DaemonSet")
+
+	in.APIVersion = ptr.String("extensions/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiextensionsv1beta1.DaemonSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapExtensionsV1beta1DaemonSetImpl) ApplyStatus(ctx context.Context, in *extensionsv1beta1.DaemonSetApplyConfiguration, opts metav1.ApplyOptions) (result *apiextensionsv1beta1.DaemonSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("DaemonSet")
+
+	in.APIVersion = ptr.String("extensions/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiextensionsv1beta1.DaemonSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapExtensionsV1beta1DaemonSetImpl) Create(ctx context.Context, in *apiextensionsv1beta1.DaemonSet, opts metav1.CreateOptions) (*apiextensionsv1beta1.DaemonSet, error) {
@@ -7983,11 +9584,43 @@ type wrapExtensionsV1beta1DeploymentImpl struct {
 var _ typedextensionsv1beta1.DeploymentInterface = (*wrapExtensionsV1beta1DeploymentImpl)(nil)
 
 func (w *wrapExtensionsV1beta1DeploymentImpl) Apply(ctx context.Context, in *extensionsv1beta1.DeploymentApplyConfiguration, opts metav1.ApplyOptions) (result *apiextensionsv1beta1.Deployment, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Deployment")
+
+	in.APIVersion = ptr.String("extensions/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiextensionsv1beta1.Deployment{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapExtensionsV1beta1DeploymentImpl) ApplyStatus(ctx context.Context, in *extensionsv1beta1.DeploymentApplyConfiguration, opts metav1.ApplyOptions) (result *apiextensionsv1beta1.Deployment, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Deployment")
+
+	in.APIVersion = ptr.String("extensions/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiextensionsv1beta1.Deployment{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapExtensionsV1beta1DeploymentImpl) Create(ctx context.Context, in *apiextensionsv1beta1.Deployment, opts metav1.CreateOptions) (*apiextensionsv1beta1.Deployment, error) {
@@ -8134,11 +9767,43 @@ type wrapExtensionsV1beta1IngressImpl struct {
 var _ typedextensionsv1beta1.IngressInterface = (*wrapExtensionsV1beta1IngressImpl)(nil)
 
 func (w *wrapExtensionsV1beta1IngressImpl) Apply(ctx context.Context, in *extensionsv1beta1.IngressApplyConfiguration, opts metav1.ApplyOptions) (result *apiextensionsv1beta1.Ingress, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Ingress")
+
+	in.APIVersion = ptr.String("extensions/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiextensionsv1beta1.Ingress{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapExtensionsV1beta1IngressImpl) ApplyStatus(ctx context.Context, in *extensionsv1beta1.IngressApplyConfiguration, opts metav1.ApplyOptions) (result *apiextensionsv1beta1.Ingress, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Ingress")
+
+	in.APIVersion = ptr.String("extensions/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiextensionsv1beta1.Ingress{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapExtensionsV1beta1IngressImpl) Create(ctx context.Context, in *apiextensionsv1beta1.Ingress, opts metav1.CreateOptions) (*apiextensionsv1beta1.Ingress, error) {
@@ -8273,11 +9938,43 @@ type wrapExtensionsV1beta1NetworkPolicyImpl struct {
 var _ typedextensionsv1beta1.NetworkPolicyInterface = (*wrapExtensionsV1beta1NetworkPolicyImpl)(nil)
 
 func (w *wrapExtensionsV1beta1NetworkPolicyImpl) Apply(ctx context.Context, in *extensionsv1beta1.NetworkPolicyApplyConfiguration, opts metav1.ApplyOptions) (result *apiextensionsv1beta1.NetworkPolicy, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("NetworkPolicy")
+
+	in.APIVersion = ptr.String("extensions/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiextensionsv1beta1.NetworkPolicy{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapExtensionsV1beta1NetworkPolicyImpl) ApplyStatus(ctx context.Context, in *extensionsv1beta1.NetworkPolicyApplyConfiguration, opts metav1.ApplyOptions) (result *apiextensionsv1beta1.NetworkPolicy, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("NetworkPolicy")
+
+	in.APIVersion = ptr.String("extensions/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiextensionsv1beta1.NetworkPolicy{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapExtensionsV1beta1NetworkPolicyImpl) Create(ctx context.Context, in *apiextensionsv1beta1.NetworkPolicy, opts metav1.CreateOptions) (*apiextensionsv1beta1.NetworkPolicy, error) {
@@ -8408,11 +10105,43 @@ type wrapExtensionsV1beta1PodSecurityPolicyImpl struct {
 var _ typedextensionsv1beta1.PodSecurityPolicyInterface = (*wrapExtensionsV1beta1PodSecurityPolicyImpl)(nil)
 
 func (w *wrapExtensionsV1beta1PodSecurityPolicyImpl) Apply(ctx context.Context, in *extensionsv1beta1.PodSecurityPolicyApplyConfiguration, opts metav1.ApplyOptions) (result *apiextensionsv1beta1.PodSecurityPolicy, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PodSecurityPolicy")
+
+	in.APIVersion = ptr.String("extensions/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiextensionsv1beta1.PodSecurityPolicy{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapExtensionsV1beta1PodSecurityPolicyImpl) ApplyStatus(ctx context.Context, in *extensionsv1beta1.PodSecurityPolicyApplyConfiguration, opts metav1.ApplyOptions) (result *apiextensionsv1beta1.PodSecurityPolicy, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PodSecurityPolicy")
+
+	in.APIVersion = ptr.String("extensions/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiextensionsv1beta1.PodSecurityPolicy{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapExtensionsV1beta1PodSecurityPolicyImpl) Create(ctx context.Context, in *apiextensionsv1beta1.PodSecurityPolicy, opts metav1.CreateOptions) (*apiextensionsv1beta1.PodSecurityPolicy, error) {
@@ -8547,11 +10276,43 @@ type wrapExtensionsV1beta1ReplicaSetImpl struct {
 var _ typedextensionsv1beta1.ReplicaSetInterface = (*wrapExtensionsV1beta1ReplicaSetImpl)(nil)
 
 func (w *wrapExtensionsV1beta1ReplicaSetImpl) Apply(ctx context.Context, in *extensionsv1beta1.ReplicaSetApplyConfiguration, opts metav1.ApplyOptions) (result *apiextensionsv1beta1.ReplicaSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ReplicaSet")
+
+	in.APIVersion = ptr.String("extensions/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiextensionsv1beta1.ReplicaSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapExtensionsV1beta1ReplicaSetImpl) ApplyStatus(ctx context.Context, in *extensionsv1beta1.ReplicaSetApplyConfiguration, opts metav1.ApplyOptions) (result *apiextensionsv1beta1.ReplicaSet, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ReplicaSet")
+
+	in.APIVersion = ptr.String("extensions/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiextensionsv1beta1.ReplicaSet{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapExtensionsV1beta1ReplicaSetImpl) Create(ctx context.Context, in *apiextensionsv1beta1.ReplicaSet, opts metav1.CreateOptions) (*apiextensionsv1beta1.ReplicaSet, error) {
@@ -8709,11 +10470,43 @@ type wrapFlowcontrolV1alpha1FlowSchemaImpl struct {
 var _ typedflowcontrolv1alpha1.FlowSchemaInterface = (*wrapFlowcontrolV1alpha1FlowSchemaImpl)(nil)
 
 func (w *wrapFlowcontrolV1alpha1FlowSchemaImpl) Apply(ctx context.Context, in *flowcontrolv1alpha1.FlowSchemaApplyConfiguration, opts metav1.ApplyOptions) (result *apiflowcontrolv1alpha1.FlowSchema, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("FlowSchema")
+
+	in.APIVersion = ptr.String("flowcontrol.apiserver.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiflowcontrolv1alpha1.FlowSchema{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapFlowcontrolV1alpha1FlowSchemaImpl) ApplyStatus(ctx context.Context, in *flowcontrolv1alpha1.FlowSchemaApplyConfiguration, opts metav1.ApplyOptions) (result *apiflowcontrolv1alpha1.FlowSchema, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("FlowSchema")
+
+	in.APIVersion = ptr.String("flowcontrol.apiserver.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiflowcontrolv1alpha1.FlowSchema{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapFlowcontrolV1alpha1FlowSchemaImpl) Create(ctx context.Context, in *apiflowcontrolv1alpha1.FlowSchema, opts metav1.CreateOptions) (*apiflowcontrolv1alpha1.FlowSchema, error) {
@@ -8844,11 +10637,43 @@ type wrapFlowcontrolV1alpha1PriorityLevelConfigurationImpl struct {
 var _ typedflowcontrolv1alpha1.PriorityLevelConfigurationInterface = (*wrapFlowcontrolV1alpha1PriorityLevelConfigurationImpl)(nil)
 
 func (w *wrapFlowcontrolV1alpha1PriorityLevelConfigurationImpl) Apply(ctx context.Context, in *flowcontrolv1alpha1.PriorityLevelConfigurationApplyConfiguration, opts metav1.ApplyOptions) (result *apiflowcontrolv1alpha1.PriorityLevelConfiguration, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PriorityLevelConfiguration")
+
+	in.APIVersion = ptr.String("flowcontrol.apiserver.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiflowcontrolv1alpha1.PriorityLevelConfiguration{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapFlowcontrolV1alpha1PriorityLevelConfigurationImpl) ApplyStatus(ctx context.Context, in *flowcontrolv1alpha1.PriorityLevelConfigurationApplyConfiguration, opts metav1.ApplyOptions) (result *apiflowcontrolv1alpha1.PriorityLevelConfiguration, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PriorityLevelConfiguration")
+
+	in.APIVersion = ptr.String("flowcontrol.apiserver.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiflowcontrolv1alpha1.PriorityLevelConfiguration{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapFlowcontrolV1alpha1PriorityLevelConfigurationImpl) Create(ctx context.Context, in *apiflowcontrolv1alpha1.PriorityLevelConfiguration, opts metav1.CreateOptions) (*apiflowcontrolv1alpha1.PriorityLevelConfiguration, error) {
@@ -8994,11 +10819,43 @@ type wrapFlowcontrolV1beta1FlowSchemaImpl struct {
 var _ typedflowcontrolv1beta1.FlowSchemaInterface = (*wrapFlowcontrolV1beta1FlowSchemaImpl)(nil)
 
 func (w *wrapFlowcontrolV1beta1FlowSchemaImpl) Apply(ctx context.Context, in *flowcontrolv1beta1.FlowSchemaApplyConfiguration, opts metav1.ApplyOptions) (result *apiflowcontrolv1beta1.FlowSchema, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("FlowSchema")
+
+	in.APIVersion = ptr.String("flowcontrol.apiserver.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiflowcontrolv1beta1.FlowSchema{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapFlowcontrolV1beta1FlowSchemaImpl) ApplyStatus(ctx context.Context, in *flowcontrolv1beta1.FlowSchemaApplyConfiguration, opts metav1.ApplyOptions) (result *apiflowcontrolv1beta1.FlowSchema, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("FlowSchema")
+
+	in.APIVersion = ptr.String("flowcontrol.apiserver.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiflowcontrolv1beta1.FlowSchema{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapFlowcontrolV1beta1FlowSchemaImpl) Create(ctx context.Context, in *apiflowcontrolv1beta1.FlowSchema, opts metav1.CreateOptions) (*apiflowcontrolv1beta1.FlowSchema, error) {
@@ -9129,11 +10986,43 @@ type wrapFlowcontrolV1beta1PriorityLevelConfigurationImpl struct {
 var _ typedflowcontrolv1beta1.PriorityLevelConfigurationInterface = (*wrapFlowcontrolV1beta1PriorityLevelConfigurationImpl)(nil)
 
 func (w *wrapFlowcontrolV1beta1PriorityLevelConfigurationImpl) Apply(ctx context.Context, in *flowcontrolv1beta1.PriorityLevelConfigurationApplyConfiguration, opts metav1.ApplyOptions) (result *apiflowcontrolv1beta1.PriorityLevelConfiguration, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PriorityLevelConfiguration")
+
+	in.APIVersion = ptr.String("flowcontrol.apiserver.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiflowcontrolv1beta1.PriorityLevelConfiguration{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapFlowcontrolV1beta1PriorityLevelConfigurationImpl) ApplyStatus(ctx context.Context, in *flowcontrolv1beta1.PriorityLevelConfigurationApplyConfiguration, opts metav1.ApplyOptions) (result *apiflowcontrolv1beta1.PriorityLevelConfiguration, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PriorityLevelConfiguration")
+
+	in.APIVersion = ptr.String("flowcontrol.apiserver.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiflowcontrolv1beta1.PriorityLevelConfiguration{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapFlowcontrolV1beta1PriorityLevelConfigurationImpl) Create(ctx context.Context, in *apiflowcontrolv1beta1.PriorityLevelConfiguration, opts metav1.CreateOptions) (*apiflowcontrolv1beta1.PriorityLevelConfiguration, error) {
@@ -9279,11 +11168,43 @@ type wrapFlowcontrolV1beta2FlowSchemaImpl struct {
 var _ typedflowcontrolv1beta2.FlowSchemaInterface = (*wrapFlowcontrolV1beta2FlowSchemaImpl)(nil)
 
 func (w *wrapFlowcontrolV1beta2FlowSchemaImpl) Apply(ctx context.Context, in *flowcontrolv1beta2.FlowSchemaApplyConfiguration, opts metav1.ApplyOptions) (result *apiflowcontrolv1beta2.FlowSchema, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("FlowSchema")
+
+	in.APIVersion = ptr.String("flowcontrol.apiserver.k8s.io/v1beta2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiflowcontrolv1beta2.FlowSchema{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapFlowcontrolV1beta2FlowSchemaImpl) ApplyStatus(ctx context.Context, in *flowcontrolv1beta2.FlowSchemaApplyConfiguration, opts metav1.ApplyOptions) (result *apiflowcontrolv1beta2.FlowSchema, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("FlowSchema")
+
+	in.APIVersion = ptr.String("flowcontrol.apiserver.k8s.io/v1beta2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiflowcontrolv1beta2.FlowSchema{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapFlowcontrolV1beta2FlowSchemaImpl) Create(ctx context.Context, in *apiflowcontrolv1beta2.FlowSchema, opts metav1.CreateOptions) (*apiflowcontrolv1beta2.FlowSchema, error) {
@@ -9414,11 +11335,43 @@ type wrapFlowcontrolV1beta2PriorityLevelConfigurationImpl struct {
 var _ typedflowcontrolv1beta2.PriorityLevelConfigurationInterface = (*wrapFlowcontrolV1beta2PriorityLevelConfigurationImpl)(nil)
 
 func (w *wrapFlowcontrolV1beta2PriorityLevelConfigurationImpl) Apply(ctx context.Context, in *flowcontrolv1beta2.PriorityLevelConfigurationApplyConfiguration, opts metav1.ApplyOptions) (result *apiflowcontrolv1beta2.PriorityLevelConfiguration, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PriorityLevelConfiguration")
+
+	in.APIVersion = ptr.String("flowcontrol.apiserver.k8s.io/v1beta2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiflowcontrolv1beta2.PriorityLevelConfiguration{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapFlowcontrolV1beta2PriorityLevelConfigurationImpl) ApplyStatus(ctx context.Context, in *flowcontrolv1beta2.PriorityLevelConfigurationApplyConfiguration, opts metav1.ApplyOptions) (result *apiflowcontrolv1beta2.PriorityLevelConfiguration, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PriorityLevelConfiguration")
+
+	in.APIVersion = ptr.String("flowcontrol.apiserver.k8s.io/v1beta2")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apiflowcontrolv1beta2.PriorityLevelConfiguration{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapFlowcontrolV1beta2PriorityLevelConfigurationImpl) Create(ctx context.Context, in *apiflowcontrolv1beta2.PriorityLevelConfiguration, opts metav1.CreateOptions) (*apiflowcontrolv1beta2.PriorityLevelConfiguration, error) {
@@ -9568,11 +11521,43 @@ type wrapNetworkingV1IngressImpl struct {
 var _ typednetworkingv1.IngressInterface = (*wrapNetworkingV1IngressImpl)(nil)
 
 func (w *wrapNetworkingV1IngressImpl) Apply(ctx context.Context, in *networkingv1.IngressApplyConfiguration, opts metav1.ApplyOptions) (result *apinetworkingv1.Ingress, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Ingress")
+
+	in.APIVersion = ptr.String("networking.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinetworkingv1.Ingress{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNetworkingV1IngressImpl) ApplyStatus(ctx context.Context, in *networkingv1.IngressApplyConfiguration, opts metav1.ApplyOptions) (result *apinetworkingv1.Ingress, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Ingress")
+
+	in.APIVersion = ptr.String("networking.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinetworkingv1.Ingress{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNetworkingV1IngressImpl) Create(ctx context.Context, in *apinetworkingv1.Ingress, opts metav1.CreateOptions) (*apinetworkingv1.Ingress, error) {
@@ -9703,11 +11688,43 @@ type wrapNetworkingV1IngressClassImpl struct {
 var _ typednetworkingv1.IngressClassInterface = (*wrapNetworkingV1IngressClassImpl)(nil)
 
 func (w *wrapNetworkingV1IngressClassImpl) Apply(ctx context.Context, in *networkingv1.IngressClassApplyConfiguration, opts metav1.ApplyOptions) (result *apinetworkingv1.IngressClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("IngressClass")
+
+	in.APIVersion = ptr.String("networking.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinetworkingv1.IngressClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNetworkingV1IngressClassImpl) ApplyStatus(ctx context.Context, in *networkingv1.IngressClassApplyConfiguration, opts metav1.ApplyOptions) (result *apinetworkingv1.IngressClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("IngressClass")
+
+	in.APIVersion = ptr.String("networking.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinetworkingv1.IngressClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNetworkingV1IngressClassImpl) Create(ctx context.Context, in *apinetworkingv1.IngressClass, opts metav1.CreateOptions) (*apinetworkingv1.IngressClass, error) {
@@ -9842,11 +11859,43 @@ type wrapNetworkingV1NetworkPolicyImpl struct {
 var _ typednetworkingv1.NetworkPolicyInterface = (*wrapNetworkingV1NetworkPolicyImpl)(nil)
 
 func (w *wrapNetworkingV1NetworkPolicyImpl) Apply(ctx context.Context, in *networkingv1.NetworkPolicyApplyConfiguration, opts metav1.ApplyOptions) (result *apinetworkingv1.NetworkPolicy, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("NetworkPolicy")
+
+	in.APIVersion = ptr.String("networking.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinetworkingv1.NetworkPolicy{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNetworkingV1NetworkPolicyImpl) ApplyStatus(ctx context.Context, in *networkingv1.NetworkPolicyApplyConfiguration, opts metav1.ApplyOptions) (result *apinetworkingv1.NetworkPolicy, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("NetworkPolicy")
+
+	in.APIVersion = ptr.String("networking.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinetworkingv1.NetworkPolicy{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNetworkingV1NetworkPolicyImpl) Create(ctx context.Context, in *apinetworkingv1.NetworkPolicy, opts metav1.CreateOptions) (*apinetworkingv1.NetworkPolicy, error) {
@@ -9992,11 +12041,43 @@ type wrapNetworkingV1alpha1ClusterCIDRImpl struct {
 var _ typednetworkingv1alpha1.ClusterCIDRInterface = (*wrapNetworkingV1alpha1ClusterCIDRImpl)(nil)
 
 func (w *wrapNetworkingV1alpha1ClusterCIDRImpl) Apply(ctx context.Context, in *networkingv1alpha1.ClusterCIDRApplyConfiguration, opts metav1.ApplyOptions) (result *apinetworkingv1alpha1.ClusterCIDR, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ClusterCIDR")
+
+	in.APIVersion = ptr.String("networking.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinetworkingv1alpha1.ClusterCIDR{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNetworkingV1alpha1ClusterCIDRImpl) ApplyStatus(ctx context.Context, in *networkingv1alpha1.ClusterCIDRApplyConfiguration, opts metav1.ApplyOptions) (result *apinetworkingv1alpha1.ClusterCIDR, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ClusterCIDR")
+
+	in.APIVersion = ptr.String("networking.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinetworkingv1alpha1.ClusterCIDR{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNetworkingV1alpha1ClusterCIDRImpl) Create(ctx context.Context, in *apinetworkingv1alpha1.ClusterCIDR, opts metav1.CreateOptions) (*apinetworkingv1alpha1.ClusterCIDR, error) {
@@ -10146,11 +12227,43 @@ type wrapNetworkingV1beta1IngressImpl struct {
 var _ typednetworkingv1beta1.IngressInterface = (*wrapNetworkingV1beta1IngressImpl)(nil)
 
 func (w *wrapNetworkingV1beta1IngressImpl) Apply(ctx context.Context, in *networkingv1beta1.IngressApplyConfiguration, opts metav1.ApplyOptions) (result *apinetworkingv1beta1.Ingress, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Ingress")
+
+	in.APIVersion = ptr.String("networking.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinetworkingv1beta1.Ingress{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNetworkingV1beta1IngressImpl) ApplyStatus(ctx context.Context, in *networkingv1beta1.IngressApplyConfiguration, opts metav1.ApplyOptions) (result *apinetworkingv1beta1.Ingress, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Ingress")
+
+	in.APIVersion = ptr.String("networking.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinetworkingv1beta1.Ingress{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNetworkingV1beta1IngressImpl) Create(ctx context.Context, in *apinetworkingv1beta1.Ingress, opts metav1.CreateOptions) (*apinetworkingv1beta1.Ingress, error) {
@@ -10281,11 +12394,43 @@ type wrapNetworkingV1beta1IngressClassImpl struct {
 var _ typednetworkingv1beta1.IngressClassInterface = (*wrapNetworkingV1beta1IngressClassImpl)(nil)
 
 func (w *wrapNetworkingV1beta1IngressClassImpl) Apply(ctx context.Context, in *networkingv1beta1.IngressClassApplyConfiguration, opts metav1.ApplyOptions) (result *apinetworkingv1beta1.IngressClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("IngressClass")
+
+	in.APIVersion = ptr.String("networking.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinetworkingv1beta1.IngressClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNetworkingV1beta1IngressClassImpl) ApplyStatus(ctx context.Context, in *networkingv1beta1.IngressClassApplyConfiguration, opts metav1.ApplyOptions) (result *apinetworkingv1beta1.IngressClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("IngressClass")
+
+	in.APIVersion = ptr.String("networking.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinetworkingv1beta1.IngressClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNetworkingV1beta1IngressClassImpl) Create(ctx context.Context, in *apinetworkingv1beta1.IngressClass, opts metav1.CreateOptions) (*apinetworkingv1beta1.IngressClass, error) {
@@ -10431,11 +12576,43 @@ type wrapNodeV1RuntimeClassImpl struct {
 var _ typednodev1.RuntimeClassInterface = (*wrapNodeV1RuntimeClassImpl)(nil)
 
 func (w *wrapNodeV1RuntimeClassImpl) Apply(ctx context.Context, in *nodev1.RuntimeClassApplyConfiguration, opts metav1.ApplyOptions) (result *apinodev1.RuntimeClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("RuntimeClass")
+
+	in.APIVersion = ptr.String("node.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinodev1.RuntimeClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNodeV1RuntimeClassImpl) ApplyStatus(ctx context.Context, in *nodev1.RuntimeClassApplyConfiguration, opts metav1.ApplyOptions) (result *apinodev1.RuntimeClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("RuntimeClass")
+
+	in.APIVersion = ptr.String("node.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinodev1.RuntimeClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNodeV1RuntimeClassImpl) Create(ctx context.Context, in *apinodev1.RuntimeClass, opts metav1.CreateOptions) (*apinodev1.RuntimeClass, error) {
@@ -10581,11 +12758,43 @@ type wrapNodeV1alpha1RuntimeClassImpl struct {
 var _ typednodev1alpha1.RuntimeClassInterface = (*wrapNodeV1alpha1RuntimeClassImpl)(nil)
 
 func (w *wrapNodeV1alpha1RuntimeClassImpl) Apply(ctx context.Context, in *nodev1alpha1.RuntimeClassApplyConfiguration, opts metav1.ApplyOptions) (result *apinodev1alpha1.RuntimeClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("RuntimeClass")
+
+	in.APIVersion = ptr.String("node.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinodev1alpha1.RuntimeClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNodeV1alpha1RuntimeClassImpl) ApplyStatus(ctx context.Context, in *nodev1alpha1.RuntimeClassApplyConfiguration, opts metav1.ApplyOptions) (result *apinodev1alpha1.RuntimeClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("RuntimeClass")
+
+	in.APIVersion = ptr.String("node.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinodev1alpha1.RuntimeClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNodeV1alpha1RuntimeClassImpl) Create(ctx context.Context, in *apinodev1alpha1.RuntimeClass, opts metav1.CreateOptions) (*apinodev1alpha1.RuntimeClass, error) {
@@ -10731,11 +12940,43 @@ type wrapNodeV1beta1RuntimeClassImpl struct {
 var _ typednodev1beta1.RuntimeClassInterface = (*wrapNodeV1beta1RuntimeClassImpl)(nil)
 
 func (w *wrapNodeV1beta1RuntimeClassImpl) Apply(ctx context.Context, in *nodev1beta1.RuntimeClassApplyConfiguration, opts metav1.ApplyOptions) (result *apinodev1beta1.RuntimeClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("RuntimeClass")
+
+	in.APIVersion = ptr.String("node.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinodev1beta1.RuntimeClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNodeV1beta1RuntimeClassImpl) ApplyStatus(ctx context.Context, in *nodev1beta1.RuntimeClassApplyConfiguration, opts metav1.ApplyOptions) (result *apinodev1beta1.RuntimeClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("RuntimeClass")
+
+	in.APIVersion = ptr.String("node.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apinodev1beta1.RuntimeClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapNodeV1beta1RuntimeClassImpl) Create(ctx context.Context, in *apinodev1beta1.RuntimeClass, opts metav1.CreateOptions) (*apinodev1beta1.RuntimeClass, error) {
@@ -10905,11 +13146,43 @@ type wrapPolicyV1PodDisruptionBudgetImpl struct {
 var _ typedpolicyv1.PodDisruptionBudgetInterface = (*wrapPolicyV1PodDisruptionBudgetImpl)(nil)
 
 func (w *wrapPolicyV1PodDisruptionBudgetImpl) Apply(ctx context.Context, in *policyv1.PodDisruptionBudgetApplyConfiguration, opts metav1.ApplyOptions) (result *apipolicyv1.PodDisruptionBudget, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PodDisruptionBudget")
+
+	in.APIVersion = ptr.String("policy/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apipolicyv1.PodDisruptionBudget{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapPolicyV1PodDisruptionBudgetImpl) ApplyStatus(ctx context.Context, in *policyv1.PodDisruptionBudgetApplyConfiguration, opts metav1.ApplyOptions) (result *apipolicyv1.PodDisruptionBudget, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PodDisruptionBudget")
+
+	in.APIVersion = ptr.String("policy/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apipolicyv1.PodDisruptionBudget{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapPolicyV1PodDisruptionBudgetImpl) Create(ctx context.Context, in *apipolicyv1.PodDisruptionBudget, opts metav1.CreateOptions) (*apipolicyv1.PodDisruptionBudget, error) {
@@ -11079,11 +13352,43 @@ type wrapPolicyV1beta1PodDisruptionBudgetImpl struct {
 var _ typedpolicyv1beta1.PodDisruptionBudgetInterface = (*wrapPolicyV1beta1PodDisruptionBudgetImpl)(nil)
 
 func (w *wrapPolicyV1beta1PodDisruptionBudgetImpl) Apply(ctx context.Context, in *policyv1beta1.PodDisruptionBudgetApplyConfiguration, opts metav1.ApplyOptions) (result *apipolicyv1beta1.PodDisruptionBudget, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PodDisruptionBudget")
+
+	in.APIVersion = ptr.String("policy/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apipolicyv1beta1.PodDisruptionBudget{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapPolicyV1beta1PodDisruptionBudgetImpl) ApplyStatus(ctx context.Context, in *policyv1beta1.PodDisruptionBudgetApplyConfiguration, opts metav1.ApplyOptions) (result *apipolicyv1beta1.PodDisruptionBudget, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PodDisruptionBudget")
+
+	in.APIVersion = ptr.String("policy/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apipolicyv1beta1.PodDisruptionBudget{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapPolicyV1beta1PodDisruptionBudgetImpl) Create(ctx context.Context, in *apipolicyv1beta1.PodDisruptionBudget, opts metav1.CreateOptions) (*apipolicyv1beta1.PodDisruptionBudget, error) {
@@ -11214,11 +13519,43 @@ type wrapPolicyV1beta1PodSecurityPolicyImpl struct {
 var _ typedpolicyv1beta1.PodSecurityPolicyInterface = (*wrapPolicyV1beta1PodSecurityPolicyImpl)(nil)
 
 func (w *wrapPolicyV1beta1PodSecurityPolicyImpl) Apply(ctx context.Context, in *policyv1beta1.PodSecurityPolicyApplyConfiguration, opts metav1.ApplyOptions) (result *apipolicyv1beta1.PodSecurityPolicy, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PodSecurityPolicy")
+
+	in.APIVersion = ptr.String("policy/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apipolicyv1beta1.PodSecurityPolicy{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapPolicyV1beta1PodSecurityPolicyImpl) ApplyStatus(ctx context.Context, in *policyv1beta1.PodSecurityPolicyApplyConfiguration, opts metav1.ApplyOptions) (result *apipolicyv1beta1.PodSecurityPolicy, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PodSecurityPolicy")
+
+	in.APIVersion = ptr.String("policy/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apipolicyv1beta1.PodSecurityPolicy{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapPolicyV1beta1PodSecurityPolicyImpl) Create(ctx context.Context, in *apipolicyv1beta1.PodSecurityPolicy, opts metav1.CreateOptions) (*apipolicyv1beta1.PodSecurityPolicy, error) {
@@ -11364,11 +13701,43 @@ type wrapRbacV1ClusterRoleImpl struct {
 var _ typedrbacv1.ClusterRoleInterface = (*wrapRbacV1ClusterRoleImpl)(nil)
 
 func (w *wrapRbacV1ClusterRoleImpl) Apply(ctx context.Context, in *rbacv1.ClusterRoleApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1.ClusterRole, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ClusterRole")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1.ClusterRole{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1ClusterRoleImpl) ApplyStatus(ctx context.Context, in *rbacv1.ClusterRoleApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1.ClusterRole, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ClusterRole")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1.ClusterRole{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1ClusterRoleImpl) Create(ctx context.Context, in *apirbacv1.ClusterRole, opts metav1.CreateOptions) (*apirbacv1.ClusterRole, error) {
@@ -11499,11 +13868,43 @@ type wrapRbacV1ClusterRoleBindingImpl struct {
 var _ typedrbacv1.ClusterRoleBindingInterface = (*wrapRbacV1ClusterRoleBindingImpl)(nil)
 
 func (w *wrapRbacV1ClusterRoleBindingImpl) Apply(ctx context.Context, in *rbacv1.ClusterRoleBindingApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1.ClusterRoleBinding, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ClusterRoleBinding")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1.ClusterRoleBinding{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1ClusterRoleBindingImpl) ApplyStatus(ctx context.Context, in *rbacv1.ClusterRoleBindingApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1.ClusterRoleBinding, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ClusterRoleBinding")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1.ClusterRoleBinding{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1ClusterRoleBindingImpl) Create(ctx context.Context, in *apirbacv1.ClusterRoleBinding, opts metav1.CreateOptions) (*apirbacv1.ClusterRoleBinding, error) {
@@ -11638,11 +14039,43 @@ type wrapRbacV1RoleImpl struct {
 var _ typedrbacv1.RoleInterface = (*wrapRbacV1RoleImpl)(nil)
 
 func (w *wrapRbacV1RoleImpl) Apply(ctx context.Context, in *rbacv1.RoleApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1.Role, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Role")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1.Role{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1RoleImpl) ApplyStatus(ctx context.Context, in *rbacv1.RoleApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1.Role, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Role")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1.Role{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1RoleImpl) Create(ctx context.Context, in *apirbacv1.Role, opts metav1.CreateOptions) (*apirbacv1.Role, error) {
@@ -11777,11 +14210,43 @@ type wrapRbacV1RoleBindingImpl struct {
 var _ typedrbacv1.RoleBindingInterface = (*wrapRbacV1RoleBindingImpl)(nil)
 
 func (w *wrapRbacV1RoleBindingImpl) Apply(ctx context.Context, in *rbacv1.RoleBindingApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1.RoleBinding, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("RoleBinding")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1.RoleBinding{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1RoleBindingImpl) ApplyStatus(ctx context.Context, in *rbacv1.RoleBindingApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1.RoleBinding, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("RoleBinding")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1.RoleBinding{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1RoleBindingImpl) Create(ctx context.Context, in *apirbacv1.RoleBinding, opts metav1.CreateOptions) (*apirbacv1.RoleBinding, error) {
@@ -11927,11 +14392,43 @@ type wrapRbacV1alpha1ClusterRoleImpl struct {
 var _ typedrbacv1alpha1.ClusterRoleInterface = (*wrapRbacV1alpha1ClusterRoleImpl)(nil)
 
 func (w *wrapRbacV1alpha1ClusterRoleImpl) Apply(ctx context.Context, in *rbacv1alpha1.ClusterRoleApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1alpha1.ClusterRole, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ClusterRole")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1alpha1.ClusterRole{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1alpha1ClusterRoleImpl) ApplyStatus(ctx context.Context, in *rbacv1alpha1.ClusterRoleApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1alpha1.ClusterRole, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ClusterRole")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1alpha1.ClusterRole{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1alpha1ClusterRoleImpl) Create(ctx context.Context, in *apirbacv1alpha1.ClusterRole, opts metav1.CreateOptions) (*apirbacv1alpha1.ClusterRole, error) {
@@ -12062,11 +14559,43 @@ type wrapRbacV1alpha1ClusterRoleBindingImpl struct {
 var _ typedrbacv1alpha1.ClusterRoleBindingInterface = (*wrapRbacV1alpha1ClusterRoleBindingImpl)(nil)
 
 func (w *wrapRbacV1alpha1ClusterRoleBindingImpl) Apply(ctx context.Context, in *rbacv1alpha1.ClusterRoleBindingApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1alpha1.ClusterRoleBinding, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ClusterRoleBinding")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1alpha1.ClusterRoleBinding{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1alpha1ClusterRoleBindingImpl) ApplyStatus(ctx context.Context, in *rbacv1alpha1.ClusterRoleBindingApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1alpha1.ClusterRoleBinding, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ClusterRoleBinding")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1alpha1.ClusterRoleBinding{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1alpha1ClusterRoleBindingImpl) Create(ctx context.Context, in *apirbacv1alpha1.ClusterRoleBinding, opts metav1.CreateOptions) (*apirbacv1alpha1.ClusterRoleBinding, error) {
@@ -12201,11 +14730,43 @@ type wrapRbacV1alpha1RoleImpl struct {
 var _ typedrbacv1alpha1.RoleInterface = (*wrapRbacV1alpha1RoleImpl)(nil)
 
 func (w *wrapRbacV1alpha1RoleImpl) Apply(ctx context.Context, in *rbacv1alpha1.RoleApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1alpha1.Role, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Role")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1alpha1.Role{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1alpha1RoleImpl) ApplyStatus(ctx context.Context, in *rbacv1alpha1.RoleApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1alpha1.Role, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Role")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1alpha1.Role{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1alpha1RoleImpl) Create(ctx context.Context, in *apirbacv1alpha1.Role, opts metav1.CreateOptions) (*apirbacv1alpha1.Role, error) {
@@ -12340,11 +14901,43 @@ type wrapRbacV1alpha1RoleBindingImpl struct {
 var _ typedrbacv1alpha1.RoleBindingInterface = (*wrapRbacV1alpha1RoleBindingImpl)(nil)
 
 func (w *wrapRbacV1alpha1RoleBindingImpl) Apply(ctx context.Context, in *rbacv1alpha1.RoleBindingApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1alpha1.RoleBinding, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("RoleBinding")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1alpha1.RoleBinding{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1alpha1RoleBindingImpl) ApplyStatus(ctx context.Context, in *rbacv1alpha1.RoleBindingApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1alpha1.RoleBinding, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("RoleBinding")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1alpha1.RoleBinding{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1alpha1RoleBindingImpl) Create(ctx context.Context, in *apirbacv1alpha1.RoleBinding, opts metav1.CreateOptions) (*apirbacv1alpha1.RoleBinding, error) {
@@ -12490,11 +15083,43 @@ type wrapRbacV1beta1ClusterRoleImpl struct {
 var _ typedrbacv1beta1.ClusterRoleInterface = (*wrapRbacV1beta1ClusterRoleImpl)(nil)
 
 func (w *wrapRbacV1beta1ClusterRoleImpl) Apply(ctx context.Context, in *rbacv1beta1.ClusterRoleApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1beta1.ClusterRole, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ClusterRole")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1beta1.ClusterRole{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1beta1ClusterRoleImpl) ApplyStatus(ctx context.Context, in *rbacv1beta1.ClusterRoleApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1beta1.ClusterRole, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ClusterRole")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1beta1.ClusterRole{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1beta1ClusterRoleImpl) Create(ctx context.Context, in *apirbacv1beta1.ClusterRole, opts metav1.CreateOptions) (*apirbacv1beta1.ClusterRole, error) {
@@ -12625,11 +15250,43 @@ type wrapRbacV1beta1ClusterRoleBindingImpl struct {
 var _ typedrbacv1beta1.ClusterRoleBindingInterface = (*wrapRbacV1beta1ClusterRoleBindingImpl)(nil)
 
 func (w *wrapRbacV1beta1ClusterRoleBindingImpl) Apply(ctx context.Context, in *rbacv1beta1.ClusterRoleBindingApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1beta1.ClusterRoleBinding, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ClusterRoleBinding")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1beta1.ClusterRoleBinding{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1beta1ClusterRoleBindingImpl) ApplyStatus(ctx context.Context, in *rbacv1beta1.ClusterRoleBindingApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1beta1.ClusterRoleBinding, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("ClusterRoleBinding")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1beta1.ClusterRoleBinding{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1beta1ClusterRoleBindingImpl) Create(ctx context.Context, in *apirbacv1beta1.ClusterRoleBinding, opts metav1.CreateOptions) (*apirbacv1beta1.ClusterRoleBinding, error) {
@@ -12764,11 +15421,43 @@ type wrapRbacV1beta1RoleImpl struct {
 var _ typedrbacv1beta1.RoleInterface = (*wrapRbacV1beta1RoleImpl)(nil)
 
 func (w *wrapRbacV1beta1RoleImpl) Apply(ctx context.Context, in *rbacv1beta1.RoleApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1beta1.Role, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Role")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1beta1.Role{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1beta1RoleImpl) ApplyStatus(ctx context.Context, in *rbacv1beta1.RoleApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1beta1.Role, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("Role")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1beta1.Role{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1beta1RoleImpl) Create(ctx context.Context, in *apirbacv1beta1.Role, opts metav1.CreateOptions) (*apirbacv1beta1.Role, error) {
@@ -12903,11 +15592,43 @@ type wrapRbacV1beta1RoleBindingImpl struct {
 var _ typedrbacv1beta1.RoleBindingInterface = (*wrapRbacV1beta1RoleBindingImpl)(nil)
 
 func (w *wrapRbacV1beta1RoleBindingImpl) Apply(ctx context.Context, in *rbacv1beta1.RoleBindingApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1beta1.RoleBinding, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("RoleBinding")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1beta1.RoleBinding{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1beta1RoleBindingImpl) ApplyStatus(ctx context.Context, in *rbacv1beta1.RoleBindingApplyConfiguration, opts metav1.ApplyOptions) (result *apirbacv1beta1.RoleBinding, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("RoleBinding")
+
+	in.APIVersion = ptr.String("rbac.authorization.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apirbacv1beta1.RoleBinding{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapRbacV1beta1RoleBindingImpl) Create(ctx context.Context, in *apirbacv1beta1.RoleBinding, opts metav1.CreateOptions) (*apirbacv1beta1.RoleBinding, error) {
@@ -13053,11 +15774,43 @@ type wrapSchedulingV1PriorityClassImpl struct {
 var _ typedschedulingv1.PriorityClassInterface = (*wrapSchedulingV1PriorityClassImpl)(nil)
 
 func (w *wrapSchedulingV1PriorityClassImpl) Apply(ctx context.Context, in *schedulingv1.PriorityClassApplyConfiguration, opts metav1.ApplyOptions) (result *apischedulingv1.PriorityClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PriorityClass")
+
+	in.APIVersion = ptr.String("scheduling.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apischedulingv1.PriorityClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapSchedulingV1PriorityClassImpl) ApplyStatus(ctx context.Context, in *schedulingv1.PriorityClassApplyConfiguration, opts metav1.ApplyOptions) (result *apischedulingv1.PriorityClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PriorityClass")
+
+	in.APIVersion = ptr.String("scheduling.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apischedulingv1.PriorityClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapSchedulingV1PriorityClassImpl) Create(ctx context.Context, in *apischedulingv1.PriorityClass, opts metav1.CreateOptions) (*apischedulingv1.PriorityClass, error) {
@@ -13203,11 +15956,43 @@ type wrapSchedulingV1alpha1PriorityClassImpl struct {
 var _ typedschedulingv1alpha1.PriorityClassInterface = (*wrapSchedulingV1alpha1PriorityClassImpl)(nil)
 
 func (w *wrapSchedulingV1alpha1PriorityClassImpl) Apply(ctx context.Context, in *schedulingv1alpha1.PriorityClassApplyConfiguration, opts metav1.ApplyOptions) (result *apischedulingv1alpha1.PriorityClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PriorityClass")
+
+	in.APIVersion = ptr.String("scheduling.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apischedulingv1alpha1.PriorityClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapSchedulingV1alpha1PriorityClassImpl) ApplyStatus(ctx context.Context, in *schedulingv1alpha1.PriorityClassApplyConfiguration, opts metav1.ApplyOptions) (result *apischedulingv1alpha1.PriorityClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PriorityClass")
+
+	in.APIVersion = ptr.String("scheduling.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apischedulingv1alpha1.PriorityClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapSchedulingV1alpha1PriorityClassImpl) Create(ctx context.Context, in *apischedulingv1alpha1.PriorityClass, opts metav1.CreateOptions) (*apischedulingv1alpha1.PriorityClass, error) {
@@ -13353,11 +16138,43 @@ type wrapSchedulingV1beta1PriorityClassImpl struct {
 var _ typedschedulingv1beta1.PriorityClassInterface = (*wrapSchedulingV1beta1PriorityClassImpl)(nil)
 
 func (w *wrapSchedulingV1beta1PriorityClassImpl) Apply(ctx context.Context, in *schedulingv1beta1.PriorityClassApplyConfiguration, opts metav1.ApplyOptions) (result *apischedulingv1beta1.PriorityClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PriorityClass")
+
+	in.APIVersion = ptr.String("scheduling.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apischedulingv1beta1.PriorityClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapSchedulingV1beta1PriorityClassImpl) ApplyStatus(ctx context.Context, in *schedulingv1beta1.PriorityClassApplyConfiguration, opts metav1.ApplyOptions) (result *apischedulingv1beta1.PriorityClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("PriorityClass")
+
+	in.APIVersion = ptr.String("scheduling.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apischedulingv1beta1.PriorityClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapSchedulingV1beta1PriorityClassImpl) Create(ctx context.Context, in *apischedulingv1beta1.PriorityClass, opts metav1.CreateOptions) (*apischedulingv1beta1.PriorityClass, error) {
@@ -13503,11 +16320,43 @@ type wrapStorageV1CSIDriverImpl struct {
 var _ typedstoragev1.CSIDriverInterface = (*wrapStorageV1CSIDriverImpl)(nil)
 
 func (w *wrapStorageV1CSIDriverImpl) Apply(ctx context.Context, in *storagev1.CSIDriverApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1.CSIDriver, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CSIDriver")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1.CSIDriver{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1CSIDriverImpl) ApplyStatus(ctx context.Context, in *storagev1.CSIDriverApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1.CSIDriver, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CSIDriver")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1.CSIDriver{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1CSIDriverImpl) Create(ctx context.Context, in *apistoragev1.CSIDriver, opts metav1.CreateOptions) (*apistoragev1.CSIDriver, error) {
@@ -13638,11 +16487,43 @@ type wrapStorageV1CSINodeImpl struct {
 var _ typedstoragev1.CSINodeInterface = (*wrapStorageV1CSINodeImpl)(nil)
 
 func (w *wrapStorageV1CSINodeImpl) Apply(ctx context.Context, in *storagev1.CSINodeApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1.CSINode, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CSINode")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1.CSINode{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1CSINodeImpl) ApplyStatus(ctx context.Context, in *storagev1.CSINodeApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1.CSINode, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CSINode")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1.CSINode{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1CSINodeImpl) Create(ctx context.Context, in *apistoragev1.CSINode, opts metav1.CreateOptions) (*apistoragev1.CSINode, error) {
@@ -13777,11 +16658,43 @@ type wrapStorageV1CSIStorageCapacityImpl struct {
 var _ typedstoragev1.CSIStorageCapacityInterface = (*wrapStorageV1CSIStorageCapacityImpl)(nil)
 
 func (w *wrapStorageV1CSIStorageCapacityImpl) Apply(ctx context.Context, in *storagev1.CSIStorageCapacityApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1.CSIStorageCapacity, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CSIStorageCapacity")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1.CSIStorageCapacity{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1CSIStorageCapacityImpl) ApplyStatus(ctx context.Context, in *storagev1.CSIStorageCapacityApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1.CSIStorageCapacity, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CSIStorageCapacity")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1.CSIStorageCapacity{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1CSIStorageCapacityImpl) Create(ctx context.Context, in *apistoragev1.CSIStorageCapacity, opts metav1.CreateOptions) (*apistoragev1.CSIStorageCapacity, error) {
@@ -13912,11 +16825,43 @@ type wrapStorageV1StorageClassImpl struct {
 var _ typedstoragev1.StorageClassInterface = (*wrapStorageV1StorageClassImpl)(nil)
 
 func (w *wrapStorageV1StorageClassImpl) Apply(ctx context.Context, in *storagev1.StorageClassApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1.StorageClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("StorageClass")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1.StorageClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1StorageClassImpl) ApplyStatus(ctx context.Context, in *storagev1.StorageClassApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1.StorageClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("StorageClass")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1.StorageClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1StorageClassImpl) Create(ctx context.Context, in *apistoragev1.StorageClass, opts metav1.CreateOptions) (*apistoragev1.StorageClass, error) {
@@ -14047,11 +16992,43 @@ type wrapStorageV1VolumeAttachmentImpl struct {
 var _ typedstoragev1.VolumeAttachmentInterface = (*wrapStorageV1VolumeAttachmentImpl)(nil)
 
 func (w *wrapStorageV1VolumeAttachmentImpl) Apply(ctx context.Context, in *storagev1.VolumeAttachmentApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1.VolumeAttachment, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("VolumeAttachment")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1.VolumeAttachment{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1VolumeAttachmentImpl) ApplyStatus(ctx context.Context, in *storagev1.VolumeAttachmentApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1.VolumeAttachment, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("VolumeAttachment")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1.VolumeAttachment{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1VolumeAttachmentImpl) Create(ctx context.Context, in *apistoragev1.VolumeAttachment, opts metav1.CreateOptions) (*apistoragev1.VolumeAttachment, error) {
@@ -14201,11 +17178,43 @@ type wrapStorageV1alpha1CSIStorageCapacityImpl struct {
 var _ typedstoragev1alpha1.CSIStorageCapacityInterface = (*wrapStorageV1alpha1CSIStorageCapacityImpl)(nil)
 
 func (w *wrapStorageV1alpha1CSIStorageCapacityImpl) Apply(ctx context.Context, in *storagev1alpha1.CSIStorageCapacityApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1alpha1.CSIStorageCapacity, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CSIStorageCapacity")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1alpha1.CSIStorageCapacity{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1alpha1CSIStorageCapacityImpl) ApplyStatus(ctx context.Context, in *storagev1alpha1.CSIStorageCapacityApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1alpha1.CSIStorageCapacity, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CSIStorageCapacity")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1alpha1.CSIStorageCapacity{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1alpha1CSIStorageCapacityImpl) Create(ctx context.Context, in *apistoragev1alpha1.CSIStorageCapacity, opts metav1.CreateOptions) (*apistoragev1alpha1.CSIStorageCapacity, error) {
@@ -14336,11 +17345,43 @@ type wrapStorageV1alpha1VolumeAttachmentImpl struct {
 var _ typedstoragev1alpha1.VolumeAttachmentInterface = (*wrapStorageV1alpha1VolumeAttachmentImpl)(nil)
 
 func (w *wrapStorageV1alpha1VolumeAttachmentImpl) Apply(ctx context.Context, in *storagev1alpha1.VolumeAttachmentApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1alpha1.VolumeAttachment, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("VolumeAttachment")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1alpha1.VolumeAttachment{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1alpha1VolumeAttachmentImpl) ApplyStatus(ctx context.Context, in *storagev1alpha1.VolumeAttachmentApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1alpha1.VolumeAttachment, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("VolumeAttachment")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1alpha1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1alpha1.VolumeAttachment{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1alpha1VolumeAttachmentImpl) Create(ctx context.Context, in *apistoragev1alpha1.VolumeAttachment, opts metav1.CreateOptions) (*apistoragev1alpha1.VolumeAttachment, error) {
@@ -14486,11 +17527,43 @@ type wrapStorageV1beta1CSIDriverImpl struct {
 var _ typedstoragev1beta1.CSIDriverInterface = (*wrapStorageV1beta1CSIDriverImpl)(nil)
 
 func (w *wrapStorageV1beta1CSIDriverImpl) Apply(ctx context.Context, in *storagev1beta1.CSIDriverApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1beta1.CSIDriver, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CSIDriver")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1beta1.CSIDriver{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1beta1CSIDriverImpl) ApplyStatus(ctx context.Context, in *storagev1beta1.CSIDriverApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1beta1.CSIDriver, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CSIDriver")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1beta1.CSIDriver{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1beta1CSIDriverImpl) Create(ctx context.Context, in *apistoragev1beta1.CSIDriver, opts metav1.CreateOptions) (*apistoragev1beta1.CSIDriver, error) {
@@ -14621,11 +17694,43 @@ type wrapStorageV1beta1CSINodeImpl struct {
 var _ typedstoragev1beta1.CSINodeInterface = (*wrapStorageV1beta1CSINodeImpl)(nil)
 
 func (w *wrapStorageV1beta1CSINodeImpl) Apply(ctx context.Context, in *storagev1beta1.CSINodeApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1beta1.CSINode, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CSINode")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1beta1.CSINode{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1beta1CSINodeImpl) ApplyStatus(ctx context.Context, in *storagev1beta1.CSINodeApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1beta1.CSINode, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CSINode")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1beta1.CSINode{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1beta1CSINodeImpl) Create(ctx context.Context, in *apistoragev1beta1.CSINode, opts metav1.CreateOptions) (*apistoragev1beta1.CSINode, error) {
@@ -14760,11 +17865,43 @@ type wrapStorageV1beta1CSIStorageCapacityImpl struct {
 var _ typedstoragev1beta1.CSIStorageCapacityInterface = (*wrapStorageV1beta1CSIStorageCapacityImpl)(nil)
 
 func (w *wrapStorageV1beta1CSIStorageCapacityImpl) Apply(ctx context.Context, in *storagev1beta1.CSIStorageCapacityApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1beta1.CSIStorageCapacity, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CSIStorageCapacity")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1beta1.CSIStorageCapacity{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1beta1CSIStorageCapacityImpl) ApplyStatus(ctx context.Context, in *storagev1beta1.CSIStorageCapacityApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1beta1.CSIStorageCapacity, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("CSIStorageCapacity")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Namespace(w.namespace).ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1beta1.CSIStorageCapacity{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1beta1CSIStorageCapacityImpl) Create(ctx context.Context, in *apistoragev1beta1.CSIStorageCapacity, opts metav1.CreateOptions) (*apistoragev1beta1.CSIStorageCapacity, error) {
@@ -14895,11 +18032,43 @@ type wrapStorageV1beta1StorageClassImpl struct {
 var _ typedstoragev1beta1.StorageClassInterface = (*wrapStorageV1beta1StorageClassImpl)(nil)
 
 func (w *wrapStorageV1beta1StorageClassImpl) Apply(ctx context.Context, in *storagev1beta1.StorageClassApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1beta1.StorageClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("StorageClass")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1beta1.StorageClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1beta1StorageClassImpl) ApplyStatus(ctx context.Context, in *storagev1beta1.StorageClassApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1beta1.StorageClass, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("StorageClass")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1beta1.StorageClass{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1beta1StorageClassImpl) Create(ctx context.Context, in *apistoragev1beta1.StorageClass, opts metav1.CreateOptions) (*apistoragev1beta1.StorageClass, error) {
@@ -15030,11 +18199,43 @@ type wrapStorageV1beta1VolumeAttachmentImpl struct {
 var _ typedstoragev1beta1.VolumeAttachmentInterface = (*wrapStorageV1beta1VolumeAttachmentImpl)(nil)
 
 func (w *wrapStorageV1beta1VolumeAttachmentImpl) Apply(ctx context.Context, in *storagev1beta1.VolumeAttachmentApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1beta1.VolumeAttachment, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("VolumeAttachment")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1beta1.VolumeAttachment{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1beta1VolumeAttachmentImpl) ApplyStatus(ctx context.Context, in *storagev1beta1.VolumeAttachmentApplyConfiguration, opts metav1.ApplyOptions) (result *apistoragev1beta1.VolumeAttachment, err error) {
-	panic("NYI")
+	in.Kind = ptr.String("VolumeAttachment")
+
+	in.APIVersion = ptr.String("storage.k8s.io/v1beta1")
+
+	uo := &unstructured.Unstructured{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &apistoragev1beta1.VolumeAttachment{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (w *wrapStorageV1beta1VolumeAttachmentImpl) Create(ctx context.Context, in *apistoragev1beta1.VolumeAttachment, opts metav1.CreateOptions) (*apistoragev1beta1.VolumeAttachment, error) {

--- a/codegen/cmd/injection-gen/generators/client.go
+++ b/codegen/cmd/injection-gen/generators/client.go
@@ -286,6 +286,11 @@ func (g *clientGenerator) GenerateType(c *generator.Context, t *types.Type, w io
 					"Group":        group,
 					"VersionLower": version,
 					"Kind":         t.Name.Name,
+
+					"ptrString": c.Universe.Function(types.Name{
+						Package: "knative.dev/pkg/ptr",
+						Name:    "String",
+					}),
 				}
 
 				for _, v := range verbs.List() {
@@ -575,13 +580,51 @@ func (w *wrap{{.GroupGoName}}{{.Version}}{{ .Type.Name.Name }}Impl) Patch(ctx {{
 `,
 	"apply": `{{if .generateApply}}
 func (w *wrap{{.GroupGoName}}{{.Version}}{{ .Type.Name.Name }}Impl) Apply(ctx {{ .contextContext|raw }}, in *{{ .ApplyType|raw }}, opts {{ .metav1ApplyOptions|raw }}) (result *{{ .ResultType|raw }}, err error) {
-	panic("NYI")
+	in.Kind = {{ .ptrString|raw }}("{{ .Kind }}")
+	{{ if .Group }}
+	in.APIVersion = {{ .ptrString|raw }}("{{ .Group }}/{{ .VersionLower }}")
+	{{ else }}
+	in.APIVersion = {{ .ptrString|raw }}("{{ .VersionLower }}")
+	{{ end }}
+
+	uo := &{{ .unstructuredUnstructured|raw }}{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn{{if .Namespaced}}.Namespace(w.namespace){{end}}.Apply(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &{{ .ResultType|raw }}{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 {{end}}
 `,
 	"applyStatus": `{{if .generateApply}}
 func (w *wrap{{.GroupGoName}}{{.Version}}{{ .Type.Name.Name }}Impl) ApplyStatus(ctx {{ .contextContext|raw }}, in *{{ .ApplyType|raw }}, opts {{ .metav1ApplyOptions|raw }}) (result *{{ .ResultType|raw }}, err error) {
-	panic("NYI")
+	in.Kind = {{ .ptrString|raw }}("{{ .Kind }}")
+	{{ if .Group }}
+	in.APIVersion = {{ .ptrString|raw }}("{{ .Group }}/{{ .VersionLower }}")
+	{{ else }}
+	in.APIVersion = {{ .ptrString|raw }}("{{ .VersionLower }}")
+	{{ end }}
+
+	uo := &{{ .unstructuredUnstructured|raw }}{}
+	if err := convert(in, uo); err != nil {
+		return nil, err
+	}
+	uo, err = w.dyn{{if .Namespaced}}.Namespace(w.namespace){{end}}.ApplyStatus(ctx, uo.GetName(), uo, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := &{{ .ResultType|raw }}{}
+	if err := convert(uo, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 {{end}}
 `,


### PR DESCRIPTION
:gift: Now that the K8s client libraries have an Apply method for the dynamic client, plumb it through the client code generation.

/kind feature

cc @k4leung4 @tcnghia 

**Release Note**

```release-note
Dynamic client-based codegen now support Apply[Status] 🎉 
```

**Docs**

```docs

```
