### PR TITLE
webhook: register metrics only with default stats reporter

### DIFF
--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -289,14 +289,6 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 	// and pass them in.
 	var wh *webhook.Webhook
 	if len(webhooks) > 0 {
-		// Register webhook metrics
-		opts := webhook.GetOptions(ctx)
-		if opts != nil {
-			webhook.RegisterMetrics(opts.StatsReporterOptions...)
-		} else {
-			webhook.RegisterMetrics()
-		}
-
 		wh, err = webhook.New(ctx, webhooks)
 		if err != nil {
 			logger.Fatalw("Failed to create webhook", zap.Error(err))

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	// Injection stuff
@@ -38,6 +39,10 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/system"
+)
+
+var (
+	metricsOnce sync.Once
 )
 
 // Options contains the configuration for the webhook
@@ -147,6 +152,8 @@ func New(
 	logger := logging.FromContext(ctx)
 
 	if opts.StatsReporter == nil {
+		// Register webhook metrics
+		metricsOnce.Do(func() { RegisterMetrics(opts.StatsReporterOptions...) })
 		reporter, err := NewStatsReporter(opts.StatsReporterOptions...)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This is a followup from [knative/pkg#2931][1]. RegisterMetrics may register unwanted metrics if the default stats reporter is not used.

[1]: https://github.com/knative/pkg/pull/2931

/kind cleanup

```release-note
None
```
