### PR TITLE
Fix: Mute the linter on error return values.

### DIFF
--- a/webhook/resourcesemantics/validation/validation_admit.go
+++ b/webhook/resourcesemantics/validation/validation_admit.go
@@ -160,7 +160,7 @@ func (ac *reconciler) decodeRequestAndPrepareContext(
 	return ctx, newObj, nil
 }
 
-func validate(ctx context.Context, resource resourcesemantics.GenericCRD, req *admissionv1.AdmissionRequest) (err error, warn []error) {
+func validate(ctx context.Context, resource resourcesemantics.GenericCRD, req *admissionv1.AdmissionRequest) (err error, warn []error) { //nolint
 	logger := logging.FromContext(ctx)
 
 	// Only run validation for supported create and update validation.


### PR DESCRIPTION
:bug: My previous change has revive/stylecheck warnings because I made the `warn` return value `[]error` and it wants the `error` last, which is kind of silly.

This mutes the linter on this signature, since it hits both revive and stylecheck

/kind bug

/assign @dprotaso 

```release-note

```

```docs

```
