### PR TITLE
asJsonPatch

### DIFF
--- a/configmap/parse.go
+++ b/configmap/parse.go
@@ -236,8 +236,8 @@ func AsNamespacedName(key string, target *types.NamespacedName) ParseFunc {
 	}
 }
 
-// AsJsonPatch parses the value at key as a jsonpatch.Patch into the target, if it exists
-func AsJsonPatch(key string, target *jsonpatch.Patch) ParseFunc {
+// AsJSONPatch parses the value at key as a jsonpatch.Patch into the target, if it exists
+func AsJSONPatch(key string, target *jsonpatch.Patch) ParseFunc {
 	return func(data map[string]string) error {
 		raw, ok := data[key]
 		if !ok {

--- a/configmap/parse_test.go
+++ b/configmap/parse_test.go
@@ -249,7 +249,7 @@ func TestParse(t *testing.T) {
 				AsQuantity("test-quantity", &test.conf.qua),
 				AsNamespacedName("test-namespaced-name", &test.conf.nsn),
 				AsOptionalNamespacedName("test-optional-namespaced-name", &test.conf.onsn),
-				AsJsonPatch("test-overlay", &test.conf.overlay),
+				AsJSONPatch("test-overlay", &test.conf.overlay),
 				CollectMapEntriesWithPrefix("test-dict", &test.conf.dict),
 			); (err == nil) == test.expectErr {
 				t.Fatal("Failed to parse data:", err)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/blendle/zapdriver v1.3.1
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/davecgh/go-spew v1.1.1
+	github.com/evanphx/json-patch v4.12.0+incompatible
 	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/gobuffalo/flect v0.2.4
 	github.com/golang/protobuf v1.5.2
@@ -65,7 +66,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
 	github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.1.0 // indirect
-	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/go-kit/log v0.1.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect


### PR DESCRIPTION
Signed-off-by: David Hadas <david.hadas@gmail.com>

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->
Add support for JsonPatch (RFC 6902) as value in a config map
See https://github.com/knative/serving/issues/13629

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind  api-change

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


<!-- Please include the 'why' behind your changes if no issue exists -->
This is part of a change in Serving to support Overlays for Deployments

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
