### PR TITLE
fix: use the controller name when creating the lease name

### DIFF
--- a/webhook/resourcesemantics/conversion/controller.go
+++ b/webhook/resourcesemantics/conversion/controller.go
@@ -18,6 +18,8 @@ package conversion
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -117,7 +119,8 @@ func NewConversionController(
 		crdLister:    crdInformer.Lister(),
 	}
 
-	const queueName = "ConversionWebhook"
+	queueName := fmt.Sprintf("ConversionWebhook.%s", path)
+	queueName = strings.ReplaceAll(queueName, "/", ".")
 	logger := logging.FromContext(ctx)
 	c := controller.NewContext(ctx, r, controller.ControllerOptions{WorkQueueName: queueName, Logger: logger.Named(queueName)})
 

--- a/webhook/resourcesemantics/defaulting/controller.go
+++ b/webhook/resourcesemantics/defaulting/controller.go
@@ -18,6 +18,8 @@ package defaulting
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	// Injection stuff
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -90,7 +92,8 @@ func NewAdmissionController(
 	}
 
 	logger := logging.FromContext(ctx)
-	const queueName = "DefaultingWebhook"
+	queueName := fmt.Sprintf("DefaultingWebhook.%s", path)
+	queueName = strings.ReplaceAll(queueName, "/", ".")
 	c := controller.NewContext(ctx, wh, controller.ControllerOptions{WorkQueueName: queueName, Logger: logger.Named(queueName)})
 
 	// Reconcile when the named MutatingWebhookConfiguration changes.

--- a/webhook/resourcesemantics/validation/controller.go
+++ b/webhook/resourcesemantics/validation/controller.go
@@ -18,6 +18,8 @@ package validation
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	// Injection stuff
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -76,7 +78,8 @@ func NewAdmissionControllerWithConfig(
 	}
 
 	logger := logging.FromContext(ctx)
-	const queueName = "ValidationWebhook"
+	queueName := fmt.Sprintf("ValidationWebhook.%s", path)
+	queueName = strings.ReplaceAll(queueName, "/", ".")
 	c := controller.NewContext(ctx, wh, controller.ControllerOptions{WorkQueueName: queueName, Logger: logger.Named(queueName)})
 
 	// Reconcile when the named ValidatingWebhookConfiguration changes.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

When defining more than a single validating/defaulting/conversion webhooks with the `sharedmain` contructors, I detected that only one of the webhooks was mutated and fully reconciled. 
After looking at the code, I found the controllers of the same type (e.g. defaulting) were competing for the lease. The main reason comes from the lease name creation which doesn't take into account the name of the controller itself. It uses a component name and a hardcoded queueName.
As a consequence, if I have two validating webhooks I'll only get one lease and the reconciliation of the second validating webhook will exit [here](https://github.com/knative/pkg/blob/main/webhook/resourcesemantics/validation/reconcile_config.go#L81).

Therefore I propose to reuse the name of the controllers or the path (for the conversion webhooks), and thus allow declaring more than a single webhook for the same `sharedmain.Main...` execution.

`{component-name}.{webhook-type}.{webhook-name}-%02d-of-%02d`

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind bug

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
webhooks: use controller name to construct the lease name.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
