### PR TITLE
Use `DialTLSContextFunc` instead of `tls.Config` for `NewProxyAutoTLSTransport`

### DIFF
--- a/network/h2c.go
+++ b/network/h2c.go
@@ -59,13 +59,11 @@ func newH2CTransport(disableCompression bool) http.RoundTripper {
 
 // newH2Transport constructs a neew H2 transport. That transport will handles HTTPS traffic
 // with TLS config.
-func newH2Transport(disableCompression bool, tlsConf *tls.Config) http.RoundTripper {
+func newH2Transport(disableCompression bool, tlsContext DialTLSContextFunc) http.RoundTripper {
 	return &http2.Transport{
 		DisableCompression: disableCompression,
-		DialTLS: func(netw, addr string, tlsConf *tls.Config) (net.Conn, error) {
-			return DialTLSWithBackOff(context.Background(),
-				netw, addr, tlsConf)
+		DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
+			return tlsContext(ctx, network, addr)
 		},
-		TLSClientConfig: tlsConf,
 	}
 }


### PR DESCRIPTION
Current `NewProxyAutoTLSTransport` takes `TLSConfig`. It is easy to use but impossible to customize to verify custom SAN.
So, this patch replaces it with `DialTLSContext`.

#### Alternative

I considered a downstream may be using `NewProxyAutoTLSTransport` with `TLSConfig`. But `NewProxyAutoTLSTransport` was added for internal encryption https://github.com/knative/pkg/pull/2479 1 year ago. If an user wants `NewProxyAutoTLSTransport` to take `TLSConfig` we can add it later.

See also https://github.com/knative/serving/pull/14452
