### PR TITLE
Support to set qps and burst via env variable

### DIFF
--- a/environment/client_config.go
+++ b/environment/client_config.go
@@ -46,14 +46,14 @@ func (c *ClientConfig) InitFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.Kubeconfig, "kubeconfig", os.Getenv("KUBECONFIG"),
 		"Path to a kubeconfig. Only required if out-of-cluster.")
 
-	fs.IntVar(&c.Burst, "kube-api-burst", envVarOrDefault("KUBE_API_BURST", 0), "Maximum burst for throttle.")
+	fs.IntVar(&c.Burst, "kube-api-burst", int(envVarOrDefault("KUBE_API_BURST", 0)), "Maximum burst for throttle.")
 
-	fs.Float64Var(&c.QPS, "kube-api-qps", float64(envVarOrDefault("KUBE_API_QPS", 0)), "Maximum QPS to the server from the client.")
+	fs.Float64Var(&c.QPS, "kube-api-qps", envVarOrDefault("KUBE_API_QPS", 0.0), "Maximum QPS to the server from the client.")
 }
 
-func envVarOrDefault(key string, val int) int {
+func envVarOrDefault(key string, val float64) float64 {
 	if v := os.Getenv(key); v != "" {
-		val, _ = strconv.Atoi(v)
+		val, _ = strconv.ParseFloat(v, 64)
 	}
 	return val
 }

--- a/environment/client_config.go
+++ b/environment/client_config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strings"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -42,12 +43,19 @@ func (c *ClientConfig) InitFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.ServerURL, "server", "",
 		"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 
-	fs.StringVar(&c.Kubeconfig, "kubeconfig", os.Getenv("KUBECONFIG"),
+	fs.StringVar(&c.Kubeconfig, "kubeconfig", "",
 		"Path to a kubeconfig. Only required if out-of-cluster.")
 
 	fs.IntVar(&c.Burst, "kube-api-burst", 0, "Maximum burst for throttle.")
 
 	fs.Float64Var(&c.QPS, "kube-api-qps", 0, "Maximum QPS to the server from the client.")
+
+	// Apply flag values from env variable if set.
+	fs.VisitAll(func(f *flag.Flag) {
+		if s := os.Getenv(strings.ToUpper(strings.Replace(f.Name, "-", "_", -1))); s != "" {
+			f.Value.Set(s)
+		}
+	})
 }
 
 func (c *ClientConfig) GetRESTConfig() (*rest.Config, error) {

--- a/environment/client_config_test.go
+++ b/environment/client_config_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestInitFlag(t *testing.T) {
 	t.Setenv("KUBE_API_BURST", "50")
-	t.Setenv("KUBE_API_QPS", "60")
+	t.Setenv("KUBE_API_QPS", "60.1")
 	t.Setenv("KUBECONFIG", "myconfig")
 
 	c := new(ClientConfig)
@@ -40,7 +40,7 @@ func TestInitFlag(t *testing.T) {
 
 	expect := &ClientConfig{
 		Burst:      100,
-		QPS:        60,
+		QPS:        60.1,
 		Kubeconfig: "myconfig",
 	}
 

--- a/environment/client_config_test.go
+++ b/environment/client_config_test.go
@@ -1,0 +1,35 @@
+package environment
+
+import (
+	"flag"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestInitFlag(t *testing.T) {
+	t.Setenv("KUBE_API_BURST", "50")
+	t.Setenv("KUBE_API_QPS", "60")
+	t.Setenv("KUBECONFIG", "myconfig")
+
+	c := new(ClientConfig)
+	c.InitFlags(flag.CommandLine)
+
+	// Override kube-api-burst via command line option.
+	flag.CommandLine.Set("kube-api-burst", strconv.Itoa(100))
+
+	// Call parse() here as InitFlags does not call it.
+	flag.Parse()
+
+	expect := &ClientConfig{
+		Burst:      100,
+		QPS:        60,
+		Kubeconfig: "myconfig",
+		Cluster:    "",
+	}
+
+	if !cmp.Equal(c, expect) {
+		t.Errorf("ClientConfig mismatch: diff(-want,+got):\n%s", cmp.Diff(expect, c))
+	}
+}

--- a/environment/client_config_test.go
+++ b/environment/client_config_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package environment
 
 import (

--- a/environment/client_config_test.go
+++ b/environment/client_config_test.go
@@ -26,7 +26,6 @@ func TestInitFlag(t *testing.T) {
 		Burst:      100,
 		QPS:        60,
 		Kubeconfig: "myconfig",
-		Cluster:    "",
 	}
 
 	if !cmp.Equal(c, expect) {


### PR DESCRIPTION
Currently some configuration such as `kube-api-burst` and `kube-api-qps` must be set via command line option.

Knative deployments usually do not have the command line option, the command line option is unusual and so knative/operator also does not support the API.

Hence This patch allows to set client config via env variable.

**Release Note**

```release-note
env variable `KUBE_API_QPS` and `KUBE_API_BURST` are available. They are same options for `--kube-api-burst` and `--kube-api-qps`
```
