### PR TITLE
Allow reconcilers to listen to leader promotion events 

### DIFF
--- a/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/controller.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1/customresourcedefinition/controller.go
@@ -64,10 +64,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := customresourcedefinitionInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -124,6 +129,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/controller.go
+++ b/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/controller.go
@@ -64,10 +64,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := customresourcedefinitionInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -124,6 +129,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/admissionregistration/v1/mutatingwebhookconfiguration/controller.go
+++ b/client/injection/kube/reconciler/admissionregistration/v1/mutatingwebhookconfiguration/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := mutatingwebhookconfigurationInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -119,6 +124,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/admissionregistration/v1/validatingwebhookconfiguration/controller.go
+++ b/client/injection/kube/reconciler/admissionregistration/v1/validatingwebhookconfiguration/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := validatingwebhookconfigurationInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -119,6 +124,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/admissionregistration/v1beta1/mutatingwebhookconfiguration/controller.go
+++ b/client/injection/kube/reconciler/admissionregistration/v1beta1/mutatingwebhookconfiguration/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := mutatingwebhookconfigurationInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -119,6 +124,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/admissionregistration/v1beta1/validatingwebhookconfiguration/controller.go
+++ b/client/injection/kube/reconciler/admissionregistration/v1beta1/validatingwebhookconfiguration/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := validatingwebhookconfigurationInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -119,6 +124,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/apps/v1/deployment/controller.go
+++ b/client/injection/kube/reconciler/apps/v1/deployment/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := deploymentInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -122,6 +127,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/apps/v1beta1/deployment/controller.go
+++ b/client/injection/kube/reconciler/apps/v1beta1/deployment/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := deploymentInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -122,6 +127,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/apps/v1beta2/deployment/controller.go
+++ b/client/injection/kube/reconciler/apps/v1beta2/deployment/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := deploymentInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -122,6 +127,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/batch/v1/cronjob/controller.go
+++ b/client/injection/kube/reconciler/batch/v1/cronjob/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := cronjobInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -122,6 +127,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/batch/v1beta1/cronjob/controller.go
+++ b/client/injection/kube/reconciler/batch/v1beta1/cronjob/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := cronjobInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -122,6 +127,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/core/v1/configmap/controller.go
+++ b/client/injection/kube/reconciler/core/v1/configmap/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := configmapInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -119,6 +124,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/core/v1/namespace/controller.go
+++ b/client/injection/kube/reconciler/core/v1/namespace/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := namespaceInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -122,6 +127,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/core/v1/node/controller.go
+++ b/client/injection/kube/reconciler/core/v1/node/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := nodeInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -122,6 +127,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/core/v1/pod/controller.go
+++ b/client/injection/kube/reconciler/core/v1/pod/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := podInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -122,6 +127,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/core/v1/secret/controller.go
+++ b/client/injection/kube/reconciler/core/v1/secret/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := secretInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -119,6 +124,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/extensions/v1beta1/deployment/controller.go
+++ b/client/injection/kube/reconciler/extensions/v1beta1/deployment/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := deploymentInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -122,6 +127,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/extensions/v1beta1/networkpolicy/controller.go
+++ b/client/injection/kube/reconciler/extensions/v1beta1/networkpolicy/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := networkpolicyInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -122,6 +127,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/client/injection/kube/reconciler/networking/v1/networkpolicy/controller.go
+++ b/client/injection/kube/reconciler/networking/v1/networkpolicy/controller.go
@@ -62,10 +62,15 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 	lister := networkpolicyInformer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt reconciler.Bucket) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
 			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List(labels.Everything())
 				if err != nil {
 					return err
@@ -122,6 +127,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -230,10 +230,15 @@ func NewImpl(ctx {{.contextContext|raw}}, r Interface{{if .hasClass}}, classValu
 	lister := {{.type|lowercaseSingular}}Informer.Lister()
 
 	var promoteFilterFunc func(obj interface{}) bool
+	var promoteFunc = func(bkt {{.reconcilerBucket|raw}}) {}
 
 	rec := &reconcilerImpl{
 		LeaderAwareFuncs: {{.reconcilerLeaderAwareFuncs|raw}}{
 			PromoteFunc: func(bkt {{.reconcilerBucket|raw}}, enq func({{.reconcilerBucket|raw}}, {{.typesNamespacedName|raw}})) error {
+
+				// Signal promotion event
+				promoteFunc(bkt)
+
 				all, err := lister.List({{.labelsEverything|raw}}())
 				if err != nil {
 					return err
@@ -294,6 +299,9 @@ func NewImpl(ctx {{.contextContext|raw}}, r Interface{{if .hasClass}}, classValu
 		}
 		if opts.PromoteFilterFunc != nil {
 			promoteFilterFunc = opts.PromoteFilterFunc
+		}
+		if opts.PromoteFunc != nil {
+			promoteFunc = opts.PromoteFunc
 		}
 	}
 

--- a/controller/options.go
+++ b/controller/options.go
@@ -46,6 +46,10 @@ type Options struct {
 	// Objects that pass the filter (return true) will be reconciled when a new leader is promoted.
 	// If no filter is specified, all objects will be reconciled.
 	PromoteFilterFunc func(obj interface{}) bool
+
+	// PromoteFunc is called when a reconciler is promoted for the given bucket
+	// The provided function must not block execution.
+	PromoteFunc func(bkt reconciler.Bucket)
 }
 
 // OptionsFn is a callback method signature that accepts an Impl and returns


### PR DESCRIPTION
The current approach doesn't allow controllers to hook 
additional logic when a reconciler is promoted for buckets,
only when it is demoted with `DemoteFunc` passed through
the `controller.OptionsFn` function.

In eventing, we have components running in the background
(aka detached to resource created/update/delete),
which should only take action when a given reconciler
is the leader ([the autoscaler](https://github.com/knative/eventing/blob/main/pkg/scheduler/statefulset/autoscaler.go)).

Fixes #2675 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Allow reconcilers to listen to leader promotion events 
```