### PR TITLE
Fix potential `--kubeconfig` redefined error

### DIFF
--- a/environment/client_config.go
+++ b/environment/client_config.go
@@ -44,8 +44,12 @@ func (c *ClientConfig) InitFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.ServerURL, "server", "",
 		"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 
-	fs.StringVar(&c.Kubeconfig, "kubeconfig", os.Getenv("KUBECONFIG"),
-		"Path to a kubeconfig. Only required if out-of-cluster.")
+	if f := fs.Lookup("kubeconfig"); f != nil {
+		c.Kubeconfig = f.Value.String()
+	} else {
+		fs.StringVar(&c.Kubeconfig, "kubeconfig", os.Getenv("KUBECONFIG"),
+			"Path to a kubeconfig. Only required if out-of-cluster.")
+	}
 
 	fs.IntVar(&c.Burst, "kube-api-burst", int(envVarOrDefault("KUBE_API_BURST", 0)), "Maximum burst for throttle.")
 

--- a/environment/client_config_test.go
+++ b/environment/client_config_test.go
@@ -48,3 +48,24 @@ func TestInitFlag(t *testing.T) {
 		t.Errorf("ClientConfig mismatch: diff(-want,+got):\n%s", cmp.Diff(expect, c))
 	}
 }
+
+// TestInitFlagWithKubeconfing verify flag conflict error "flag redefined: kubeconfig"
+func TestInitFlagWithKubeconfing(t *testing.T) {
+	t.Setenv("KUBECONFIG", "myconfig")
+
+	c := new(ClientConfig)
+	flags := flag.NewFlagSet("test", flag.ExitOnError)
+	flags.String("kubeconfig", "/test/path", "")
+	c.InitFlags(flags)
+
+	// Call parse() here as InitFlags does not call it.
+	flags.Parse([]string{})
+
+	expect := &ClientConfig{
+		Kubeconfig: "/test/path",
+	}
+
+	if !cmp.Equal(c, expect) {
+		t.Errorf("ClientConfig mismatch: diff(-want,+got):\n%s", cmp.Diff(expect, c))
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Fix potential redefined error with kubeconfig flag


The `--kubeconfing` flag is a popular one. I've run into a case with `sigs.k8s.io/controller-runtime` & `/pkg` when vendoring together there's `flag redefined` error thrown. Depending on the order of package inits.

This change should make `/pkg` safer to use alongside other K8s libs.  