### PR TITLE
Update AuthStatus to have list of ServiceAccountNames

### DIFF
--- a/apis/duck/v1/auth_types.go
+++ b/apis/duck/v1/auth_types.go
@@ -22,4 +22,9 @@ type AuthStatus struct {
 	// ServiceAccountName is the name of the generated service account
 	// used for this components OIDC authentication.
 	ServiceAccountName *string `json:"serviceAccountName,omitempty"`
+
+	// ServiceAccountNames is the list of names of the generated service accounts
+	// used for this components OIDC authentication. This list can have len() > 1,
+	// when the component uses multiple identities (e.g. in case of a Parallel).
+	ServiceAccountNames []string `json:"serviceAccountNames,omitempty"`
 }

--- a/apis/duck/v1/zz_generated.deepcopy.go
+++ b/apis/duck/v1/zz_generated.deepcopy.go
@@ -158,6 +158,11 @@ func (in *AuthStatus) DeepCopyInto(out *AuthStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ServiceAccountNames != nil {
+		in, out := &in.ServiceAccountNames, &out.ServiceAccountNames
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Some components can have multiple identities for sending events (e.g. the Parallel). Therefor the AuthStatus should support exposing multiple IDs.