### PR TITLE
[observability/trace] allow for stdout exporter for tracing - to allow for debugging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.37.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.59.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.37.0
 	go.opentelemetry.io/otel/metric v1.37.0
 	go.opentelemetry.io/otel/sdk v1.37.0
 	go.opentelemetry.io/otel/sdk/metric v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -379,6 +379,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.37.0 h1:bDMKF
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.37.0/go.mod h1:dDT67G/IkA46Mr2l9Uj7HsQVwsjASyV9SjGofsiUZDA=
 go.opentelemetry.io/otel/exporters/prometheus v0.59.0 h1:HHf+wKS6o5++XZhS98wvILrLVgHxjA/AMjqHKes+uzo=
 go.opentelemetry.io/otel/exporters/prometheus v0.59.0/go.mod h1:R8GpRXTZrqvXHDEGVH5bF6+JqAZcK8PjJcZ5nGhEWiE=
+go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.37.0 h1:SNhVp/9q4Go/XHBkQ1/d5u9P/U+L1yaGPoi0x+mStaI=
+go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.37.0/go.mod h1:tx8OOlGH6R4kLV67YaYO44GFXloEjGPZuMjEkaaqIp4=
 go.opentelemetry.io/otel/metric v1.37.0 h1:mvwbQS5m0tbmqML4NqK+e3aDiO02vsf/WgbsdpcPoZE=
 go.opentelemetry.io/otel/metric v1.37.0/go.mod h1:04wGrZurHYKOc+RKeye86GwKiTb9FKm1WHtO+4EVr2E=
 go.opentelemetry.io/otel/sdk v1.37.0 h1:ItB0QUqnjesGRvNcmAcU0LyvkVyGJ2xftD29bWdDvKI=

