### PR TITLE
drop eventing natss from downstream tests

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -37,7 +37,6 @@ jobs:
           - knative-sandbox/eventing-gitlab
           - knative-sandbox/eventing-kafka
           - knative-sandbox/eventing-kafka-broker
-          - knative-sandbox/eventing-natss
           - knative-sandbox/eventing-rabbitmq
           - knative-sandbox/eventing-redis
           - knative-sandbox/kn-plugin-admin


### PR DESCRIPTION
It's not being maintained so it's always failing

/assign @pierDipi 