### PR TITLE
create a knative semconv package to simplify otel dep bumps

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -28,3 +28,4 @@ ignore:
   - "testing"
   - "third_party"
   - "vendor"
+  - "observability/semconv/**/*"

--- a/observability/metrics/k8s/tools.go
+++ b/observability/metrics/k8s/tools.go
@@ -23,11 +23,12 @@ import (
 	"strings"
 	"time"
 
+	"knative.dev/pkg/observability/semconv"
+	"knative.dev/pkg/observability/semconv/httpconv"
+
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
-	"go.opentelemetry.io/otel/semconv/v1.37.0/httpconv"
 	"k8s.io/client-go/tools/metrics"
 )
 

--- a/observability/metrics/k8s/tools_test.go
+++ b/observability/metrics/k8s/tools_test.go
@@ -22,11 +22,12 @@ import (
 	"testing"
 	"time"
 
+	"knative.dev/pkg/observability/semconv"
+
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"knative.dev/pkg/observability/metrics/metricstest"
 )
 

--- a/observability/resource/default.go
+++ b/observability/resource/default.go
@@ -20,11 +20,11 @@ import (
 	"os"
 
 	"knative.dev/pkg/changeset"
+	"knative.dev/pkg/observability/semconv"
 	"knative.dev/pkg/system"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 )
 
 const otelServiceNameKey = "OTEL_SERVICE_NAME"

--- a/observability/resource/default_test.go
+++ b/observability/resource/default_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	"knative.dev/pkg/observability/semconv"
 
 	_ "knative.dev/pkg/system/testing"
 )

--- a/observability/semconv/httpconv/httpconv.go
+++ b/observability/semconv/httpconv/httpconv.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpconv
+
+import (
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/semconv/v1.37.0/httpconv"
+)
+
+type (
+	ClientRequestDuration = httpconv.ClientRequestDuration
+	RequestMethodAttr     = httpconv.RequestMethodAttr
+)
+
+func NewClientRequestDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (httpconv.ClientRequestDuration, error) {
+	return httpconv.NewClientRequestDuration(m, opt...)
+}

--- a/observability/semconv/semconv.go
+++ b/observability/semconv/semconv.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package semconv
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+)
+
+const (
+	SchemaURL = semconv.SchemaURL
+
+	ServiceNameKey = semconv.ServiceNameKey
+
+	ServerAddressKey = semconv.ServerAddressKey
+	ServerPortKey    = semconv.ServerPortKey
+
+	HTTPRequestMethodKey      = semconv.HTTPRequestMethodKey
+	HTTPResponseStatusCodeKey = semconv.HTTPResponseStatusCodeKey
+
+	URLSchemeKey   = semconv.URLSchemeKey
+	URLTemplateKey = semconv.URLTemplateKey
+
+	K8SNamespaceNameKey = semconv.K8SNamespaceNameKey
+	K8SPodNameKey       = semconv.K8SPodNameKey
+	K8SContainerNameKey = semconv.K8SContainerNameKey
+)
+
+func K8SContainerName(val string) attribute.KeyValue {
+	return semconv.ContainerName(val)
+}
+
+func K8SPodName(val string) attribute.KeyValue {
+	return semconv.K8SPodName(val)
+}
+
+func K8SNamespaceName(val string) attribute.KeyValue {
+	return semconv.K8SNamespaceName(val)
+}
+
+func ServiceVersion(val string) attribute.KeyValue {
+	return semconv.ServiceVersion(val)
+}
+
+func ServiceName(val string) attribute.KeyValue {
+	return semconv.ServiceName(val)
+}
+
+func ServiceInstanceID(val string) attribute.KeyValue {
+	return semconv.ServiceInstanceID(val)
+}
+
+func HTTPResponseStatusCode(val int) attribute.KeyValue {
+	return semconv.HTTPResponseStatusCode(val)
+}


### PR DESCRIPTION
Instead of manually bumping the semconv version across many downstream repos I created this package that will do the versioning for us.

If a key or function is missing we should feel free to add more here