### PR TITLE
:broom: Give users the ability to disable namespace ownership of webhook configurations

### DIFF
--- a/webhook/configmaps/configmaps.go
+++ b/webhook/configmaps/configmaps.go
@@ -58,7 +58,8 @@ type reconciler struct {
 	vwhlister    admissionlisters.ValidatingWebhookConfigurationLister
 	secretlister corelisters.SecretLister
 
-	secretName string
+	secretName                string
+	disableNamespaceOwnership bool
 }
 
 var (
@@ -138,13 +139,15 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 
 	webhook := configuredWebhook.DeepCopy()
 
-	// Set the owner to namespace.
-	ns, err := ac.client.CoreV1().Namespaces().Get(ctx, system.Namespace(), metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to fetch namespace: %w", err)
+	if !ac.disableNamespaceOwnership {
+		// Set the owner to namespace.
+		ns, err := ac.client.CoreV1().Namespaces().Get(ctx, system.Namespace(), metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to fetch namespace: %w", err)
+		}
+		nsRef := *metav1.NewControllerRef(ns, corev1.SchemeGroupVersion.WithKind("Namespace"))
+		webhook.OwnerReferences = []metav1.OwnerReference{nsRef}
 	}
-	nsRef := *metav1.NewControllerRef(ns, corev1.SchemeGroupVersion.WithKind("Namespace"))
-	webhook.OwnerReferences = []metav1.OwnerReference{nsRef}
 
 	for i, wh := range webhook.Webhooks {
 		if wh.Name != webhook.Name {

--- a/webhook/configmaps/controller.go
+++ b/webhook/configmaps/controller.go
@@ -60,8 +60,9 @@ func NewAdmissionController(
 		key:  key,
 		path: path,
 
-		constructors: make(map[string]reflect.Value),
-		secretName:   options.SecretName,
+		constructors:              make(map[string]reflect.Value),
+		secretName:                options.SecretName,
+		disableNamespaceOwnership: options.DisableNamespaceOwnership,
 
 		client:       client,
 		vwhlister:    vwhInformer.Lister(),

--- a/webhook/resourcesemantics/defaulting/controller.go
+++ b/webhook/resourcesemantics/defaulting/controller.go
@@ -100,9 +100,10 @@ func newController(ctx context.Context, name string, optsFunc ...OptionFunc) *co
 		handlers:  opts.types,
 		callbacks: opts.callbacks,
 
-		withContext:           opts.wc,
-		disallowUnknownFields: opts.disallowUnknownFields,
-		secretName:            wopts.SecretName,
+		withContext:               opts.wc,
+		disallowUnknownFields:     opts.disallowUnknownFields,
+		secretName:                wopts.SecretName,
+		disableNamespaceOwnership: wopts.DisableNamespaceOwnership,
 
 		client:       client,
 		mwhlister:    mwhInformer.Lister(),

--- a/webhook/resourcesemantics/validation/controller.go
+++ b/webhook/resourcesemantics/validation/controller.go
@@ -86,9 +86,10 @@ func newController(ctx context.Context, name string, optsFunc ...OptionFunc) *co
 		handlers:  opts.types,
 		callbacks: opts.callbacks,
 
-		withContext:           opts.wc,
-		disallowUnknownFields: opts.DisallowUnknownFields(),
-		secretName:            woptions.SecretName,
+		withContext:               opts.wc,
+		disallowUnknownFields:     opts.DisallowUnknownFields(),
+		secretName:                woptions.SecretName,
+		disableNamespaceOwnership: woptions.DisableNamespaceOwnership,
 
 		client:       client,
 		vwhlister:    vwhInformer.Lister(),

--- a/webhook/resourcesemantics/validation/reconcile_config.go
+++ b/webhook/resourcesemantics/validation/reconcile_config.go
@@ -60,8 +60,9 @@ type reconciler struct {
 	vwhlister    admissionlisters.ValidatingWebhookConfigurationLister
 	secretlister corelisters.SecretLister
 
-	disallowUnknownFields bool
-	secretName            string
+	disallowUnknownFields     bool
+	secretName                string
+	disableNamespaceOwnership bool
 }
 
 var (
@@ -193,13 +194,15 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 
 	current := configuredWebhook.DeepCopy()
 
-	// Set the owner to namespace.
-	ns, err := ac.client.CoreV1().Namespaces().Get(ctx, system.Namespace(), metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to fetch namespace: %w", err)
+	if !ac.disableNamespaceOwnership {
+		// Set the owner to namespace.
+		ns, err := ac.client.CoreV1().Namespaces().Get(ctx, system.Namespace(), metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to fetch namespace: %w", err)
+		}
+		nsRef := *metav1.NewControllerRef(ns, corev1.SchemeGroupVersion.WithKind("Namespace"))
+		current.OwnerReferences = []metav1.OwnerReference{nsRef}
 	}
-	nsRef := *metav1.NewControllerRef(ns, corev1.SchemeGroupVersion.WithKind("Namespace"))
-	current.OwnerReferences = []metav1.OwnerReference{nsRef}
 
 	for i, wh := range current.Webhooks {
 		if wh.Name != current.Name {

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -81,6 +81,10 @@ type Options struct {
 	// before shutting down.
 	GracePeriod time.Duration
 
+	// DisableNamespaceOwnership configures whether the webhook adds an owner reference for the SYSTEM_NAMESPACE
+	// Disabling this is useful when you expect the webhook configuration to be managed by something other than knative
+	DisableNamespaceOwnership bool
+
 	// ControllerOptions encapsulates options for creating a new controller,
 	// including throttling and stats behavior.
 	ControllerOptions *controller.ControllerOptions


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

Allow users to configure `DisableNamespaceOwnership` in webhook options. This ensures that users that have other manifest managers of ValidatingWebhookConfigurations and MutatingWebhookConfigurations don't hit conflicts when ownership is overridden.

This has specific detrimental impact when using ArgoCD which [checks for ownerReferences before determining whether it should prune a resource](https://github.com/argoproj/gitops-engine/blob/master/pkg/cache/cluster.go#L1167). This has [caused issues for `kubernetes-sigs/karpenter`](https://github.com/aws/karpenter-provider-aws/issues/6982), which uses `knative/pkg` for webhook management.

I've tested this change in the `sigs.k8s.io/karpenter` codebase with [this commit](https://github.com/jonathan-innis/karpenter/commit/0922f28fae7718a3f46912c859f15a67a5ed757d) and it's completely solved our Argo interaction issues.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind cleanup

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/knative/serving/issues/15483

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Allow passing `DisableNamespaceOwnership` in `webhook.Options` to remove webhook ownerReferences
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
