### PR TITLE
[controller/observability] adjust metrics reporting for the two lane queue

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -972,7 +972,7 @@ func TestStartAndShutdownWithLeaderAwareNoElection(t *testing.T) {
 	select {
 	case <-doneCh:
 		t.Fatal("StartAll finished early.")
-	case <-time.After(10 * time.Second):
+	case <-time.After(1 * time.Second):
 		// Give it some time to run.
 	}
 

--- a/controller/queue_metrics.go
+++ b/controller/queue_metrics.go
@@ -28,11 +28,14 @@ import (
 // Copyright The Kubernetes Authors.
 // Forked from: https://github.com/kubernetes/client-go/blob/release-1.33/util/workqueue/metrics.go
 
-// Unfortunately k8s package doesn't expose this variable so for now
-// we'll create our own and potentially upstream some changes in the future.
-var globalMetricsProvider workqueue.MetricsProvider = k8s.NewNoopWorkqueueMetricsProvider()
+var (
+	noopProvider = k8s.NewNoopWorkqueueMetricsProvider()
 
-var setGlobalMetricsProviderOnce sync.Once
+	// Unfortunately k8s package doesn't expose this variable so for now
+	// we'll create our own and potentially upstream some changes in the future.
+	globalMetricsProvider        workqueue.MetricsProvider = noopProvider
+	setGlobalMetricsProviderOnce sync.Once
+)
 
 func SetMetricsProvider(metricsProvider workqueue.MetricsProvider) {
 	setGlobalMetricsProviderOnce.Do(func() {
@@ -109,6 +112,9 @@ func (m *queueMetrics) done(item any) {
 }
 
 func (m *queueMetrics) updateUnfinishedWork() {
+	if m == nil {
+		return
+	}
 	// Note that a summary metric would be better for this, but prometheus
 	// doesn't seem to have non-hacky ways to reset the summary metrics.
 	var total float64

--- a/controller/queue_metrics.go
+++ b/controller/queue_metrics.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2025 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
+	"knative.dev/pkg/observability/metrics/k8s"
+)
+
+// Copyright The Kubernetes Authors.
+// Forked from: https://github.com/kubernetes/client-go/blob/release-1.33/util/workqueue/metrics.go
+
+// Unfortunately k8s package doesn't expose this variable so for now
+// we'll create our own and potentially upstream some changes in the future.
+var globalMetricsProvider workqueue.MetricsProvider = k8s.NewNoopWorkqueueMetricsProvider()
+
+var setGlobalMetricsProviderOnce sync.Once
+
+func SetMetricsProvider(metricsProvider workqueue.MetricsProvider) {
+	setGlobalMetricsProviderOnce.Do(func() {
+		globalMetricsProvider = metricsProvider
+	})
+}
+
+// queueMetrics expects the caller to lock before setting any metrics.
+type queueMetrics struct {
+	clock clock.Clock
+
+	// current depth of a workqueue
+	depth workqueue.GaugeMetric
+	// total number of adds handled by a workqueue
+	adds workqueue.CounterMetric
+	// how long an item stays in a workqueue
+	latency workqueue.HistogramMetric
+	// how long processing an item from a workqueue takes
+	workDuration         workqueue.HistogramMetric
+	addTimes             map[any]time.Time
+	processingStartTimes map[any]time.Time
+
+	mu sync.Mutex
+
+	// how long have current threads been working?
+	unfinishedWorkSeconds   workqueue.SettableGaugeMetric
+	longestRunningProcessor workqueue.SettableGaugeMetric
+}
+
+func (m *queueMetrics) add(item any) {
+	if m == nil {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.addTimes[item]; !exists {
+		m.adds.Inc()
+		m.depth.Inc()
+		m.addTimes[item] = m.clock.Now()
+	}
+}
+
+func (m *queueMetrics) get(item any) {
+	if m == nil {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.depth.Dec()
+	m.processingStartTimes[item] = m.clock.Now()
+
+	if startTime, exists := m.addTimes[item]; exists {
+		m.latency.Observe(m.sinceInSeconds(startTime))
+		delete(m.addTimes, item)
+	}
+}
+
+func (m *queueMetrics) done(item any) {
+	if m == nil {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if startTime, exists := m.processingStartTimes[item]; exists {
+		m.workDuration.Observe(m.sinceInSeconds(startTime))
+		delete(m.processingStartTimes, item)
+	}
+}
+
+func (m *queueMetrics) updateUnfinishedWork() {
+	// Note that a summary metric would be better for this, but prometheus
+	// doesn't seem to have non-hacky ways to reset the summary metrics.
+	var total float64
+	var oldest float64
+	for _, t := range m.processingStartTimes {
+		age := m.sinceInSeconds(t)
+		total += age
+		if age > oldest {
+			oldest = age
+		}
+	}
+	m.unfinishedWorkSeconds.Set(total)
+	m.longestRunningProcessor.Set(oldest)
+}
+
+func (m *queueMetrics) sinceInSeconds(start time.Time) float64 {
+	return m.clock.Since(start).Seconds()
+}

--- a/controller/two_lane_queue.go
+++ b/controller/two_lane_queue.go
@@ -16,15 +16,20 @@ limitations under the License.
 
 package controller
 
-import "k8s.io/client-go/util/workqueue"
+import (
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
+)
 
 // twoLaneQueue is a rate limited queue that wraps around two queues
 // -- fast queue (anonymously aliased), whose contents are processed with priority.
 // -- slow queue (slowLane queue), whose contents are processed if fast queue has no items.
 // All the default methods operate on the fast queue, unless noted otherwise.
 type twoLaneQueue struct {
-	workqueue.TypedRateLimitingInterface[any]
-	slowLane workqueue.TypedRateLimitingInterface[any]
+	fastLane workqueue.TypedInterface[any]
+	slowLane workqueue.TypedInterface[any]
 	// consumerQueue is necessary to ensure that we're not reconciling
 	// the same object at the exact same time (e.g. if it had been enqueued
 	// in both fast and slow and is the only object there).
@@ -32,35 +37,68 @@ type twoLaneQueue struct {
 
 	name string
 
-	fastChan chan interface{}
-	slowChan chan interface{}
+	fastChan chan any
+	slowChan chan any
+
+	metrics *queueMetrics
 }
 
+type twoLaneRateLimitingQueue struct {
+	q *twoLaneQueue
+	workqueue.TypedRateLimitingInterface[any]
+}
+
+var _ workqueue.TypedInterface[any] = (*twoLaneQueue)(nil)
+
 // Creates a new twoLaneQueue.
-func newTwoLaneWorkQueue(name string, rl workqueue.TypedRateLimiter[any]) *twoLaneQueue {
+func newTwoLaneWorkQueue(name string, rl workqueue.TypedRateLimiter[any]) *twoLaneRateLimitingQueue {
+	mp := globalMetricsProvider
+
 	tlq := &twoLaneQueue{
-		TypedRateLimitingInterface: workqueue.NewNamedRateLimitingQueue(
-			rl,
-			name+"-fast",
-		),
-		slowLane: workqueue.NewNamedRateLimitingQueue(
-			rl,
-			name+"-slow",
-		),
-		consumerQueue: workqueue.NewNamed(name + "-consumer"),
 		name:          name,
-		fastChan:      make(chan interface{}),
-		slowChan:      make(chan interface{}),
+		fastLane:      workqueue.NewTyped[any](),
+		slowLane:      workqueue.NewTyped[any](),
+		consumerQueue: workqueue.NewTyped[any](),
+		fastChan:      make(chan any),
+		slowChan:      make(chan any),
+
+		metrics: &queueMetrics{
+			clock:                   clock.RealClock{},
+			depth:                   mp.NewDepthMetric(name),
+			adds:                    mp.NewAddsMetric(name),
+			latency:                 mp.NewLatencyMetric(name),
+			workDuration:            mp.NewWorkDurationMetric(name),
+			unfinishedWorkSeconds:   mp.NewUnfinishedWorkSecondsMetric(name),
+			longestRunningProcessor: mp.NewUnfinishedWorkSecondsMetric(name),
+			addTimes:                make(map[any]time.Time),
+			processingStartTimes:    make(map[any]time.Time),
+		},
 	}
 	// Run consumer thread.
 	go tlq.runConsumer()
 	// Run producer threads.
-	go process(tlq.TypedRateLimitingInterface, tlq.fastChan)
+	go process(tlq.fastLane, tlq.fastChan)
 	go process(tlq.slowLane, tlq.slowChan)
-	return tlq
+
+	q := &twoLaneRateLimitingQueue{
+		q: tlq,
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+			rl,
+			workqueue.TypedRateLimitingQueueConfig[any]{
+				DelayingQueue: workqueue.NewTypedDelayingQueueWithConfig(
+					workqueue.TypedDelayingQueueConfig[any]{
+						Name:            name, // Name needs to be set for retry metrics
+						Queue:           tlq,
+						MetricsProvider: mp,
+					},
+				),
+			},
+		),
+	}
+	return q
 }
 
-func process(q workqueue.TypedInterface[any], ch chan interface{}) {
+func process(q workqueue.TypedInterface[any], ch chan any) {
 	// Sender closes the channel
 	defer close(ch)
 	for {
@@ -125,32 +163,56 @@ func (tlq *twoLaneQueue) runConsumer() {
 // Shutdown implements workqueue.Interface.
 // Shutdown shuts down both queues.
 func (tlq *twoLaneQueue) ShutDown() {
-	tlq.TypedRateLimitingInterface.ShutDown()
+	tlq.fastLane.ShutDown()
 	tlq.slowLane.ShutDown()
 }
 
 // Done implements workqueue.Interface.
 // Done marks the item as completed in all the queues.
-// NB: this will just re-enqueue the object on the queue that
-// didn't originate the object.
-func (tlq *twoLaneQueue) Done(i interface{}) {
-	tlq.consumerQueue.Done(i)
+// NB: this will just re-enqueue the object on the queue that didn't originate the object.
+func (tlq *twoLaneQueue) Done(item any) {
+	tlq.consumerQueue.Done(item)
+	tlq.metrics.done(item)
+}
+
+func (tlq *twoLaneQueue) Add(item any) {
+	tlq.metrics.add(item)
+	tlq.fastLane.Add(item)
+}
+
+func (q *twoLaneRateLimitingQueue) AddSlow(item any) {
+	q.q.metrics.add(item)
+	q.q.slowLane.Add(item)
+}
+
+func (q *twoLaneRateLimitingQueue) SlowLen() int {
+	return q.q.slowLane.Len()
+}
+
+func (q *twoLaneRateLimitingQueue) slowLane() workqueue.TypedInterface[any] {
+	return q.q.slowLane
 }
 
 // Get implements workqueue.Interface.
 // It gets the item from fast lane if it has anything, alternatively
 // the slow lane.
-func (tlq *twoLaneQueue) Get() (interface{}, bool) {
-	return tlq.consumerQueue.Get()
+func (tlq *twoLaneQueue) Get() (any, bool) {
+	item, ok := tlq.consumerQueue.Get()
+	tlq.metrics.get(item)
+	return item, ok
 }
 
 // Len returns the sum of lengths.
 // NB: actual _number_ of unique object might be less than this sum.
 func (tlq *twoLaneQueue) Len() int {
-	return tlq.TypedRateLimitingInterface.Len() + tlq.slowLane.Len() + tlq.consumerQueue.Len()
+	return tlq.fastLane.Len() + tlq.slowLane.Len() + tlq.consumerQueue.Len()
 }
 
-// SlowLane gives direct access to the slow queue.
-func (tlq *twoLaneQueue) SlowLane() workqueue.TypedRateLimitingInterface[any] {
-	return tlq.slowLane
+func (tlq *twoLaneQueue) ShutDownWithDrain() {
+	tlq.fastLane.ShutDownWithDrain()
+	tlq.slowLane.ShutDownWithDrain()
+}
+
+func (tlq *twoLaneQueue) ShuttingDown() bool {
+	return tlq.fastLane.ShuttingDown() || tlq.slowLane.ShuttingDown()
 }

--- a/injection/sharedmain/main.go
+++ b/injection/sharedmain/main.go
@@ -418,6 +418,7 @@ func SetupObservabilityOrDie(
 	}
 
 	workqueue.SetProvider(workQueueMetrics)
+	controller.SetMetricsProvider(workQueueMetrics)
 
 	clientMetrics, err := k8smetrics.NewClientMetricProvider(
 		k8smetrics.WithMeterProvider(meterProvider),

--- a/observability/metrics/k8s/noop.go
+++ b/observability/metrics/k8s/noop.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"k8s.io/client-go/util/workqueue"
+)
+
+type (
+	noopProvider struct{}
+	noopMetric   struct{}
+)
+
+func NewNoopWorkqueueMetricsProvider() workqueue.MetricsProvider {
+	return &noopProvider{}
+}
+
+func (noopMetric) Inc()            {}
+func (noopMetric) Dec()            {}
+func (noopMetric) Set(float64)     {}
+func (noopMetric) Observe(float64) {}
+
+var (
+	_ workqueue.GaugeMetric         = (*noopMetric)(nil)
+	_ workqueue.CounterMetric       = (*noopMetric)(nil)
+	_ workqueue.HistogramMetric     = (*noopMetric)(nil)
+	_ workqueue.SettableGaugeMetric = (*noopMetric)(nil)
+)
+
+func (noopProvider) NewDepthMetric(name string) workqueue.GaugeMetric {
+	return noopMetric{}
+}
+
+func (noopProvider) NewAddsMetric(name string) workqueue.CounterMetric {
+	return noopMetric{}
+}
+
+func (noopProvider) NewLatencyMetric(name string) workqueue.HistogramMetric {
+	return noopMetric{}
+}
+
+func (noopProvider) NewWorkDurationMetric(name string) workqueue.HistogramMetric {
+	return noopMetric{}
+}
+
+func (noopProvider) NewUnfinishedWorkSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	return noopMetric{}
+}
+
+func (noopProvider) NewLongestRunningProcessorSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	return noopMetric{}
+}
+
+func (noopProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
+	return noopMetric{}
+}


### PR DESCRIPTION
`k8s.io/client-go` workqueue package will report metrics for named queues. Our two lane queue was reporting three different metrics named `name-slow`, `name-fast`, `name-consumer` 

The metrics from these queues don't really paint the entire picture of how long a resource is queued in the two lane queue.

This change duplicates/forks some k8s code so that we can properly report 'accurate' metrics for our two lane queue.

/hold for review


/assign @Cali0707 @evankanderson @skonto 