### PR TITLE
Fix memory leaks in expired matchers

### DIFF
--- a/tracker/enqueue.go
+++ b/tracker/enqueue.go
@@ -277,8 +277,8 @@ func (i *impl) GetObservers(obj interface{}) []types.NamespacedName {
 				keys = append(keys, key)
 			}
 		}
-		if len(s) == 0 {
-			delete(i.exact, ref)
+		if len(ms) == 0 {
+			delete(i.inexact, ref)
 		}
 	}
 
@@ -309,7 +309,7 @@ func (i *impl) OnDeletedObserver(obj interface{}) {
 	for ref, matchers := range i.inexact {
 		delete(matchers, key)
 		if len(matchers) == 0 {
-			delete(i.exact, ref)
+			delete(i.inexact, ref)
 		}
 	}
 }

--- a/tracker/enqueue_test.go
+++ b/tracker/enqueue_test.go
@@ -808,5 +808,32 @@ func TestHappyPathsByBoth(t *testing.T) {
 		if got, want := len(trk.GetObservers(thing1)), 0; got != want {
 			t.Fatalf("len(GetObservers()) = %v, wanted %v", got, want)
 		}
+		if got, want := len(trk.(*impl).exact), 0; got != want {
+			t.Fatalf("OnDeletedObserver() did not clean up exact map: len = %v, wanted %v", got, want)
+		}
+		if got, want := len(trk.(*impl).inexact), 0; got != want {
+			t.Fatalf("OnDeletedObserver() did not clean up inexact map: len = %v, wanted %v", got, want)
+		}
+	}
+
+	// Verify inexact map cleanup on expiry when exact tracker is also present.
+	{
+		if err := trk.TrackReference(ref1, thing2); err != nil {
+			t.Fatal("Track() =", err)
+		}
+		if err := trk.TrackReference(ref2, thing2); err != nil {
+			t.Fatal("Track() =", err)
+		}
+
+		time.Sleep(101 * time.Millisecond)
+
+		trk.GetObservers(thing1)
+
+		if got, want := len(trk.(*impl).exact), 0; got != want {
+			t.Fatalf("Timeout passed, but exact map not cleaned up: len = %v, wanted %v", got, want)
+		}
+		if got, want := len(trk.(*impl).inexact), 0; got != want {
+			t.Fatalf("Timeout passed, but inexact map not cleaned up: len = %v, wanted %v", got, want)
+		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Fix memory leak in metrics' expired matchers


Memory leaks observed in @maschmid long running soak tests:

After pruning expired inexact matchers, the code checked `len(s)` (the exact matchers map) instead of `len(ms)` (the inexact matchers map), and then deleted from i.exact instead of `i.inexact`. This meant empty inexact matcher entries were never cleaned up, causing a memory leak for every label-selector-based tracker reference.

When removing inexact matchers for a deleted object, the code called delete(i.exact, ref) instead of `delete(i.inexact, ref)`, so empty inexact entries accumulated indefinitely and could also incorrectly remove unrelated exact entries.

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Fix memory leak in metrics' expired matchers
```

PTAL, it's a follow-up to other memory leak in networking hanging idle connections. 

/cc @dprotaso 
