### PR TITLE
Update linter config and address lint warnings/failures

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,27 +1,215 @@
 run:
   timeout: 10m
-
-  skip-dirs:
+  allow-parallel-runners: true
+  exclude-dirs:
     - client
-    - injection/client
-    - third_party
+    - injection/clients
 
-linters:
-  enable:
-    - asciicheck
-    - errorlint
-    - gosec
-    - prealloc
-    - revive
-    - stylecheck
-    - unconvert
-    - unparam
-  disable:
-    - errcheck
+output:
+  uniq-by-line: true
+  sort-results: true
+  sort-order:
+  - linter
+  - file
+  show-stats: true
+
 
 issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
   exclude-rules:
-    - path: test # Excludes /test, *_test.go etc.
-      linters:
-        - gosec
-        - unparam
+  - path: test # Excludes /test, *_test.go etc.
+    linters:
+    - gosec
+    - unparam
+    - noctx
+    - protogetter
+  - linters: ["gocritic"]
+    # Fixes are non-trivial do in a follow up
+    text: "ifElseChain"
+
+linters-settings:
+  # goimports:
+  #   local-prefixes: knative.dev/pkg
+  gomodguard:
+    blocked:
+      modules:
+      - github.com/ghodss/yaml:
+          recommendations:
+            - sigs.k8s.io/yaml
+      - go.uber.org/atomic:
+          recommendations:
+          - sync/atomic
+      - io/ioutil:
+          recommendations:
+          - os
+          - io
+      - github.com/hashicorp/go-multierror:
+          reason: "use errors.Join"
+          recommendations:
+          - errors
+      - go.uber.org/multierr:
+          reason: "use errors.Join"
+          recommendations:
+          - errors
+  revive:
+    rules:
+    # use unparam linter instead - defaults are better
+    - name: unused-parameter
+      disabled: true
+
+linters:
+  disable:
+    - errcheck
+  enable:
+    # Check for pass []any as any in variadic func(...any).
+    - asasalint
+
+    # Only use ASCII chars in indentifiers
+    - asciicheck
+
+    # Dangerous unicode characters
+    - bidichk
+
+    # Checks whether HTTP response body is closed successfully.
+    - bodyclose
+
+    # Canonicalheader checks whether net/http.Header uses canonical header.
+    - canonicalheader
+
+    # TODO - do a follow up PR
+    # # Containedctx is a linter that detects struct contained context.Context
+    # # field.
+    # - containedctx
+
+    # TODO - do a follow up PR
+    # # Check whether the function uses a non-inherited context.
+    # - contextcheck
+
+    # Copyloopvar is a linter detects places where loop variables are copied.
+    - copyloopvar
+
+    # Check declaration order of types, consts, vars and funcs.
+    - decorder
+
+    # Check for two durations multiplied together.
+    - durationcheck
+
+    # Checks that sentinel errors are prefixed with the Err- and error types
+    # are suffixed with the -Error.
+    - errname
+
+    # Errorlint is a linter for that can be used to find code that will cause
+    # problems with the error wrapping scheme introduced in Go 1.13.
+    - errorlint
+
+    # Checks for pointers to enclosing loop variables.
+    - exportloopref
+
+    # Detects nested contexts in loops.
+    - fatcontext
+
+    # Checks that go compiler directive comments (//go:) are valid.
+    - gocheckcompilerdirectives
+
+    # Provides diagnostics that check for bugs, performance and style issues.
+    # Extensible without recompilation through dynamic rules.
+    # Dynamic rules are written declaratively with AST patterns, filters,
+    # report message and optional suggestion.
+    - gocritic
+
+    # Gofmt checks whether code was gofmt-ed. By default this tool runs
+    # with -s option to check for code simplification.
+    - gofmt
+
+    # Gofumpt checks whether code was gofumpt-ed.
+    - gofumpt
+
+     # Check import statements are formatted according to the 'goimport'
+     # command. Reformat imports in autofix mode.
+    - goimports
+
+    # See config below
+    - gomodguard
+
+    # Inspects source code for security problems.
+    - gosec
+
+      # Linter that specializes in simplifying code.
+    - gosimple
+    - govet
+
+    # Intrange is a linter to find places where for loops could make use of
+    # an integer range.
+    - intrange
+
+    # Checks key value pairs for common logger libraries (kitlog,klog,logr,zap).
+    - loggercheck
+
+    # Finds slice declarations with non-zero initial length.
+    - makezero
+
+    # Reports wrong mirror patterns of bytes/strings usage
+    - mirror
+
+    # Finds commonly misspelled English words.
+    - misspell
+
+    # Finds the code that returns nil even if it checks that the error is not nil.
+    - nilerr
+
+    # Finds sending HTTP request without context.Context.
+    - noctx
+
+    # Reports ill-formed or insufficient nolint directives.
+    - nolintlint
+
+    # Checks for misuse of Sprintf to construct a host with port in a URL.
+    - nosprintfhostport
+
+    # Checks that fmt.Sprintf can be replaced with a faster alternative.
+    - perfsprint
+
+    # Finds slice declarations that could potentially be pre-allocated.
+    - prealloc
+
+    # Reports direct reads from proto message fields when getters should be used.
+    - protogetter
+
+    # Checks that package variables are not reassigned.
+    - reassign
+
+    # Fast, configurable, extensible, flexible, and beautiful linter for
+    # Go. Drop-in replacement of golint.
+    - revive
+
+    # Checks for mistakes with OpenTelemetry/Census spans.
+    - spancheck
+
+    # Stylecheck is a replacement for golint.
+    - stylecheck
+
+    # Tenv is analyzer that detects using os.Setenv instead of t.Setenv
+    # since Go1.17.
+    - tenv
+
+    # Linter checks if examples are testable (have an expected output).
+    - testableexamples
+
+    # Remove unnecessary type conversions.
+    - unconvert
+
+    # Reports unused function parameters and results in your code.
+    - unparam
+
+    # A linter that detect the possibility to use variables/constants from the
+    # Go standard library.
+    - usestdlibvars
+
+    # Finds wasted assignment statements.
+    - wastedassign
+
+    # Whitespace is a linter that checks for unnecessary newlines at the start
+    # and end of functions, if, for, etc.
+    - whitespace
+

--- a/apiextensions/storageversion/migrator_test.go
+++ b/apiextensions/storageversion/migrator_test.go
@@ -176,7 +176,7 @@ func TestMigrate_Errors(t *testing.T) {
 						return true, nil, apierrs.NewNotFound(fakeGR, "resource-removed")
 					})
 			},
-			// Resouce not found error should not block the storage migration.
+			// Resource not found error should not block the storage migration.
 			pass: true,
 		},
 		// todo paging fails

