### PR TITLE
Fix some webhook testing tech debt

### DIFF
--- a/webhook/admission_integration_test.go
+++ b/webhook/admission_integration_test.go
@@ -243,7 +243,7 @@ func TestAdmissionValidResponseForResource(t *testing.T) {
 		}
 	}()
 
-	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
+	pollErr := waitForNonTLSServerAvailable(t, serverURL, testTimeout)
 	if pollErr != nil {
 		t.Fatal("waitForServerAvailable() =", err)
 	}
@@ -594,7 +594,7 @@ func TestAdmissionValidResponseForRequestBody(t *testing.T) {
 		}
 	}()
 
-	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
+	pollErr := waitForNonTLSServerAvailable(t, serverURL, testTimeout)
 	if pollErr != nil {
 		t.Fatal("waitForServerAvailable() =", err)
 	}

--- a/webhook/admission_integration_test.go
+++ b/webhook/admission_integration_test.go
@@ -115,8 +115,7 @@ func TestAdmissionValidResponseForResourceTLS(t *testing.T) {
 		}
 	}()
 
-	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
-	if pollErr != nil {
+	if err = waitForServerAvailable(t, serverURL, testTimeout); err != nil {
 		t.Fatal("waitForServerAvailable() =", err)
 	}
 	tlsClient, err := createSecureTLSClient(t, kubeclient.Get(ctx), &wh.Options)
@@ -243,8 +242,7 @@ func TestAdmissionValidResponseForResource(t *testing.T) {
 		}
 	}()
 
-	pollErr := waitForNonTLSServerAvailable(t, serverURL, testTimeout)
-	if pollErr != nil {
+	if err = waitForNonTLSServerAvailable(t, serverURL, testTimeout); err != nil {
 		t.Fatal("waitForServerAvailable() =", err)
 	}
 	client := createNonTLSClient()
@@ -370,8 +368,7 @@ func TestAdmissionInvalidResponseForResource(t *testing.T) {
 		}
 	}()
 
-	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
-	if pollErr != nil {
+	if err = waitForServerAvailable(t, serverURL, testTimeout); err != nil {
 		t.Fatal("waitForServerAvailable() =", err)
 	}
 	tlsClient, err := createSecureTLSClient(t, kubeclient.Get(ctx), &wh.Options)
@@ -488,8 +485,7 @@ func TestAdmissionWarningResponseForResource(t *testing.T) {
 		}
 	}()
 
-	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
-	if pollErr != nil {
+	if err = waitForServerAvailable(t, serverURL, testTimeout); err != nil {
 		t.Fatal("waitForServerAvailable() =", err)
 	}
 	tlsClient, err := createSecureTLSClient(t, kubeclient.Get(ctx), &wh.Options)
@@ -594,8 +590,7 @@ func TestAdmissionValidResponseForRequestBody(t *testing.T) {
 		}
 	}()
 
-	pollErr := waitForNonTLSServerAvailable(t, serverURL, testTimeout)
-	if pollErr != nil {
+	if err = waitForNonTLSServerAvailable(t, serverURL, testTimeout); err != nil {
 		t.Fatal("waitForServerAvailable() =", err)
 	}
 	client := createNonTLSClient()

--- a/webhook/conversion_integration_test.go
+++ b/webhook/conversion_integration_test.go
@@ -79,8 +79,7 @@ func TestConversionValidResponse(t *testing.T) {
 		}
 	}()
 
-	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
-	if pollErr != nil {
+	if err = waitForServerAvailable(t, serverURL, testTimeout); err != nil {
 		t.Fatal("waitForServerAvailable() =", err)
 	}
 	tlsClient, err := createSecureTLSClient(t, kubeclient.Get(ctx), &wh.Options)
@@ -168,8 +167,7 @@ func TestConversionInvalidResponse(t *testing.T) {
 		}
 	}()
 
-	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
-	if pollErr != nil {
+	if err = waitForServerAvailable(t, serverURL, testTimeout); err != nil {
 		t.Fatal("waitForServerAvailable() =", err)
 	}
 	tlsClient, err := createSecureTLSClient(t, kubeclient.Get(ctx), &wh.Options)

--- a/webhook/helper_test.go
+++ b/webhook/helper_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"net"
 	"net/http"
-	"strconv"
 	"testing"
 	"time"
 
@@ -169,22 +168,6 @@ func waitForServerAvailable(t *testing.T, serverURL string, timeout time.Duratio
 	}
 
 	return wait.PollImmediate(interval, timeout, conditionFunc)
-}
-
-func newTestPort() (port int, err error) {
-	server, err := net.Listen("tcp", ":0")
-	if err != nil {
-		return 0, err
-	}
-
-	defer server.Close()
-
-	_, portString, err := net.SplitHostPort(server.Addr().String())
-	if err != nil {
-		return 0, err
-	}
-
-	return strconv.Atoi(portString)
 }
 
 func createNamespace(t *testing.T, kubeClient kubernetes.Interface, name string) error {

--- a/webhook/webhook_integration_test.go
+++ b/webhook/webhook_integration_test.go
@@ -67,8 +67,7 @@ func TestMissingContentType(t *testing.T) {
 		}
 	}()
 
-	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
-	if pollErr != nil {
+	if err = waitForServerAvailable(t, serverURL, testTimeout); err != nil {
 		t.Fatal("waitForServerAvailable() =", err)
 	}
 
@@ -121,8 +120,7 @@ func testEmptyRequestBody(t *testing.T, controller interface{}) {
 		}
 	}()
 
-	pollErr := waitForServerAvailable(t, serverURL, testTimeout)
-	if pollErr != nil {
+	if err = waitForServerAvailable(t, serverURL, testTimeout); err != nil {
 		t.Fatal("waitForServerAvailable() =", err)
 	}
 


### PR DESCRIPTION
Contributing to the webhook package is a bit annoying

- Some tests couldn't be run in parallel
- Verbose log messages about tls handshake EOF
- Races occur with ephemeral ports since we temporary allocate them to discover which ones are free but then release them in order for the webhook to bind to them

