### PR TITLE
[CVE-2023-44487] Disable http2 for webhooks

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -256,6 +256,7 @@ func (wh *Webhook) Run(stop <-chan struct{}) error {
 		QuietPeriod: wh.Options.GracePeriod,
 	}
 
+	// If TLSNextProto is not nil, HTTP/2 support is not enabled automatically.
 	nextProto := map[string]func(*http.Server, *tls.Conn, http.Handler){}
 	if wh.Options.EnableHTTP2 {
 		nextProto = nil

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -81,6 +81,17 @@ type Options struct {
 	// ControllerOptions encapsulates options for creating a new controller,
 	// including throttling and stats behavior.
 	ControllerOptions *controller.ControllerOptions
+
+	// EnableHTTP2 enables HTTP2 for webhooks.
+	// Mitigate CVE-2023-44487 by disabling HTTP2 by default until the Go
+	// standard library and golang.org/x/net are fully fixed.
+	// Right now, it is possible for authenticated and unauthenticated users to
+	// hold open HTTP2 connections and consume huge amounts of memory.
+	// See:
+	// * https://github.com/kubernetes/kubernetes/pull/121120
+	// * https://github.com/kubernetes/kubernetes/issues/121197
+	// * https://github.com/golang/go/issues/63417#issuecomment-1758858612
+	EnableHTTP2 bool
 }
 
 // Operation is the verb being operated on
@@ -245,12 +256,18 @@ func (wh *Webhook) Run(stop <-chan struct{}) error {
 		QuietPeriod: wh.Options.GracePeriod,
 	}
 
+	nextProto := map[string]func(*http.Server, *tls.Conn, http.Handler){}
+	if wh.Options.EnableHTTP2 {
+		nextProto = nil
+	}
+
 	server := &http.Server{
 		ErrorLog:          log.New(&zapWrapper{logger}, "", 0),
 		Handler:           drainer,
 		Addr:              fmt.Sprint(":", wh.Options.Port),
 		TLSConfig:         wh.tlsConfig,
 		ReadHeaderTimeout: time.Minute, //https://medium.com/a-journey-with-go/go-understand-and-mitigate-slowloris-attack-711c1b1403f6
+		TLSNextProto:      nextProto,
 	}
 
 	var serve = server.ListenAndServe


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Disables http2 by default for webhooks. Allows to set it on demand via options.
- Similar to https://github.com/prometheus-operator/prometheus-operator/pull/6028.


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # CVE-2023-44487 (partially)

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Due to CVE-2023-44487 webhooks will use http1 by default, until the issue is fixed properly.
```
