### PR TITLE
Multi-controller leadership electors

### DIFF
--- a/leaderelection/context_test.go
+++ b/leaderelection/context_test.go
@@ -391,3 +391,14 @@ func TestUnopposedElectorInitialBucket(t *testing.T) {
 		t.Errorf("unexpected u.InitialBuckets() (-want,+got): %s", diff)
 	}
 }
+
+func TestWithNoElectorBuilder(t *testing.T) {
+	ctx := WithNoElectorBuilder(context.Background())
+	if HasLeaderElection(ctx) {
+		t.Error("Want HasLeaderElection() false for context marked WithNoElectorBuilder")
+	}
+
+	if HasLeaderElection(context.Background()) {
+		t.Error("Want HasLeaderElection() false for undecorated context")
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

This is an approach to constructing and running one leadership elector that promotes and demotes more than one controller/reconciler in tandem based on a single lease. Such capability is a must when it is desirable for several related reconcilers to run from the same process.

There are definitely cleaner ways to do this, but I'm not sure there are cleaner ways that don't break BC. For example currently an undecorated context will still result in construction and running of an `unopposedElector` when the controller is run, so that any `LeaderAware` reconcilers get promote()d. So to start running a controller without (re)running its elector, we have to decorate the context explicitly with `ErrElectorBuiltManually`.

Relates to bug https://github.com/knative/serving/issues/13447
This solution would probably also be a minor enhancement.

/kind bug
/kind enhancement

Still needs more unit and manual testing.