### PR TITLE
Add TLS support to Prometheus metrics server

### DIFF
--- a/observability/metrics/prometheus/server.go
+++ b/observability/metrics/prometheus/server.go
@@ -18,30 +18,41 @@ package prometheus
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	knativetls "knative.dev/pkg/network/tls"
 )
 
 const (
 	defaultPrometheusPort            = "9090"
-	defaultPrometheusReportingPeriod = 5
 	maxPrometheusPort                = 65535
 	minPrometheusPort                = 1024
 	defaultPrometheusHost            = "" // IPv4 and IPv6
 	prometheusPortEnvName            = "METRICS_PROMETHEUS_PORT"
 	prometheusHostEnvName            = "METRICS_PROMETHEUS_HOST"
+	prometheusTLSCertEnvName         = "METRICS_PROMETHEUS_TLS_CERT"
+	prometheusTLSKeyEnvName          = "METRICS_PROMETHEUS_TLS_KEY"
+	prometheusTLSClientAuthEnvName   = "METRICS_PROMETHEUS_TLS_CLIENT_AUTH"
+	prometheusTLSClientCAFileEnvName = "METRICS_PROMETHEUS_TLS_CLIENT_CA_FILE"
+	// used with network/tls.DefaultConfigFromEnv. E.g. METRICS_PROMETHEUS_TLS_MIN_VERSION.
+	prometheusTLSEnvPrefix = "METRICS_PROMETHEUS_"
 )
 
 type ServerOption func(*options)
 
 type Server struct {
-	http *http.Server
+	http     *http.Server
+	certFile string
+	keyFile  string
 }
 
 func NewServer(opts ...ServerOption) (*Server, error) {
@@ -56,9 +67,25 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 
 	envOverride(&o.host, prometheusHostEnvName)
 	envOverride(&o.port, prometheusPortEnvName)
+	envOverride(&o.certFile, prometheusTLSCertEnvName)
+	envOverride(&o.keyFile, prometheusTLSKeyEnvName)
+	envOverride(&o.clientAuth, prometheusTLSClientAuthEnvName)
+	envOverride(&o.clientCAFile, prometheusTLSClientCAFileEnvName)
 
 	if err := validate(&o); err != nil {
 		return nil, err
+	}
+
+	var tlsConfig *tls.Config
+	if o.certFile != "" && o.keyFile != "" {
+		cfg, err := knativetls.DefaultConfigFromEnv(prometheusTLSEnvPrefix)
+		if err != nil {
+			return nil, err
+		}
+		if err := applyPrometheusClientAuth(cfg, &o); err != nil {
+			return nil, err
+		}
+		tlsConfig = cfg
 	}
 
 	mux := http.NewServeMux()
@@ -68,16 +95,34 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 
 	return &Server{
 		http: &http.Server{
-			Addr:    addr,
-			Handler: mux,
+			Addr:      addr,
+			Handler:   mux,
+			TLSConfig: tlsConfig,
 			// https://medium.com/a-journey-with-go/go-understand-and-mitigate-slowloris-attack-711c1b1403f6
 			ReadHeaderTimeout: 5 * time.Second,
 		},
+		certFile: o.certFile,
+		keyFile:  o.keyFile,
 	}, nil
 }
 
