### PR TITLE
Add rest.Config to fake context

### DIFF
--- a/reconciler/testing/context.go
+++ b/reconciler/testing/context.go
@@ -53,7 +53,9 @@ func SetupFakeContextWithCancel(t testing.TB, fs ...func(context.Context) contex
 	for _, f := range fs {
 		ctx = f(ctx)
 	}
-	ctx, is := injection.Fake.SetupInformers(ctx, &rest.Config{})
+	ctx = injection.WithConfig(ctx, &rest.Config{})
+
+	ctx, is := injection.Fake.SetupInformers(ctx, injection.GetConfig(ctx))
 	return ctx, c, is
 }
 


### PR DESCRIPTION
When we use `testing.SetupFakeContext`, we create a rest.Config, but don't add this to the context. Some reconcilers might need this config in the context.
This PR adds the rest.Config to the context (as it is created anyhow).

# Changes

- :broom: Add rest.Config to fake context from `SetupFaceContextWithCancel`