### PR TITLE
Provide option to exclude a registered informer from starting

### DIFF
--- a/injection/injection.go
+++ b/injection/injection.go
@@ -59,7 +59,7 @@ func EnableInjectionOrDie(ctx context.Context, cfg *rest.Config) (context.Contex
 
 	ctx, informers := Default.SetupInformers(ctx, cfg)
 
-	var includedInformers []controller.Informer
+	includedInformers := make([]controller.Informer, 0)
 
 	for _, inf := range informers {
 		if p := getExcludeInformerPredicate(ctx); p != nil && (*p)(ctx, inf) {

--- a/injection/injection.go
+++ b/injection/injection.go
@@ -80,6 +80,7 @@ type ExcludeInformerPredicate func(ctx context.Context, inf controller.Informer)
 type excludeInformerPredicateKey struct{}
 
 // WithExcludeInformerPredicate sets the predicate to exclude informers from being started.
+// If predicate returns true the informer will not be started.
 func WithExcludeInformerPredicate(ctx context.Context, predicate ExcludeInformerPredicate) context.Context {
 	return context.WithValue(ctx, excludeInformerPredicateKey{}, predicate)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Adds a context based predicate to filter out registered informers that should not start.
- Needed by https://github.com/knative/serving/pull/14955 (integrating net-certmanager in Serving)
- Here is how to use the filtering mechanism:
```
// informer to skip from starting, it implies that we have generated code for that informer as usual
"knative.dev/serving/pkg/net-certmanager/client/certmanager/injection/informers/acme/v1/challenge"

func main () {
       ....
        if shouldEnableNetCertManagerController(ctx, client) {
		ctors = append(ctors, certificate.NewController) // add the net-certmanager controller
	} else {
		// Remove all non required informers
		ctx = injection.WithInformerExcludingFilter(ctx, excludeNetCertManagerInformers)
	}
	sharedmain.MainWithConfig(ctx, "controller", cfg, ctors...)
}

func excludeNetCertManagerInformers(ctx context.Context, inf controller.Informer) (bool, string) {
	switch {
	case v1certificate.Get(ctx).Informer() == inf:
		return true, "CertificateInformer"
	case ...
	}
	return false, ""
}
```

This works because injection via an init func stores instances of [cache.SharedIndexInformer](https://github.com/knative/pkg/blob/main/injection/clients/namespacedkube/informers/core/v1/secret/secret.go#L39), it calls `inf.Informer()`,  which are unique at the k8s client go side (one per watched resource type). Thus we can always get back the same instance (`inf.Informer()`) and compare.
* Tested in https://github.com/knative/serving/pull/14955

Output in controller logs without any flag set:

```
2024/03/08 11:42:15 Registering 6 clients
2024/03/08 11:42:15 Registering 6 informer factories
2024/03/08 11:42:15 Registering 20 informers
2024/03/08 11:42:15 Registering 9 controllers
{"level":"info","ts":1709898135.6646473,"logger":"fallback","caller":"injection/injection.go:68","msg":"Excluding informer ChallengeInformer"}
{"level":"info","ts":1709898135.6646998,"logger":"fallback","caller":"injection/injection.go:68","msg":"Excluding informer CertificateInformer"}
{"level":"info","ts":1709898135.6647108,"logger":"fallback","caller":"injection/injection.go:68","msg":"Excluding informer CertificateRequestInformer"}
{"level":"info","ts":1709898135.664719,"logger":"fallback","caller":"injection/injection.go:68","msg":"Excluding informer ClusterIssuerInformer"}
{"level":"info","ts":1709898135.6647272,"logger":"fallback","caller":"injection/injection.go:68","msg":"Excluding informer IssuerInformer"}
....
{"level":"info","ts":1709898135.7881877,"logger":"fallback","caller":"injection/injection.go:76","msg":"Starting 15 informers..."}

```

In config-network cm we set  `external-domain-tls: enabled`, install cert-manager and then delete the previous controller pod:

```
2024/03/08 11:47:35 Registering 6 clients
2024/03/08 11:47:35 Registering 6 informer factories
2024/03/08 11:47:35 Registering 20 informers
2024/03/08 11:47:35 Registering 10 controllers
...
{"level":"info","ts":1709898455.9024231,"logger":"fallback","caller":"injection/injection.go:76","msg":"Starting 20 informers..."}

```
All related informers are started.

* It could be an option to avoid even registering the informers but that requires further changes at the codegen part which is more intrusive imho.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement



<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
