### PR TITLE
feat: add shared tls package for reading TLS config from environment

### DIFF
--- a/tls/config.go
+++ b/tls/config.go
@@ -51,7 +51,7 @@ func NewConfigFromEnv(prefix string) (*Config, error) {
 	var cfg Config
 
 	if v := os.Getenv(prefix + MinVersionEnvKey); v != "" {
-		ver, err := ParseVersion(v)
+		ver, err := parseVersion(v)
 		if err != nil {
 			return nil, fmt.Errorf("invalid %s%s %q: %w", prefix, MinVersionEnvKey, v, err)
 		}
@@ -59,7 +59,7 @@ func NewConfigFromEnv(prefix string) (*Config, error) {
 	}
 
 	if v := os.Getenv(prefix + MaxVersionEnvKey); v != "" {
-		ver, err := ParseVersion(v)
+		ver, err := parseVersion(v)
 		if err != nil {
 			return nil, fmt.Errorf("invalid %s%s %q: %w", prefix, MaxVersionEnvKey, v, err)
 		}
@@ -67,7 +67,7 @@ func NewConfigFromEnv(prefix string) (*Config, error) {
 	}
 
 	if v := os.Getenv(prefix + CipherSuitesEnvKey); v != "" {
-		suites, err := ParseCipherSuites(v)
+		suites, err := parseCipherSuites(v)
 		if err != nil {
 			return nil, fmt.Errorf("invalid %s%s: %w", prefix, CipherSuitesEnvKey, err)
 		}
@@ -75,7 +75,7 @@ func NewConfigFromEnv(prefix string) (*Config, error) {
 	}
 
 	if v := os.Getenv(prefix + CurvePreferencesEnvKey); v != "" {
-		curves, err := ParseCurvePreferences(v)
+		curves, err := parseCurvePreferences(v)
 		if err != nil {
 			return nil, fmt.Errorf("invalid %s%s: %w", prefix, CurvePreferencesEnvKey, err)
 		}
@@ -97,9 +97,9 @@ func (c *Config) TLSConfig() *cryptotls.Config {
 	}
 }
 
-// ParseVersion converts a TLS version string to the corresponding
+// parseVersion converts a TLS version string to the corresponding
 // crypto/tls constant. Accepted values are "1.2" and "1.3".
-func ParseVersion(v string) (uint16, error) {
+func parseVersion(v string) (uint16, error) {
 	switch v {
 	case "1.2":
 		return cryptotls.VersionTLS12, nil
@@ -110,11 +110,11 @@ func ParseVersion(v string) (uint16, error) {
 	}
 }
 
-// ParseCipherSuites parses a comma-separated list of TLS cipher-suite names
+// parseCipherSuites parses a comma-separated list of TLS cipher-suite names
 // (e.g. "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
 // into a slice of cipher-suite IDs. Names must match those returned by
 // crypto/tls.CipherSuiteName.
-func ParseCipherSuites(s string) ([]uint16, error) {
+func parseCipherSuites(s string) ([]uint16, error) {
 	lookup := cipherSuiteLookup()
 	parts := strings.Split(s, ",")
 	suites := make([]uint16, 0, len(parts))
@@ -134,10 +134,10 @@ func ParseCipherSuites(s string) ([]uint16, error) {
 	return suites, nil
 }
 
-// ParseCurvePreferences parses a comma-separated list of elliptic-curve names
+// parseCurvePreferences parses a comma-separated list of elliptic-curve names
 // (e.g. "X25519,CurveP256") into a slice of crypto/tls.CurveID values.
 // Both Go constant names (CurveP256) and standard names (P-256) are accepted.
-func ParseCurvePreferences(s string) ([]cryptotls.CurveID, error) {
+func parseCurvePreferences(s string) ([]cryptotls.CurveID, error) {
 	parts := strings.Split(s, ",")
 	curves := make([]cryptotls.CurveID, 0, len(parts))
 

--- a/tls/config_test.go
+++ b/tls/config_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-func TestParseVersion(t *testing.T) {
+func Test_parseVersion(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
@@ -39,24 +39,24 @@ func TestParseVersion(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := ParseVersion(tc.input)
+			got, err := parseVersion(tc.input)
 			if tc.wantErr {
 				if err == nil {
-					t.Fatalf("ParseVersion(%q) = %d, want error", tc.input, got)
+					t.Fatalf("parseVersion(%q) = %d, want error", tc.input, got)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("ParseVersion(%q) unexpected error: %v", tc.input, err)
+				t.Fatalf("parseVersion(%q) unexpected error: %v", tc.input, err)
 			}
 			if got != tc.want {
-				t.Errorf("ParseVersion(%q) = %d, want %d", tc.input, got, tc.want)
+				t.Errorf("parseVersion(%q) = %d, want %d", tc.input, got, tc.want)
 			}
 		})
 	}
 }
 
-func TestParseCipherSuites(t *testing.T) {
+func Test_parseCipherSuites(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
@@ -102,29 +102,29 @@ func TestParseCipherSuites(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := ParseCipherSuites(tc.input)
+			got, err := parseCipherSuites(tc.input)
 			if tc.wantErr {
 				if err == nil {
-					t.Fatalf("ParseCipherSuites(%q) = %v, want error", tc.input, got)
+					t.Fatalf("parseCipherSuites(%q) = %v, want error", tc.input, got)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("ParseCipherSuites(%q) unexpected error: %v", tc.input, err)
+				t.Fatalf("parseCipherSuites(%q) unexpected error: %v", tc.input, err)
 			}
 			if len(got) != len(tc.want) {
-				t.Fatalf("ParseCipherSuites(%q) returned %d suites, want %d", tc.input, len(got), len(tc.want))
+				t.Fatalf("parseCipherSuites(%q) returned %d suites, want %d", tc.input, len(got), len(tc.want))
 			}
 			for i := range tc.want {
 				if got[i] != tc.want[i] {
-					t.Errorf("ParseCipherSuites(%q)[%d] = %d, want %d", tc.input, i, got[i], tc.want[i])
+					t.Errorf("parseCipherSuites(%q)[%d] = %d, want %d", tc.input, i, got[i], tc.want[i])
 				}
 			}
 		})
 	}
 }
 
-func TestParseCurvePreferences(t *testing.T) {
+func Test_parseCurvePreferences(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
@@ -191,22 +191,22 @@ func TestParseCurvePreferences(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := ParseCurvePreferences(tc.input)
+			got, err := parseCurvePreferences(tc.input)
 			if tc.wantErr {
 				if err == nil {
-					t.Fatalf("ParseCurvePreferences(%q) = %v, want error", tc.input, got)
+					t.Fatalf("parseCurvePreferences(%q) = %v, want error", tc.input, got)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("ParseCurvePreferences(%q) unexpected error: %v", tc.input, err)
+				t.Fatalf("parseCurvePreferences(%q) unexpected error: %v", tc.input, err)
 			}
 			if len(got) != len(tc.want) {
-				t.Fatalf("ParseCurvePreferences(%q) returned %d curves, want %d", tc.input, len(got), len(tc.want))
+				t.Fatalf("parseCurvePreferences(%q) returned %d curves, want %d", tc.input, len(got), len(tc.want))
 			}
 			for i := range tc.want {
 				if got[i] != tc.want[i] {
-					t.Errorf("ParseCurvePreferences(%q)[%d] = %d, want %d", tc.input, i, got[i], tc.want[i])
+					t.Errorf("parseCurvePreferences(%q)[%d] = %d, want %d", tc.input, i, got[i], tc.want[i])
 				}
 			}
 		})
@@ -352,16 +352,14 @@ func TestNewConfigFromEnv(t *testing.T) {
 }
 
 func TestConfig_TLSConfig(t *testing.T) {
-	cfg := &Config{
-		MinVersion: cryptotls.VersionTLS12,
-		MaxVersion: cryptotls.VersionTLS13,
-		CipherSuites: []uint16{
-			cryptotls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		},
-		CurvePreferences: []cryptotls.CurveID{
-			cryptotls.X25519,
-			cryptotls.CurveP256,
-		},
+	t.Setenv(MinVersionEnvKey, "1.2")
+	t.Setenv(MaxVersionEnvKey, "1.3")
+	t.Setenv(CipherSuitesEnvKey, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+	t.Setenv(CurvePreferencesEnvKey, "X25519,CurveP256")
+
+	cfg, err := NewConfigFromEnv("")
+	if err != nil {
+		t.Fatal("unexpected error:", err)
 	}
 
 	tc := cfg.TLSConfig()
@@ -380,5 +378,8 @@ func TestConfig_TLSConfig(t *testing.T) {
 	}
 	if tc.CurvePreferences[0] != cryptotls.X25519 {
 		t.Errorf("CurvePreferences[0] = %d, want %d", tc.CurvePreferences[0], cryptotls.X25519)
+	}
+	if tc.CurvePreferences[1] != cryptotls.CurveP256 {
+		t.Errorf("CurvePreferences[1] = %d, want %d", tc.CurvePreferences[1], cryptotls.CurveP256)
 	}
 }

--- a/webhook/env.go
+++ b/webhook/env.go
@@ -72,7 +72,7 @@ func SecretNameFromEnv(defaultSecretName string) string {
 	return secret
 }
 
-// Deprecated: Use knative.dev/pkg/tls.NewConfigFromEnv or knative.dev/pkg/tls.ParseVersion instead.
+// Deprecated: Use knative.dev/pkg/tls.NewConfigFromEnv instead.
 // TLS configuration is now read automatically inside webhook.New via the shared tls package.
 func TLSMinVersionFromEnv(defaultTLSMinVersion uint16) uint16 {
 	switch tlsMinVersion := os.Getenv(tlsMinVersionEnvKey); tlsMinVersion {

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -49,7 +49,15 @@ import (
 	"knative.dev/pkg/system"
 )
 
-// Options contains the configuration for the webhook
+// Options contains the configuration for the webhook.
+//
+// TLS fields (TLSMinVersion, TLSMaxVersion, TLSCipherSuites, TLSCurvePreferences)
+// are resolved with the following precedence:
+//  1. Values set explicitly in Options (programmatic).
+//  2. WEBHOOK_TLS_* environment variables (WEBHOOK_TLS_MIN_VERSION,
+//     WEBHOOK_TLS_MAX_VERSION, WEBHOOK_TLS_CIPHER_SUITES, WEBHOOK_TLS_CURVE_PREFERENCES).
+//  3. Defaults (TLS 1.3 minimum version; zero values for the rest, meaning the
+//     Go standard library picks its defaults).
 type Options struct {
 	// TLSMinVersion contains the minimum TLS version that is acceptable to communicate with the API server.
 	// TLS 1.3 is the minimum version if not specified otherwise.
@@ -210,6 +218,9 @@ func New(
 
 	if opts.TLSMinVersion != 0 && opts.TLSMinVersion != tls.VersionTLS12 && opts.TLSMinVersion != tls.VersionTLS13 {
 		return nil, fmt.Errorf("unsupported TLS minimum version %d: must be TLS 1.2 or TLS 1.3", opts.TLSMinVersion)
+	}
+	if opts.TLSMaxVersion != 0 && opts.TLSMinVersion > opts.TLSMaxVersion {
+		return nil, fmt.Errorf("TLS minimum version (%#x) is greater than maximum version (%#x)", opts.TLSMinVersion, opts.TLSMaxVersion)
 	}
 
 	syncCtx, cancel := context.WithCancel(context.Background())

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -103,10 +103,16 @@ func newAdmissionControllerWebhook(t *testing.T, options Options, acs ...interfa
 
 func TestTLSMinVersionWebhookOption(t *testing.T) {
 	opts := newDefaultOptions()
-	t.Run("when TLSMinVersion is not configured, and the default is used", func(t *testing.T) {
-		_, err := newAdmissionControllerWebhook(t, opts)
+	t.Run("when TLSMinVersion is not configured, default is TLS 1.3", func(t *testing.T) {
+		wh, err := newAdmissionControllerWebhook(t, opts)
 		if err != nil {
 			t.Fatal("Unexpected error", err)
+		}
+		if wh.tlsConfig == nil {
+			t.Fatal("Expected tlsConfig to be set")
+		}
+		if wh.tlsConfig.MinVersion != tls.VersionTLS13 {
+			t.Errorf("Expected default MinVersion to be TLS 1.3 (%#x), got %#x", tls.VersionTLS13, wh.tlsConfig.MinVersion)
 		}
 	})
 	t.Run("when the TLS minimum version configured is supported", func(t *testing.T) {
@@ -165,6 +171,36 @@ func TestTLSMaxVersionWebhookOption(t *testing.T) {
 		}
 		if wh.tlsConfig.MaxVersion != tls.VersionTLS13 {
 			t.Errorf("Expected MaxVersion to be TLS 1.3, got %d", wh.tlsConfig.MaxVersion)
+		}
+	})
+}
+
+func TestTLSMinMaxVersionValidation(t *testing.T) {
+	t.Run("max version less than min version returns error", func(t *testing.T) {
+		opts := newDefaultOptions()
+		opts.TLSMinVersion = tls.VersionTLS13
+		opts.TLSMaxVersion = tls.VersionTLS12
+		_, err := newAdmissionControllerWebhook(t, opts)
+		if err == nil {
+			t.Fatal("Expected error when TLS max version is less than min version")
+		}
+	})
+	t.Run("max version equal to min version is ok", func(t *testing.T) {
+		opts := newDefaultOptions()
+		opts.TLSMinVersion = tls.VersionTLS13
+		opts.TLSMaxVersion = tls.VersionTLS13
+		_, err := newAdmissionControllerWebhook(t, opts)
+		if err != nil {
+			t.Fatal("Unexpected error:", err)
+		}
+	})
+	t.Run("max version zero skips validation", func(t *testing.T) {
+		opts := newDefaultOptions()
+		opts.TLSMinVersion = tls.VersionTLS13
+		opts.TLSMaxVersion = 0
+		_, err := newAdmissionControllerWebhook(t, opts)
+		if err != nil {
+			t.Fatal("Unexpected error:", err)
 		}
 	})
 }
@@ -315,7 +351,10 @@ func TestTLSConfigFromEnvironment(t *testing.T) {
 		if wh.tlsConfig == nil {
 			t.Fatal("Expected tlsConfig to be set")
 		}
-		if len(wh.tlsConfig.CipherSuites) != 1 || wh.tlsConfig.CipherSuites[0] != tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
+		if len(wh.tlsConfig.CipherSuites) != 1 {
+			t.Fatalf("Expected 1 cipher suite from env, got %d", len(wh.tlsConfig.CipherSuites))
+		}
+		if wh.tlsConfig.CipherSuites[0] != tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
 			t.Errorf("Expected CipherSuites from env, got %v", wh.tlsConfig.CipherSuites)
 		}
 	})
@@ -331,7 +370,10 @@ func TestTLSConfigFromEnvironment(t *testing.T) {
 		if wh.tlsConfig == nil {
 			t.Fatal("Expected tlsConfig to be set")
 		}
-		if len(wh.tlsConfig.CipherSuites) != 1 || wh.tlsConfig.CipherSuites[0] != tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 {
+		if len(wh.tlsConfig.CipherSuites) != 1 {
+			t.Fatalf("Expected 1 cipher suite from opts, got %d", len(wh.tlsConfig.CipherSuites))
+		}
+		if wh.tlsConfig.CipherSuites[0] != tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 {
 			t.Errorf("Expected CipherSuites from opts, got %v", wh.tlsConfig.CipherSuites)
 		}
 	})
@@ -368,7 +410,10 @@ func TestTLSConfigFromEnvironment(t *testing.T) {
 		if wh.tlsConfig == nil {
 			t.Fatal("Expected tlsConfig to be set")
 		}
-		if len(wh.tlsConfig.CurvePreferences) != 1 || wh.tlsConfig.CurvePreferences[0] != tls.CurveP384 {
+		if len(wh.tlsConfig.CurvePreferences) != 1 {
+			t.Fatalf("Expected 1 curve preference from opts, got %d", len(wh.tlsConfig.CurvePreferences))
+		}
+		if wh.tlsConfig.CurvePreferences[0] != tls.CurveP384 {
 			t.Errorf("Expected CurvePreferences from opts, got %v", wh.tlsConfig.CurvePreferences)
 		}
 	})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

Extract TLS configuration parsing into a reusable knative.dev/pkg/tls package so that any Knative component (not just webhooks) can read TLS_MIN_VERSION, TLS_MAX_VERSION, TLS_CIPHER_SUITES, and TLS_CURVE_PREFERENCES from environment variables with an optional prefix.

The webhook package is updated to use the new tls package, extending env var support from just WEBHOOK_TLS_MIN_VERSION to all four WEBHOOK_TLS_* variables. Programmatic Options values continue to take precedence over environment variables.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Add new `knative.dev/pkg/tls` package for shared TLS configuration. Webhook now supports `WEBHOOK_TLS_MAX_VERSION`, `WEBHOOK_TLS_CIPHER_SUITES`, and `WEBHOOK_TLS_CURVE_PREFERENCES` environment variables in addition to the existing `WEBHOOK_TLS_MIN_VERSION`.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
