### PR TITLE
fix closure variable in filtered factory

### DIFF
--- a/client/injection/apiextensions/informers/factory/filtered/fake/fake_filtered_factory.go
+++ b/client/injection/apiextensions/informers/factory/filtered/fake/fake_filtered_factory.go
@@ -45,14 +45,15 @@ func withInformerFactory(ctx context.Context) context.Context {
 	}
 	labelSelectors := untyped.([]string)
 	for _, selector := range labelSelectors {
+		selectorVal := selector
 		opts := []externalversions.SharedInformerOption{}
 		if injection.HasNamespaceScope(ctx) {
 			opts = append(opts, externalversions.WithNamespace(injection.GetNamespaceScope(ctx)))
 		}
 		opts = append(opts, externalversions.WithTweakListOptions(func(l *v1.ListOptions) {
-			l.LabelSelector = selector
+			l.LabelSelector = selectorVal
 		}))
-		ctx = context.WithValue(ctx, filtered.Key{Selector: selector},
+		ctx = context.WithValue(ctx, filtered.Key{Selector: selectorVal},
 			externalversions.NewSharedInformerFactoryWithOptions(c, controller.GetResyncPeriod(ctx), opts...))
 	}
 	return ctx

--- a/client/injection/apiextensions/informers/factory/filtered/filtered_factory.go
+++ b/client/injection/apiextensions/informers/factory/filtered/filtered_factory.go
@@ -53,14 +53,15 @@ func withInformerFactory(ctx context.Context) context.Context {
 	}
 	labelSelectors := untyped.([]string)
 	for _, selector := range labelSelectors {
+		selectorVal := selector
 		opts := []externalversions.SharedInformerOption{}
 		if injection.HasNamespaceScope(ctx) {
 			opts = append(opts, externalversions.WithNamespace(injection.GetNamespaceScope(ctx)))
 		}
 		opts = append(opts, externalversions.WithTweakListOptions(func(l *v1.ListOptions) {
-			l.LabelSelector = selector
+			l.LabelSelector = selectorVal
 		}))
-		ctx = context.WithValue(ctx, Key{Selector: selector},
+		ctx = context.WithValue(ctx, Key{Selector: selectorVal},
 			externalversions.NewSharedInformerFactoryWithOptions(c, controller.GetResyncPeriod(ctx), opts...))
 	}
 	return ctx

--- a/client/injection/kube/informers/factory/filtered/fake/fake_filtered_factory.go
+++ b/client/injection/kube/informers/factory/filtered/fake/fake_filtered_factory.go
@@ -45,14 +45,15 @@ func withInformerFactory(ctx context.Context) context.Context {
 	}
 	labelSelectors := untyped.([]string)
 	for _, selector := range labelSelectors {
+		selectorVal := selector
 		opts := []informers.SharedInformerOption{}
 		if injection.HasNamespaceScope(ctx) {
 			opts = append(opts, informers.WithNamespace(injection.GetNamespaceScope(ctx)))
 		}
 		opts = append(opts, informers.WithTweakListOptions(func(l *v1.ListOptions) {
-			l.LabelSelector = selector
+			l.LabelSelector = selectorVal
 		}))
-		ctx = context.WithValue(ctx, filtered.Key{Selector: selector},
+		ctx = context.WithValue(ctx, filtered.Key{Selector: selectorVal},
 			informers.NewSharedInformerFactoryWithOptions(c, controller.GetResyncPeriod(ctx), opts...))
 	}
 	return ctx

--- a/client/injection/kube/informers/factory/filtered/filtered_factory.go
+++ b/client/injection/kube/informers/factory/filtered/filtered_factory.go
@@ -53,14 +53,15 @@ func withInformerFactory(ctx context.Context) context.Context {
 	}
 	labelSelectors := untyped.([]string)
 	for _, selector := range labelSelectors {
+		selectorVal := selector
 		opts := []informers.SharedInformerOption{}
 		if injection.HasNamespaceScope(ctx) {
 			opts = append(opts, informers.WithNamespace(injection.GetNamespaceScope(ctx)))
 		}
 		opts = append(opts, informers.WithTweakListOptions(func(l *v1.ListOptions) {
-			l.LabelSelector = selector
+			l.LabelSelector = selectorVal
 		}))
-		ctx = context.WithValue(ctx, Key{Selector: selector},
+		ctx = context.WithValue(ctx, Key{Selector: selectorVal},
 			informers.NewSharedInformerFactoryWithOptions(c, controller.GetResyncPeriod(ctx), opts...))
 	}
 	return ctx

--- a/codegen/cmd/injection-gen/generators/fake_filtered_factory.go
+++ b/codegen/cmd/injection-gen/generators/fake_filtered_factory.go
@@ -116,14 +116,15 @@ func withInformerFactory(ctx {{.contextContext|raw}}) {{.contextContext|raw}} {
 	}
 	labelSelectors := untyped.([]string)
 	for _, selector := range labelSelectors {
+        selectorVal := selector
 		opts := []{{.informersSharedInformerOption|raw}}{}
 		if {{.injectionHasNamespace|raw}}(ctx) {
 			opts = append(opts, {{.informersWithNamespace|raw}}({{.injectionGetNamespace|raw}}(ctx)))
 		}		
 		opts = append(opts, {{.informersWithTweakListOptions|raw}}(func(l *{{.metav1ListOptions|raw}}) {
-			l.LabelSelector = selector
+			l.LabelSelector = selectorVal
 		}))
-		ctx = context.WithValue(ctx, {{.factoryKey|raw}}{Selector: selector},
+		ctx = context.WithValue(ctx, {{.factoryKey|raw}}{Selector: selectorVal},
 			{{.informersNewSharedInformerFactoryWithOptions|raw}}(c, {{.controllerGetResyncPeriod|raw}}(ctx), opts...))
 	}
 	return ctx

--- a/codegen/cmd/injection-gen/generators/filtered_factory.go
+++ b/codegen/cmd/injection-gen/generators/filtered_factory.go
@@ -117,14 +117,15 @@ func withInformerFactory(ctx {{.contextContext|raw}}) {{.contextContext|raw}} {
 	}
 	labelSelectors := untyped.([]string)
 	for _, selector := range labelSelectors {
+        selectorVal := selector
 		opts := []{{.informersSharedInformerOption|raw}}{}
 		if {{.injectionHasNamespace|raw}}(ctx) {
 			opts = append(opts, {{.informersWithNamespace|raw}}({{.injectionGetNamespace|raw}}(ctx)))
 		}	
 		opts = append(opts, {{.informersWithTweakListOptions|raw}}(func(l *{{.metav1ListOptions|raw}}) {
-			l.LabelSelector = selector
+			l.LabelSelector = selectorVal
 		}))
-		ctx = context.WithValue(ctx, Key{Selector: selector},
+		ctx = context.WithValue(ctx, Key{Selector: selectorVal},
 			{{.informersNewSharedInformerFactoryWithOptions|raw}}(c, {{.controllerGetResyncPeriod|raw}}(ctx), opts...))
 	}
 	return ctx


### PR DESCRIPTION
# Changes
- Copy the value of `selector` in `withInformerFactory` within the for loop to avoid issues in func()

/kind bug

Fixes #2883

/hold verifying this in Serving