### PR TITLE
Skip disabling keep-alives when shutting down the webhook server

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -333,9 +333,6 @@ func (wh *Webhook) Run(stop <-chan struct{}) error {
 	select {
 	case <-stop:
 		eg.Go(func() error {
-			// As we start to shutdown, disable keep-alives to avoid clients hanging onto connections.
-			server.SetKeepAlivesEnabled(false)
-
 			// Start failing readiness probes immediately.
 			logger.Info("Starting to fail readiness probes...")
 			drainer.Drain()


### PR DESCRIPTION
Fixes: https://github.com/knative/pkg/issues/1509

My theory is that when this happens the go runtime will close
idle connections. If by chance the API server is making a
request and re-using a connection (that is closing) it will receive
an io.EOF. Thus introducing a flake.

So we now remove this setting change and let all the connections
close during the regular graceful shutdown. We would have
already lame ducked so the webhook shouldn't be receiving new
requests.
