### PR TITLE
export MinimumVersion() accessor

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -36,6 +36,12 @@ const (
 	defaultMinimumVersion = "v1.34.0"
 )
 
+// MinimumVersion returns the minimum Kubernetes version Knative is built
+// and tested against. The returned value has a leading "v" (e.g. "v1.34.0").
+func MinimumVersion() string {
+	return defaultMinimumVersion
+}
+
 func getMinimumVersion() string {
 	if v := os.Getenv(KubernetesMinVersionKey); v != "" {
 		return v

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -108,3 +108,9 @@ func TestVersionCheck(t *testing.T) {
 		})
 	}
 }
+
+func TestMinimumVersion(t *testing.T) {
+	if got := MinimumVersion(); got != defaultMinimumVersion {
+		t.Errorf("MinimumVersion() = %q, want %q", got, defaultMinimumVersion)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Expose the minimum Kubernetes version Knative is built and tested against via a new exported function, so tools that need the target version before a cluster exists can read it directly instead of hardcoding and hand-bumping it each release.

xref knative-extensions/kn-plugin-quickstart#644


