### PR TITLE
Add `WEBHOOK_DISABLE_NAMESPACE_OWNERSHIP` env-var

### DIFF
--- a/webhook/env.go
+++ b/webhook/env.go
@@ -32,6 +32,8 @@ const (
 	secretNameEnvKey = "WEBHOOK_SECRET_NAME" //nolint:gosec // This is not a hardcoded credential
 
 	tlsMinVersionEnvKey = "WEBHOOK_TLS_MIN_VERSION"
+
+	disableNamespaceOwnershipEnvKey = "WEBHOOK_DISABLE_NAMESPACE_OWNERSHIP"
 )
 
 // PortFromEnv returns the webhook port set by portEnvKey, or default port if env var is not set.
@@ -81,4 +83,16 @@ func TLSMinVersionFromEnv(defaultTLSMinVersion uint16) uint16 {
 	default:
 		panic(fmt.Sprintf("the environment variable %q has to be either '1.2' or '1.3'", tlsMinVersionEnvKey))
 	}
+}
+
+func DisableNamespaceOwnershipFromEnv() *bool {
+	disableNamespaceOwnership := os.Getenv(disableNamespaceOwnershipEnvKey)
+	if disableNamespaceOwnership == "" {
+		return nil
+	}
+	disableNamespaceOwnershipBool, err := strconv.ParseBool(disableNamespaceOwnership)
+	if err != nil {
+		panic(fmt.Sprintf("failed to convert the environment variable %q : %v", disableNamespaceOwnershipEnvKey, err))
+	}
+	return &disableNamespaceOwnershipBool
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Added a new environment variable `WEBHOOK_DISABLE_NAMESPACE_OWNERSHIP` to set the `DisableNamespaceOwnership` webhook option added by https://github.com/knative/pkg/pull/3095
- This allows the downstream apps (like Knative Serving) to make use of the ability to not have the Namespace own the webhook configurations, which breaks ArgoCD: https://github.com/knative/serving/issues/15483

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related https://github.com/knative/serving/issues/15483

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Added `WEBHOOK_DISABLE_NAMESPACE_OWNERSHIP` env-var to set `DisableNamespaceOwnership` in `webhook.Options`
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
