### PR TITLE
Revert "drop eventing-rabbitmq downstream testing (#2969)"

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -37,6 +37,7 @@ jobs:
           - knative-extensions/eventing-gitlab
           - knative-extensions/eventing-kafka
           - knative-extensions/eventing-kafka-broker
+          - knative-extensions/eventing-rabbitmq
           - knative-extensions/eventing-redis
           - knative-extensions/kn-plugin-admin
           - knative-extensions/net-certmanager


### PR DESCRIPTION
This reverts commit bea88256cb23aa54c5ead0e4c25a831557f745c1.

Part of https://github.com/knative/eventing/issues/7670


/assign @ikavgo 
/assign @mkuratczyk 
/assign @Zerpet 

This ensures when people make changes to the shared library here we'll know if it breaks rabbitmq downstream