### PR TITLE
Parameterize `WEBHOOK_NAME` env key in error message

### DIFF
--- a/webhook/env.go
+++ b/webhook/env.go
@@ -50,11 +50,11 @@ func NameFromEnv() string {
 		return webhook
 	}
 
-	panic(fmt.Sprintf(`The environment variable %q is not set.
+	panic(fmt.Sprintf(`The environment variable %[1]q is not set.
 This should be unique for the webhooks in a namespace
 If this is a process running on Kubernetes, then initialize this variable via:
   env:
-  - name: WEBHOOK_NAME
+  - name: %[1]s
     value: webhook
 `, webhookNameEnvKey))
 }


### PR DESCRIPTION
Tiny fix to parameterize `WEBHOOK_NAME` env in an error message correctly.