--- a/apiextensions/storageversion/migrator_test.go
+++ b/apiextensions/storageversion/migrator_test.go
@@ -19,7 +19,6 @@ package storageversion
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -109,10 +108,10 @@ func TestMigrate_SingleStoredVersion(t *testing.T) {
 	dclient := dynamicFake.NewSimpleDynamicClient(runtime.NewScheme())
 	cclient := apixFake.NewSimpleClientset(singleVersionFakeCRD)
 
-	cclient.Fake.PrependReactor("patch", "customresourcedefinitions", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+	cclient.PrependReactor("patch", "customresourcedefinitions", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 		if pa, ok := action.(k8stesting.PatchAction); ok {
 			if pa.GetName() == singleVersionFakeCRD.Name {
-				return false, nil, fmt.Errorf("resource shouldn't have been patched")
+				return false, nil, errors.New("resource shouldn't have been patched")
 			}
 		}
 

--- a/apis/condition_set.go
+++ b/apis/condition_set.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apis
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -233,7 +234,7 @@ func (r conditionsImpl) ClearCondition(t ConditionType) error {
 	}
 	// Terminal conditions are not handled as they can't be nil
 	if r.isTerminal(t) {
-		return fmt.Errorf("clearing terminal conditions not implemented")
+		return errors.New("clearing terminal conditions not implemented")
 	}
 	cond := r.GetCondition(t)
 	if cond == nil {

--- a/apis/contexts_test.go
+++ b/apis/contexts_test.go
@@ -231,7 +231,7 @@ func TestGetHTTPRequest(t *testing.T) {
 		t.Errorf("GetHTTPRequest() = %v, wanted %v", got, nil)
 	}
 
-	req, err := http.NewRequest("GET", "https://google.com", nil)
+	req, err := http.NewRequest(http.MethodGet, "https://google.com", nil)
 	if err != nil {
 		t.Fatalf("NewRequest() = %v", err)
 	}

--- a/apis/deprecated.go
+++ b/apis/deprecated.go
@@ -94,7 +94,7 @@ func getPrefixedNamedFieldValues(prefix string, obj interface{}) (map[string]ref
 		return fields, inlined
 	}
 
-	for i := 0; i < objValue.NumField(); i++ {
+	for i := range objValue.NumField() {
 		tf := objValue.Type().Field(i)
 		if v := objValue.Field(i); v.IsValid() {
 			jTag := tf.Tag.Get("json")

--- a/apis/duck/cached_test.go
+++ b/apis/duck/cached_test.go
@@ -72,7 +72,7 @@ func TestSameGVR(t *testing.T) {
 	}
 
 	const iter = 10
-	for i := 0; i < iter; i++ {
+	for range iter {
 		errGrp.Go(func() error {
 			_, _, err := cif.Get(ctx, gvr)
 			retGetCount.Add(1)
@@ -124,7 +124,7 @@ func TestDifferentGVRs(t *testing.T) {
 	errGrp, ctx := errgroup.WithContext(context.Background())
 
 	const iter = 10
-	for i := 0; i < iter; i++ {
+	for i := range iter {
 		// Use a different GVR each iteration to check that calls
 		// to bif.Get can proceed even if a call is in progress
 		// for another GVR.

--- a/apis/duck/v1/destination.go
+++ b/apis/duck/v1/destination.go
@@ -103,11 +103,11 @@ func (d *Destination) SetDefaults(ctx context.Context) {
 	}
 }
 
-func validateCACerts(CACert *string) *apis.FieldError {
+func validateCACerts(caCert *string) *apis.FieldError {
 	// Check the object.
 	var errs *apis.FieldError
 
-	block, err := pem.Decode([]byte(*CACert))
+	block, err := pem.Decode([]byte(*caCert))
 	if err != nil && block == nil {
 		errs = errs.Also(apis.ErrInvalidValue("CA Cert provided is invalid", "caCert"))
 		return errs

--- a/apis/duck/v1/knative_reference.go
+++ b/apis/duck/v1/knative_reference.go
@@ -102,7 +102,6 @@ func (kr *KReference) Validate(ctx context.Context) *apis.FieldError {
 					Details: fmt.Sprintf("parent namespace: %q does not match ref: %q", parentNS, kr.Namespace),
 				})
 			}
-
 		}
 	}
 	return errs

--- a/apis/duck/v1/status_types.go
+++ b/apis/duck/v1/status_types.go
@@ -97,7 +97,6 @@ func (s *Status) ConvertTo(ctx context.Context, sink *Status, predicates ...func
 
 	conditions := make(apis.Conditions, 0, len(s.Conditions))
 	for _, c := range s.Conditions {
-
 		// Copy over the "happy" condition, which is the only condition that
 		// we can reliably transfer.
 		if c.Type == apis.ConditionReady || c.Type == apis.ConditionSucceeded {

--- a/apis/duck/v1beta1/destination.go
+++ b/apis/duck/v1beta1/destination.go
@@ -168,11 +168,11 @@ func validateDestinationRef(ref corev1.ObjectReference) *apis.FieldError {
 	return errs
 }
 
-func validateCACerts(CACert *string) *apis.FieldError {
+func validateCACerts(caCert *string) *apis.FieldError {
 	// Check the object.
 	var errs *apis.FieldError
 
-	block, err := pem.Decode([]byte(*CACert))
+	block, err := pem.Decode([]byte(*caCert))
 	if err != nil && block == nil {
 		errs = errs.Also(apis.ErrInvalidValue("CA Cert provided is invalid", "caCert"))
 		return errs

--- a/apis/duck/verify_test.go
+++ b/apis/duck/verify_test.go
@@ -302,6 +302,7 @@ type (
 		Status SliceStatus `json:"status"`
 	}
 )
+
 type SliceStatus struct {
 	Sliceable *Sliceable `json:"sliceable,omitempty"`
 }
@@ -338,6 +339,7 @@ type (
 		Status StringStatus `json:"status"`
 	}
 )
+
 type StringStatus struct {
 	Stringable Stringable `json:"stringable,omitempty"`
 }

--- a/apis/field_error_test.go
+++ b/apis/field_error_test.go
@@ -227,7 +227,7 @@ Second: X, Y, Z`,
 			}
 
 			for _, p := range []string{"3", "2", "1"} {
-				for i := 0; i < 3; i++ {
+				for range 3 {
 					fe = fe.Also(fe)
 				}
 				fe = fe.ViaField(p)
@@ -247,7 +247,7 @@ Second: X, Y, Z`,
 			for _, p := range []string{"3", "2", "1"} {
 				e := fe.ViaField(p)
 				e.Details = "here at " + p
-				for i := 0; i < 3; i++ {
+				for range 3 {
 					fe = fe.Also(e)
 				}
 			}

--- a/apis/kind2resource.go
+++ b/apis/kind2resource.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apis
 
 import (
-	"fmt"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -41,7 +40,7 @@ func KindToResource(gvk schema.GroupVersionKind) schema.GroupVersionResource {
 func pluralizeKind(kind string) string {
 	ret := strings.ToLower(kind)
 	if strings.HasSuffix(ret, "s") {
-		return fmt.Sprintf("%ses", ret)
+		return ret + "es"
 	}
-	return fmt.Sprintf("%ss", ret)
+	return ret + "s"
 }

--- a/apis/testing/roundtrip/roundtrip.go
+++ b/apis/testing/roundtrip/roundtrip.go
@@ -144,7 +144,7 @@ func ExternalTypesViaHub(t *testing.T, scheme, hubs *runtime.Scheme, fuzzerFuncs
 		}
 
 		t.Run(gvk.Group+"."+gvk.Version+"."+gvk.Kind, func(t *testing.T) {
-			for i := 0; i < *roundtrip.FuzzIters; i++ {
+			for range *roundtrip.FuzzIters {
 				roundTripViaHub(t, gvk, scheme, hubs, f)
 
 				if t.Failed() {

--- a/codegen/cmd/injection-gen/args/args.go
+++ b/codegen/cmd/injection-gen/args/args.go
@@ -17,7 +17,7 @@ limitations under the License.
 package args
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/spf13/pflag"
 	"k8s.io/gengo/args"
@@ -59,13 +59,13 @@ func Validate(genericArgs *args.GeneratorArgs) error {
 	customArgs := genericArgs.CustomArgs.(*CustomArgs)
 
 	if len(genericArgs.OutputPackagePath) == 0 {
-		return fmt.Errorf("output package cannot be empty")
+		return errors.New("output package cannot be empty")
 	}
 	if len(customArgs.VersionedClientSetPackage) == 0 {
-		return fmt.Errorf("versioned clientset package cannot be empty")
+		return errors.New("versioned clientset package cannot be empty")
 	}
 	if len(customArgs.ExternalVersionsInformersPackage) == 0 {
-		return fmt.Errorf("external versions informers package cannot be empty")
+		return errors.New("external versions informers package cannot be empty")
 	}
 
 	return nil

--- a/codegen/cmd/injection-gen/generators/packages.go
+++ b/codegen/cmd/injection-gen/generators/packages.go
@@ -389,8 +389,6 @@ func versionInformerPackages(basePackage string, groupPkgName string, gv clientg
 	vers := make([]generator.Package, 0, 2*len(typesToGenerate))
 
 	for _, t := range typesToGenerate {
-		// Fix for golang iterator bug.
-		t := t
 		packagePath := packagePath + "/" + strings.ToLower(t.Name.Name)
 		typedInformerPackage := typedInformerPackage(groupPkgName, gv, customArgs.ExternalVersionsInformersPackage)
 
@@ -512,8 +510,6 @@ func reconcilerPackages(basePackage string, groupPkgName string, gv clientgentyp
 	vers := make([]generator.Package, 0, 4*len(typesToGenerate))
 
 	for _, t := range typesToGenerate {
-		// Fix for golang iterator bug.
-		t := t
 		extracted := extractCommentTags(t)
 		reconcilerClasses, hasReconcilerClass := extractReconcilerClassesTag(extracted)
 		nonNamespaced := isNonNamespaced(extracted)
@@ -676,7 +672,6 @@ func versionDuckPackages(basePackage string, groupPkgName string, gv clientgenty
 
 	for _, t := range typesToGenerate {
 		// Fix for golang iterator bug.
-		t := t
 		packagePath := filepath.Join(packagePath, strings.ToLower(t.Name.Name))
 
 		// Impl

--- a/codegen/cmd/injection-gen/generators/packages.go
+++ b/codegen/cmd/injection-gen/generators/packages.go
@@ -43,7 +43,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		klog.Fatalf("Wrong CustomArgs type: %T", arguments.CustomArgs)
 	}
 
-	versionPackagePath := filepath.Join(arguments.OutputPackagePath)
+	versionPackagePath := filepath.Clean(arguments.OutputPackagePath)
 
 	var packageList generator.Packages
 
@@ -501,6 +501,7 @@ func versionInformerPackages(basePackage string, groupPkgName string, gv clientg
 				return tags.NeedsInformerInjection()
 			},
 		})
+
 	}
 	return vers
 }

--- a/codegen/cmd/injection-gen/generators/packages.go
+++ b/codegen/cmd/injection-gen/generators/packages.go
@@ -501,7 +501,6 @@ func versionInformerPackages(basePackage string, groupPkgName string, gv clientg
 				return tags.NeedsInformerInjection()
 			},
 		})
-
 	}
 	return vers
 }

--- a/configmap/filter.go
+++ b/configmap/filter.go
@@ -17,7 +17,7 @@ limitations under the License.
 package configmap
 
 import (
-	"fmt"
+	"errors"
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
@@ -58,17 +58,17 @@ func ValidateConstructor(constructor interface{}) error {
 	cType := reflect.TypeOf(constructor)
 
 	if cType.Kind() != reflect.Func {
-		return fmt.Errorf("config constructor must be a function")
+		return errors.New("config constructor must be a function")
 	}
 
 	if cType.NumIn() != 1 || cType.In(0) != reflect.TypeOf(&corev1.ConfigMap{}) {
-		return fmt.Errorf("config constructor must be of the type func(*k8s.io/api/core/v1/ConfigMap) (..., error)")
+		return errors.New("config constructor must be of the type func(*k8s.io/api/core/v1/ConfigMap) (..., error)")
 	}
 
 	errorType := reflect.TypeOf((*error)(nil)).Elem()
 
 	if cType.NumOut() != 2 || !cType.Out(1).Implements(errorType) {
-		return fmt.Errorf("config constructor must be of the type func(*k8s.io/api/core/v1/ConfigMap) (..., error)")
+		return errors.New("config constructor must be of the type func(*k8s.io/api/core/v1/ConfigMap) (..., error)")
 	}
 	return nil
 }

--- a/configmap/informer/synced_callback.go
+++ b/configmap/informer/synced_callback.go
@@ -17,10 +17,10 @@ limitations under the License.
 package informer
 
 import (
+	"context"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // namedWaitGroup is used to increment and decrement a WaitGroup by name
@@ -107,6 +107,6 @@ func (s *syncedCallback) WaitForAllKeys(stopCh <-chan struct{}) error {
 	case <-c:
 		return nil
 	case <-stopCh:
-		return wait.ErrWaitTimeout
+		return context.DeadlineExceeded
 	}
 }

--- a/configmap/store_test.go
+++ b/configmap/store_test.go
@@ -18,7 +18,6 @@ package configmap
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"testing"
@@ -196,7 +195,7 @@ func TestStoreFailedFirstConversionCrashes(t *testing.T) {
 		return
 	}
 
-	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
+	cmd := exec.Command(os.Args[0], "-test.run="+t.Name())
 	cmd.Env = append(os.Environ(), "CRASH=1")
 	err := cmd.Run()
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -762,8 +762,8 @@ func RunInformers(stopCh <-chan struct{}, informers ...Informer) (func(), error)
 // WaitForCacheSyncQuick is the same as cache.WaitForCacheSync but with a much reduced
 // check-rate for the sync period.
 func WaitForCacheSyncQuick(stopCh <-chan struct{}, cacheSyncs ...cache.InformerSynced) bool {
-	err := wait.PollImmediateUntil(time.Millisecond,
-		func() (bool, error) {
+	err := wait.PollUntilContextCancel(wait.ContextForChannel(stopCh), time.Millisecond, true,
+		func(context.Context) (bool, error) {
 			for _, syncFunc := range cacheSyncs {
 				if !syncFunc() {
 					return false, nil
@@ -771,7 +771,7 @@ func WaitForCacheSyncQuick(stopCh <-chan struct{}, cacheSyncs ...cache.InformerS
 			}
 			return true, nil
 		},
-		stopCh)
+	)
 	return err == nil
 }
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -482,7 +482,7 @@ func (c *Impl) RunContext(ctx context.Context, threadiness int) error {
 
 	// Launch workers to process resources that get enqueued to our workqueue.
 	c.logger.Info("Starting controller and workers")
-	for i := 0; i < threadiness; i++ {
+	for range threadiness {
 		sg.Add(1)
 		go func() {
 			defer sg.Done()

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -224,7 +224,7 @@ type Impl struct {
 
 // ControllerOptions encapsulates options for creating a new controller,
 // including throttling and stats behavior.
-type ControllerOptions struct { //nolint // for backcompat.
+type ControllerOptions struct {
 	WorkQueueName string
 	Logger        *zap.SugaredLogger
 	Reporter      StatsReporter
@@ -623,7 +623,6 @@ func IsSkipKey(err error) bool {
 // Is implements the Is() interface of error. It returns whether the target
 // error can be treated as equivalent to a permanentError.
 func (skipKeyError) Is(target error) bool {
-	//nolint: errorlint // This check is actually fine.
 	_, ok := target.(skipKeyError)
 	return ok
 }
@@ -650,7 +649,6 @@ func IsPermanentError(err error) bool {
 // Is implements the Is() interface of error. It returns whether the target
 // error can be treated as equivalent to a permanentError.
 func (permanentError) Is(target error) bool {
-	//nolint: errorlint // This check is actually fine.
 	_, ok := target.(permanentError)
 	return ok
 }
@@ -710,7 +708,6 @@ func IsRequeueKey(err error) (bool, time.Duration) {
 // Is implements the Is() interface of error. It returns whether the target
 // error can be treated as equivalent to a requeueKeyError.
 func (requeueKeyError) Is(target error) bool {
-	//nolint: errorlint // This check is actually fine.
 	_, ok := target.(requeueKeyError)
 	return ok
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -723,7 +723,6 @@ type Informer interface {
 // of them to synchronize.
 func StartInformers(stopCh <-chan struct{}, informers ...Informer) error {
 	for _, informer := range informers {
-		informer := informer
 		go informer.Run(stopCh)
 	}
 
@@ -741,7 +740,6 @@ func RunInformers(stopCh <-chan struct{}, informers ...Informer) (func(), error)
 	var wg sync.WaitGroup
 	wg.Add(len(informers))
 	for _, informer := range informers {
-		informer := informer
 		go func() {
 			defer wg.Done()
 			informer.Run(stopCh)

--- a/hack/format-code.sh
+++ b/hack/format-code.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+go run mvdan.cc/gofumpt@latest -l -w .
+

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -149,12 +149,12 @@ func TestOverlay(t *testing.T) {
 		threshold = want / 5 // 20%
 	)
 	from := sets.New[string]()
-	for i := 0; i < sources; i++ {
+	for range sources {
 		from.Insert(uuid.NewString())
 	}
 	freqs := make(map[string]int, sources)
 
-	for i := 0; i < samples; i++ {
+	for range samples {
 		target := uuid.NewString()
 		got := ChooseSubset(from, selection, target)
 		for k := range got {
@@ -177,7 +177,7 @@ func TestOverlay(t *testing.T) {
 func BenchmarkSelection(b *testing.B) {
 	const maxSet = 200
 	from := make([]string, maxSet)
-	for i := 0; i < maxSet; i++ {
+	for i := range maxSet {
 		from[i] = uuid.NewString()
 	}
 	for _, v := range []int{5, 10, 25, 50, 100, 150, maxSet} {

--- a/injection/informers.go
+++ b/injection/informers.go
@@ -93,7 +93,6 @@ func (i *impl) SetupInformers(ctx context.Context, cfg *rest.Config) (context.Co
 	for _, fii := range i.GetFilteredInformers() {
 		ctx, filteredinfs = fii(ctx)
 		informers = append(informers, filteredinfs...)
-
 	}
 	return ctx, informers
 }

--- a/injection/informers.go
+++ b/injection/informers.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:fatcontext
 package injection
 
 import (

--- a/kmeta/names.go
+++ b/kmeta/names.go
@@ -18,6 +18,7 @@ package kmeta
 
 import (
 	"crypto/md5" //nolint:gosec // No strong cryptography needed.
+	"encoding/hex"
 	"fmt"
 	"regexp"
 )
@@ -53,7 +54,7 @@ func ChildName(parent, suffix string) string {
 			// Format the return string, if it's shorter than longest: pad with
 			// beginning of the suffix. This happens, for example, when parent is
 			// short, but the suffix is very long.
-			ret := parent + fmt.Sprintf("%x", h)
+			ret := parent + hex.EncodeToString(h[:])
 			if d := longest - len(ret); d > 0 {
 				ret += suffix[:d]
 			}

--- a/leaderelection/chaosduck/main.go
+++ b/leaderelection/chaosduck/main.go
@@ -153,7 +153,6 @@ func main() {
 				continue
 			}
 
-			name, leaders := name, leaders
 			eg.Go(func() error {
 				return quack(ctx, kc, name, leaders)
 			})

--- a/leaderelection/context.go
+++ b/leaderelection/context.go
@@ -133,9 +133,6 @@ func (b *standardBuilder) buildElector(ctx context.Context, la reconciler.Leader
 	bkts := newStandardBuckets(queueName, b.lec)
 	electors := make([]Elector, 0, b.lec.Buckets)
 	for _, bkt := range bkts {
-		// Use a local var which won't change across the for loop since it is
-		// used in a callback asynchronously.
-		bkt := bkt
 		rl, err := resourcelock.New(knativeResourceLock,
 			system.Namespace(), // use namespace we are running in
 			bkt.Name(),

--- a/leaderelection/context.go
+++ b/leaderelection/context.go
@@ -192,7 +192,7 @@ func newStandardBuckets(queueName string, cc ComponentConfig) []reconciler.Bucke
 		}
 	}
 	names := make(sets.Set[string], cc.Buckets)
-	for i := uint32(0); i < cc.Buckets; i++ {
+	for i := range cc.Buckets {
 		names.Insert(ln(i))
 	}
 
@@ -239,7 +239,7 @@ func NewStatefulSetBucketAndSet(buckets int) (reconciler.Bucket, *hash.BucketSet
 	}
 
 	names := make(sets.Set[string], buckets)
-	for i := 0; i < buckets; i++ {
+	for i := range buckets {
 		names.Insert(statefulSetPodDNS(i, ssc))
 	}
 

--- a/leaderelection/context_test.go
+++ b/leaderelection/context_test.go
@@ -118,7 +118,7 @@ func TestWithBuilder(t *testing.T) {
 	go le.Run(ctx)
 
 	// We expect 3 lease to be created.
-	for i := 0; i < buckets; i++ {
+	for range buckets {
 		select {
 		case <-created:
 		case <-time.After(1 * time.Second):
@@ -126,7 +126,7 @@ func TestWithBuilder(t *testing.T) {
 		}
 	}
 	// We expect to have been promoted 3 times.
-	for i := 0; i < buckets; i++ {
+	for range buckets {
 		select {
 		case s := <-promoted:
 			gotNames.Insert(s)
@@ -145,7 +145,7 @@ func TestWithBuilder(t *testing.T) {
 		t.Fatal("Timed out waiting for lease update.")
 	}
 	// We expect to have been demoted 3 times.
-	for i := 0; i < buckets; i++ {
+	for range buckets {
 		select {
 		case <-demoted:
 		case <-time.After(time.Second):
@@ -198,7 +198,7 @@ func TestBuilderWithCustomizedLeaseName(t *testing.T) {
 	go le.Run(ctx)
 
 	// We expect to have been promoted 3 times.
-	for i := 0; i < buckets; i++ {
+	for range buckets {
 		select {
 		case s := <-promoted:
 			gotNames.Insert(s)

--- a/metrics/e2e_test.go
+++ b/metrics/e2e_test.go
@@ -153,6 +153,9 @@ func TestMetricsExport(t *testing.T) {
 			// Wait for the webserver to actually start serving metrics
 			return wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 				resp, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", prometheusPort))
+				if err != nil {
+					defer resp.Body.Close()
+				}
 				return err == nil && resp.StatusCode == http.StatusOK, nil
 			})
 		},

--- a/metrics/opencensus_exporter.go
+++ b/metrics/opencensus_exporter.go
@@ -64,7 +64,9 @@ func getFactory(defaultExporter view.Exporter, stored []ocagent.ExporterOption) 
 			// Don't create duplicate exporters for the default exporter.
 			return defaultExporter, nil
 		}
-		opts := append(stored, ocagent.WithResourceDetector(
+		opts := make([]ocagent.ExporterOption, 0, len(stored)+1)
+		opts = append(opts, stored...)
+		opts = append(opts, ocagent.WithResourceDetector(
 			func(context.Context) (*resource.Resource, error) {
 				return r, nil
 			}))

--- a/metrics/prometheus_exporter.go
+++ b/metrics/prometheus_exporter.go
@@ -42,7 +42,6 @@ func (emptyPromExporter) ExportView(viewData *view.Data) {
 	// a signal to enrich the internal Meters with Resource information.
 }
 
-// nolint: unparam // False positive of flagging the second result of this function unused.
 func newPrometheusExporter(config *metricsConfig, logger *zap.SugaredLogger) (view.Exporter, ResourceExporterFactory, error) {
 	e, err := prom.NewExporter(prom.Options{Namespace: config.component})
 	if err != nil {

--- a/metrics/resource_view.go
+++ b/metrics/resource_view.go
@@ -307,7 +307,7 @@ func optionForResource(r *resource.Resource) (stats.Options, error) {
 			// If we can't create exporters but we have a Meter, return that.
 			return mE.o, nil
 		}
-		return nil, fmt.Errorf("whoops, allMeters.factory is nil")
+		return nil, errors.New("whoops, allMeters.factory is nil")
 	}
 	exporter, err := allMeters.factory(r)
 	if err != nil {

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -204,7 +205,7 @@ func TestIfAllMeterResourcesAreRemoved(t *testing.T) {
 	// Register many resources at once
 	for i := 1; i <= 100; i++ {
 		res := resource.Resource{Labels: map[string]string{"foo": "bar"}}
-		res.Labels["id"] = fmt.Sprint(i)
+		res.Labels["id"] = strconv.Itoa(i)
 		if _, err := optionForResource(&res); err != nil {
 			t.Error("Should succeed getting option, instead got error ", err)
 		}

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -266,7 +266,7 @@ func TestResourceAsString(t *testing.T) {
 	r3 := &resource.Resource{Type: "foobar", Labels: map[string]string{"k1": "v1", "k2": "v2", "k4": "v4"}}
 
 	// Test 5 time since the iteration could be random.
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		if s1, s2 := resourceToKey(r1), resourceToKey(r2); s1 != s2 {
 			t.Errorf("Expect same resources, but got %q and %q", s1, s2)
 		}
@@ -280,7 +280,7 @@ func TestResourceAsString(t *testing.T) {
 func BenchmarkResourceToKey(b *testing.B) {
 	for _, count := range []int{0, 1, 5, 10} {
 		labels := make(map[string]string, count)
-		for i := 0; i < count; i++ {
+		for i := range count {
 			labels[fmt.Sprint("key", i)] = fmt.Sprint("value", i)
 		}
 		r := &resource.Resource{Type: "foobar", Labels: labels}

--- a/network/handlers/drain_test.go
+++ b/network/handlers/drain_test.go
@@ -560,7 +560,7 @@ func TestResetWithActiveRequests(t *testing.T) {
 	defer close(trafficStopped)
 
 	go func() {
-		req, _ := http.NewRequest("GET", "knative.dev", nil)
+		req, _ := http.NewRequest(http.MethodGet, "knative.dev", nil)
 		rec := httptest.NewRecorder()
 
 		close(trafficStarted)

--- a/network/handlers/drain_test.go
+++ b/network/handlers/drain_test.go
@@ -154,7 +154,7 @@ func TestDrainMechanics(t *testing.T) {
 	}
 	rc++
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		mt.advance(timeout - epsilon)
 		select {
 		case <-done:

--- a/network/transports_test.go
+++ b/network/transports_test.go
@@ -236,7 +236,7 @@ func findUnusedPortOrFail(t testingT) int {
 var errTest = errors.New("testing")
 
 func newTestErr(msg string, err error) error {
-	return fmt.Errorf("%w: %s: %v", errTest, msg, err)
+	return fmt.Errorf("%w: %s: %w", errTest, msg, err)
 }
 
 // listenOne creates a socket with backlog of one, and use that socket, so

--- a/network/transports_test.go
+++ b/network/transports_test.go
@@ -68,7 +68,10 @@ func TestHTTPRoundTripper(t *testing.T) {
 		t.Run(e.label, func(t *testing.T) {
 			wants.Delete(e.want)
 			r := &http.Request{ProtoMajor: e.protoMajor}
-			rt.RoundTrip(r)
+			resp, err := rt.RoundTrip(r)
+			if err != nil {
+				defer resp.Body.Close()
+			}
 
 			if !wants.Has(e.want) {
 				t.Error("Wrong transport selected for request.")

--- a/reconciler/configstore.go
+++ b/reconciler/configstore.go
@@ -33,7 +33,7 @@ var _ ConfigStore = ConfigStores{}
 
 func (stores ConfigStores) ToContext(ctx context.Context) context.Context {
 	for _, s := range stores {
-		ctx = s.ToContext(ctx)
+		ctx = s.ToContext(ctx) //nolint:fatcontext
 	}
 	return ctx
 }

--- a/reconciler/events.go
+++ b/reconciler/events.go
@@ -62,7 +62,7 @@ func NewEvent(eventtype, reason, messageFmt string, args ...interface{}) Event {
 
 // ReconcilerEvent wraps the fields required for recorders to create a
 // kubernetes recorder Event.
-type ReconcilerEvent struct { //nolint:revive // for backcompat.
+type ReconcilerEvent struct { //nolint:errname
 	EventType string
 	Reason    string
 	Format    string

--- a/reconciler/testing/context.go
+++ b/reconciler/testing/context.go
@@ -51,7 +51,7 @@ func SetupFakeContextWithCancel(t testing.TB, fs ...func(context.Context) contex
 	ctx, c := context.WithCancel(logtesting.TestContextWithLogger(t))
 	ctx = controller.WithEventRecorder(ctx, record.NewFakeRecorder(1000))
 	for _, f := range fs {
-		ctx = f(ctx)
+		ctx = f(ctx) //nolint:fatcontext
 	}
 	ctx = injection.WithConfig(ctx, &rest.Config{})
 

--- a/reconciler/testing/table.go
+++ b/reconciler/testing/table.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"path"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -168,7 +169,8 @@ func (r *TableRow) Test(t *testing.T, factory Factory) {
 		t.Errorf("Error capturing actions by verb: %q", err)
 	}
 
-	effectiveOpts := append(r.CmpOpts, defaultCmpOpts...)
+	effectiveOpts := slices.Concat(r.CmpOpts, defaultCmpOpts)
+
 	// Previous state is used to diff resource expected state for update requests that were missed.
 	objPrevState := make(map[string]runtime.Object, len(r.Objects))
 	for _, o := range r.Objects {

--- a/test/helpers/name.go
+++ b/test/helpers/name.go
@@ -32,12 +32,14 @@ const (
 	testNamePrefix  = "Test"
 )
 
+var nameRand *rand.Rand
+
 func init() {
 	// Properly seed the random number generator so RandomString() is actually random.
 	// Otherwise, rerunning tests will generate the same names for the test resources, causing conflicts with
 	// already existing resources.
 	seed := time.Now().UTC().UnixNano()
-	rand.Seed(seed)
+	nameRand = rand.New(rand.NewSource(seed))
 }
 
 type named interface {
@@ -74,7 +76,7 @@ func AppendRandomString(prefix string) string {
 func RandomString() string {
 	suffix := make([]byte, randSuffixLen)
 	for i := range suffix {
-		suffix[i] = letterBytes[rand.Intn(len(letterBytes))]
+		suffix[i] = letterBytes[nameRand.Intn(len(letterBytes))]
 	}
 	return string(suffix)
 }

--- a/test/ingress/ingress.go
+++ b/test/ingress/ingress.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,8 +60,8 @@ func GetIngressEndpoint(ctx context.Context, kubeClientset kubernetes.Interface,
 	if endpointOverride != "" {
 		return endpointOverride, func(port string) string {
 			for _, sp := range ingress.Spec.Ports {
-				if fmt.Sprint(sp.Port) == port {
-					return fmt.Sprint(sp.NodePort)
+				if strconv.Itoa(int(sp.Port)) == port {
+					return strconv.Itoa(int(sp.NodePort))
 				}
 			}
 			return port

--- a/test/logging/logging.go
+++ b/test/logging/logging.go
@@ -67,6 +67,8 @@ func (e *zapMetricExporter) ExportView(vd *view.Data) {
 
 // GetEmitableSpan starts and returns a trace.Span with a name that
 // is used by the ExportSpan method to emit the span.
+//
+//nolint:spancheck
 func GetEmitableSpan(ctx context.Context, metricName string) *trace.Span {
 	_, span := trace.StartSpan(ctx, emitableSpanNamePrefix+metricName)
 	return span

--- a/test/logstream/v2/stream.go
+++ b/test/logstream/v2/stream.go
@@ -156,7 +156,6 @@ func (s *logSource) watchPods() error {
 							s.startForPod(p)
 						}
 					}
-
 				}
 			}
 		}()

--- a/test/logstream/v2/stream_test.go
+++ b/test/logstream/v2/stream_test.go
@@ -376,7 +376,6 @@ func logsForContainer(container string) string {
 			result += "\n"
 		}
 		result += s
-
 	}
 	return result
 }

--- a/test/spoof/error_checks_test.go
+++ b/test/spoof/error_checks_test.go
@@ -51,7 +51,7 @@ func TestDNSError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
 			resp, err := client.Do(req)
-			if err != nil {
+			if resp != nil {
 				defer resp.Body.Close()
 			}
 			if dnsError := isDNSError(err); tt.dnsError != dnsError {
@@ -84,7 +84,7 @@ func TestConnectionRefused(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
 			resp, err := client.Do(req)
-			if err != nil {
+			if resp != nil {
 				defer resp.Body.Close()
 			}
 			if connRefused := isConnectionRefused(err); tt.connRefused != connRefused {
@@ -144,7 +144,7 @@ func TestTCPTimeout(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
 			resp, err := client.Do(req)
-			if err != nil {
+			if resp != nil {
 				defer resp.Body.Close()
 			}
 			if tcpTimeout := isTCPTimeout(err); tt.tcpTimeout != tcpTimeout {

--- a/test/spoof/error_checks_test.go
+++ b/test/spoof/error_checks_test.go
@@ -50,7 +50,10 @@ func TestDNSError(t *testing.T) {
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
-			_, err := client.Do(req)
+			resp, err := client.Do(req)
+			if err != nil {
+				defer resp.Body.Close()
+			}
 			if dnsError := isDNSError(err); tt.dnsError != dnsError {
 				t.Errorf("Expected dnsError=%v, got %v", tt.dnsError, dnsError)
 			}
@@ -80,7 +83,10 @@ func TestConnectionRefused(t *testing.T) {
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
-			_, err := client.Do(req)
+			resp, err := client.Do(req)
+			if err != nil {
+				defer resp.Body.Close()
+			}
 			if connRefused := isConnectionRefused(err); tt.connRefused != connRefused {
 				t.Errorf("Expected connRefused=%v, got %v", tt.connRefused, connRefused)
 			}
@@ -137,7 +143,10 @@ func TestTCPTimeout(t *testing.T) {
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
-			_, err := client.Do(req)
+			resp, err := client.Do(req)
+			if err != nil {
+				defer resp.Body.Close()
+			}
 			if tcpTimeout := isTCPTimeout(err); tt.tcpTimeout != tcpTimeout {
 				t.Errorf("Expected tcpTimeout=%v, got %v", tt.tcpTimeout, tcpTimeout)
 			}

--- a/test/spoof/error_checks_test.go
+++ b/test/spoof/error_checks_test.go
@@ -49,7 +49,7 @@ func TestDNSError(t *testing.T) {
 		dnsError: false,
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", tt.url, nil)
+			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
 			_, err := client.Do(req)
 			if dnsError := isDNSError(err); tt.dnsError != dnsError {
 				t.Errorf("Expected dnsError=%v, got %v", tt.dnsError, dnsError)
@@ -79,7 +79,7 @@ func TestConnectionRefused(t *testing.T) {
 		connRefused: false,
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", tt.url, nil)
+			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
 			_, err := client.Do(req)
 			if connRefused := isConnectionRefused(err); tt.connRefused != connRefused {
 				t.Errorf("Expected connRefused=%v, got %v", tt.connRefused, connRefused)
@@ -136,7 +136,7 @@ func TestTCPTimeout(t *testing.T) {
 		tcpTimeout: false,
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", tt.url, nil)
+			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
 			_, err := client.Do(req)
 			if tcpTimeout := isTCPTimeout(err); tt.tcpTimeout != tcpTimeout {
 				t.Errorf("Expected tcpTimeout=%v, got %v", tt.tcpTimeout, tcpTimeout)

--- a/test/spoof/spoof_test.go
+++ b/test/spoof/spoof_test.go
@@ -21,7 +21,6 @@ package spoof
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"sync/atomic"
@@ -75,7 +74,7 @@ func TestSpoofingClient_CheckEndpointState(t *testing.T) {
 		name:      "Error response doesn't trigger a second check",
 		transport: &fakeTransport{response: successResponse},
 		inState: func(resp *Response) (done bool, err error) {
-			return false, fmt.Errorf("response error")
+			return false, errors.New("response error")
 		},
 		wantErr:   true,
 		wantCalls: 1,
@@ -147,7 +146,7 @@ func TestSpoofingClient_WaitForEndpointState(t *testing.T) {
 		name:      "Error response doesn't trigger more requests",
 		transport: &fakeTransport{response: successResponse},
 		inState: func(resp *Response) (done bool, err error) {
-			return false, fmt.Errorf("response error")
+			return false, errors.New("response error")
 		},
 		wantErr:   true,
 		wantCalls: 1,

--- a/test/spoof/spoof_test.go
+++ b/test/spoof/spoof_test.go
@@ -47,12 +47,16 @@ type fakeTransport struct {
 
 func (ft *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	call := ft.calls.Add(1)
-	if ft.response != nil && call == 2 {
-		// If both a response and an error is defined, we return just the response on
-		// the second call to simulate a retry that passes eventually.
+	if ft.response != nil && ft.err != nil {
+		if call == 2 {
+			return ft.response, nil
+		}
+		return nil, ft.err
+	} else if ft.response != nil {
 		return ft.response, nil
 	}
-	return ft.response, ft.err
+
+	return nil, ft.err
 }
 
 func TestSpoofingClient_CheckEndpointState(t *testing.T) {

--- a/test/spoof/spoof_test.go
+++ b/test/spoof/spoof_test.go
@@ -32,7 +32,7 @@ import (
 var (
 	successResponse = &http.Response{
 		Status:     "200 ok",
-		StatusCode: 200,
+		StatusCode: http.StatusOK,
 		Header:     http.Header{},
 		Body:       http.NoBody,
 	}

--- a/test/upgrade/testing_operations_test.go
+++ b/test/upgrade/testing_operations_test.go
@@ -238,7 +238,7 @@ func (o operation) Name() string {
 }
 
 func (o *operation) fail(setupFail bool) {
-	testName := fmt.Sprintf("FailingOf%s", o.Name())
+	testName := "FailingOf" + o.Name()
 	if o.op != nil {
 		prev := o.op
 		o.op = upgrade.NewOperation(testName, func(c upgrade.Context) {

--- a/test/vegeta/pacers/steady_up_pacer.go
+++ b/test/vegeta/pacers/steady_up_pacer.go
@@ -96,7 +96,7 @@ func (sup *steadyUpPacer) Pace(elapsedTime time.Duration, elapsedHits uint64) (t
 
 	// If we can't converge to an error of <1e-3 within 10 iterations, bail.
 	// This rarely even loops for any large Period if hitsToWait is small.
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		hitsAtGuess := sup.hits(elapsedTime + nextHitIn)
 		err := float64(elapsedHits+1) - hitsAtGuess
 		if math.Abs(err) < 1e-3 {

--- a/testing/resource.go
+++ b/testing/resource.go
@@ -156,7 +156,7 @@ func (r *Resource) CheckAllowedSubresourceUpdate(ctx context.Context, original *
 	if apis.GetUpdatedSubresource(ctx) == disallowedSubresource {
 		return &apis.FieldError{
 			Message: "Disallowed subresource update",
-			Details: fmt.Sprintf("Disallowed subresource update: %s", disallowedSubresource),
+			Details: "Disallowed subresource update: " + disallowedSubresource,
 		}
 	}
 	return nil

--- a/tracing/config/tracing.go
+++ b/tracing/config/tracing.go
@@ -150,7 +150,7 @@ func TracingConfigToJSON(cfg *Config) (string, error) { //nolint // for backcomp
 	if cfg.ZipkinEndpoint != "" {
 		out[zipkinEndpointKey] = cfg.ZipkinEndpoint
 	}
-	out[debugKey] = fmt.Sprint(cfg.Debug)
+	out[debugKey] = strconv.FormatBool(cfg.Debug)
 	out[sampleRateKey] = fmt.Sprint(cfg.SampleRate)
 
 	jsonCfg, err := json.Marshal(out)

--- a/tracing/config/tracing.go
+++ b/tracing/config/tracing.go
@@ -135,7 +135,7 @@ func JSONToTracingConfig(jsonCfg string) (*Config, error) {
 
 	cfg, err := NewTracingConfigFromMap(configMap)
 	if err != nil {
-		return NoopConfig(), nil
+		return NoopConfig(), nil //nolint:nilerr
 	}
 	return cfg, nil
 }

--- a/tracing/config/tracing.go
+++ b/tracing/config/tracing.go
@@ -140,7 +140,7 @@ func JSONToTracingConfig(jsonCfg string) (*Config, error) {
 	return cfg, nil
 }
 
-func TracingConfigToJSON(cfg *Config) (string, error) { //nolint // for backcompat.
+func TracingConfigToJSON(cfg *Config) (string, error) {
 	if cfg == nil {
 		return "", nil
 	}

--- a/tracing/sampler_test.go
+++ b/tracing/sampler_test.go
@@ -78,7 +78,7 @@ func TestCreateOCTConfig(t *testing.T) {
 			octCfg := createOCTConfig(&tc.cfg)
 
 			// Create 100 traceIDs and make sure our expected sampler samples the same as what we get
-			for i := 0; i < 100; i++ {
+			for range 100 {
 				spanID := make([]byte, 8)
 				rand.Read(spanID)
 				param := trace.SamplingParameters{}

--- a/tracker/enqueue_test.go
+++ b/tracker/enqueue_test.go
@@ -401,7 +401,7 @@ func TestBadObjectReferences(t *testing.T) {
 			if err := trk.Track(test.objRef, thing1); err == nil {
 				t.Fatal("Track() = nil, wanted error")
 			} else {
-				match, e2 := regexp.Match(test.match, []byte(err.Error()))
+				match, e2 := regexp.MatchString(test.match, err.Error())
 				if e2 != nil {
 					t.Fatalf("Failed to compile %q: %v", e2, test.match)
 				} else if !match {
@@ -463,7 +463,7 @@ func TestBadReferences(t *testing.T) {
 			if err := trk.TrackReference(test.objRef, thing1); err == nil {
 				t.Fatal("Track() = nil, wanted error")
 			} else {
-				match, e2 := regexp.Match(test.match, []byte(err.Error()))
+				match, e2 := regexp.MatchString(test.match, err.Error())
 				if e2 != nil {
 					t.Fatalf("Failed to compile %q: %v", e2, test.match)
 				} else if !match {

--- a/webhook/admission_integration_test.go
+++ b/webhook/admission_integration_test.go
@@ -156,7 +156,7 @@ func TestAdmissionValidResponseForResourceTLS(t *testing.T) {
 
 	u.Path = path.Join(u.Path, ac.Path())
 
-	req, err := http.NewRequest("GET", u.String(), reqBuf)
+	req, err := http.NewRequest(http.MethodGet, u.String(), reqBuf)
 	if err != nil {
 		t.Fatal("http.NewRequest() =", err)
 	}
@@ -280,7 +280,7 @@ func TestAdmissionValidResponseForResource(t *testing.T) {
 
 	u.Path = path.Join(u.Path, ac.Path())
 
-	req, err := http.NewRequest("GET", u.String(), reqBuf)
+	req, err := http.NewRequest(http.MethodGet, u.String(), reqBuf)
 	if err != nil {
 		t.Fatal("http.NewRequest() =", err)
 	}
@@ -415,7 +415,7 @@ func TestAdmissionInvalidResponseForResource(t *testing.T) {
 
 	u.Path = path.Join(u.Path, ac.Path())
 
-	req, err := http.NewRequest("GET", u.String(), reqBuf)
+	req, err := http.NewRequest(http.MethodGet, u.String(), reqBuf)
 	if err != nil {
 		t.Fatal("http.NewRequest() =", err)
 	}
@@ -531,7 +531,7 @@ func TestAdmissionWarningResponseForResource(t *testing.T) {
 
 	u.Path = path.Join(u.Path, ac.Path())
 
-	req, err := http.NewRequest("GET", u.String(), reqBuf)
+	req, err := http.NewRequest(http.MethodGet, u.String(), reqBuf)
 	if err != nil {
 		t.Fatal("http.NewRequest() =", err)
 	}
@@ -628,7 +628,7 @@ func TestAdmissionValidResponseForRequestBody(t *testing.T) {
 
 	u.Path = path.Join(u.Path, ac.Path())
 
-	req, err := http.NewRequest("GET", u.String(), reqBuf)
+	req, err := http.NewRequest(http.MethodGet, u.String(), reqBuf)
 	if err != nil {
 		t.Fatal("http.NewRequest() =", err)
 	}

--- a/webhook/configmaps/configmaps_test.go
+++ b/webhook/configmaps/configmaps_test.go
@@ -19,6 +19,7 @@ package configmaps
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"testing"
@@ -274,7 +275,7 @@ func newConfigFromConfigMap(configMap *corev1.ConfigMap) (*config, error) {
 		field: &cfg.value,
 	}} {
 		if raw, ok := data[b.key]; !ok {
-			return nil, fmt.Errorf("not found")
+			return nil, errors.New("not found")
 		} else if val, err := strconv.ParseFloat(raw, 64); err != nil {
 			return nil, err
 		} else {
@@ -284,7 +285,7 @@ func newConfigFromConfigMap(configMap *corev1.ConfigMap) (*config, error) {
 
 	// some sample validation on the value
 	if cfg.value > 2.0 || cfg.value < 0.0 {
-		return nil, fmt.Errorf("out of range")
+		return nil, errors.New("out of range")
 	}
 
 	return cfg, nil

--- a/webhook/conversion_integration_test.go
+++ b/webhook/conversion_integration_test.go
@@ -105,7 +105,7 @@ func TestConversionValidResponse(t *testing.T) {
 		t.Fatal("Failed to marshal conversion review:", err)
 	}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s%s", serverURL, cc.Path()), reqBuf)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s%s", serverURL, cc.Path()), reqBuf)
 	if err != nil {
 		t.Fatal("http.NewRequest() =", err)
 	}
@@ -193,7 +193,7 @@ func TestConversionInvalidResponse(t *testing.T) {
 		t.Fatal("Failed to marshal conversion review:", err)
 	}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s%s", serverURL, cc.Path()), reqBuf)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s%s", serverURL, cc.Path()), reqBuf)
 	if err != nil {
 		t.Fatal("http.NewRequest() =", err)
 	}

--- a/webhook/json/decode.go
+++ b/webhook/json/decode.go
@@ -19,6 +19,7 @@ package json
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 )
 
@@ -95,7 +96,7 @@ func findMetadataOffsets(bites []byte) (start, end int64, err error) {
 
 	for {
 		t, err = dec.Token()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/webhook/json/decode.go
+++ b/webhook/json/decode.go
@@ -95,7 +95,7 @@ func findMetadataOffsets(bites []byte) (start, end int64, err error) {
 
 	for {
 		t, err = dec.Token()
-		if err == io.EOF { //nolint
+		if err == io.EOF {
 			break
 		}
 		if err != nil {

--- a/webhook/psbinding/reconciler.go
+++ b/webhook/psbinding/reconciler.go
@@ -391,7 +391,6 @@ func (r *BaseReconciler) ReconcileSubject(ctx context.Context, fb Bindable, muta
 	// For each of the referents, apply the mutation.
 	eg := errgroup.Group{}
 	for _, ps := range referents {
-		ps := ps
 		eg.Go(func() error {
 			// Do the binding to the pod specable.
 			orig := ps.DeepCopy()

--- a/webhook/psbinding/reconciler.go
+++ b/webhook/psbinding/reconciler.go
@@ -113,7 +113,7 @@ func (r *BaseReconciler) Reconcile(ctx context.Context, key string) error {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		logging.FromContext(ctx).Error("invalid resource key: ", key)
-		return nil
+		return nil //nolint:nilerr
 	}
 
 	// Only the leader should reconcile binding resources.

--- a/webhook/resourcesemantics/conversion/internal/types.go
+++ b/webhook/resourcesemantics/conversion/internal/types.go
@@ -88,7 +88,7 @@ type (
 	// ErrorResource explodes in various settings depending on the property
 	// set. Use the Error* constants
 	//
-	//This type is used for testing conversion webhooks
+	// This type is used for testing conversion webhooks
 	//
 	// +k8s:deepcopy-gen=true
 	// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/webhook/resourcesemantics/defaulting/defaulting_test.go
+++ b/webhook/resourcesemantics/defaulting/defaulting_test.go
@@ -978,13 +978,13 @@ func resourceCallback(ctx context.Context, uns *unstructured.Unstructured) error
 		resource.Spec.FieldForCallbackDefaulting = "I'm a default"
 		if apis.IsInUpdate(ctx) {
 			if apis.GetBaseline(ctx) == nil {
-				return fmt.Errorf("expected baseline object")
+				return errors.New("expected baseline object")
 			}
 			if v, ok := apis.GetBaseline(ctx).(*unstructured.Unstructured); !ok {
 				return fmt.Errorf("expected *unstructured.Unstructured, got %v", reflect.TypeOf(v))
 			}
 		} else if !apis.IsInCreate(ctx) {
-			return fmt.Errorf("expected to have context within update or create")
+			return errors.New("expected to have context within update or create")
 		}
 	}
 

--- a/webhook/resourcesemantics/validation/validation_admit.go
+++ b/webhook/resourcesemantics/validation/validation_admit.go
@@ -160,7 +160,8 @@ func (ac *reconciler) decodeRequestAndPrepareContext(
 	return ctx, newObj, nil
 }
 
-func validate(ctx context.Context, resource resourcesemantics.GenericCRD, req *admissionv1.AdmissionRequest) (err error, warn []error) { //nolint
+//nolint:stylecheck
+func validate(ctx context.Context, resource resourcesemantics.GenericCRD, req *admissionv1.AdmissionRequest) (err error, warn []error) {
 	logger := logging.FromContext(ctx)
 
 	// Only run validation for supported create and update validation.

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -176,6 +176,7 @@ func New(
 		// a new secret informer from it.
 		secretInformer := kubeinformerfactory.Get(ctx).Core().V1().Secrets()
 
+		//nolint:gosec // operator configures TLS min version (default is 1.3)
 		webhook.tlsConfig = &tls.Config{
 			MinVersion: opts.TLSMinVersion,
 

--- a/webhook/webhook_integration_test.go
+++ b/webhook/webhook_integration_test.go
@@ -77,7 +77,7 @@ func TestMissingContentType(t *testing.T) {
 		t.Fatal("createSecureTLSClient() =", err)
 	}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s", serverURL), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s", serverURL), nil)
 	if err != nil {
 		t.Fatal("http.NewRequest() =", err)
 	}
@@ -152,7 +152,7 @@ func testEmptyRequestBody(t *testing.T, controller interface{}) {
 		t.Fatal("createSecureTLSClient() =", err)
 	}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/bazinga", serverURL), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s/bazinga", serverURL), nil)
 	if err != nil {
 		t.Fatal("http.NewRequest() =", err)
 	}

--- a/webhook/webhook_integration_test.go
+++ b/webhook/webhook_integration_test.go
@@ -77,7 +77,7 @@ func TestMissingContentType(t *testing.T) {
 		t.Fatal("createSecureTLSClient() =", err)
 	}
 
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s", serverURL), nil)
+	req, err := http.NewRequest(http.MethodGet, "https://"+serverURL, nil)
 	if err != nil {
 		t.Fatal("http.NewRequest() =", err)
 	}

--- a/websocket/connection.go
+++ b/websocket/connection.go
@@ -134,7 +134,7 @@ func NewDurableConnection(target string, messageChan chan []byte, logger *zap.Su
 			// by restarting the serving side of the connection behind a Kubernetes Service.
 			HandshakeTimeout: 3 * time.Second,
 		}
-		conn, resp, err := dialer.Dial(target, nil)
+		conn, resp, err := dialer.Dial(target, nil) //nolint:bodyclose
 		if err != nil {
 			if resp != nil {
 				dresp, _ := httputil.DumpResponse(resp, true /*body*/) // This is for logging so don't care if it fails.

--- a/websocket/connection_test.go
+++ b/websocket/connection_test.go
@@ -364,7 +364,7 @@ func TestDurableConnectionWhenConnectionBreaksDown(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		err := wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 			if err := conn.Send(testPayload); err != nil {
-				return false, nil
+				return false, nil //nolint:nilerr
 			}
 			return true, nil
 		})

--- a/websocket/connection_test.go
+++ b/websocket/connection_test.go
@@ -361,7 +361,7 @@ func TestDurableConnectionWhenConnectionBreaksDown(t *testing.T) {
 	conn := NewDurableSendingConnection(target, logger)
 	defer conn.Shutdown()
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		err := wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 			if err := conn.Send(testPayload); err != nil {
 				return false, nil //nolint:nilerr
@@ -414,7 +414,7 @@ func TestDurableConnectionSendsPingsRegularly(t *testing.T) {
 	defer conn.Shutdown()
 
 	// Wait for 5 pings to be received by the server.
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		<-pingReceived
 	}
 }


### PR DESCRIPTION
- **fix whitespace linter**
- **fix usestdlibvars**
- **fix staticheck**
- **ignore spancheck warning**
- **fix linter perfsprint**
- **fix nolintlint feedback**
- **fix nilerr lint checks**
- **fix misspell**
- **fix mirror lint**
- **fix intrange linter**
- **fix gofumpt linter**
- **fix gosec linter - ignore warning since default min tls version is 1.3**
- **fix gocritic linter**
- **fix whitespace**
- **fix fatcontext linter**
- **fix errorlint**
- **fix errname linter**
- **fix copyloopvar (go1.22) linter**
- **fix bodyclose linter**
- **update linter config**
- **add script to format code**
