### PR TITLE
Allow skipping conversion crd update

### DIFF
--- a/webhook/resourcesemantics/conversion/controller.go
+++ b/webhook/resourcesemantics/conversion/controller.go
@@ -131,6 +131,8 @@ func newController(ctx context.Context, optsFunc ...OptionFunc) *controller.Impl
 		client:       client,
 		secretLister: secretInformer.Lister(),
 		crdLister:    crdInformer.Lister(),
+
+		skipReconcile: shouldSkipReconcile(ctx),
 	}
 
 	logger := logging.FromContext(ctx)
@@ -160,4 +162,19 @@ func newController(ctx context.Context, optsFunc ...OptionFunc) *controller.Impl
 	}
 
 	return c
+}
+
+type skipReconcileKey struct{}
+
+func shouldSkipReconcile(ctx context.Context) bool {
+	v, ok := ctx.Value(skipReconcileKey{}).(*bool)
+	if ok && v != nil {
+		return *v
+	}
+	return false
+}
+
+// WithSkipReconcile returns a context with the skipReconcile value set
+func WithSkipReconcile(ctx context.Context, skipReconcile *bool) context.Context {
+	return context.WithValue(ctx, skipReconcileKey{}, skipReconcile)
 }

--- a/webhook/resourcesemantics/conversion/reconciler.go
+++ b/webhook/resourcesemantics/conversion/reconciler.go
@@ -49,6 +49,8 @@ type reconciler struct {
 	secretLister corelisters.SecretLister
 	crdLister    apixlisters.CustomResourceDefinitionLister
 	client       apixclient.Interface
+
+	skipReconcile bool
 }
 
 var _ webhook.ConversionController = (*reconciler)(nil)
@@ -73,6 +75,10 @@ func (r *reconciler) Reconcile(ctx context.Context, key string) error {
 	if err != nil {
 		logger.Errorw("Error fetching secret", zap.Error(err))
 		return err
+	}
+
+	if r.skipReconcile { // delegate crd update externally, only validate the secret, contents might be filled in later
+		return nil
 	}
 
 	cacert, ok := secret.Data[certresources.CACert]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Downstream we need skip the crd update as this is done by OLM. See https://github.com/openshift-knative/serverless-operator/pull/2597
- We would like to be able to delegate crd updates and only keep the reconciler for validation.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


