### PR TITLE
drop special logic when handling kubelet probe header for istio mTLS

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -59,11 +59,12 @@ const (
 	// KubeletProbeHeaderName is the header name to augment the probes, because
 	// Istio with mTLS rewrites probes, but their probes pass a different
 	// user-agent.
+	//
+	// Deprecated: use knative.dev/networking/pkg/http/header.UserAgentKey
 	KubeletProbeHeaderName = "K-Kubelet-Probe"
 )
 
 // IsKubeletProbe returns true if the request is a Kubernetes probe.
 func IsKubeletProbe(r *http.Request) bool {
-	return strings.HasPrefix(r.Header.Get(UserAgentKey), KubeProbeUAPrefix) ||
-		r.Header.Get(KubeletProbeHeaderName) != ""
+	return strings.HasPrefix(r.Header.Get(UserAgentKey), KubeProbeUAPrefix)
 }

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -37,8 +37,8 @@ func TestIsKubeletProbe(t *testing.T) {
 	if IsKubeletProbe(req) {
 		t.Error("Not a kubelet probe but counted as such")
 	}
-	req.Header.Set(KubeletProbeHeaderName, "no matter")
-	if !IsKubeletProbe(req) {
-		t.Error("kubelet probe but not counted as such")
+	req.Header.Set(KubeletProbeHeaderName, "custom header no longer used")
+	if IsKubeletProbe(req) {
+		t.Error("custom kubelet probe header should no longer be used")
 	}
 }


### PR DESCRIPTION
# Changes

- Deprecates k-kubelet-probe header

Part of https://github.com/knative/serving/issues/14981