### PR TITLE
Make SetDefaults of Destination duck type nil safer

### DIFF
--- a/apis/duck/v1/destination.go
+++ b/apis/duck/v1/destination.go
@@ -73,6 +73,10 @@ func (d *Destination) GetRef() *KReference {
 }
 
 func (d *Destination) SetDefaults(ctx context.Context) {
+	if d == nil {
+		return
+	}
+
 	if d.Ref != nil && d.Ref.Namespace == "" {
 		d.Ref.Namespace = apis.ParentMeta(ctx).Namespace
 	}

--- a/apis/duck/v1/destination_test.go
+++ b/apis/duck/v1/destination_test.go
@@ -179,7 +179,10 @@ func TestDestinationSetDefaults(t *testing.T) {
 		d    *Destination
 		ctx  context.Context
 		want string
-	}{"uri set, nothing in ref, not modified ": {
+	}{"destination nil ": {
+		d:   nil,
+		ctx: ctx,
+	}, "uri set, nothing in ref, not modified ": {
 		d:   &Destination{URI: apis.HTTP("example.com")},
 		ctx: ctx,
 	}, "namespace set, nothing in context, not modified ": {
@@ -206,11 +209,13 @@ func TestDestinationSetDefaults(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			tc.d.SetDefaults(tc.ctx)
-			if tc.d.Ref != nil && tc.d.Ref.Namespace != tc.want {
-				t.Errorf("Got: %s wanted %s", tc.d.Ref.Namespace, tc.want)
-			}
-			if tc.d.Ref == nil && tc.want != "" {
-				t.Error("Got: nil Ref wanted", tc.want)
+			if tc.d != nil {
+				if tc.d.Ref != nil && tc.d.Ref.Namespace != tc.want {
+					t.Errorf("Got: %s wanted %s", tc.d.Ref.Namespace, tc.want)
+				}
+				if tc.d.Ref == nil && tc.want != "" {
+					t.Error("Got: nil Ref wanted", tc.want)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
To use `SetDefaults` on the `Destination` type, the caller must check that the destination is not nil currently:

e.g.
```
if subscriber != nil {
    subscriber.SetDefaults(ctx)
}
```

Some other `SetDefaults` implementations, check this internally to prevent panics. E.g.: https://github.com/knative/eventing/blob/7e899fd166deb40c885d3fc4fb9e2901375a7bff/pkg/apis/duck/v1/delivery_defaults.go#L22-L24
This makes it easier to directly call `SetDefaults` without surrounding it with `nil` checks.

This PR addresses it and includes the "nil check" into the `SetDefaults` methods of a `Destination`