### PR TITLE
Add `SinkAudience` to `SourceStatus`

### DIFF
--- a/apis/duck/v1/source_types.go
+++ b/apis/duck/v1/source_types.go
@@ -90,6 +90,10 @@ type SourceStatus struct {
 	// +optional
 	SinkCACerts *string `json:"sinkCACerts,omitempty"`
 
+	// SinkAudience is the OIDC audience of the sink.
+	// +optional
+	SinkAudience *string `json:"sinkAudience,omitempty"`
+
 	// Auth defines the attributes that provide the generated service account
 	// name in the resource status.
 	// +optional

--- a/apis/duck/v1/zz_generated.deepcopy.go
+++ b/apis/duck/v1/zz_generated.deepcopy.go
@@ -666,6 +666,11 @@ func (in *SourceStatus) DeepCopyInto(out *SourceStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SinkAudience != nil {
+		in, out := &in.SinkAudience, &out.SinkAudience
+		*out = new(string)
+		**out = **in
+	}
 	if in.Auth != nil {
 		in, out := &in.Auth, &out.Auth
 		*out = new(AuthStatus)


### PR DESCRIPTION
Add `SinkAudience` to `SourceStatus` so that we store the Audience of the resolved sink's destination.