### PR TITLE
run dependabot workflow only on dependabot branches

### DIFF
--- a/.github/workflows/knative-dependabot.yaml
+++ b/.github/workflows/knative-dependabot.yaml
@@ -1,7 +1,12 @@
 name: update-dependabot
 
 on:
+  push:
+    branches:
+      - dependabot/**
   pull_request:
+    branches:
+      - dependabot/**
 
 permissions:
   contents: write


### PR DESCRIPTION
/assign @skonto 

Got the idea from - https://github.com/dependabot/dependabot-core/issues/935#issuecomment-698481919

