### PR TITLE
[observability] Default missing endpoint scheme to HTTPS

### DIFF
--- a/configmap/parser/parse.go
+++ b/configmap/parser/parse.go
@@ -19,6 +19,7 @@ package parser
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -71,7 +72,7 @@ func parse[T parseable](s string) (T, error) {
 
 	switch any(zero).(type) {
 	case string:
-		val = s
+		val = strings.TrimSpace(s)
 	case int16:
 		val, err = strconv.ParseInt(s, 10, 16)
 		val = int16(val.(int64))


### PR DESCRIPTION
When testing prometheus endpoints I entered
`some.domain.com:9090/some/path`

And this took `some.domain.com` as the scheme. To avoid this landmine
if we end up with an opaque URL we prepend the 'https' scheme to
the endpoint 