### PR TITLE
Make ZipkinTracingEnabled flag thread safe

### DIFF
--- a/test/spoof/spoof.go
+++ b/test/spoof/spoof.go
@@ -265,7 +265,7 @@ func DefaultResponseRetryChecker(resp *Response) (bool, error) {
 // logZipkinTrace provides support to log Zipkin Trace for param: spoofResponse
 // We only log Zipkin trace for HTTP server errors i.e for HTTP status codes between 500 to 600
 func (sc *SpoofingClient) logZipkinTrace(spoofResp *Response) {
-	if !zipkin.ZipkinTracingEnabled || spoofResp.StatusCode < http.StatusInternalServerError || spoofResp.StatusCode >= 600 {
+	if !zipkin.TracingEnabled.Load() || spoofResp.StatusCode < http.StatusInternalServerError || spoofResp.StatusCode >= 600 {
 		return
 	}
 

--- a/test/zipkin/util.go
+++ b/test/zipkin/util.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/atomic"
 	tracingconfig "knative.dev/pkg/tracing/config"
 
 	"github.com/openzipkin/zipkin-go/model"
@@ -60,8 +61,12 @@ const (
 var (
 	zipkinPortForwardPID int
 
-	// ZipkinTracingEnabled variable indicating if zipkin tracing is enabled.
+	// Deprecated: Use TracingEnabled for checking the current state. Setting this flag
+	// is done automatically in SetupZipkinTracing.
 	ZipkinTracingEnabled = false
+
+	// TracingEnabled variable indicating if zipkin tracing is enabled.
+	TracingEnabled atomic.Bool
 
 	// sync.Once variable to ensure we execute zipkin setup only once.
 	setupOnce sync.Once
@@ -138,6 +143,9 @@ func SetupZipkinTracing(ctx context.Context, kubeClientset kubernetes.Interface,
 
 		// Applying AlwaysSample config to ensure we propagate zipkin header for every request made by this client.
 		trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+
+		ZipkinTracingEnabled = true
+		TracingEnabled.Store(true)
 		logf("Successfully setup SpoofingClient for Zipkin Tracing")
 	})
 	return
@@ -166,7 +174,7 @@ func CleanupZipkinTracingSetup(logf logging.FormatLogger) {
 		// run, SetupZipkinTracing will no longer setup any port forwarding.
 		setupOnce.Do(func() {})
 
-		if !ZipkinTracingEnabled {
+		if TracingEnabled.Load() {
 			return
 		}
 
@@ -176,6 +184,7 @@ func CleanupZipkinTracingSetup(logf logging.FormatLogger) {
 		}
 
 		ZipkinTracingEnabled = false
+		TracingEnabled.Store(false)
 	})
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Introduce a new variable TracingEnabled of type atomic.Bool
- Deprecate the old ZipkinTracingEnabled
- Set the TracingEnabled to true automatically when SetupZipkinTracing is called. This simplifies usage in multiple places as it's not required to manually set the flag. Currently, it's being set on multiple places, these might be removed after integrating this change:
  - https://github.com/knative/eventing/blob/main/test/upgrade/prober/verify.go#L63
  - https://github.com/knative-sandbox/reconciler-test/blob/main/pkg/milestone/emitter_tracing.go#L51
  - https://github.com/knative-sandbox/eventing-kafka-broker/blob/main/test/pkg/tracing/zipkin.go#L34 


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
