### PR TITLE
Update dependabot config so we only get k8s patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,15 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "knative.dev/*"
+      - dependency-name: "k8s.io/*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     groups:
       otel:
         patterns:
           - "go.opentelemetry.io/*"
       k8s:
-        update-types: patch
         patterns:
           - "k8s.io/*"
       golang-x:


### PR DESCRIPTION
GitHub support says this is how to setup only patch updates for the k8s group