### PR TITLE
Fix github action for dependabot

### DIFF
--- a/.github/workflows/knative-dependabot.yaml
+++ b/.github/workflows/knative-dependabot.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run hack scripts
         working-directory: ./src/github.com/${{ github.repository }}
-        run: 
+        run: |
           ./hack/update-deps.sh
           ./hack/update-codegen.sh
 


### PR DESCRIPTION
This patch fixes the current github action for dependabot.

/cc @kvmware @dprotaso 