--- a/observability/tracing/config.go
+++ b/observability/tracing/config.go
@@ -27,6 +27,7 @@ const (
 	ProtocolGRPC         = "grpc"
 	ProtocolHTTPProtobuf = "http/protobuf"
 	ProtocolNone         = "none"
+	ProtocolStdout       = "stdout"
 )
 
 type Config struct {
@@ -41,7 +42,7 @@ func (c *Config) Validate() error {
 		if c.Endpoint == "" {
 			return fmt.Errorf("endpoint should be set for protocol %q", c.Protocol)
 		}
-	case ProtocolNone:
+	case ProtocolNone, ProtocolStdout:
 		if c.Endpoint != "" {
 			return errors.New("endpoint should not be set when protocol is 'none'")
 		}

--- a/vendor/go.opentelemetry.io/otel/exporters/stdout/stdouttrace/LICENSE
+++ b/vendor/go.opentelemetry.io/otel/exporters/stdout/stdouttrace/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/go.opentelemetry.io/otel/exporters/stdout/stdouttrace/README.md
+++ b/vendor/go.opentelemetry.io/otel/exporters/stdout/stdouttrace/README.md
@@ -1,0 +1,3 @@
+# STDOUT Trace Exporter
+
+[![PkgGoDev](https://pkg.go.dev/badge/go.opentelemetry.io/otel/exporters/stdout/stdouttrace)](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/stdout/stdouttrace)

--- a/vendor/go.opentelemetry.io/otel/exporters/stdout/stdouttrace/config.go
+++ b/vendor/go.opentelemetry.io/otel/exporters/stdout/stdouttrace/config.go
@@ -1,0 +1,85 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package stdouttrace // import "go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+
+import (
+	"io"
+	"os"
+)
+
+var (
+	defaultWriter      = os.Stdout
+	defaultPrettyPrint = false
+	defaultTimestamps  = true
+)
+
+// config contains options for the STDOUT exporter.
+type config struct {
+	// Writer is the destination.  If not set, os.Stdout is used.
+	Writer io.Writer
+
+	// PrettyPrint will encode the output into readable JSON. Default is
+	// false.
+	PrettyPrint bool
+
+	// Timestamps specifies if timestamps should be printed. Default is
+	// true.
+	Timestamps bool
+}
+
+// newConfig creates a validated Config configured with options.
+func newConfig(options ...Option) config {
+	cfg := config{
+		Writer:      defaultWriter,
+		PrettyPrint: defaultPrettyPrint,
+		Timestamps:  defaultTimestamps,
+	}
+	for _, opt := range options {
+		cfg = opt.apply(cfg)
+	}
+	return cfg
+}
+
+// Option sets the value of an option for a Config.
+type Option interface {
+	apply(config) config
+}
+
+// WithWriter sets the export stream destination.
+func WithWriter(w io.Writer) Option {
+	return writerOption{w}
+}
+
+type writerOption struct {
+	W io.Writer
+}
+
+func (o writerOption) apply(cfg config) config {
+	cfg.Writer = o.W
+	return cfg
+}
+
+// WithPrettyPrint prettifies the emitted output.
+func WithPrettyPrint() Option {
+	return prettyPrintOption(true)
+}
+
+type prettyPrintOption bool
+
+func (o prettyPrintOption) apply(cfg config) config {
+	cfg.PrettyPrint = bool(o)
+	return cfg
+}
+
+// WithoutTimestamps sets the export stream to not include timestamps.
+func WithoutTimestamps() Option {
+	return timestampsOption(false)
+}
+
+type timestampsOption bool
+
+func (o timestampsOption) apply(cfg config) config {
+	cfg.Timestamps = bool(o)
+	return cfg
+}

--- a/vendor/go.opentelemetry.io/otel/exporters/stdout/stdouttrace/doc.go
+++ b/vendor/go.opentelemetry.io/otel/exporters/stdout/stdouttrace/doc.go
@@ -1,0 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package stdouttrace contains an OpenTelemetry exporter for tracing
+// telemetry to be written to an output destination as JSON.
+package stdouttrace // import "go.opentelemetry.io/otel/exporters/stdout/stdouttrace"

--- a/vendor/go.opentelemetry.io/otel/exporters/stdout/stdouttrace/trace.go
+++ b/vendor/go.opentelemetry.io/otel/exporters/stdout/stdouttrace/trace.go
@@ -1,0 +1,103 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package stdouttrace // import "go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+var zeroTime time.Time
+
+var _ trace.SpanExporter = &Exporter{}
+
+// New creates an Exporter with the passed options.
+func New(options ...Option) (*Exporter, error) {
+	cfg := newConfig(options...)
+
+	enc := json.NewEncoder(cfg.Writer)
+	if cfg.PrettyPrint {
+		enc.SetIndent("", "\t")
+	}
+
+	return &Exporter{
+		encoder:    enc,
+		timestamps: cfg.Timestamps,
+	}, nil
+}
+
+// Exporter is an implementation of trace.SpanSyncer that writes spans to stdout.
+type Exporter struct {
+	encoder    *json.Encoder
+	encoderMu  sync.Mutex
+	timestamps bool
+
+	stoppedMu sync.RWMutex
+	stopped   bool
+}
+
+// ExportSpans writes spans in json format to stdout.
+func (e *Exporter) ExportSpans(ctx context.Context, spans []trace.ReadOnlySpan) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	e.stoppedMu.RLock()
+	stopped := e.stopped
+	e.stoppedMu.RUnlock()
+	if stopped {
+		return nil
+	}
+
+	if len(spans) == 0 {
+		return nil
+	}
+
+	stubs := tracetest.SpanStubsFromReadOnlySpans(spans)
+
+	e.encoderMu.Lock()
+	defer e.encoderMu.Unlock()
+	for i := range stubs {
+		stub := &stubs[i]
+		// Remove timestamps
+		if !e.timestamps {
+			stub.StartTime = zeroTime
+			stub.EndTime = zeroTime
+			for j := range stub.Events {
+				ev := &stub.Events[j]
+				ev.Time = zeroTime
+			}
+		}
+
+		// Encode span stubs, one by one
+		if err := e.encoder.Encode(stub); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Shutdown is called to stop the exporter, it performs no action.
+func (e *Exporter) Shutdown(ctx context.Context) error {
+	e.stoppedMu.Lock()
+	e.stopped = true
+	e.stoppedMu.Unlock()
+
+	return nil
+}
+
+// MarshalLog is the marshaling function used by the logging system to represent this Exporter.
+func (e *Exporter) MarshalLog() interface{} {
+	return struct {
+		Type           string
+		WithTimestamps bool
+	}{
+		Type:           "stdout",
+		WithTimestamps: e.timestamps,
+	}
+}

--- a/vendor/go.opentelemetry.io/otel/sdk/trace/tracetest/README.md
+++ b/vendor/go.opentelemetry.io/otel/sdk/trace/tracetest/README.md
@@ -1,0 +1,3 @@
+# SDK Trace test
+
+[![PkgGoDev](https://pkg.go.dev/badge/go.opentelemetry.io/otel/sdk/trace/tracetest)](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/trace/tracetest)

--- a/vendor/go.opentelemetry.io/otel/sdk/trace/tracetest/exporter.go
+++ b/vendor/go.opentelemetry.io/otel/sdk/trace/tracetest/exporter.go
@@ -1,0 +1,74 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package tracetest is a testing helper package for the SDK. User can
+// configure no-op or in-memory exporters to verify different SDK behaviors or
+// custom instrumentation.
+package tracetest // import "go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+var _ trace.SpanExporter = (*NoopExporter)(nil)
+
+// NewNoopExporter returns a new no-op exporter.
+func NewNoopExporter() *NoopExporter {
+	return new(NoopExporter)
+}
+
+// NoopExporter is an exporter that drops all received spans and performs no
+// action.
+type NoopExporter struct{}
+
+// ExportSpans handles export of spans by dropping them.
+func (nsb *NoopExporter) ExportSpans(context.Context, []trace.ReadOnlySpan) error { return nil }
+
+// Shutdown stops the exporter by doing nothing.
+func (nsb *NoopExporter) Shutdown(context.Context) error { return nil }
+
+var _ trace.SpanExporter = (*InMemoryExporter)(nil)
+
+// NewInMemoryExporter returns a new InMemoryExporter.
+func NewInMemoryExporter() *InMemoryExporter {
+	return new(InMemoryExporter)
+}
+
+// InMemoryExporter is an exporter that stores all received spans in-memory.
+type InMemoryExporter struct {
+	mu sync.Mutex
+	ss SpanStubs
+}
+
+// ExportSpans handles export of spans by storing them in memory.
+func (imsb *InMemoryExporter) ExportSpans(_ context.Context, spans []trace.ReadOnlySpan) error {
+	imsb.mu.Lock()
+	defer imsb.mu.Unlock()
+	imsb.ss = append(imsb.ss, SpanStubsFromReadOnlySpans(spans)...)
+	return nil
+}
+
+// Shutdown stops the exporter by clearing spans held in memory.
+func (imsb *InMemoryExporter) Shutdown(context.Context) error {
+	imsb.Reset()
+	return nil
+}
+
+// Reset the current in-memory storage.
+func (imsb *InMemoryExporter) Reset() {
+	imsb.mu.Lock()
+	defer imsb.mu.Unlock()
+	imsb.ss = nil
+}
+
+// GetSpans returns the current in-memory stored spans.
+func (imsb *InMemoryExporter) GetSpans() SpanStubs {
+	imsb.mu.Lock()
+	defer imsb.mu.Unlock()
+	ret := make(SpanStubs, len(imsb.ss))
+	copy(ret, imsb.ss)
+	return ret
+}

--- a/vendor/go.opentelemetry.io/otel/sdk/trace/tracetest/recorder.go
+++ b/vendor/go.opentelemetry.io/otel/sdk/trace/tracetest/recorder.go
@@ -1,0 +1,94 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tracetest // import "go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+import (
+	"context"
+	"sync"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// SpanRecorder records started and ended spans.
+type SpanRecorder struct {
+	startedMu sync.RWMutex
+	started   []sdktrace.ReadWriteSpan
+
+	endedMu sync.RWMutex
+	ended   []sdktrace.ReadOnlySpan
+}
+
+var _ sdktrace.SpanProcessor = (*SpanRecorder)(nil)
+
+// NewSpanRecorder returns a new initialized SpanRecorder.
+func NewSpanRecorder() *SpanRecorder {
+	return new(SpanRecorder)
+}
+
+// OnStart records started spans.
+//
+// This method is safe to be called concurrently.
+func (sr *SpanRecorder) OnStart(_ context.Context, s sdktrace.ReadWriteSpan) {
+	sr.startedMu.Lock()
+	defer sr.startedMu.Unlock()
+	sr.started = append(sr.started, s)
+}
+
+// OnEnd records completed spans.
+//
+// This method is safe to be called concurrently.
+func (sr *SpanRecorder) OnEnd(s sdktrace.ReadOnlySpan) {
+	sr.endedMu.Lock()
+	defer sr.endedMu.Unlock()
+	sr.ended = append(sr.ended, s)
+}
+
+// Shutdown does nothing.
+//
+// This method is safe to be called concurrently.
+func (sr *SpanRecorder) Shutdown(context.Context) error {
+	return nil
+}
+
+// ForceFlush does nothing.
+//
+// This method is safe to be called concurrently.
+func (sr *SpanRecorder) ForceFlush(context.Context) error {
+	return nil
+}
+
+// Started returns a copy of all started spans that have been recorded.
+//
+// This method is safe to be called concurrently.
+func (sr *SpanRecorder) Started() []sdktrace.ReadWriteSpan {
+	sr.startedMu.RLock()
+	defer sr.startedMu.RUnlock()
+	dst := make([]sdktrace.ReadWriteSpan, len(sr.started))
+	copy(dst, sr.started)
+	return dst
+}
+
+// Reset clears the recorded spans.
+//
+// This method is safe to be called concurrently.
+func (sr *SpanRecorder) Reset() {
+	sr.startedMu.Lock()
+	sr.endedMu.Lock()
+	defer sr.startedMu.Unlock()
+	defer sr.endedMu.Unlock()
+
+	sr.started = nil
+	sr.ended = nil
+}
+
+// Ended returns a copy of all ended spans that have been recorded.
+//
+// This method is safe to be called concurrently.
+func (sr *SpanRecorder) Ended() []sdktrace.ReadOnlySpan {
+	sr.endedMu.RLock()
+	defer sr.endedMu.RUnlock()
+	dst := make([]sdktrace.ReadOnlySpan, len(sr.ended))
+	copy(dst, sr.ended)
+	return dst
+}

--- a/vendor/go.opentelemetry.io/otel/sdk/trace/tracetest/span.go
+++ b/vendor/go.opentelemetry.io/otel/sdk/trace/tracetest/span.go
@@ -1,0 +1,166 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tracetest // import "go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+import (
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// SpanStubs is a slice of SpanStub use for testing an SDK.
+type SpanStubs []SpanStub
+
+// SpanStubsFromReadOnlySpans returns SpanStubs populated from ro.
+func SpanStubsFromReadOnlySpans(ro []tracesdk.ReadOnlySpan) SpanStubs {
+	if len(ro) == 0 {
+		return nil
+	}
+
+	s := make(SpanStubs, 0, len(ro))
+	for _, r := range ro {
+		s = append(s, SpanStubFromReadOnlySpan(r))
+	}
+
+	return s
+}
+
+// Snapshots returns s as a slice of ReadOnlySpans.
+func (s SpanStubs) Snapshots() []tracesdk.ReadOnlySpan {
+	if len(s) == 0 {
+		return nil
+	}
+
+	ro := make([]tracesdk.ReadOnlySpan, len(s))
+	for i := 0; i < len(s); i++ {
+		ro[i] = s[i].Snapshot()
+	}
+	return ro
+}
+
+// SpanStub is a stand-in for a Span.
+type SpanStub struct {
+	Name                 string
+	SpanContext          trace.SpanContext
+	Parent               trace.SpanContext
+	SpanKind             trace.SpanKind
+	StartTime            time.Time
+	EndTime              time.Time
+	Attributes           []attribute.KeyValue
+	Events               []tracesdk.Event
+	Links                []tracesdk.Link
+	Status               tracesdk.Status
+	DroppedAttributes    int
+	DroppedEvents        int
+	DroppedLinks         int
+	ChildSpanCount       int
+	Resource             *resource.Resource
+	InstrumentationScope instrumentation.Scope
+
+	// Deprecated: use InstrumentationScope instead.
+	InstrumentationLibrary instrumentation.Library //nolint:staticcheck // This method needs to be define for backwards compatibility
+}
+
+// SpanStubFromReadOnlySpan returns a SpanStub populated from ro.
+func SpanStubFromReadOnlySpan(ro tracesdk.ReadOnlySpan) SpanStub {
+	if ro == nil {
+		return SpanStub{}
+	}
+
+	return SpanStub{
+		Name:                   ro.Name(),
+		SpanContext:            ro.SpanContext(),
+		Parent:                 ro.Parent(),
+		SpanKind:               ro.SpanKind(),
+		StartTime:              ro.StartTime(),
+		EndTime:                ro.EndTime(),
+		Attributes:             ro.Attributes(),
+		Events:                 ro.Events(),
+		Links:                  ro.Links(),
+		Status:                 ro.Status(),
+		DroppedAttributes:      ro.DroppedAttributes(),
+		DroppedEvents:          ro.DroppedEvents(),
+		DroppedLinks:           ro.DroppedLinks(),
+		ChildSpanCount:         ro.ChildSpanCount(),
+		Resource:               ro.Resource(),
+		InstrumentationScope:   ro.InstrumentationScope(),
+		InstrumentationLibrary: ro.InstrumentationScope(),
+	}
+}
+
+// Snapshot returns a read-only copy of the SpanStub.
+func (s SpanStub) Snapshot() tracesdk.ReadOnlySpan {
+	scopeOrLibrary := s.InstrumentationScope
+	if scopeOrLibrary.Name == "" && scopeOrLibrary.Version == "" && scopeOrLibrary.SchemaURL == "" {
+		scopeOrLibrary = s.InstrumentationLibrary
+	}
+
+	return spanSnapshot{
+		name:                 s.Name,
+		spanContext:          s.SpanContext,
+		parent:               s.Parent,
+		spanKind:             s.SpanKind,
+		startTime:            s.StartTime,
+		endTime:              s.EndTime,
+		attributes:           s.Attributes,
+		events:               s.Events,
+		links:                s.Links,
+		status:               s.Status,
+		droppedAttributes:    s.DroppedAttributes,
+		droppedEvents:        s.DroppedEvents,
+		droppedLinks:         s.DroppedLinks,
+		childSpanCount:       s.ChildSpanCount,
+		resource:             s.Resource,
+		instrumentationScope: scopeOrLibrary,
+	}
+}
+
+type spanSnapshot struct {
+	// Embed the interface to implement the private method.
+	tracesdk.ReadOnlySpan
+
+	name                 string
+	spanContext          trace.SpanContext
+	parent               trace.SpanContext
+	spanKind             trace.SpanKind
+	startTime            time.Time
+	endTime              time.Time
+	attributes           []attribute.KeyValue
+	events               []tracesdk.Event
+	links                []tracesdk.Link
+	status               tracesdk.Status
+	droppedAttributes    int
+	droppedEvents        int
+	droppedLinks         int
+	childSpanCount       int
+	resource             *resource.Resource
+	instrumentationScope instrumentation.Scope
+}
+
+func (s spanSnapshot) Name() string                     { return s.name }
+func (s spanSnapshot) SpanContext() trace.SpanContext   { return s.spanContext }
+func (s spanSnapshot) Parent() trace.SpanContext        { return s.parent }
+func (s spanSnapshot) SpanKind() trace.SpanKind         { return s.spanKind }
+func (s spanSnapshot) StartTime() time.Time             { return s.startTime }
+func (s spanSnapshot) EndTime() time.Time               { return s.endTime }
+func (s spanSnapshot) Attributes() []attribute.KeyValue { return s.attributes }
+func (s spanSnapshot) Links() []tracesdk.Link           { return s.links }
+func (s spanSnapshot) Events() []tracesdk.Event         { return s.events }
+func (s spanSnapshot) Status() tracesdk.Status          { return s.status }
+func (s spanSnapshot) DroppedAttributes() int           { return s.droppedAttributes }
+func (s spanSnapshot) DroppedLinks() int                { return s.droppedLinks }
+func (s spanSnapshot) DroppedEvents() int               { return s.droppedEvents }
+func (s spanSnapshot) ChildSpanCount() int              { return s.childSpanCount }
+func (s spanSnapshot) Resource() *resource.Resource     { return s.resource }
+func (s spanSnapshot) InstrumentationScope() instrumentation.Scope {
+	return s.instrumentationScope
+}
+
+func (s spanSnapshot) InstrumentationLibrary() instrumentation.Library { //nolint:staticcheck // This method needs to be define for backwards compatibility
+	return s.instrumentationScope
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -269,6 +269,9 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/retry
 # go.opentelemetry.io/otel/exporters/prometheus v0.59.0
 ## explicit; go 1.23.0
 go.opentelemetry.io/otel/exporters/prometheus
+# go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.37.0
+## explicit; go 1.23.0
+go.opentelemetry.io/otel/exporters/stdout/stdouttrace
 # go.opentelemetry.io/otel/metric v1.37.0
 ## explicit; go 1.23.0
 go.opentelemetry.io/otel/metric
@@ -282,6 +285,7 @@ go.opentelemetry.io/otel/sdk/internal/env
 go.opentelemetry.io/otel/sdk/internal/x
 go.opentelemetry.io/otel/sdk/resource
 go.opentelemetry.io/otel/sdk/trace
+go.opentelemetry.io/otel/sdk/trace/tracetest
 # go.opentelemetry.io/otel/sdk/metric v1.37.0
 ## explicit; go 1.23.0
 go.opentelemetry.io/otel/sdk/metric


### PR DESCRIPTION
Setting up a collector or jaeger for manual testing is a bit much  - looking at the stdout is sometimes easier.

Thought this would be useful to have