### PR TITLE
Printf log message with the right type when showing port

### DIFF
--- a/injection/health_check.go
+++ b/injection/health_check.go
@@ -40,7 +40,7 @@ func ServeHealthProbes(ctx context.Context, port int) error {
 	}()
 
 	// start the web server on port and accept requests
-	logger.Infof("Probes server listening on port %s", port)
+	logger.Infof("Probes server listening on port %d", port)
 	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}


### PR DESCRIPTION

---
name: Bug Fix
about: Fixes a bug in knative/pkg
title: 'print log message with the proper type'
labels: kind/bug
assignees: ''

---

Fixes:

This will show up like this in the log

13:35:17 Probes server listening on port %!s(int=8080)

with proper type casted it will look a bit better !

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>
