### PR TITLE
Replace gopkg.in/yaml.v3 with go.yaml.in/yaml/v3

### DIFF
--- a/configmap/hash-gen/main.go
+++ b/configmap/hash-gen/main.go
@@ -23,7 +23,7 @@ import (
 	"log"
 	"os"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"knative.dev/pkg/configmap"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -33,11 +33,11 @@ require (
 	go.opentelemetry.io/otel/trace v1.39.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/zap v1.27.1
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/net v0.48.0
 	golang.org/x/sync v0.19.0
 	golang.org/x/tools v0.40.0
 	gomodules.xyz/jsonpatch/v2 v2.5.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.34.3
 	k8s.io/apiextensions-apiserver v0.34.3
 	k8s.io/apimachinery v0.34.3
@@ -86,7 +86,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac // indirect
 	golang.org/x/mod v0.31.0 // indirect
 	golang.org/x/oauth2 v0.32.0 // indirect
@@ -101,6 +100,7 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect


### PR DESCRIPTION
# Changes

- :broom: This replaces the unmaintained gopkg.in/yaml.v3 library with its maintained fork go.yaml.in/yaml/v3 from https://github.com/yaml/go-yaml/tree/v3/. It stays as indirect dependency due to zap for example where the change is not yet released.

/kind cleanup

**Release Note**

None

**Docs**

None