### PR TITLE
Don't migrate storage version if CRD has one storage version

### DIFF
--- a/apiextensions/storageversion/migrator.go
+++ b/apiextensions/storageversion/migrator.go
@@ -68,6 +68,11 @@ func (m *Migrator) Migrate(ctx context.Context, gr schema.GroupResource) error {
 		return fmt.Errorf("unable to determine storage version for %s", gr)
 	}
 
+	// don't migrate storage version if CRD has a single valid storage in its status
+	if len(crd.Status.StoredVersions) == 1 && crd.Status.StoredVersions[0] == version {
+		return nil
+	}
+
 	if err := m.migrateResources(ctx, gr.WithVersion(version)); err != nil {
 		return err
 	}

--- a/apiextensions/storageversion/migrator_test.go
+++ b/apiextensions/storageversion/migrator_test.go
@@ -110,14 +110,12 @@ func TestMigrate_SingleStoredVersion(t *testing.T) {
 	cclient := apixFake.NewSimpleClientset(singleVersionFakeCRD)
 
 	cclient.Fake.PrependReactor("patch", "customresourcedefinitions", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-		pa, ok := action.(k8stesting.PatchAction)
-		if !ok {
-			return true, nil, fmt.Errorf("not a patch action: %#v", action)
+		if pa, ok := action.(k8stesting.PatchAction); ok {
+			if pa.GetName() == singleVersionFakeCRD.Name {
+				return false, nil, fmt.Errorf("resource shouldn't have been patched")
+			}
 		}
 
-		if pa.GetName() == singleVersionFakeCRD.Name {
-			return true, nil, fmt.Errorf("resource shouldn't have been patched")
-		}
 		return false, nil, nil
 	})
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 
-->
- :bug: Fixed an issue where the [storage version migrator ](https://github.com/knative/pkg/blob/efe9f4a7b3f33a9db1a355b5375136b3a8c0fb1d/apiextensions/storageversion/migrator.go#L57)was running on CRDs that only had one storage version (related [comment](https://github.com/knative/serving/issues/14029#issuecomment-1741550974) for context).

Fixes #2845 

<!-- Please include the 'why' behind your changes if no issue exists -->
