### PR TITLE
Make minimum TLS version configurable for webhooks

### DIFF
--- a/metrics/opencensus_exporter.go
+++ b/metrics/opencensus_exporter.go
@@ -99,7 +99,7 @@ func getCredentials(component string, secret *corev1.Secret, logger *zap.Sugared
 		return nil
 	}
 	return credentials.NewTLS(&tls.Config{
-		MinVersion: tls.VersionTLS12,
+		MinVersion: tls.VersionTLS13,
 		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 			cert, err := tls.X509KeyPair(secret.Data["client-cert.pem"], secret.Data["client-key.pem"])
 			if err != nil {

--- a/network/transports_test.go
+++ b/network/transports_test.go
@@ -189,7 +189,7 @@ func exampleTLSConf() *tls.Config {
 	return &tls.Config{
 		InsecureSkipVerify: false,
 		ServerName:         "example.com",
-		MinVersion:         tls.VersionTLS12,
+		MinVersion:         tls.VersionTLS13,
 	}
 }
 

--- a/webhook/env.go
+++ b/webhook/env.go
@@ -79,6 +79,6 @@ func TLSMinVersionFromEnv(defaultTLSMinVersion uint16) uint16 {
 	case "":
 		return defaultTLSMinVersion
 	default:
-		panic(fmt.Sprintf("the environment variable %q has to be either '1.2' or '1.3'", tlsMinVersion))
+		panic(fmt.Sprintf("the environment variable %q has to be either '1.2' or '1.3'", tlsMinVersionEnvKey))
 	}
 }

--- a/webhook/env.go
+++ b/webhook/env.go
@@ -31,7 +31,7 @@ const (
 
 	secretNameEnvKey = "WEBHOOK_SECRET_NAME" //nolint:gosec // This is not a hardcoded credential
 
-	tlsMinVersionEnvKey = "TLS_MIN_VERSION"
+	tlsMinVersionEnvKey = "WEBHOOK_TLS_MIN_VERSION"
 )
 
 // PortFromEnv returns the webhook port set by portEnvKey, or default port if env var is not set.

--- a/webhook/env.go
+++ b/webhook/env.go
@@ -17,6 +17,7 @@ limitations under the License.
 package webhook
 
 import (
+	"crypto/tls"
 	"fmt"
 	"os"
 	"strconv"
@@ -29,6 +30,8 @@ const (
 	webhookNameEnvKey = "WEBHOOK_NAME"
 
 	secretNameEnvKey = "WEBHOOK_SECRET_NAME" //nolint:gosec // This is not a hardcoded credential
+
+	tlsMinVersionEnvKey = "TLS_MIN_VERSION"
 )
 
 // PortFromEnv returns the webhook port set by portEnvKey, or default port if env var is not set.
@@ -65,4 +68,18 @@ func SecretNameFromEnv(defaultSecretName string) string {
 		return defaultSecretName
 	}
 	return secret
+}
+
+func TLSMinVersionFromEnv(defaultTLSMinVersion uint16) uint16 {
+	tlsMinVersion := os.Getenv(tlsMinVersionEnvKey)
+	if tlsMinVersion == "" {
+		return defaultTLSMinVersion
+	}
+	if tlsMinVersion != "1.2" && tlsMinVersion != "1.3" {
+		panic(fmt.Sprintf("the environment variable %q has to be either '1.2' or '1.3'", tlsMinVersion))
+	}
+	if tlsMinVersion == "1.3" {
+		return tls.VersionTLS13
+	}
+	return defaultTLSMinVersion
 }

--- a/webhook/env.go
+++ b/webhook/env.go
@@ -71,15 +71,14 @@ func SecretNameFromEnv(defaultSecretName string) string {
 }
 
 func TLSMinVersionFromEnv(defaultTLSMinVersion uint16) uint16 {
-	tlsMinVersion := os.Getenv(tlsMinVersionEnvKey)
-	if tlsMinVersion == "" {
+	switch tlsMinVersion := os.Getenv(tlsMinVersionEnvKey); tlsMinVersion {
+	case "1.2":
+		return tls.VersionTLS12
+	case "1.3":
+		return tls.VersionTLS13
+	case "":
 		return defaultTLSMinVersion
-	}
-	if tlsMinVersion != "1.2" && tlsMinVersion != "1.3" {
+	default:
 		panic(fmt.Sprintf("the environment variable %q has to be either '1.2' or '1.3'", tlsMinVersion))
 	}
-	if tlsMinVersion == "1.3" {
-		return tls.VersionTLS13
-	}
-	return defaultTLSMinVersion
 }

--- a/webhook/env_test.go
+++ b/webhook/env_test.go
@@ -26,7 +26,7 @@ const (
 
 	testDefaultPort          = 8888
 	testDefaultSecretName    = "webhook-certs"
-	testDefaultTLSMinVersion = tls.VersionTLS12
+	testDefaultTLSMinVersion = tls.VersionTLS13
 )
 
 type portTest struct {

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -138,7 +138,7 @@ func New(
 		secretInformer := kubeinformerfactory.Get(ctx).Core().V1().Secrets()
 
 		webhook.tlsConfig = &tls.Config{
-			MinVersion: TLSMinVersionFromEnv(tls.VersionTLS12),
+			MinVersion: TLSMinVersionFromEnv(tls.VersionTLS13),
 
 			// If we return (nil, error) the client sees - 'tls: internal error"
 			// If we return (nil, nil) the client sees - 'tls: no certificates configured'

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -40,6 +40,8 @@ import (
 
 // Options contains the configuration for the webhook
 type Options struct {
+	TLSMinVersion uint16
+
 	// ServiceName is the service name of the webhook.
 	ServiceName string
 
@@ -136,7 +138,7 @@ func New(
 		secretInformer := kubeinformerfactory.Get(ctx).Core().V1().Secrets()
 
 		webhook.tlsConfig = &tls.Config{
-			MinVersion: tls.VersionTLS12,
+			MinVersion: TLSMinVersionFromEnv(tls.VersionTLS12),
 
 			// If we return (nil, error) the client sees - 'tls: internal error"
 			// If we return (nil, nil) the client sees - 'tls: no certificates configured'

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -34,10 +34,9 @@ import (
 
 func newDefaultOptions() Options {
 	return Options{
-		ServiceName:   "webhook",
-		Port:          8443,
-		SecretName:    "webhook-certs",
-		TLSMinVersion: tls.VersionTLS13,
+		ServiceName: "webhook",
+		Port:        8443,
+		SecretName:  "webhook-certs",
 	}
 }
 
@@ -94,4 +93,35 @@ func TestRegistrationStopChanFire(t *testing.T) {
 		conn.Close()
 		t.Error("Unexpected success to dial to port", opts.Port)
 	}
+}
+
+func newAdmissionControllerWebhook(t *testing.T, options Options, acs ...interface{}) (*Webhook, error) {
+	ctx, cancel, _ := SetupFakeContextWithCancel(t)
+	defer cancel()
+	ctx = WithOptions(ctx, options)
+	return New(ctx, acs)
+}
+
+func TestTLSMinVersionWebhookOption(t *testing.T) {
+	opts := newDefaultOptions()
+	t.Run("when TLSMinVersion is not configured, and the default is used", func(t *testing.T) {
+		_, err := newAdmissionControllerWebhook(t, opts)
+		if err != nil {
+			t.Fatal("Unexpected error", err)
+		}
+	})
+	t.Run("when the TLS minimum version configured is supported", func(t *testing.T) {
+		opts.TLSMinVersion = tls.VersionTLS12
+		_, err := newAdmissionControllerWebhook(t, opts)
+		if err != nil {
+			t.Fatal("Unexpected error", err)
+		}
+	})
+	t.Run("when the TLS minimum version configured is not supported", func(t *testing.T) {
+		opts.TLSMinVersion = tls.VersionTLS11
+		_, err := newAdmissionControllerWebhook(t, opts)
+		if err == nil {
+			t.Fatal("Admission Controller Webhook creation expected to fail due to unsupported TLS version")
+		}
+	})
 }

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -18,6 +18,7 @@ package webhook
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"testing"
@@ -33,9 +34,10 @@ import (
 
 func newDefaultOptions() Options {
 	return Options{
-		ServiceName: "webhook",
-		Port:        8443,
-		SecretName:  "webhook-certs",
+		ServiceName:   "webhook",
+		Port:          8443,
+		SecretName:    "webhook-certs",
+		TLSMinVersion: tls.VersionTLS13,
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :gift: make TLS minimum version configurable via environment variables for webhooks
- changes the TLS minimum version to 1.3

/kind enhancement

TLS 1.3 comes with numerous enhancements, such as a quicker TLS handshake and more secure cipher suites, which make it simpler to use. Additionally, the introduction of Zero Round-Trip Time (0-RTT) key exchanges further simplifies the TLS handshake. 

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
- Added an additional option when creating a webhook, which allows to configure the minimum TLS version acceptable to communicate with the API server.
- The default TLS version was also changed from TLS 1.2 to TLS 1.3.
```

**Docs**
N/A
<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

