### PR TITLE
group golang.org/x dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
     ignore:
       - dependency-name: "k8s.io/*"
       - dependency-name: "knative.dev/*"
+    groups:
+      golang-x:
+        patterns:
+          - "golang.org/x/*"


### PR DESCRIPTION
this groups the golang.org/x/ dependencies which frequently conflict with each other when their versions are bumped