### PR TITLE
Add OnConnect and OnDisconnect callbacks to ManagedConnection

### DIFF
--- a/websocket/connection_test.go
+++ b/websocket/connection_test.go
@@ -441,13 +441,14 @@ func TestOnConnectAndOnDisconnectCallbacks(t *testing.T) {
 	onConnectCalled := make(chan struct{}, 10)
 	onDisconnectCalled := make(chan error, 10)
 
-	conn := NewDurableSendingConnection(target, logger)
-	conn.OnConnect = func() {
-		onConnectCalled <- struct{}{}
-	}
-	conn.OnDisconnect = func(err error) {
-		onDisconnectCalled <- err
-	}
+	conn := NewDurableSendingConnection(target, logger,
+		WithOnConnect(func() {
+			onConnectCalled <- struct{}{}
+		}),
+		WithOnDisconnect(func(err error) {
+			onDisconnectCalled <- err
+		}),
+	)
 	defer conn.Shutdown()
 
 	// Wait for the first OnConnect call


### PR DESCRIPTION
This enables consumers to react to connection state changes without polling. Callbacks are invoked when:
- OnConnect: connection is established (including reconnections)
- OnDisconnect: connection is lost (with error reason)

<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-  Add `OnConnect` callback field to [ManagedConnection](cci:2://file:///Users/prashanth.chaitanya/git-workspaces/knative-open-source/serving/vendor/knative.dev/pkg/websocket/connection.go:60:0-88:1) - invoked when connection is established
-  Add `OnDisconnect` callback field to [ManagedConnection](cci:2://file:///Users/prashanth.chaitanya/git-workspaces/knative-open-source/serving/vendor/knative.dev/pkg/websocket/connection.go:60:0-88:1) - invoked when connection is lost with error reason
-  Add tests for callback functionality

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

This change supports observability improvements in knative/serving#16318, where the activator needs to track autoscaler connection status. With callbacks, consumers can update metrics and logs in real-time without polling [Status()](cci:1://file:///Users/prashanth.chaitanya/git-workspaces/knative-open-source/serving/pkg/activator/stat_reporter.go:41:1-41:15).

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Add OnConnect and OnDisconnect callbacks to websocket ManagedConnection for event-driven connection state monitoring