### PR TITLE
feat: support default values in tls.NewConfigFromEnv

### DIFF
--- a/tls/config.go
+++ b/tls/config.go
@@ -23,6 +23,10 @@ import (
 	"strings"
 )
 
+// DefaultMinTLSVersion is the minimum TLS version used when no override
+// is provided via environment variable or caller-supplied defaults.
+const DefaultMinTLSVersion = cryptotls.VersionTLS13
+
 // Environment variable name suffixes for TLS configuration.
 // Use with a prefix to namespace them, e.g. "WEBHOOK_" + MinVersionEnvKey
 // reads the WEBHOOK_TLS_MIN_VERSION variable.
@@ -46,9 +50,19 @@ type Config struct {
 // returns a Config. The prefix is prepended to each standard env-var suffix;
 // for example with prefix "WEBHOOK_" the function reads
 // WEBHOOK_TLS_MIN_VERSION, WEBHOOK_TLS_MAX_VERSION, etc.
-// Fields whose corresponding env var is unset are left at their zero value.
-func NewConfigFromEnv(prefix string) (*Config, error) {
+//
+// An optional defaults Config may be supplied; its values are used for any
+// field whose corresponding environment variable is unset. When no defaults
+// are provided, unset fields remain at their zero value.
+func NewConfigFromEnv(prefix string, defaults ...Config) (*Config, error) {
+	if len(defaults) > 1 {
+		return nil, fmt.Errorf("at most one defaults Config may be provided, got %d", len(defaults))
+	}
+
 	var cfg Config
+	if len(defaults) == 1 {
+		cfg = defaults[0]
+	}
 
 	if v := os.Getenv(prefix + MinVersionEnvKey); v != "" {
 		ver, err := parseVersion(v)

--- a/tls/config_test.go
+++ b/tls/config_test.go
@@ -349,6 +349,68 @@ func TestNewConfigFromEnv(t *testing.T) {
 			t.Fatal("expected error for invalid curve")
 		}
 	})
+
+	t.Run("defaults used when env vars are unset", func(t *testing.T) {
+		defaults := Config{
+			MinVersion:   DefaultMinTLSVersion,
+			MaxVersion:   cryptotls.VersionTLS13,
+			CipherSuites: []uint16{cryptotls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+			CurvePreferences: []cryptotls.CurveID{
+				cryptotls.X25519,
+			},
+		}
+		cfg, err := NewConfigFromEnv("", defaults)
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if cfg.MinVersion != DefaultMinTLSVersion {
+			t.Errorf("MinVersion = %d, want %d", cfg.MinVersion, DefaultMinTLSVersion)
+		}
+		if cfg.MaxVersion != cryptotls.VersionTLS13 {
+			t.Errorf("MaxVersion = %d, want %d", cfg.MaxVersion, cryptotls.VersionTLS13)
+		}
+		if len(cfg.CipherSuites) != 1 || cfg.CipherSuites[0] != cryptotls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
+			t.Errorf("CipherSuites = %v, want [%d]", cfg.CipherSuites, cryptotls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
+		}
+		if len(cfg.CurvePreferences) != 1 || cfg.CurvePreferences[0] != cryptotls.X25519 {
+			t.Errorf("CurvePreferences = %v, want [%d]", cfg.CurvePreferences, cryptotls.X25519)
+		}
+	})
+
+	t.Run("env vars override defaults", func(t *testing.T) {
+		t.Setenv(MinVersionEnvKey, "1.2")
+		t.Setenv(CurvePreferencesEnvKey, "CurveP256")
+
+		defaults := Config{
+			MinVersion: DefaultMinTLSVersion,
+			CurvePreferences: []cryptotls.CurveID{
+				cryptotls.X25519,
+			},
+		}
+		cfg, err := NewConfigFromEnv("", defaults)
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if cfg.MinVersion != cryptotls.VersionTLS12 {
+			t.Errorf("MinVersion = %d, want %d (env should override default)", cfg.MinVersion, cryptotls.VersionTLS12)
+		}
+		if len(cfg.CurvePreferences) != 1 || cfg.CurvePreferences[0] != cryptotls.CurveP256 {
+			t.Errorf("CurvePreferences = %v, want [%d] (env should override default)", cfg.CurvePreferences, cryptotls.CurveP256)
+		}
+	})
+
+	t.Run("multiple defaults returns error", func(t *testing.T) {
+		_, err := NewConfigFromEnv("", Config{}, Config{})
+		if err == nil {
+			t.Fatal("expected error when passing multiple defaults")
+		}
+	})
+
+	t.Run("DefaultMinTLSVersion equals TLS 1.3", func(t *testing.T) {
+		if DefaultMinTLSVersion != cryptotls.VersionTLS13 {
+			t.Errorf("DefaultMinTLSVersion = %d, want %d (TLS 1.3)", DefaultMinTLSVersion, cryptotls.VersionTLS13)
+		}
+	})
 }
 
 func TestConfig_TLSConfig(t *testing.T) {

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -191,20 +191,17 @@ func New(
 
 	logger := logging.FromContext(ctx)
 
-	tlsCfg, err := knativetls.NewConfigFromEnv("WEBHOOK_")
+	tlsCfg, err := knativetls.NewConfigFromEnv("WEBHOOK_", knativetls.Config{
+		MinVersion: knativetls.DefaultMinTLSVersion,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("reading TLS configuration from environment: %w", err)
 	}
 
-	// Replace the TLS configuration with the one from the environment if not set.
-	// Default to TLS 1.3 as the minimum version when neither the caller nor the
-	// environment specifies one.
-	if opts.TLSMinVersion == 0 {
-		if tlsCfg.MinVersion != 0 {
-			opts.TLSMinVersion = tlsCfg.MinVersion
-		} else {
-			opts.TLSMinVersion = tls.VersionTLS13
-		}
+	// Apply environment / default TLS settings for any fields the caller
+	// has not already configured.
+	if opts.TLSMinVersion == 0 && tlsCfg.MinVersion != 0 {
+		opts.TLSMinVersion = tlsCfg.MinVersion
 	}
 	if opts.TLSMaxVersion == 0 && tlsCfg.MaxVersion != 0 {
 		opts.TLSMaxVersion = tlsCfg.MaxVersion


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

Add a DefaultMinTLSVersion constant (TLS 1.3) and an optional defaults parameter to NewConfigFromEnv so callers can supply fallback values for fields not set by environment variables. The webhook package now passes DefaultMinTLSVersion through the new parameter, simplifying its TLS setup logic.

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
tls.NewConfigFromEnv now accepts an optional defaults Config, letting callers supply fallback values for any field not set by an environment variable. A new DefaultMinTLSVersion constant (TLS 1.3) is exported for convenience. The webhook package uses this to simplify its TLS setup.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
