### PR TITLE
Lock before iterating map so that code does not panic on concurrent write

### DIFF
--- a/controller/queue_metrics.go
+++ b/controller/queue_metrics.go
@@ -121,6 +121,10 @@ func (m *queueMetrics) updateUnfinishedWork() {
 	// doesn't seem to have non-hacky ways to reset the summary metrics.
 	var total float64
 	var oldest float64
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	for _, t := range m.processingStartTimes {
 		age := m.sinceInSeconds(t)
 		total += age


### PR DESCRIPTION
# Changes

After an upgrade to Knative 1.19, we see panics:

```
fatal error: concurrent map iteration and map write

goroutine 214 [running]:
internal/runtime/maps.fatal({0x2a84f6c?, 0x135ca73?})
	runtime/panic.go:1046 +0x18
internal/runtime/maps.(*Iter).Next(0x4535a80?)
	internal/runtime/maps/table.go:792 +0x86
knative.dev/pkg/controller.(*queueMetrics).updateUnfinishedWork(0xc000174630)
	knative.dev/pkg@v0.0.0-20250909011231-077dcf0d00e8/controller/queue_metrics.go:124 +0x86
knative.dev/pkg/controller.updateUnfinishedWorkLoop(0xc0005d60c0)
	knative.dev/pkg@v0.0.0-20250909011231-077dcf0d00e8/controller/two_lane_queue.go:123 +0x74
created by knative.dev/pkg/controller.createMetrics in goroutine 1
	knative.dev/pkg@v0.0.0-20250909011231-077dcf0d00e8/controller/two_lane_queue.go:109 +0x309
```

- :bug: The code in queue_metrics.go correct locks the map whenever it writes it. But in `updateUnfinishedWork`, the lock was missing when iterating the map to ensure that no concurrent write would be happening.

/kind bug

**Release Note**

```release-note
Fixes a concurrent map access panic in queue_metrics.go
```
