### PR TITLE
Make webhook owner references not a controller

### DIFF
--- a/webhook/configmaps/configmaps.go
+++ b/webhook/configmaps/configmaps.go
@@ -146,6 +146,7 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 			return fmt.Errorf("failed to fetch namespace: %w", err)
 		}
 		nsRef := *metav1.NewControllerRef(ns, corev1.SchemeGroupVersion.WithKind("Namespace"))
+		nsRef.Controller = ptr.Bool(false)
 		webhook.OwnerReferences = []metav1.OwnerReference{nsRef}
 	}
 

--- a/webhook/configmaps/table_test.go
+++ b/webhook/configmaps/table_test.go
@@ -66,6 +66,7 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 	nsRef := *metav1.NewControllerRef(ns, corev1.SchemeGroupVersion.WithKind("Namespace"))
+	nsRef.Controller = ptr.Bool(false)
 	expectedOwnerReferences := []metav1.OwnerReference{nsRef}
 
 	ruleScope := admissionregistrationv1.NamespacedScope

--- a/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/webhook/resourcesemantics/defaulting/defaulting.go
@@ -232,6 +232,7 @@ func (ac *reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 			return fmt.Errorf("failed to fetch namespace: %w", err)
 		}
 		nsRef := *metav1.NewControllerRef(ns, corev1.SchemeGroupVersion.WithKind("Namespace"))
+		nsRef.Controller = ptr.Bool(false)
 		current.OwnerReferences = []metav1.OwnerReference{nsRef}
 	}
 

--- a/webhook/resourcesemantics/defaulting/table_test.go
+++ b/webhook/resourcesemantics/defaulting/table_test.go
@@ -67,6 +67,7 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 	nsRef := *metav1.NewControllerRef(ns, corev1.SchemeGroupVersion.WithKind("Namespace"))
+	nsRef.Controller = ptr.Bool(false)
 	expectedOwnerReferences := []metav1.OwnerReference{nsRef}
 
 	// This is the namespace selector setup

--- a/webhook/resourcesemantics/validation/reconcile_config.go
+++ b/webhook/resourcesemantics/validation/reconcile_config.go
@@ -201,6 +201,7 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 			return fmt.Errorf("failed to fetch namespace: %w", err)
 		}
 		nsRef := *metav1.NewControllerRef(ns, corev1.SchemeGroupVersion.WithKind("Namespace"))
+		nsRef.Controller = ptr.Bool(false)
 		current.OwnerReferences = []metav1.OwnerReference{nsRef}
 	}
 

--- a/webhook/resourcesemantics/validation/reconcile_config_test.go
+++ b/webhook/resourcesemantics/validation/reconcile_config_test.go
@@ -68,6 +68,7 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 	nsRef := *metav1.NewControllerRef(ns, corev1.SchemeGroupVersion.WithKind("Namespace"))
+	nsRef.Controller = ptr.Bool(false)
 	expectedOwnerReferences := []metav1.OwnerReference{nsRef}
 
 	// This is the namespace selector setup


### PR DESCRIPTION
Part of https://github.com/knative/serving/issues/15483

We setup namespace as the owner of the webhooks in order to clean up
instances where a user deletes the namespace.

This has issues with ArgoCD which we've included a workaround.
But an upcoming ArgoCD PR will handle owner references properly if
it is not a 'controller=true' reference.

This PR changes the owner reference to not be a controlling one.
We still block owner deletion because that was the original intent
of adding the owner reference.
