### PR TITLE
Add TLSMaxVersion, TLSCipherSuites, and TLSCurvePreferences to webhook.Options for minimal tls customization

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -52,6 +52,21 @@ type Options struct {
 	// TLS 1.3 is the minimum version if not specified otherwise.
 	TLSMinVersion uint16
 
+	// TLSMaxVersion contains the maximum TLS version that is acceptable.
+	// If not set (0), the maximum version supported by the implementation will be used.
+	// This is useful for enforcing Modern profile (TLS 1.3 only) by setting both
+	// TLSMinVersion and TLSMaxVersion to tls.VersionTLS13.
+	TLSMaxVersion uint16
+
+	// TLSCipherSuites specifies the list of enabled cipher suites.
+	// If empty, a default list of secure cipher suites will be used.
+	// Note: Cipher suites are not configurable in TLS 1.3; they are determined by the implementation.
+	TLSCipherSuites []uint16
+
+	// TLSCurvePreferences specifies the elliptic curves that will be used in an ECDHE handshake.
+	// If empty, the default curves will be used.
+	TLSCurvePreferences []tls.CurveID
+
 	// ServiceName is the service name of the webhook.
 	ServiceName string
 
@@ -191,7 +206,10 @@ func New(
 
 		//nolint:gosec // operator configures TLS min version (default is 1.3)
 		webhook.tlsConfig = &tls.Config{
-			MinVersion: opts.TLSMinVersion,
+			MinVersion:       opts.TLSMinVersion,
+			MaxVersion:       opts.TLSMaxVersion,
+			CipherSuites:     opts.TLSCipherSuites,
+			CurvePreferences: opts.TLSCurvePreferences,
 
 			// If we return (nil, error) the client sees - 'tls: internal error"
 			// If we return (nil, nil) the client sees - 'tls: no certificates configured'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->
This change adds minimal TLS configuration API for webhooks : TLSMaxVersion, TLSCipherSuites, and TLSCurvePreferences fields to webhook.Options for granular TLS control

- TLSMaxVersion: enforce Modern profile
- TLSCipherSuites: custom cipher suites
- TLSCurvePreferences: elliptic curve configuration

Changes:
- Add TLSMaxVersion, TLSCipherSuites, and TLSCurvePreferences fields to webhook.Options 
- Added unit tests for all new fields
- Added documentation  for webhook tls (README)
- Maintains backward compatibility with existing TLSMinVersion usage

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->


- :gift: Add new feature
- :bug: Fix bug

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3299

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Enhanced webhook TLS configuration with support for max version, custom cipher suites, and curve preferences.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