-func (s *Server) ListenAndServe() {
-	s.http.ListenAndServe()
+// ListenAndServe starts the metrics server on plain HTTP.
+func (s *Server) ListenAndServe() error {
+	return s.http.ListenAndServe()
+}
+
+// ListenAndServeTLS starts the metrics server on TLS (HTTPS) using the given certificate and key files.
+func (s *Server) ListenAndServeTLS(certFile, keyFile string) error {
+	return s.http.ListenAndServeTLS(certFile, keyFile)
+}
+
+// Serve starts the metrics server, choosing TLS or plain HTTP based on the server configuration.
+// If both METRICS_PROMETHEUS_TLS_CERT and METRICS_PROMETHEUS_TLS_KEY are set, it calls ListenAndServeTLS
+func (s *Server) Serve() error {
+	if s.certFile != "" && s.keyFile != "" {
+		return s.http.ListenAndServeTLS(s.certFile, s.keyFile)
+	}
+	return s.http.ListenAndServe()
 }
 
 func (s *Server) Shutdown(ctx context.Context) error {
@@ -85,8 +130,12 @@ func (s *Server) Shutdown(ctx context.Context) error {
 }
 
 type options struct {
-	host string
-	port string
+	host         string
+	port         string
+	certFile     string
+	keyFile      string
+	clientAuth   string
+	clientCAFile string
 }
 
 func WithHost(host string) ServerOption {
@@ -113,6 +162,33 @@ func validate(o *options) error {
 			port, minPrometheusPort, maxPrometheusPort)
 	}
 
+	if (o.certFile != "" && o.keyFile == "") || (o.certFile == "" && o.keyFile != "") {
+		return fmt.Errorf("both %s and %s must be set or neither", prometheusTLSCertEnvName, prometheusTLSKeyEnvName)
+	}
+
+	tlsEnabled := o.certFile != "" && o.keyFile != ""
+	auth := strings.TrimSpace(strings.ToLower(o.clientAuth))
+
+	if auth != "" && auth != "none" && auth != "optional" && auth != "require" {
+		return fmt.Errorf("invalid %s %q: must be %q, %q, or %q",
+			prometheusTLSClientAuthEnvName, o.clientAuth, "none", "optional", "require")
+	}
+
+	if !tlsEnabled && ((auth != "" && auth != "none") || o.clientCAFile != "") {
+		return fmt.Errorf("%s and %s require TLS to be enabled (%s and %s must be set)",
+			prometheusTLSClientAuthEnvName, prometheusTLSClientCAFileEnvName, prometheusTLSCertEnvName, prometheusTLSKeyEnvName)
+	}
+
+	if tlsEnabled && (auth == "optional" || auth == "require") && strings.TrimSpace(o.clientCAFile) == "" {
+		return fmt.Errorf("%s must be set when %s is %q (client certs cannot be validated without a CA)",
+			prometheusTLSClientCAFileEnvName, prometheusTLSClientAuthEnvName, auth)
+	}
+
+	if tlsEnabled && (auth == "" || auth == "none") && strings.TrimSpace(o.clientCAFile) != "" {
+		return fmt.Errorf("%s is set but %s is %q; set %s to %q or %q to use client certificate verification",
+			prometheusTLSClientCAFileEnvName, prometheusTLSClientAuthEnvName, auth, prometheusTLSClientAuthEnvName, "optional", "require")
+	}
+
 	return nil
 }
 
@@ -121,4 +197,37 @@ func envOverride(target *string, envName string) {
 	if val != "" {
 		*target = val
 	}
+}
+
+// applyPrometheusClientAuth configures mTLS (client certificate verification) on cfg.
+// o.clientAuth and o.clientCAFile are populated from env vars; validate() has already checked them.
+func applyPrometheusClientAuth(cfg *tls.Config, o *options) error {
+	v := strings.TrimSpace(strings.ToLower(o.clientAuth))
+	if v == "" || v == "none" {
+		return nil
+	}
+
+	var clientAuth tls.ClientAuthType
+	switch v {
+	case "optional":
+		clientAuth = tls.VerifyClientCertIfGiven
+	case "require":
+		clientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	caFile := strings.TrimSpace(o.clientCAFile)
+	if caFile != "" {
+		pem, err := os.ReadFile(caFile)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", prometheusTLSClientCAFileEnvName, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return fmt.Errorf("no valid CA certificates found in %s", prometheusTLSClientCAFileEnvName)
+		}
+		cfg.ClientCAs = pool
+	}
+
+	cfg.ClientAuth = clientAuth
+	return nil
 }

--- a/observability/metrics/prometheus/server_test.go
+++ b/observability/metrics/prometheus/server_test.go
@@ -17,7 +17,16 @@ limitations under the License.
 package prometheus
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -71,4 +80,278 @@ func TestNewServerFailure(t *testing.T) {
 	if _, err := NewServer(WithPort("65536")); err == nil {
 		t.Error("expected above port range to fail")
 	}
+}
+
+func TestNewServerTLSRequiresBothCertAndKey(t *testing.T) {
+	t.Run("only cert set", func(t *testing.T) {
+		t.Setenv(prometheusTLSCertEnvName, "/etc/tls/tls.crt")
+		t.Setenv(prometheusTLSKeyEnvName, "") // ensure key is unset
+		_, err := NewServer()
+		if err == nil {
+			t.Fatal("expected NewServer to fail when only TLS cert is set")
+		}
+		if !strings.Contains(err.Error(), "must be set or neither") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+	t.Run("only key set", func(t *testing.T) {
+		t.Setenv(prometheusTLSCertEnvName, "")
+		t.Setenv(prometheusTLSKeyEnvName, "/etc/tls/tls.key")
+		_, err := NewServer()
+		if err == nil {
+			t.Fatal("expected NewServer to fail when only TLS key is set")
+		}
+		if !strings.Contains(err.Error(), "must be set or neither") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestNewServerWithTLSConfigFromEnv(t *testing.T) {
+	t.Setenv(prometheusTLSCertEnvName, "/etc/tls/tls.crt")
+	t.Setenv(prometheusTLSKeyEnvName, "/etc/tls/tls.key")
+	t.Setenv("METRICS_PROMETHEUS_TLS_MIN_VERSION", "1.2")
+
+	s, err := NewServer()
+	if err != nil {
+		t.Fatal("NewServer() =", err)
+	}
+
+	if s.http.TLSConfig == nil {
+		t.Fatal("expected TLSConfig to be set when cert/key env vars are set")
+	}
+	if s.http.TLSConfig.MinVersion != tls.VersionTLS12 {
+		t.Errorf("expected MinVersion TLS 1.2 from env, got %v", s.http.TLSConfig.MinVersion)
+	}
+}
+
+func TestNewServerWithTLSEnvVars(t *testing.T) {
+	t.Setenv(prometheusTLSCertEnvName, "/etc/tls/tls.crt")
+	t.Setenv(prometheusTLSKeyEnvName, "/etc/tls/tls.key")
+
+	s, err := NewServer()
+	if err != nil {
+		t.Fatal("NewServer() =", err)
+	}
+
+	if s.certFile != "/etc/tls/tls.crt" {
+		t.Errorf("expected certFile to be /etc/tls/tls.crt, got %s", s.certFile)
+	}
+
+	if s.keyFile != "/etc/tls/tls.key" {
+		t.Errorf("expected keyFile to be /etc/tls/tls.key, got %s", s.keyFile)
+	}
+}
+
+func TestTLSConfigWithCertFilesFromEnv(t *testing.T) {
+	t.Setenv(prometheusTLSCertEnvName, "/etc/tls/tls.crt")
+	t.Setenv(prometheusTLSKeyEnvName, "/etc/tls/tls.key")
+	t.Setenv("METRICS_PROMETHEUS_TLS_MIN_VERSION", "1.3")
+	t.Setenv("METRICS_PROMETHEUS_TLS_MAX_VERSION", "1.3")
+	t.Setenv("METRICS_PROMETHEUS_TLS_CIPHER_SUITES", "TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256")
+
+	s, err := NewServer()
+	if err != nil {
+		t.Fatal("NewServer() =", err)
+	}
+
+	if s.http.TLSConfig == nil {
+		t.Fatal("expected TLSConfig to be set")
+	}
+	if s.http.TLSConfig.MinVersion != tls.VersionTLS13 {
+		t.Errorf("expected MinVersion TLS 1.3, got %v", s.http.TLSConfig.MinVersion)
+	}
+	if s.http.TLSConfig.MaxVersion != tls.VersionTLS13 {
+		t.Errorf("expected MaxVersion TLS 1.3, got %v", s.http.TLSConfig.MaxVersion)
+	}
+	if len(s.http.TLSConfig.CipherSuites) != 2 {
+		t.Errorf("expected 2 cipher suites, got %d", len(s.http.TLSConfig.CipherSuites))
+	}
+	if s.certFile != "/etc/tls/tls.crt" {
+		t.Errorf("expected certFile=/etc/tls/tls.crt, got %s", s.certFile)
+	}
+	if s.keyFile != "/etc/tls/tls.key" {
+		t.Errorf("expected keyFile=/etc/tls/tls.key, got %s", s.keyFile)
+	}
+}
+
+func TestPrometheusMTLSFromEnv(t *testing.T) {
+	t.Run("require without client CA file returns error", func(t *testing.T) {
+		t.Setenv(prometheusTLSCertEnvName, "/etc/tls/tls.crt")
+		t.Setenv(prometheusTLSKeyEnvName, "/etc/tls/tls.key")
+		t.Setenv(prometheusTLSClientAuthEnvName, "require")
+		t.Setenv(prometheusTLSClientCAFileEnvName, "") // unset
+		_, err := NewServer()
+		if err == nil {
+			t.Fatal("expected NewServer to fail when client auth is require but client CA file is unset")
+		}
+		if !strings.Contains(err.Error(), "cannot be validated without a CA") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid client auth value returns error", func(t *testing.T) {
+		t.Setenv(prometheusTLSCertEnvName, "/etc/tls/tls.crt")
+		t.Setenv(prometheusTLSKeyEnvName, "/etc/tls/tls.key")
+		t.Setenv(prometheusTLSClientAuthEnvName, "invalid")
+		_, err := NewServer()
+		if err == nil {
+			t.Fatal("expected NewServer to fail with invalid client auth value")
+		}
+		if !strings.Contains(err.Error(), `invalid METRICS_PROMETHEUS_TLS_CLIENT_AUTH`) {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("optional with valid client CA file sets ClientAuth and ClientCAs", func(t *testing.T) {
+		caFile := createTempCACertFile(t)
+		t.Setenv(prometheusTLSCertEnvName, "/etc/tls/tls.crt")
+		t.Setenv(prometheusTLSKeyEnvName, "/etc/tls/tls.key")
+		t.Setenv(prometheusTLSClientAuthEnvName, "optional")
+		t.Setenv(prometheusTLSClientCAFileEnvName, caFile)
+
+		s, err := NewServer()
+		if err != nil {
+			t.Fatal("NewServer() =", err)
+		}
+		if s.http.TLSConfig == nil {
+			t.Fatal("expected TLSConfig to be set")
+		}
+		if s.http.TLSConfig.ClientAuth != tls.VerifyClientCertIfGiven {
+			t.Errorf("expected ClientAuth VerifyClientCertIfGiven, got %v", s.http.TLSConfig.ClientAuth)
+		}
+		if s.http.TLSConfig.ClientCAs == nil {
+			t.Error("expected ClientCAs to be set")
+		}
+	})
+
+	t.Run("require with valid client CA file sets RequireAndVerifyClientCert", func(t *testing.T) {
+		caFile := createTempCACertFile(t)
+		t.Setenv(prometheusTLSCertEnvName, "/etc/tls/tls.crt")
+		t.Setenv(prometheusTLSKeyEnvName, "/etc/tls/tls.key")
+		t.Setenv(prometheusTLSClientAuthEnvName, "require")
+		t.Setenv(prometheusTLSClientCAFileEnvName, caFile)
+
+		s, err := NewServer()
+		if err != nil {
+			t.Fatal("NewServer() =", err)
+		}
+		if s.http.TLSConfig == nil {
+			t.Fatal("expected TLSConfig to be set")
+		}
+		if s.http.TLSConfig.ClientAuth != tls.RequireAndVerifyClientCert {
+			t.Errorf("expected ClientAuth RequireAndVerifyClientCert, got %v", s.http.TLSConfig.ClientAuth)
+		}
+		if s.http.TLSConfig.ClientCAs == nil {
+			t.Error("expected ClientCAs to be set")
+		}
+	})
+
+	t.Run("explicit none does not set client auth", func(t *testing.T) {
+		t.Setenv(prometheusTLSCertEnvName, "/etc/tls/tls.crt")
+		t.Setenv(prometheusTLSKeyEnvName, "/etc/tls/tls.key")
+		t.Setenv(prometheusTLSClientAuthEnvName, "none")
+		t.Setenv(prometheusTLSClientCAFileEnvName, "")
+
+		s, err := NewServer()
+		if err != nil {
+			t.Fatal("NewServer() =", err)
+		}
+		if s.http.TLSConfig == nil {
+			t.Fatal("expected TLSConfig to be set")
+		}
+		if s.http.TLSConfig.ClientAuth != tls.NoClientCert {
+			t.Errorf("expected ClientAuth NoClientCert, got %v", s.http.TLSConfig.ClientAuth)
+		}
+		if s.http.TLSConfig.ClientCAs != nil {
+			t.Error("expected ClientCAs to be nil")
+		}
+	})
+
+	t.Run("mTLS env vars without TLS enabled returns error", func(t *testing.T) {
+		t.Setenv(prometheusTLSCertEnvName, "")
+		t.Setenv(prometheusTLSKeyEnvName, "")
+		t.Setenv(prometheusTLSClientAuthEnvName, "require")
+		t.Setenv(prometheusTLSClientCAFileEnvName, "/etc/tls/ca.pem")
+		_, err := NewServer()
+		if err == nil {
+			t.Fatal("expected NewServer to fail when mTLS is set but TLS is not enabled")
+		}
+		if !strings.Contains(err.Error(), "require TLS to be enabled") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("client CA file with empty client auth returns error", func(t *testing.T) {
+		t.Setenv(prometheusTLSCertEnvName, "/etc/tls/tls.crt")
+		t.Setenv(prometheusTLSKeyEnvName, "/etc/tls/tls.key")
+		t.Setenv(prometheusTLSClientAuthEnvName, "")
+		t.Setenv(prometheusTLSClientCAFileEnvName, "/etc/tls/ca.pem")
+		_, err := NewServer()
+		if err == nil {
+			t.Fatal("expected NewServer to fail when CA file is set but client auth is unset")
+		}
+		if !strings.Contains(err.Error(), "is set but") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("client CA file with none client auth returns error", func(t *testing.T) {
+		t.Setenv(prometheusTLSCertEnvName, "/etc/tls/tls.crt")
+		t.Setenv(prometheusTLSKeyEnvName, "/etc/tls/tls.key")
+		t.Setenv(prometheusTLSClientAuthEnvName, "none")
+		t.Setenv(prometheusTLSClientCAFileEnvName, "/etc/tls/ca.pem")
+		_, err := NewServer()
+		if err == nil {
+			t.Fatal("expected NewServer to fail when CA file is set but client auth is none")
+		}
+		if !strings.Contains(err.Error(), "is set but") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("client CA file without TLS enabled returns error", func(t *testing.T) {
+		t.Setenv(prometheusTLSCertEnvName, "")
+		t.Setenv(prometheusTLSKeyEnvName, "")
+		t.Setenv(prometheusTLSClientAuthEnvName, "")
+		t.Setenv(prometheusTLSClientCAFileEnvName, "/etc/tls/ca.pem")
+		_, err := NewServer()
+		if err == nil {
+			t.Fatal("expected NewServer to fail when client CA file is set but TLS is not enabled")
+		}
+		if !strings.Contains(err.Error(), "require TLS to be enabled") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}
+
+// createTempCACertFile writes a minimal self-signed CA cert to a temp file and returns its path.
+func createTempCACertFile(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.CreateTemp("", "prometheus-mtls-ca-*.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		t.Fatal(err)
+	}
+	name := f.Name()
+	t.Cleanup(func() { _ = os.Remove(name) })
+	return name
 }

--- a/observability/metrics/prometheus_enabled.go
+++ b/observability/metrics/prometheus_enabled.go
@@ -20,8 +20,10 @@ package metrics
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"net/http"
 
 	"github.com/prometheus/otlptranslator"
 	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
@@ -55,10 +57,15 @@ func buildPrometheus(_ context.Context, cfg Config) (sdkmetric.Reader, shutdownF
 	}
 
 	server, err := prometheus.NewServer(opts...)
+	if err != nil {
+		return nil, noopFunc, fmt.Errorf("create prometheus metrics server: %w", err)
+	}
 
 	go func() {
-		server.ListenAndServe()
+		if err := server.Serve(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			fmt.Printf("metrics server error: %v\n", err)
+		}
 	}()
 
-	return r, server.Shutdown, err
+	return r, server.Shutdown, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->
This PR adds native TLS/HTTPS support to the Prometheus metrics server in `knative.dev/pkg/observability/metrics/prometheus`, enabling secure metrics collection without requiring additional sidecars or proxies.

### Problem
Many production environments require encrypted metrics endpoints for compliance and security, but the current Prometheus server only supports plain HTTP. Existing solutions have significant drawbacks:

1. **kube-rbac-proxy limitations:**
   - Deprecated and unmaintained (archived by Brancz in 2023)
   - Requires sidecar container for each component (15+ containers in multi-component operators)
   - Increased memory overhead and operational complexity
   - Additional maintenance burden for certificate rotation

2. **Post-Quantum Cryptography (PQC) Readiness:**
   - Organizations need to configure TLS settings (MinVersion, MaxVersion, CipherSuites) to prepare for PQC migration
   - Current solution provides no programmatic control over TLS configuration
   
### Solution
Native TLS support in the Prometheus server provides:
- Zero additional containers or sidecars
- Minimal memory footprint
- Built-in support for all Knative components
- Full programmatic control over TLS configuration (PQC-ready)
- Simple certificate file-based configuration for basic use cases
- Backward compatible (plain HTTP when TLS not configured)

# Changes

- Add certFile and keyFile on the server (populated from env). 
Env vars: METRICS_PROMETHEUS_TLS_CERT, METRICS_PROMETHEUS_TLS_KEY for cert/key paths; TLS settings (MinVersion, MaxVersion, CipherSuites, CurvePreferences) via METRICS_PROMETHEUS_TLS_* using knative.dev/pkg/network/tls.DefaultConfigFromEnv("METRICS_PROMETHEUS_").

- Add mTLS (client certificate verification) via two new env vars:
METRICS_PROMETHEUS_TLS_CLIENT_AUTH: controls client cert policy (none, optional, require).
METRICS_PROMETHEUS_TLS_CLIENT_CA_FILE: path to the CA bundle used to verify client certificates (e.g. the 


- API: ListenAndServe() (plain HTTP), ListenAndServeTLS(certFile, keyFile) (TLS), and Serve() (use TLS when both cert and key are set, otherwise plain HTTP).

- Validation: In validate(), require both cert and key set or both unset; return a clear error otherwise (no silent fallback to plain HTTP when only one is set). Also validates mTLS configuration: clientAuth must be one of none, optional, or require; setting mTLS env vars without TLS enabled is an error; optional or require without a client CA file is an error.

- Godoc updated for TLS and mTLS behavior and env vars.

- observability/metrics/prometheus_enabled.go
Call server.Serve() so TLS vs plain is chosen from config (e.g. when using sharedmain and env-based config). Check NewServer error before starting the serve goroutine to prevent nil-pointer panics. Ignore http.ErrServerClosed when logging server errors so graceful shutdown is not reported as an error.

- observability/metrics/prometheus/server_test.go
Tests for TLS from env (cert/key + METRICS_PROMETHEUS_TLS_MIN_VERSION and related vars). 



# Configuration
- Cert/key (required for TLS): METRICS_PROMETHEUS_TLS_CERT, METRICS_PROMETHEUS_TLS_KEY (file paths). Both must be set or both unset.

- TLS parameters (optional, via network/tls): METRICS_PROMETHEUS_TLS_MIN_VERSION, METRICS_PROMETHEUS_TLS_MAX_VERSION, METRICS_PROMETHEUS_TLS_CIPHER_SUITES, METRICS_PROMETHEUS_TLS_CURVE_PREFERENCES. Defaults (e.g. TLS 1.3) apply when not set.

- Client authentication (optional, requires TLS): METRICS_PROMETHEUS_TLS_CLIENT_AUTH (none, optional, require), METRICS_PROMETHEUS_TLS_CLIENT_CA_FILE (path to CA bundle for verifying client certs). optional or require requires METRICS_PROMETHEUS_TLS_CLIENT_CA_FILE to be set. Setting either without TLS cert/key is a validation error.

- Host/port: Existing METRICS_PROMETHEUS_HOST, METRICS_PROMETHEUS_PORT unchanged.
   
<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
The Prometheus metrics server in knative.dev/pkg now supports native HTTPS and mTLS. TLS is configured via environment variables: set METRICS_PROMETHEUS_TLS_CERT and METRICS_PROMETHEUS_TLS_KEY for certificate and key file paths, and optionally METRICS_PROMETHEUS_TLS_MIN_VERSION, METRICS_PROMETHEUS_TLS_MAX_VERSION, METRICS_PROMETHEUS_TLS_CIPHER_SUITES, and METRICS_PROMETHEUS_TLS_CURVE_PREFERENCES (using knative.dev/pkg/network/tls) for Post-Quantum Cryptography (PQC)–ready tuning. For mutual TLS (mTLS), set METRICS_PROMETHEUS_TLS_CLIENT_AUTH (none, optional, or require) and METRICS_PROMETHEUS_TLS_CLIENT_CA_FILE (path to the CA bundle used to verify client certificates). This enables operators to enforce client certificate authentication on the metrics endpoint,
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
