### PR TITLE
Add script to update semconv version if OTel is updated

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -21,3 +21,42 @@ set -o pipefail
 source $(dirname "$0")/../vendor/knative.dev/hack/library.sh
 
 go_update_deps "$@"
+
+# Sync semconv imports with the resolved OTEL module.
+log.step "Syncing semconv imports"
+OTEL_VERSION=$(go list -m -f '{{.Version}}' go.opentelemetry.io/otel 2>/dev/null || true)
+if [ -n "$OTEL_VERSION" ]; then
+  group "Detected go.opentelemetry.io/otel ${OTEL_VERSION}"
+
+  # Semconv versions are package directories inside the OTEL module.
+  OTEL_DIR=$(GOFLAGS=-mod=mod go list -m -f '{{.Dir}}' go.opentelemetry.io/otel 2>/dev/null || true)
+  SEMCONV_VERSION=""
+  if [ -d "${OTEL_DIR}/semconv" ]; then
+    SEMCONV_VERSION=$(find "${OTEL_DIR}/semconv" -mindepth 1 -maxdepth 1 \
+      -type d -name 'v[0-9]*.[0-9]*.[0-9]*' -exec basename {} \; | sort -V | tail -1)
+  fi
+
+  if [ -n "$SEMCONV_VERSION" ]; then
+    group "Updating semconv imports to ${SEMCONV_VERSION}"
+    mapfile -t SEMCONV_FILES < <(
+      find observability -type f -name '*.go' -exec \
+        grep -lE 'go\.opentelemetry\.io/otel/semconv/v[0-9]+\.[0-9]+\.[0-9]+' {} + || true
+    )
+    SEMCONV_IMPORTS_CHANGED=false
+    for file in "${SEMCONV_FILES[@]}"; do
+      current_versions=$(grep -oE \
+        'go\.opentelemetry\.io/otel/semconv/v[0-9]+\.[0-9]+\.[0-9]+' "$file" | \
+        sed -E 's#.*(v[0-9]+\.[0-9]+\.[0-9]+)$#\1#' | sort -u)
+      if [ "$current_versions" != "$SEMCONV_VERSION" ]; then
+        group "  ${file}"
+        sed -i -E "s|(go.opentelemetry.io/otel/semconv/)v[0-9]+\.[0-9]+\.[0-9]+|\1$SEMCONV_VERSION|g" "$file"
+        SEMCONV_IMPORTS_CHANGED=true
+      fi
+    done
+
+    [ "$SEMCONV_IMPORTS_CHANGED" = true ] && go_update_deps
+
+  else
+    group "Could not determine semconv version, skipping"
+  fi
+fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add script to update semconv version if OTel is updated


Semconv version is used in the import path, after OTel version update there might be a mismatch between schemas. The script should detect the version and based on inline mapping or fetching correct version from OTel gomod file update the appropriate imports. 

E.g.: https://github.com/knative/pkg/pull/3381
https://github.com/knative/pkg/blob/main/observability/semconv/semconv.go#L21

/cc @dprotaso @gauron99 