### PR TITLE
parse the endpoint as a URL to allow paths

### DIFF
--- a/observability/metrics/provider.go
+++ b/observability/metrics/provider.go
@@ -87,7 +87,7 @@ func readerFor(ctx context.Context, cfg Config) (sdkmetric.Reader, shutdownFunc,
 func buildGRPC(ctx context.Context, cfg Config) (sdkmetric.Reader, shutdownFunc, error) {
 	var grpcOpts []otlpmetricgrpc.Option
 
-	if opt := endpointFor(cfg, otlpmetricgrpc.WithEndpoint); opt != nil {
+	if opt := endpointFor(cfg, otlpmetricgrpc.WithEndpointURL); opt != nil {
 		grpcOpts = append(grpcOpts, opt)
 	}
 
@@ -108,7 +108,7 @@ func buildGRPC(ctx context.Context, cfg Config) (sdkmetric.Reader, shutdownFunc,
 func buildHTTP(ctx context.Context, cfg Config) (sdkmetric.Reader, shutdownFunc, error) {
 	var httpOpts []otlpmetrichttp.Option
 
-	if opt := endpointFor(cfg, otlpmetrichttp.WithEndpoint); opt != nil {
+	if opt := endpointFor(cfg, otlpmetrichttp.WithEndpointURL); opt != nil {
 		httpOpts = append(httpOpts, opt)
 	}
 

--- a/observability/metrics/provider_test.go
+++ b/observability/metrics/provider_test.go
@@ -40,6 +40,12 @@ func TestNewMeterProviderProtocols(t *testing.T) {
 		name: "prometheus",
 		c:    Config{Protocol: ProtocolPrometheus},
 	}, {
+		name: "prometheus push with path in endpoint",
+		c: Config{
+			Protocol: ProtocolHTTPProtobuf,
+			Endpoint: "http://example.com:9090/api/v1/otlp/v1/metrics",
+		},
+	}, {
 		name:    "bad protocol",
 		c:       Config{Protocol: "bad"},
 		wantErr: true,

--- a/observability/tracing/provider.go
+++ b/observability/tracing/provider.go
@@ -94,7 +94,7 @@ func exporterFor(ctx context.Context, cfg Config) (sdktrace.SpanExporter, error)
 func buildGRPC(ctx context.Context, cfg Config) (sdktrace.SpanExporter, error) {
 	var grpcOpts []otlptracegrpc.Option
 
-	if opt := endpointFor(cfg, otlptracegrpc.WithEndpoint); opt != nil {
+	if opt := endpointFor(cfg, otlptracegrpc.WithEndpointURL); opt != nil {
 		grpcOpts = append(grpcOpts, opt)
 	}
 
@@ -108,7 +108,7 @@ func buildGRPC(ctx context.Context, cfg Config) (sdktrace.SpanExporter, error) {
 func buildHTTP(ctx context.Context, cfg Config) (sdktrace.SpanExporter, error) {
 	var httpOpts []otlptracehttp.Option
 
-	if opt := endpointFor(cfg, otlptracehttp.WithEndpoint); opt != nil {
+	if opt := endpointFor(cfg, otlptracehttp.WithEndpointURL); opt != nil {
 		httpOpts = append(httpOpts, opt)
 	}
 

--- a/observability/tracing/provider_test.go
+++ b/observability/tracing/provider_test.go
@@ -42,6 +42,12 @@ func TestNewTrackerProviderProtocols(t *testing.T) {
 		name:    "bad protocol",
 		c:       Config{Protocol: "bad"},
 		wantErr: true,
+	}, {
+		name: "http with path in endpoint",
+		c: Config{
+			Protocol: ProtocolHTTPProtobuf,
+			Endpoint: "http://example.com:9090/api/v1/otlp/v1/traces",
+		},
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This is useful for Prometheus when it has the OTLP receiver on
