### PR TITLE
webhook/testing: replace deprecated autoscaling/v2beta1 with autoscaling/v2

### DIFF
--- a/webhook/testing/listers.go
+++ b/webhook/testing/listers.go
@@ -19,7 +19,7 @@ package testing
 import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apixlisters "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
@@ -29,7 +29,7 @@ import (
 
 	fakeapix "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
-	autoscalingv2beta1listers "k8s.io/client-go/listers/autoscaling/v2beta1"
+	autoscalingv2listers "k8s.io/client-go/listers/autoscaling/v2"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/reconciler/testing"
@@ -39,7 +39,7 @@ import (
 
 var clientSetSchemes = []func(*runtime.Scheme) error{
 	fakekubeclientset.AddToScheme,
-	autoscalingv2beta1.AddToScheme,
+	autoscalingv2.AddToScheme,
 	pkgtesting.AddToScheme,
 	pkgducktesting.AddToScheme,
 	fakeapix.AddToScheme,
@@ -104,8 +104,8 @@ func (l *Listers) GetAPIExtensionsObjects() []runtime.Object {
 }
 
 // GetHorizontalPodAutoscalerLister gets lister for HorizontalPodAutoscaler resources.
-func (l *Listers) GetHorizontalPodAutoscalerLister() autoscalingv2beta1listers.HorizontalPodAutoscalerLister {
-	return autoscalingv2beta1listers.NewHorizontalPodAutoscalerLister(l.IndexerFor(&autoscalingv2beta1.HorizontalPodAutoscaler{}))
+func (l *Listers) GetHorizontalPodAutoscalerLister() autoscalingv2listers.HorizontalPodAutoscalerLister {
+	return autoscalingv2listers.NewHorizontalPodAutoscalerLister(l.IndexerFor(&autoscalingv2.HorizontalPodAutoscaler{}))
 }
 
 // GetDeploymentLister gets lister for K8s Deployment resource.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

 :wastebasket: Replace deprecated `autoscaling/v2beta1` imports with stable `autoscaling/v2` in `webhook/testing/listers.go`

`k8s.io/api` v0.36.0 (Kubernetes 1.36) deleted `k8s.io/api/autoscaling/v2beta1` and `k8s.io/client-go/listers/autoscaling/v2beta1`, which were deprecated since Kubernetes 1.12 and server-removed in Kubernetes 1.26. 

The trigger for this PR is because Go resolves a single version of `k8s.io/api` across the entire module graph, any project that depends on both `knative/pkg` and `k8s.io/api >= v0.36.0` hits a hard build failure:
`k8s.io/api/autoscaling/v2beta1: module k8s.io/api@v0.36.0 found, but does not contain package k8s.io/api/autoscaling/v2beta1` 

Example case : Experienced this issue while upgrading k8s.io/client-go to 0.36.0(https://github.com/tektoncd/operator/blob/main/go.mod#L45) to address https://github.com/kubernetes/client-go/commit/ea7a7e7cf9697850f17631f79ef4ef45b95c449e . We are blocked because of this.

/kind removal

**Release Note**

```release-note
webhook/testing: replaced deprecated autoscaling/v2beta1 with stable autoscaling/v2. Projects depending on knative/pkg alongside k8s.io/api >= v0.36.0 will no longer hit a hard build failure due to the removed v2beta1 package.
```