### PR TITLE
fix: revert string parsing in configmap to not trim spaces

### DIFF
--- a/configmap/parser/parse.go
+++ b/configmap/parser/parse.go
@@ -19,7 +19,6 @@ package parser
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -72,7 +71,7 @@ func parse[T parseable](s string) (T, error) {
 
 	switch any(zero).(type) {
 	case string:
-		val = strings.TrimSpace(s)
+		val = s
 	case int16:
 		val, err = strconv.ParseInt(s, 10, 16)
 		val = int16(val.(int64))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->
In #3200 we switched the configmap parser to trim spaces in strings. Unfortunately, this has broken the parsing of configmaps with multi-line embedded yamls in downstream repos like eventing (see failures in https://github.com/knative/eventing/pull/8618). This PR reverts the change

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Do not trim spaces in configmap string parsing

