### PR TITLE
drop http01 from downstream testing

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -42,7 +42,6 @@ jobs:
           - knative-extensions/kn-plugin-admin
           - knative-extensions/net-certmanager
           - knative-extensions/net-contour
-          - knative-extensions/net-http01
           - knative-extensions/net-istio
           - knative-extensions/net-kourier
 


### PR DESCRIPTION
This is deprecated - ﻿https://github.com/knative/serving/issues/14640