### PR TITLE
drop toolchain directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module knative.dev/pkg
 
 go 1.21
 
-toolchain go1.21.1
-
 require (
 	cloud.google.com/go/compute/metadata v0.2.3
 	cloud.google.com/go/storage v1.38.0


### PR DESCRIPTION
I missed that we bumped some non-dependency properties in the go.mod file in https://github.com/knative/pkg/pull/2964

We shouldn't need to specify the `toolchain` directive - this oddly this breaks our go-licenses tool.

Bumping go version to v1.21 should be fine

see failure: https://github.com/knative-extensions/net-http01/pull/593

/assign @izabelacg @ReToCode @skonto 