### PR TITLE
Add a flag in tracing config to use service instead of pod name

### DIFF
--- a/tracing/config/tracing.go
+++ b/tracing/config/tracing.go
@@ -31,11 +31,12 @@ const (
 	// ConfigName is the name of the configmap
 	ConfigName = "config-tracing"
 
-	enableKey         = "enable"
-	backendKey        = "backend"
-	zipkinEndpointKey = "zipkin-endpoint"
-	debugKey          = "debug"
-	sampleRateKey     = "sample-rate"
+	enableKey            = "enable"
+	backendKey           = "backend"
+	zipkinEndpointKey    = "zipkin-endpoint"
+	debugKey             = "debug"
+	sampleRateKey        = "sample-rate"
+	useServingServiceKey = "use-serving-service"
 )
 
 // BackendType specifies the backend to use for tracing
@@ -54,8 +55,9 @@ type Config struct {
 	Backend        BackendType
 	ZipkinEndpoint string
 
-	Debug      bool
-	SampleRate float64
+	Debug             bool
+	SampleRate        float64
+	UseServingService bool
 }
 
 // Equals returns true if two Configs are identical
@@ -66,9 +68,10 @@ func (cfg *Config) Equals(other *Config) bool {
 // NoopConfig returns a new noop config
 func NoopConfig() *Config {
 	return &Config{
-		Backend:    None,
-		Debug:      false,
-		SampleRate: 0.1,
+		Backend:           None,
+		Debug:             false,
+		SampleRate:        0.1,
+		UseServingService: false,
 	}
 }
 
@@ -98,6 +101,7 @@ func NewTracingConfigFromMap(cfgMap map[string]string) (*Config, error) {
 		cm.AsString(zipkinEndpointKey, &tc.ZipkinEndpoint),
 		cm.AsBool(debugKey, &tc.Debug),
 		cm.AsFloat64(sampleRateKey, &tc.SampleRate),
+		cm.AsBool(useServingServiceKey, &tc.UseServingService),
 	); err != nil {
 		return nil, err
 	}
@@ -152,6 +156,7 @@ func TracingConfigToJSON(cfg *Config) (string, error) {
 	}
 	out[debugKey] = strconv.FormatBool(cfg.Debug)
 	out[sampleRateKey] = fmt.Sprint(cfg.SampleRate)
+	out[useServingServiceKey] = strconv.FormatBool(cfg.UseServingService)
 
 	jsonCfg, err := json.Marshal(out)
 	return string(jsonCfg), err

--- a/tracing/config/tracing_test.go
+++ b/tracing/config/tracing_test.go
@@ -62,30 +62,34 @@ func TestNewConfigSuccess(t *testing.T) {
 	}, {
 		name: "Everything enabled (legacy)",
 		input: map[string]string{
-			enableKey:         "true",
-			zipkinEndpointKey: "some-endpoint",
-			debugKey:          "true",
-			sampleRateKey:     "0.5",
+			enableKey:            "true",
+			zipkinEndpointKey:    "some-endpoint",
+			debugKey:             "true",
+			sampleRateKey:        "0.5",
+			useServingServiceKey: "true",
 		},
 		output: &Config{
-			Backend:        Zipkin,
-			Debug:          true,
-			ZipkinEndpoint: "some-endpoint",
-			SampleRate:     0.5,
+			Backend:           Zipkin,
+			Debug:             true,
+			ZipkinEndpoint:    "some-endpoint",
+			SampleRate:        0.5,
+			UseServingService: true,
 		},
 	}, {
 		name: "Everything enabled (zipkin)",
 		input: map[string]string{
-			backendKey:        "zipkin",
-			zipkinEndpointKey: "some-endpoint",
-			debugKey:          "true",
-			sampleRateKey:     "0.5",
+			backendKey:           "zipkin",
+			zipkinEndpointKey:    "some-endpoint",
+			debugKey:             "true",
+			sampleRateKey:        "0.5",
+			useServingServiceKey: "true",
 		},
 		output: &Config{
-			Backend:        Zipkin,
-			Debug:          true,
-			ZipkinEndpoint: "some-endpoint",
-			SampleRate:     0.5,
+			Backend:           Zipkin,
+			Debug:             true,
+			ZipkinEndpoint:    "some-endpoint",
+			SampleRate:        0.5,
+			UseServingService: true,
 		},
 	}}
 
@@ -116,30 +120,34 @@ func TestNewConfigJSON(t *testing.T) {
 	}, {
 		name: "Everything enabled (legacy)",
 		input: map[string]string{
-			enableKey:         "true",
-			zipkinEndpointKey: "some-endpoint",
-			debugKey:          "true",
-			sampleRateKey:     "0.5",
+			enableKey:            "true",
+			zipkinEndpointKey:    "some-endpoint",
+			debugKey:             "true",
+			sampleRateKey:        "0.5",
+			useServingServiceKey: "true",
 		},
 		output: &Config{
-			Backend:        Zipkin,
-			Debug:          true,
-			ZipkinEndpoint: "some-endpoint",
-			SampleRate:     0.5,
+			Backend:           Zipkin,
+			Debug:             true,
+			ZipkinEndpoint:    "some-endpoint",
+			SampleRate:        0.5,
+			UseServingService: true,
 		},
 	}, {
 		name: "Everything enabled (zipkin)",
 		input: map[string]string{
-			backendKey:        "zipkin",
-			zipkinEndpointKey: "some-endpoint",
-			debugKey:          "true",
-			sampleRateKey:     "0.5",
+			backendKey:           "zipkin",
+			zipkinEndpointKey:    "some-endpoint",
+			debugKey:             "true",
+			sampleRateKey:        "0.5",
+			useServingServiceKey: "true",
 		},
 		output: &Config{
-			Backend:        Zipkin,
-			Debug:          true,
-			ZipkinEndpoint: "some-endpoint",
-			SampleRate:     0.5,
+			Backend:           Zipkin,
+			Debug:             true,
+			ZipkinEndpoint:    "some-endpoint",
+			SampleRate:        0.5,
+			UseServingService: true,
 		},
 	}}
 
@@ -205,6 +213,11 @@ func TestNewConfigFailures(t *testing.T) {
 		name: "legacy key invalid",
 		input: map[string]string{
 			enableKey: "dot dash dot",
+		},
+	}, {
+		name: "useServingService invalid value",
+		input: map[string]string{
+			enableKey: "not a boolean",
 		},
 	}}
 	for _, tc := range tests {


### PR DESCRIPTION
### Add a flag in tracing config to use service instead of pod name

<!-- 
- :gift: Add new feature
-->

While the OTel migration is in progress it would be very helpful to have a flag which allows users toggling the `ServingService` to be used as the `service.name` in traces. 
This is related to [this issue](https://github.com/knative/serving/issues/12969) and would still be relevant after the migration to OTel.

From my own experience, `service.name` is used to group the traces together and when it's set to the pod name it's impossible to keep them all together.

This flag is a `noop` for existing configurations, since it defaults to `false` and will be used in [another PR](https://github.com/knative/serving/pull/15822)
I've tested it in a live cluster for true/false/undefined values in the config map, in all the cases it worked as expected.

/kind enhancement


<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
You can now use the `useServingService` flag in the tracing config to use the `ServingService` as the `service.name` in traces. Current default is to use the `ServingPod` as the `service.name`, and it remains the same if the flag is not set.
```
