### PR TITLE
bump golang version in downstream tests

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set up Go 1.18.x
+    - name: Set up Go 1.20.x
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: 1.20.x
 
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
Fixes the operator downstream test which had their go version bumped to go1.19