### PR TITLE
Use go sync/atomic instead of go.uber.org/atomic

### DIFF
--- a/apis/duck/cached_test.go
+++ b/apis/duck/cached_test.go
@@ -19,12 +19,11 @@ package duck
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
-	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 )
@@ -37,7 +36,7 @@ type BlockingInformerFactory struct {
 var _ InformerFactory = (*BlockingInformerFactory)(nil)
 
 func (bif *BlockingInformerFactory) Get(ctx context.Context, gvr schema.GroupVersionResource) (cache.SharedIndexInformer, cache.GenericLister, error) {
-	bif.nCalls.Inc()
+	bif.nCalls.Add(1)
 	// Wait here until we can acquire the lock
 	<-bif.block
 
@@ -58,7 +57,7 @@ func TestSameGVR(t *testing.T) {
 	}
 
 	// counts the number of calls to cif.Get that returned
-	retGetCount := atomic.NewInt32(0)
+	var retGetCount atomic.Int32
 
 	errGrp, ctx := errgroup.WithContext(context.Background())
 
@@ -75,7 +74,7 @@ func TestSameGVR(t *testing.T) {
 	for i := 0; i < iter; i++ {
 		errGrp.Go(func() error {
 			_, _, err := cif.Get(ctx, gvr)
-			retGetCount.Inc()
+			retGetCount.Add(1)
 			return err
 		})
 	}
@@ -119,7 +118,7 @@ func TestDifferentGVRs(t *testing.T) {
 	}
 
 	// counts the number of calls to cif.Get that returned
-	retGetCount := atomic.NewInt32(0)
+	var retGetCount atomic.Int32
 
 	errGrp, ctx := errgroup.WithContext(context.Background())
 
@@ -136,7 +135,7 @@ func TestDifferentGVRs(t *testing.T) {
 
 		errGrp.Go(func() error {
 			_, _, err := cif.Get(ctx, gvr)
-			retGetCount.Inc()
+			retGetCount.Add(1)
 			return err
 		})
 	}

--- a/apis/duck/cached_test.go
+++ b/apis/duck/cached_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 )

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -21,11 +21,11 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"go.uber.org/atomic"
 
 	coordinationv1 "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -874,7 +874,7 @@ type CountingReconciler struct {
 }
 
 func (cr *CountingReconciler) Reconcile(context.Context, string) error {
-	cr.count.Inc()
+	cr.count.Add(1)
 	return nil
 }
 
@@ -927,7 +927,7 @@ type countingLeaderAwareReconciler struct {
 var _ reconciler.LeaderAware = (*countingLeaderAwareReconciler)(nil)
 
 func (cr *countingLeaderAwareReconciler) Promote(b reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
-	cr.promotionCount.Inc()
+	cr.promotionCount.Add(1)
 	return cr.LeaderAwareFuncs.Promote(b, enq)
 }
 
@@ -941,7 +941,7 @@ func (cr *countingLeaderAwareReconciler) Reconcile(ctx context.Context, key stri
 		Namespace: namespace,
 		Name:      name,
 	}) {
-		cr.reconcileCount.Inc()
+		cr.reconcileCount.Add(1)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/tsenart/vegeta/v12 v12.11.0
 	go.opencensus.io v0.24.0
-	go.uber.org/atomic v1.9.0
 	go.uber.org/automaxprocs v1.4.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/net v0.12.0
@@ -90,6 +89,7 @@ require (
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/rs/dnscache v0.0.0-20211102005908-e0241e321417 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/goleak v1.2.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.11.0 // indirect

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -19,12 +19,12 @@ package metrics
 import (
 	"context"
 	"net/url"
+	"sync/atomic"
 	"time"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
-	"go.uber.org/atomic"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/metrics"
 	"k8s.io/client-go/util/workqueue"
@@ -74,13 +74,13 @@ var _ workqueue.GaugeMetric = (*gaugeMetric)(nil)
 
 // Inc implements CounterMetric
 func (m *gaugeMetric) Inc() {
-	total := m.total.Inc()
+	total := m.total.Add(1)
 	Record(context.Background(), m.measure.M(total), stats.WithTags(m.mutators...))
 }
 
 // Dec implements GaugeMetric
 func (m *gaugeMetric) Dec() {
-	total := m.total.Dec()
+	total := m.total.Add(-1)
 	Record(context.Background(), m.measure.M(total), stats.WithTags(m.mutators...))
 }
 

--- a/profiling/server.go
+++ b/profiling/server.go
@@ -22,9 +22,9 @@ import (
 	"net/http/pprof"
 	"os"
 	"strconv"
+	"sync/atomic"
 	"time"
 
-	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -63,8 +63,11 @@ func NewHandler(logger *zap.SugaredLogger, enableProfiling bool) *Handler {
 	mux.HandleFunc(pprofPrefix+"trace", pprof.Trace)
 
 	logger.Info("Profiling enabled: ", enableProfiling)
+	var enabled atomic.Bool
+	enabled.Store(enableProfiling)
+
 	return &Handler{
-		enabled: atomic.NewBool(enableProfiling),
+		enabled: &enabled,
 		handler: mux,
 		log:     logger,
 	}

--- a/reconciler/testing/context.go
+++ b/reconciler/testing/context.go
@@ -18,10 +18,9 @@ package testing
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
-
-	"go.uber.org/atomic"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -94,7 +93,7 @@ func RunAndSyncInformers(ctx context.Context, informers ...controller.Informer) 
 
 		c.PrependReactor("list", "*", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 			// Every list (before actual informer usage) is going to be followed by a Watch call.
-			watchesPending.Inc()
+			watchesPending.Add(1)
 			return false, nil, nil
 		})
 
@@ -108,7 +107,7 @@ func RunAndSyncInformers(ctx context.Context, informers ...controller.Informer) 
 				return false, nil, err
 			}
 
-			watchesPending.Dec()
+			watchesPending.Add(-1)
 
 			return true, watch, nil
 		})

--- a/reconciler/testing/hooks.go
+++ b/reconciler/testing/hooks.go
@@ -20,9 +20,9 @@ package testing
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
-	"go.uber.org/atomic"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubetesting "k8s.io/client-go/testing"
 )
@@ -94,16 +94,18 @@ type Hooks struct {
 // more fake clients and wait for all hooks to complete.
 // TODO(grantr): Allow validating that a hook never fires
 func NewHooks() *Hooks {
+	var ci atomic.Int32
+	ci.Store(-1)
 	return &Hooks{
 		completionCh:    make(chan int32, 100),
-		completionIndex: atomic.NewInt32(-1),
+		completionIndex: &ci,
 	}
 }
 
 // OnCreate attaches a create hook to the given Fake. The hook function is
 // executed every time a resource of the given type is created.
 func (h *Hooks) OnCreate(fake *kubetesting.Fake, resource string, rf CreateHookFunc) {
-	index := h.completionIndex.Inc()
+	index := h.completionIndex.Add(1)
 	fake.PrependReactor("create", resource, func(a kubetesting.Action) (bool, runtime.Object, error) {
 		obj := a.(kubetesting.CreateActionImpl).Object
 
@@ -119,7 +121,7 @@ func (h *Hooks) OnCreate(fake *kubetesting.Fake, resource string, rf CreateHookF
 // OnUpdate attaches an update hook to the given Fake. The hook function is
 // executed every time a resource of the given type is updated.
 func (h *Hooks) OnUpdate(fake *kubetesting.Fake, resource string, rf UpdateHookFunc) {
-	index := h.completionIndex.Inc()
+	index := h.completionIndex.Add(1)
 	fake.PrependReactor("update", resource, func(a kubetesting.Action) (bool, runtime.Object, error) {
 		obj := a.(kubetesting.UpdateActionImpl).Object
 
@@ -135,7 +137,7 @@ func (h *Hooks) OnUpdate(fake *kubetesting.Fake, resource string, rf UpdateHookF
 // OnDelete attaches a delete hook to the given Fake. The hook function is
 // executed every time a resource of the given type is deleted.
 func (h *Hooks) OnDelete(fake *kubetesting.Fake, resource string, rf DeleteHookFunc) {
-	index := h.completionIndex.Inc()
+	index := h.completionIndex.Add(1)
 	fake.PrependReactor("delete", resource, func(a kubetesting.Action) (bool, runtime.Object, error) {
 		name := a.(kubetesting.DeleteActionImpl).Name
 
@@ -173,7 +175,7 @@ func (h *Hooks) WaitForHooks(timeout time.Duration) error {
 		case i := <-h.completionCh:
 			hookCompletions[i] = HookComplete
 			if len(hookCompletions) == ci {
-				h.completionIndex.Dec()
+				h.completionIndex.Add(-1)
 				return nil
 			}
 		case <-timer:

--- a/test/zipkin/util.go
+++ b/test/zipkin/util.go
@@ -28,10 +28,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
-	"go.uber.org/atomic"
 	tracingconfig "knative.dev/pkg/tracing/config"
 
 	"github.com/openzipkin/zipkin-go/model"


### PR DESCRIPTION
Since Go 1.19, new type for sync/atomic was introduced like Int32 and Bool so it is possible to replace `go.uber.org/atomic`.

This patch makes the change.

**Release Note**

```release-note
NONE
```