### PR TITLE
Limit the webhook request body size

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -395,7 +395,9 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wh.mux.ServeHTTP(w, r)
+	const MaxBodySize = 3 * 1024 * 1024 // 3 MiB
+	h := http.MaxBytesHandler(&wh.mux, MaxBodySize)
+	h.ServeHTTP(w, r)
 }
 
 type routeLabeler struct {


### PR DESCRIPTION
This limits the webhook request size to 3MiB. I believe K8s max request body size is the same.