### PR TITLE
Add composite ConfigStore to combine multiple `ConfigStore`

### DIFF
--- a/reconciler/configstore.go
+++ b/reconciler/configstore.go
@@ -20,6 +20,20 @@ import "context"
 
 // ConfigStore is used to attach the frozen configuration to the context.
 type ConfigStore interface {
-	// ConfigStore is used to attach the frozen configuration to the context.
+	// ToContext is used to attach the frozen configuration to the context.
 	ToContext(ctx context.Context) context.Context
+}
+
+// ConfigStores is used to combine multiple ConfigStore and attach multiple frozen configurations
+// to the context.
+type ConfigStores []ConfigStore
+
+// ConfigStores implements ConfigStore interface.
+var _ ConfigStore = ConfigStores{}
+
+func (stores ConfigStores) ToContext(ctx context.Context) context.Context {
+	for _, s := range stores {
+		ctx = s.ToContext(ctx)
+	}
+	return ctx
 }


### PR DESCRIPTION
In some repositories, we used multiple ConfigStores to store feature flags, for example, in eventing kafka broker, we use the Eventing core feature flags store and the EKB feature flags store

<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add composite ConfigStore to combine multiple `ConfigStore`
