### PR TITLE
drop cert-manager from downstream tests

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -39,7 +39,6 @@ jobs:
           - knative-extensions/eventing-rabbitmq
           - knative-extensions/eventing-redis
           - knative-extensions/kn-plugin-admin
-          - knative-extensions/net-certmanager
           - knative-extensions/net-contour
           - knative-extensions/net-istio
           - knative-extensions/net-kourier


### PR DESCRIPTION
This repo was archived when we moved the functionality into the serving controller