### PR TITLE
run golangci-lint run to run gofumpt on various files

### DIFF
--- a/codegen/cmd/injection-gen/generators/duck/duck.go
+++ b/codegen/cmd/injection-gen/generators/duck/duck.go
@@ -70,7 +70,7 @@ func (g *duckGenerator) Namers(c *generator.Context) namer.NameSystems {
 
 func (g *duckGenerator) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
-	return
+	return imports
 }
 
 func (g *duckGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {

--- a/codegen/cmd/injection-gen/generators/duck/fake_duck.go
+++ b/codegen/cmd/injection-gen/generators/duck/fake_duck.go
@@ -72,7 +72,7 @@ func (g *fakeDuckGenerator) Namers(c *generator.Context) namer.NameSystems {
 
 func (g *fakeDuckGenerator) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
-	return
+	return imports
 }
 
 func (g *fakeDuckGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {

--- a/codegen/cmd/injection-gen/generators/factory/factory.go
+++ b/codegen/cmd/injection-gen/generators/factory/factory.go
@@ -55,7 +55,7 @@ func (g *factoryGenerator) Namers(c *generator.Context) namer.NameSystems {
 
 func (g *factoryGenerator) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
-	return
+	return imports
 }
 
 func (g *factoryGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {

--- a/codegen/cmd/injection-gen/generators/factory/fake_factory.go
+++ b/codegen/cmd/injection-gen/generators/factory/fake_factory.go
@@ -57,7 +57,7 @@ func (g *fakeFactoryGenerator) Namers(c *generator.Context) namer.NameSystems {
 
 func (g *fakeFactoryGenerator) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
-	return
+	return imports
 }
 
 func (g *fakeFactoryGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {

--- a/codegen/cmd/injection-gen/generators/factory/fake_filtered_factory.go
+++ b/codegen/cmd/injection-gen/generators/factory/fake_filtered_factory.go
@@ -57,7 +57,7 @@ func (g *fakeFilteredFactoryGenerator) Namers(c *generator.Context) namer.NameSy
 
 func (g *fakeFilteredFactoryGenerator) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
-	return
+	return imports
 }
 
 func (g *fakeFilteredFactoryGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {

--- a/codegen/cmd/injection-gen/generators/factory/filtered_factory.go
+++ b/codegen/cmd/injection-gen/generators/factory/filtered_factory.go
@@ -54,7 +54,7 @@ func (g *filteredFactoryGenerator) Namers(c *generator.Context) namer.NameSystem
 
 func (g *filteredFactoryGenerator) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
-	return
+	return imports
 }
 
 func (g *filteredFactoryGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {

--- a/codegen/cmd/injection-gen/generators/informers/fake_filtered_informer.go
+++ b/codegen/cmd/injection-gen/generators/informers/fake_filtered_informer.go
@@ -73,7 +73,7 @@ func (g *fakeFilteredInformerGenerator) Namers(c *generator.Context) namer.NameS
 
 func (g *fakeFilteredInformerGenerator) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
-	return
+	return imports
 }
 
 func (g *fakeFilteredInformerGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {

--- a/codegen/cmd/injection-gen/generators/informers/fake_informer.go
+++ b/codegen/cmd/injection-gen/generators/informers/fake_informer.go
@@ -73,7 +73,7 @@ func (g *fakeInformerGenerator) Namers(c *generator.Context) namer.NameSystems {
 
 func (g *fakeInformerGenerator) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
-	return
+	return imports
 }
 
 func (g *fakeInformerGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {

--- a/codegen/cmd/injection-gen/generators/informers/filtered_informer.go
+++ b/codegen/cmd/injection-gen/generators/informers/filtered_informer.go
@@ -72,7 +72,7 @@ func (g *filteredInjectionGenerator) Namers(c *generator.Context) namer.NameSyst
 
 func (g *filteredInjectionGenerator) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
-	return
+	return imports
 }
 
 func (g *filteredInjectionGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {

--- a/codegen/cmd/injection-gen/generators/informers/informer.go
+++ b/codegen/cmd/injection-gen/generators/informers/informer.go
@@ -73,7 +73,7 @@ func (g *injectionGenerator) Namers(c *generator.Context) namer.NameSystems {
 
 func (g *injectionGenerator) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
-	return
+	return imports
 }
 
 func (g *injectionGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {

--- a/codegen/cmd/injection-gen/generators/reconciler/reconciler_controller.go
+++ b/codegen/cmd/injection-gen/generators/reconciler/reconciler_controller.go
@@ -58,7 +58,7 @@ func (g *reconcilerControllerGenerator) Namers(c *generator.Context) namer.NameS
 
 func (g *reconcilerControllerGenerator) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
-	return
+	return imports
 }
 
 func (g *reconcilerControllerGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {

--- a/codegen/cmd/injection-gen/generators/reconciler/reconciler_controller_stub.go
+++ b/codegen/cmd/injection-gen/generators/reconciler/reconciler_controller_stub.go
@@ -54,7 +54,7 @@ func (g *reconcilerControllerStubGenerator) Namers(c *generator.Context) namer.N
 
 func (g *reconcilerControllerStubGenerator) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
-	return
+	return imports
 }
 
 func (g *reconcilerControllerStubGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {

--- a/codegen/cmd/injection-gen/generators/reconciler/reconciler_reconciler.go
+++ b/codegen/cmd/injection-gen/generators/reconciler/reconciler_reconciler.go
@@ -62,7 +62,7 @@ func (g *reconcilerReconcilerGenerator) Namers(c *generator.Context) namer.NameS
 
 func (g *reconcilerReconcilerGenerator) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
-	return
+	return imports
 }
 
 func (g *reconcilerReconcilerGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {

--- a/codegen/cmd/injection-gen/generators/reconciler/reconciler_reconciler_stub.go
+++ b/codegen/cmd/injection-gen/generators/reconciler/reconciler_reconciler_stub.go
@@ -51,7 +51,7 @@ func (g *reconcilerReconcilerStubGenerator) Namers(c *generator.Context) namer.N
 
 func (g *reconcilerReconcilerStubGenerator) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
-	return
+	return imports
 }
 
 func (g *reconcilerReconcilerStubGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {

--- a/codegen/cmd/injection-gen/generators/reconciler/reconciler_state.go
+++ b/codegen/cmd/injection-gen/generators/reconciler/reconciler_state.go
@@ -48,7 +48,7 @@ func (g *reconcilerStateGenerator) Namers(c *generator.Context) namer.NameSystem
 
 func (g *reconcilerStateGenerator) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
-	return
+	return imports
 }
 
 func (g *reconcilerStateGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1347,7 +1347,7 @@ func drainWorkQueue(wq workqueue.TypedRateLimitingInterface[any]) (hasQueue []ty
 		}
 		hasQueue = append(hasQueue, key.(types.NamespacedName))
 	}
-	return
+	return hasQueue
 }
 
 type fakeInformer struct {

--- a/kmp/diff.go
+++ b/kmp/diff.go
@@ -49,7 +49,7 @@ func SafeDiff(x, y interface{}, opts ...cmp.Option) (diff string, err error) {
 	opts = append(opts, defaultOpts...)
 	diff = cmp.Diff(x, y, opts...)
 
-	return
+	return diff, err
 }
 
 // SafeEqual wraps cmp.Equal but recovers from panics and uses custom Comparers for:
@@ -67,7 +67,7 @@ func SafeEqual(x, y interface{}, opts ...cmp.Option) (equal bool, err error) {
 	opts = append(opts, defaultOpts...)
 	equal = cmp.Equal(x, y, opts...)
 
-	return
+	return equal, err
 }
 
 // CompareSetFields returns a list of field names that differ between

--- a/reconciler/testing/table.go
+++ b/reconciler/testing/table.go
@@ -372,7 +372,7 @@ func filterUpdatesWithSubresource(
 			result = append(result, action)
 		}
 	}
-	return
+	return result
 }
 
 // TableTest represents a list of TableRow tests instances.

--- a/signals/signal.go
+++ b/signals/signal.go
@@ -56,7 +56,7 @@ type signalContext struct {
 
 // Deadline implements context.Context
 func (scc *signalContext) Deadline() (deadline time.Time, ok bool) {
-	return
+	return deadline, ok
 }
 
 // Done implements context.Context

--- a/webhook/certificates/resources/certs.go
+++ b/webhook/certificates/resources/certs.go
@@ -102,15 +102,15 @@ func createCert(template, parent *x509.Certificate, pub, parentPriv interface{})
 ) {
 	certDER, err := x509.CreateCertificate(rand.Reader, template, parent, pub, parentPriv)
 	if err != nil {
-		return
+		return cert, certPEM, err
 	}
 	cert, err = x509.ParseCertificate(certDER)
 	if err != nil {
-		return
+		return cert, certPEM, err
 	}
 	b := pem.Block{Type: "CERTIFICATE", Bytes: certDER}
 	certPEM = pem.EncodeToMemory(&b)
-	return
+	return cert, certPEM, err
 }
 
 func createCA(ctx context.Context, name, namespace string, notAfter time.Time) (*ecdsa.PrivateKey, *x509.Certificate, []byte, error) {

--- a/webhook/configmaps/configmaps_test.go
+++ b/webhook/configmaps/configmaps_test.go
@@ -87,7 +87,7 @@ func newNonRunningTestConfigValidationController(t *testing.T) (
 	kubeClient = fakekubeclientset.NewSimpleClientset(initialConfigWebhook)
 
 	ac = newTestConfigValidationController(t)
-	return
+	return kubeClient, ac
 }
 
 func newTestConfigValidationController(t *testing.T) *reconciler {

--- a/webhook/json/decode.go
+++ b/webhook/json/decode.go
@@ -100,7 +100,7 @@ func findMetadataOffsets(bites []byte) (start, end int64, err error) {
 			break
 		}
 		if err != nil {
-			return
+			return start, end, err
 		}
 
 		switch v := t.(type) {
@@ -121,7 +121,7 @@ func findMetadataOffsets(bites []byte) (start, end int64, err error) {
 				end = dec.InputOffset()
 
 				// we exit early to stop processing the rest of the object
-				return
+				return start, end, err
 			}
 		}
 	}

--- a/webhook/resourcesemantics/conversion/internal/types.go
+++ b/webhook/resourcesemantics/conversion/internal/types.go
@@ -266,7 +266,7 @@ func (e *ErrorResource) UnmarshalJSON(data []byte) (err error) {
 	if err == nil && e.Spec.Property == ErrorUnmarshal {
 		err = errors.New("boooom - unmarshal json")
 	}
-	return
+	return err
 }
 
 // MarshalJSON implements json.Marshaler

--- a/webhook/resourcesemantics/defaulting/defaulting_test.go
+++ b/webhook/resourcesemantics/defaulting/defaulting_test.go
@@ -139,7 +139,7 @@ func newNonRunningTestResourceAdmissionController(t *testing.T) (
 	kubeClient = fakekubeclientset.NewSimpleClientset(initialResourceWebhook)
 
 	ac = newTestResourceAdmissionController(t)
-	return
+	return kubeClient, ac
 }
 
 func TestDeleteAllowed(t *testing.T) {

--- a/webhook/resourcesemantics/validation/validation_admit_test.go
+++ b/webhook/resourcesemantics/validation/validation_admit_test.go
@@ -128,7 +128,7 @@ func newNonRunningTestResourceAdmissionController(t *testing.T) (
 	kubeClient = fakekubeclientset.NewSimpleClientset(initialResourceWebhook)
 
 	ac = newTestResourceAdmissionController(t)
-	return
+	return kubeClient, ac
 }
 
 func TestDeleteAllowed(t *testing.T) {

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -243,7 +243,7 @@ func New(
 		}
 	}
 
-	return
+	return webhook, err
 }
 
 // InformersHaveSynced is called when the informers have all been synced, which allows any outstanding

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -69,7 +69,7 @@ func newNonRunningTestWebhook(t *testing.T, options Options, acs ...interface{})
 	if err != nil {
 		t.Fatal("Failed to create new admission controller:", err)
 	}
-	return
+	return ctx, ac, cancel
 }
 
 func TestRegistrationStopChanFire(t *testing.T) {


### PR DESCRIPTION
Unclear why go linter is complaining about this now (https://github.com/knative/pkg/pull/3286)

I ran `golangci-lint run --fix` 

 