### PR TITLE
[controller] fix depth metrics

### DIFF
--- a/controller/queue_metrics.go
+++ b/controller/queue_metrics.go
@@ -88,12 +88,14 @@ func (m *queueMetrics) get(item any) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.depth.Dec()
-	m.processingStartTimes[item] = m.clock.Now()
-
 	if startTime, exists := m.addTimes[item]; exists {
+		m.depth.Dec()
 		m.latency.Observe(m.sinceInSeconds(startTime))
 		delete(m.addTimes, item)
+	}
+
+	if _, exists := m.processingStartTimes[item]; !exists {
+		m.processingStartTimes[item] = m.clock.Now()
 	}
 }
 

--- a/controller/two_lane_queue.go
+++ b/controller/two_lane_queue.go
@@ -223,9 +223,9 @@ func (q *twoLaneRateLimitingQueue) slowLane() workqueue.TypedInterface[any] {
 // It gets the item from fast lane if it has anything, alternatively
 // the slow lane.
 func (tlq *twoLaneQueue) Get() (any, bool) {
-	item, ok := tlq.consumerQueue.Get()
+	item, shutdown := tlq.consumerQueue.Get()
 	tlq.metrics.get(item)
-	return item, ok
+	return item, shutdown
 }
 
 // Len returns the sum of lengths.


### PR DESCRIPTION
Fixes: https://github.com/knative/pkg/issues/3242

- **fix two lane workqueue depth metric calculation by decrementing when we have something in the queue metrics tracking map**
- **fix var name to reflect it's true purpose**

I think the bug occurs when we have something in the consumer work queue and then something is added to the fast queue. We skip the `add` time recording on the second entry (and depth increment) and we end up with multiple `Get` calls that decremented the queue depth by too much.

Thus right now the depth metric is 'best-effort' since we're not really counting duplicate entries in the queue (that can't be deduped)

To address this we'd probably have to fork the client-go code to better instrument the metrics, or write our own queue implementation

