### PR TITLE
Add threadiness in log line

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -470,7 +470,7 @@ func (c *Impl) RunContext(ctx context.Context, threadiness int) error {
 	}
 
 	// Launch workers to process resources that get enqueued to our workqueue.
-	c.logger.Info("Starting controller and workers")
+	c.logger.Infow("Starting controller and workers", zap.Int("threadiness", threadiness))
 	for range threadiness {
 		sg.Add(1)
 		go func() {


### PR DESCRIPTION
# Changes

- :broom: Surface the threadiness value of controller

/kind enhancement

**why**

knative/pkg already supports controlling concurrency of the workers in controller (look at below codes), but it doesn't give back any feedback except it actually runs concurrently. This small change will help users to quickly catch how concurrently the controller runs.

https://github.com/knative/pkg/blob/528bde37b646f02c95ed92ee682c0e48c98504b5/injection/sharedmain/main.go#L205-L211

