### PR TITLE
Fix prometheus exporter names

### DIFF
--- a/observability/metrics/prometheus_enabled.go
+++ b/observability/metrics/prometheus_enabled.go
@@ -35,10 +35,7 @@ func init() {
 }
 
 func buildPrometheus(_ context.Context, cfg Config) (sdkmetric.Reader, shutdownFunc, error) {
-	r, err := otelprom.New(
-		otelprom.WithoutCounterSuffixes(),
-		otelprom.WithoutUnits(),
-	)
+	r, err := otelprom.New()
 	if err != nil {
 		return nil, noopFunc, fmt.Errorf("unable to create otel prometheus exporter: %w", err)
 	}


### PR DESCRIPTION
There was a typo in a comment https://github.com/knative/pkg/issues/3224

This change will update the OTel prom exporter metric names to match
what will become the default in the future. If N is the current
SDK version the N+2 is when the new default will apply.

In the N+1 release - a new TranslationStrategy option will be introduced and we
will want to set the strategy to 'UnderscoreEscapingWithSuffixes'.

Then in N+2 we can drop that option as it will become the default
(or leave it explicitly).
