### PR TITLE
Print each line separately in shell executor

### DIFF
--- a/test/upgrade/shell/executor.go
+++ b/test/upgrade/shell/executor.go
@@ -185,7 +185,9 @@ func (w testingWriter) Write(p []byte) (n int, err error) {
 	// Strip trailing newline because t.Log always adds one.
 	p = bytes.TrimRight(p, "\n")
 
-	w.t.Logf("%s", p)
+	for _, line := range strings.Split(string(p), "\n") {
+		w.t.Logf(line)
+	}
 
 	return n, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

This is a follow-up on https://github.com/knative/serving/pull/14495#discussion_r1357018523

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Prints each line separately so that the output is nicely formatted:
```
{Failed  === RUN   TestServingUpgrades/Run/Steps/UpgradeWith/ServingHead
    executor.go:189: Oct 16 07:12:49.696 install_head_reuse_ingress [OUT] =============================================================
    executor.go:189: Oct 16 07:12:49.696 install_head_reuse_ingress [OUT] ==== INSTALLING KNATIVE HEAD RELEASE AND REUSING INGRESS ====
    executor.go:189: Oct 16 07:12:49.696 install_head_reuse_ingress [OUT] =============================================================
    executor.go:189: Oct 16 07:12:49.698 install_head_reuse_ingress [OUT] ==== 2023-10-16 07:12:49.697870734+00:00
    executor.go:189: Oct 16 07:12:49.698 install_head_reuse_ingress [OUT] =============================================================
    executor.go:189: Oct 16 07:12:49.699 install_head_reuse_ingress [ERR] test/e2e-common.sh: line 499: install-nonexistent: command not found
    executor.go:189: Oct 16 07:12:49.700 install_head_reuse_ingress [OUT] ***************************************
    executor.go:189: Oct 16 07:12:49.700 install_head_reuse_ingress [OUT] ***         E2E TEST FAILED         ***
    executor.go:189: Oct 16 07:12:49.700 install_head_reuse_ingress [OUT] ***    Start of information dump    ***
    executor.go:189: Oct 16 07:12:49.700 install_head_reuse_ingress [OUT] ***************************************
    executor.go:189: Oct 16 07:12:49.701 install_head_reuse_ingress [OUT] >>> The dump is located at /logs/artifacts/k8s.dump-.txt
    executor.go:189: Oct 16 07:12:50.080 install_head_reuse_ingress [OUT] >>> allowlistedv2workloads.auto.gke.io (0 objects)
    executor.go:189: Oct 16 07:12:50.286 install_head_reuse_ingress [OUT] >>> allowlistedworkloads.auto.gke.io (0 objects)
```
instead of 
```
{Failed  === RUN   TestServingUpgrades/Run/Steps/UpgradeWith/ServingHead
    executor.go:207: Oct 12 07:08:25.735 install_head_reuse_ingress [OUT] =============================================================
        Oct 12 07:08:25.735 install_head_reuse_ingress [OUT] ==== INSTALLING KNATIVE HEAD RELEASE AND REUSING INGRESS ====
        Oct 12 07:08:25.735 install_head_reuse_ingress [OUT] =============================================================
    executor.go:207: Oct 12 07:08:25.737 install_head_reuse_ingress [OUT] ==== 2023-10-12 07:08:25.736830951+00:00
        Oct 12 07:08:25.737 install_head_reuse_ingress [OUT] =============================================================
    executor.go:207: Oct 12 07:08:25.737 install_head_reuse_ingress [ERR] test/e2e-common.sh: line 499: install-nonexistent: command not found
    executor.go:207: Oct 12 07:08:25.738 install_head_reuse_ingress [OUT] ***************************************
        Oct 12 07:08:25.738 install_head_reuse_ingress [OUT] ***         E2E TEST FAILED         ***
        Oct 12 07:08:25.738 install_head_reuse_ingress [OUT] ***    Start of information dump    ***
        Oct 12 07:08:25.738 install_head_reuse_ingress [OUT] ***************************************
    executor.go:207: Oct 12 07:08:25.739 install_head_reuse_ingress [OUT] >>> The dump is located at /logs/artifacts/k8s.dump-.txt
```
<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
